### PR TITLE
Async event handler for terrain providers

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -4,7 +4,6 @@ if (window.CESIUM_BASE_URL === undefined) {
 
 import {
   Cartesian3,
-  createWorldTerrainAsync,
   defined,
   formatError,
   Math as CesiumMath,
@@ -14,6 +13,7 @@ import {
   GeoJsonDataSource,
   KmlDataSource,
   GpxDataSource,
+  Terrain,
   TileMapServiceImageryProvider,
   Viewer,
   viewerCesiumInspectorMixin,
@@ -50,21 +50,21 @@ async function main() {
   }
 
   const loadingIndicator = document.getElementById("loadingIndicator");
+  const hasBaseLayerPicker = !defined(imageryProvider);
+
+  const terrain = Terrain.fromWorldTerrain({
+    requestWaterMask: true,
+    requestVertexNormals: true,
+  });
+
   let viewer;
   try {
-    const hasBaseLayerPicker = !defined(imageryProvider);
-
-    const terrainProvider = await createWorldTerrainAsync({
-      requestWaterMask: true,
-      requestVertexNormals: true,
-    });
-
     viewer = new Viewer("cesiumContainer", {
       imageryProvider: imageryProvider,
       baseLayerPicker: hasBaseLayerPicker,
       scene3DOnly: endUserOptions.scene3DOnly,
       requestRenderMode: true,
-      terrainProvider: terrainProvider,
+      terrain: terrain,
     });
 
     if (hasBaseLayerPicker) {

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -36,7 +36,7 @@
         // A simple demo of 3D Tiles feature picking with hover and select behavior
         // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -56,7 +56,7 @@
         // How to use the 3D Tiles Styling language to style individual features, like buildings.
         // Styling language specification: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
 

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -75,7 +75,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -39,7 +39,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           infoBox: false,
           orderIndependentTranslucency: false,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         // An example of using a b3dm tileset to classify another b3dm tileset.
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         // A normal b3dm tileset containing photogrammetry

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -37,7 +37,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const tileset = new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         // An example showing a point cloud tileset classified by a Geometry tileset.
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -161,7 +161,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const tileset = new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -37,7 +37,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const geocoder = viewer.geocoder.viewModel;

--- a/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
+++ b/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
@@ -32,11 +32,15 @@
       window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
+        try {
+          viewer.scene.terrainProvider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
             "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
-          ),
-        }); //Sandcastle_End
+          );
+        } catch (error) {
+          window.alert(`Failed to load terrain. ${error}`);
+        } //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;

--- a/Apps/Sandcastle/gallery/ArcticDEM.html
+++ b/Apps/Sandcastle/gallery/ArcticDEM.html
@@ -35,13 +35,17 @@
       window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
+        try {
           // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
           // https://www.pgc.umn.edu/data/arcticdem/
-          terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+          viewer.scene.terrainProvider = await Cesium.CesiumTerrainProvider.fromUrl(
             Cesium.IonResource.fromAssetId(3956)
-          ),
-        });
+          );
+        } catch (error) {
+          window.alert(`Failed to load terrain. ${error}`);
+        }
 
         // Add Alaskan locations
         Sandcastle.addDefaultToolbarMenu(

--- a/Apps/Sandcastle/gallery/Atmosphere.html
+++ b/Apps/Sandcastle/gallery/Atmosphere.html
@@ -794,10 +794,9 @@
           .getObservable(viewModel, "enableTerrain")
           .subscribe(async function (newValue) {
             if (newValue) {
-              const provider = await Cesium.createWorldTerrainAsync();
-              globe.terrainProvider = provider;
+              scene.setTerrain(Cesium.Terrain.fromWorldTerrain());
             } else {
-              globe.terrainProvider = new Cesium.EllipsoidTerrainProvider();
+              scene.terrainProvider = new Cesium.EllipsoidTerrainProvider();
             }
           });
         Cesium.knockout

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -247,14 +247,23 @@
           });
         }
 
-        let terrainProvider;
         async function disableDepthTest() {
           Sandcastle.declare(disableDepthTest);
 
-          terrainProvider = viewer.terrainProvider;
-          const worldTerrainProvider = await Cesium.createWorldTerrainAsync();
-          viewer.terrainProvider = worldTerrainProvider;
           viewer.scene.globe.depthTestAgainstTerrain = true;
+
+          try {
+            const worldTerrainProvider = await Cesium.createWorldTerrainAsync();
+
+            // Return early in case a different option has been selected in the meantime
+            if (!viewer.scene.globe.depthTestAgainstTerrain) {
+              return;
+            }
+
+            viewer.terrainProvider = worldTerrainProvider;
+          } catch (error) {
+            window.alert(`Failed to load terrain. ${error}`);
+          }
 
           viewer.entities.add({
             position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
@@ -351,15 +360,11 @@
           },
         ]);
 
-        Sandcastle.reset = function () {
+        Sandcastle.reset = async function () {
           viewer.camera.flyHome(0);
           viewer.entities.removeAll();
-
-          if (Cesium.defined(terrainProvider)) {
-            viewer.terrainProvider = terrainProvider;
-            terrainProvider = undefined;
-            viewer.scene.globe.depthTestAgainstTerrain = false;
-          }
+          viewer.scene.terrainProvider = new Cesium.EllipsoidTerrainProvider();
+          viewer.scene.globe.depthTestAgainstTerrain = false;
         };
         //Sandcastle_End
       };

--- a/Apps/Sandcastle/gallery/CZML Path.html
+++ b/Apps/Sandcastle/gallery/CZML Path.html
@@ -7244,7 +7244,7 @@
         ];
 
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
           baseLayerPicker: false,
           shouldAnimate: true,
         });

--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -37,7 +37,7 @@
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           vrButton: true,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         // Click the VR button in the bottom right of the screen to switch to VR mode.
 

--- a/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
+++ b/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Cesium Inspector.html
+++ b/Apps/Sandcastle/gallery/Cesium Inspector.html
@@ -40,7 +40,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
+++ b/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
@@ -39,7 +39,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.scene.primitives.add(Cesium.createOsmBuildings());

--- a/Apps/Sandcastle/gallery/Cesium World Terrain.html
+++ b/Apps/Sandcastle/gallery/Cesium World Terrain.html
@@ -37,7 +37,7 @@
         //Sandcastle_Begin
         // For more information on Cesium World Terrain, see https://cesium.com/platform/cesium-ion/content/cesium-world-terrain/
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         const scene = viewer.scene;
         const clock = viewer.clock;

--- a/Apps/Sandcastle/gallery/Clamp to Terrain.html
+++ b/Apps/Sandcastle/gallery/Clamp to Terrain.html
@@ -37,10 +37,16 @@
       window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
-        });
+        const viewer = new Cesium.Viewer("cesiumContainer");
         viewer.scene.globe.depthTestAgainstTerrain = true;
+
+        let worldTerrain;
+        try {
+          worldTerrain = await Cesium.createWorldTerrainAsync();
+          viewer.scene.terrainProvider = worldTerrain;
+        } catch (error) {
+          window.alert(`There was an error creating world terrain. ${error}`);
+        }
 
         Sandcastle.addDefaultToolbarMenu(
           [
@@ -237,7 +243,14 @@
             },
             {
               text: "Sample line positions and draw with depth test disabled",
-              onselect: function () {
+              onselect: async function () {
+                if (!Cesium.defined(worldTerrain)) {
+                  window.alert(
+                    "Cannot sample terrain. World terrain failed to load."
+                  );
+                  return;
+                }
+
                 const length = 1000;
 
                 const startLon = Cesium.Math.toRadians(86.953793);
@@ -256,12 +269,11 @@
                   terrainSamplePositions.push(position);
                 }
 
-                Promise.resolve(
-                  Cesium.sampleTerrainMostDetailed(
-                    viewer.terrainProvider,
+                try {
+                  const samples = await Cesium.sampleTerrainMostDetailed(
+                    worldTerrain,
                     terrainSamplePositions
-                  )
-                ).then(function (samples) {
+                  );
                   let offset = 10.0;
                   for (let i = 0; i < samples.length; ++i) {
                     samples[i].height += offset;
@@ -301,7 +313,9 @@
                   );
                   viewer.camera.lookAt(target, offset);
                   viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-                });
+                } catch (error) {
+                  window.alert(`There was an error sampling terrain ${error}`);
+                }
               },
             },
             {

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const tileset = new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -80,7 +80,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Clouds.html
+++ b/Apps/Sandcastle/gallery/Clouds.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
           infoBox: false,
           shouldAnimate: true,
         });

--- a/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
@@ -43,7 +43,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         const scene = viewer.scene;
         scene.globe.depthTestAgainstTerrain = false;

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -49,7 +49,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           selectionIndicator: false,
           infoBox: false,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(

--- a/Apps/Sandcastle/gallery/Elevation Band Material.html
+++ b/Apps/Sandcastle/gallery/Elevation Band Material.html
@@ -119,7 +119,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync({
+          terrain: Cesium.Terrain.fromWorldTerrain({
             requestVertexNormals: true, //Needed to visualize slope
           }),
         });

--- a/Apps/Sandcastle/gallery/FXAA.html
+++ b/Apps/Sandcastle/gallery/FXAA.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.scene.camera.setView({

--- a/Apps/Sandcastle/gallery/GPX.html
+++ b/Apps/Sandcastle/gallery/GPX.html
@@ -35,7 +35,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const pinBuilder = new Cesium.PinBuilder();

--- a/Apps/Sandcastle/gallery/Geometry Height Reference.html
+++ b/Apps/Sandcastle/gallery/Geometry Height Reference.html
@@ -36,10 +36,11 @@
         "use strict";
         //Sandcastle_Begin
         const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
+        const worldTerrain = Cesium.Terrain.fromWorldTerrain();
 
         const viewer = new Cesium.Viewer("cesiumContainer", {
           baseLayerPicker: false,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: worldTerrain,
         });
 
         // depth test against terrain is required to make the polygons clamp to terrain
@@ -66,12 +67,8 @@
         Sandcastle.addToolbarMenu([
           {
             text: "Terrain Enabled",
-            onselect: async function () {
-              try {
-                viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-              } catch (error) {
-                console.log(error);
-              }
+            onselect: function () {
+              viewer.scene.setTerrain(worldTerrain);
             },
           },
           {

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -123,7 +123,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync({
+          terrain: Cesium.Terrain.fromWorldTerrain({
             requestVertexNormals: true, //Needed to visualize slope
           }),
         });

--- a/Apps/Sandcastle/gallery/Globe Translucency.html
+++ b/Apps/Sandcastle/gallery/Globe Translucency.html
@@ -85,7 +85,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Google Earth Enterprise.html
+++ b/Apps/Sandcastle/gallery/Google Earth Enterprise.html
@@ -35,22 +35,32 @@
       window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const geeMetadata = await Cesium.GoogleEarthEnterpriseMetadata.fromUrl(
-          new Cesium.Resource({
-            url: "http://www.earthenterprise.org/3d",
-            proxy: new Cesium.DefaultProxy("/proxy/"),
-          })
-        );
-
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          imageryProvider: new Cesium.GoogleEarthEnterpriseImageryProvider({
-            metadata: geeMetadata,
-          }),
-          terrainProvider: Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(
-            geeMetadata
-          ),
           baseLayerPicker: false,
         });
+
+        try {
+          const geeMetadata = await Cesium.GoogleEarthEnterpriseMetadata.fromUrl(
+            new Cesium.Resource({
+              url: "http://www.earthenterprise.org/3d",
+              proxy: new Cesium.DefaultProxy("/proxy/"),
+            })
+          );
+
+          viewer.scene.terrainProvider = Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+            geeMetadata
+          );
+
+          const layers = viewer.scene.imageryLayers;
+          const blackMarble = layers.addImageryProvider(
+            new Cesium.GoogleEarthEnterpriseImageryProvider({
+              metadata: geeMetadata,
+            })
+          );
+        } catch (error) {
+          console.log(`Failed to create Google Earth providers from metadata. Confirm GEE service is correctly configured. 
+          ${error}`);
+        }
 
         // Start off looking at San Francisco.
         viewer.camera.setView({

--- a/Apps/Sandcastle/gallery/High Dynamic Range.html
+++ b/Apps/Sandcastle/gallery/High Dynamic Range.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
           shadows: true,
         });
 

--- a/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
+++ b/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
@@ -39,7 +39,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
           animation: false,
           timeline: false,
         });

--- a/Apps/Sandcastle/gallery/I3S Feature Picking.html
+++ b/Apps/Sandcastle/gallery/I3S Feature Picking.html
@@ -39,7 +39,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
           animation: false,
           timeline: false,
         });

--- a/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
+++ b/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
@@ -39,7 +39,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
           animation: false,
           timeline: false,
         });

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -41,7 +41,7 @@
           infoBox: false, //Disable InfoBox widget
           selectionIndicator: false, //Disable selection indicator
           shouldAnimate: true, // Enable animations
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         //Enable lighting based on the sun position

--- a/Apps/Sandcastle/gallery/Lighting.html
+++ b/Apps/Sandcastle/gallery/Lighting.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync({
+          terrain: Cesium.Terrain.fromWorldTerrain({
             requestWaterMask: true,
             requestVertexNormals: true,
           }),

--- a/Apps/Sandcastle/gallery/MSAA.html
+++ b/Apps/Sandcastle/gallery/MSAA.html
@@ -36,7 +36,7 @@
           contextOptions: {
             requestWebgl1: false,
           },
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -87,7 +87,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         // A ~10 billion point 3D Tileset of the city of Montreal, Canada captured in 2015 with a resolution of 20 cm. Tiled and hosted by Cesium ion.

--- a/Apps/Sandcastle/gallery/PAMAP Terrain.html
+++ b/Apps/Sandcastle/gallery/PAMAP Terrain.html
@@ -35,13 +35,17 @@
       window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
+        try {
           // High resolution terrain of Pennsylvania curated by Pennsylvania Spatial Data Access (PASDA)
           // http://www.pasda.psu.edu/
-          terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+          viewer.terrainProvider = await Cesium.CesiumTerrainProvider.fromUrl(
             Cesium.IonResource.fromAssetId(3957)
-          ),
-        });
+          );
+        } catch (error) {
+          window.alert(`Failed to load terrain. ${error}`);
+        }
 
         // Add PA locations
         Sandcastle.addDefaultToolbarMenu(

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -37,7 +37,7 @@
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           shouldAnimate: true,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         const scene = viewer.scene;
         scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -48,7 +48,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           clockViewModel: new Cesium.ClockViewModel(clock),
           selectionIndicator: false,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         Sandcastle.addToggleButton("Shadows", viewer.shadows, function (

--- a/Apps/Sandcastle/gallery/Procedural Terrain.html
+++ b/Apps/Sandcastle/gallery/Procedural Terrain.html
@@ -130,9 +130,7 @@
           },
         });
 
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: noiseTerrainProvider,
-        });
+        const viewer = new Cesium.Viewer("cesiumContainer");
 
         Sandcastle.addDefaultToolbarMenu([
           {

--- a/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         const scene = viewer.scene;
 

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -146,7 +146,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           requestRenderMode: true,
           maximumRenderTimeChange: Infinity,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -41,7 +41,7 @@
           shadows: true,
           terrainShadows: Cesium.ShadowMode.ENABLED,
           shouldAnimate: true,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const shadowMap = viewer.shadowMap;

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -65,7 +65,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           skyAtmosphere: false,
           shouldAnimate: true,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
           scene3DOnly: true,
         });
         const globe = viewer.scene.globe;

--- a/Apps/Sandcastle/gallery/Terrain Exaggeration.html
+++ b/Apps/Sandcastle/gallery/Terrain Exaggeration.html
@@ -77,7 +77,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -39,18 +39,12 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-              requestWaterMask: true,
-              requestVertexNormals: true,
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrain: Cesium.Terrain.fromWorldTerrain({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
+        });
 
         // set lighting to true
         viewer.scene.globe.enableLighting = true;
@@ -91,36 +85,41 @@
           [
             {
               text: "CesiumTerrainProvider - Cesium World Terrain",
-              onselect: async function () {
-                const provider = await Cesium.createWorldTerrainAsync({
-                  requestWaterMask: true,
-                  requestVertexNormals: true,
-                });
-                viewer.terrainProvider = provider;
+              onselect: function () {
+                viewer.scene.setTerrain(
+                  Cesium.Terrain.fromWorldTerrain({
+                    requestWaterMask: true,
+                    requestVertexNormals: true,
+                  })
+                );
                 viewer.scene.globe.enableLighting = true;
               },
             },
             {
               text: "CesiumTerrainProvider - Cesium World Terrain - no effects",
-              onselect: async function () {
-                viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+              onselect: function () {
+                viewer.scene.setTerrain(Cesium.Terrain.fromWorldTerrain());
               },
             },
             {
               text: "CesiumTerrainProvider - Cesium World Terrain w/ Lighting",
-              onselect: async function () {
-                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-                  requestVertexNormals: true,
-                });
+              onselect: function () {
+                viewer.scene.setTerrain(
+                  Cesium.Terrain.fromWorldTerrain({
+                    requestVertexNormals: true,
+                  })
+                );
                 viewer.scene.globe.enableLighting = true;
               },
             },
             {
               text: "CesiumTerrainProvider - Cesium World Terrain w/ Water",
-              onselect: async function () {
-                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-                  requestWaterMask: true,
-                });
+              onselect: function () {
+                viewer.scene.setTerrain(
+                  Cesium.Terrain.fromWorldTerrain({
+                    requestWaterMask: true,
+                  })
+                );
               },
             },
             {
@@ -137,23 +136,29 @@
             },
             {
               text: "VRTheWorldTerrainProvider",
-              onselect: async function () {
-                const provider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
-                  "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
-                  {
-                    credit: "Terrain data courtesy VT MÄK",
-                  }
+              onselect: function () {
+                viewer.scene.setTerrain(
+                  new Cesium.Terrain(
+                    Cesium.VRTheWorldTerrainProvider.fromUrl(
+                      "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
+                      {
+                        credit: "Terrain data courtesy VT MÄK",
+                      }
+                    )
+                  )
                 );
-                viewer.terrainProvider = provider;
               },
             },
             {
               text: "ArcGISTerrainProvider",
-              onselect: async function () {
-                const provider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-                  "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+              onselect: function () {
+                viewer.scene.setTerrain(
+                  new Cesium.Terrain(
+                    Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+                      "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    )
+                  )
                 );
-                viewer.terrainProvider = provider;
               },
             },
           ],

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -38,7 +38,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         viewer.scene.globe.depthTestAgainstTerrain = true;
 

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -38,7 +38,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/development/Fog.html
+++ b/Apps/Sandcastle/gallery/development/Fog.html
@@ -51,7 +51,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.extend(Cesium.viewerCesiumInspectorMixin);

--- a/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
+++ b/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         const scene = viewer.scene;
 

--- a/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync({
+          terrain: Cesium.Terrain.fromWorldTerrain({
             requestWaterMask: true,
             requestVertexNormals: true,
           }),

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -72,7 +72,7 @@
           selectionIndicator: false,
           shouldAnimate: true,
           projectionPicker: true,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -46,7 +46,7 @@
           infoBox: false,
           selectionIndicator: false,
           timeline: false,
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/development/Picking.html
+++ b/Apps/Sandcastle/gallery/development/Picking.html
@@ -50,6 +50,9 @@
           originalColor: new Cesium.Color(),
         };
 
+        const worldTerrain = Cesium.Terrain.fromWorldTerrain();
+        const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
+
         Sandcastle.addToolbarMenu([
           {
             text: "Billboard",
@@ -477,8 +480,8 @@
           },
           {
             text: "Vector tile polygons",
-            onselect: async function () {
-              viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+            onselect: function () {
+              viewer.scene.setTerrain(worldTerrain);
 
               tileset = viewer.scene.primitives.add(
                 new Cesium.Cesium3DTileset({
@@ -537,8 +540,8 @@
           },
           {
             text: "Vector tile polylines",
-            onselect: async function () {
-              viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+            onselect: function () {
+              viewer.scene.setTerrain(worldTerrain);
 
               tileset = viewer.scene.primitives.add(
                 new Cesium.Cesium3DTileset({
@@ -613,11 +616,8 @@
           }
           handler = handler && handler.destroy();
           viewer.scene.camera.flyHome(0.0);
-          if (
-            !(viewer.terrainProvider instanceof Cesium.EllipsoidTerrainProvider)
-          ) {
-            viewer.terrainProvider = new Cesium.EllipsoidTerrainProvider();
-          }
+
+          viewer.terrainProvider = ellipsoidTerrainProvider;
         };
         //Sandcastle_End
       };

--- a/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
+++ b/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
@@ -54,7 +54,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync({
+          terrain: Cesium.Terrain.fromWorldTerrain({
             requestWaterMask: true,
             requestVertexNormals: true,
           }),

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -743,8 +743,6 @@
 
         scene.debugShowFramesPerSecond = true;
 
-        const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
-
         function getModelPosition() {
           if (viewModel.modelPosition === "Ground") {
             return 0.0;
@@ -759,7 +757,14 @@
           }
         }
 
-        const createWorldTerrainPromise = Cesium.createWorldTerrainAsync();
+        const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
+        let worldTerrain;
+        try {
+          worldTerrain = await Cesium.createWorldTerrainAsync();
+        } catch (error) {
+          console.log(`Failed to create world terrain. ${error}`);
+        }
+
         async function updateLocation() {
           // Get the height of the terrain at the given longitude/latitude, then create the scene.
           const location = uiOptions.locations[viewModel.location];
@@ -769,19 +774,28 @@
               location.centerLatitude
             ),
           ];
+
           let terrainProvider = ellipsoidTerrainProvider;
-          if (viewModel.terrain) {
-            terrainProvider = await createWorldTerrainPromise;
+          if (viewModel.terrain && Cesium.defined(worldTerrain)) {
+            terrainProvider = worldTerrain;
           }
-          globe.terrainProvider = terrainProvider;
-          const updatedPositions = await Cesium.sampleTerrain(
-            terrainProvider,
-            11,
-            positions
-          );
-          location.height = updatedPositions[0].height + getModelPosition();
+
+          scene.terrainProvider = terrainProvider;
+
+          try {
+            const updatedPositions = await Cesium.sampleTerrain(
+              terrainProvider,
+              11,
+              positions
+            );
+            location.height = updatedPositions[0].height + getModelPosition();
+          } catch (error) {
+            console.log(`There was an error sampling terrain. ${error}`);
+          }
+
           createScene();
         }
+
         updateLocation();
 
         function createScene() {

--- a/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync({
+          terrain: Cesium.Terrain.fromWorldTerrain({
             requestWaterMask: true,
             requestVertexNormals: true,
           }),

--- a/Apps/Sandcastle/gallery/development/Terrain Performance.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Performance.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          terrain: Cesium.Terrain.fromWorldTerrain(),
         });
         const scene = viewer.scene;
         const camera = scene.camera;

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -984,6 +984,7 @@ Globe.prototype.beginFrame = function (frameState) {
   const terrainProvider = this.terrainProvider;
   const hasWaterMask =
     this.showWaterEffect &&
+    defined(terrainProvider) &&
     terrainProvider.hasWaterMask &&
     // ready is deprecated; This is here for backwards compatibility
     terrainProvider._ready;

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -237,6 +237,7 @@ Object.defineProperties(GlobeSurfaceTileProvider.prototype, {
   ready: {
     get: function () {
       return (
+        defined(this._terrainProvider) &&
         // ready is deprecated; This is here for backwards compatibility
         this._terrainProvider._ready &&
         (this._imageryLayers.length === 0 ||
@@ -295,12 +296,6 @@ Object.defineProperties(GlobeSurfaceTileProvider.prototype, {
         return;
       }
 
-      //>>includeStart('debug', pragmas.debug);
-      if (!defined(terrainProvider)) {
-        throw new DeveloperError("terrainProvider is required.");
-      }
-      //>>includeEnd('debug');
-
       this._terrainProvider = terrainProvider;
 
       if (defined(this._quadtree)) {
@@ -350,6 +345,7 @@ GlobeSurfaceTileProvider.prototype.update = function (frameState) {
 function updateCredits(surface, frameState) {
   const creditDisplay = frameState.creditDisplay;
   if (
+    defined(surface._terrainProvider) &&
     // ready is deprecated; This is here for backwards compatibility
     surface._terrainProvider._ready &&
     defined(surface._terrainProvider.credit)
@@ -573,6 +569,10 @@ GlobeSurfaceTileProvider.prototype.cancelReprojections = function () {
 GlobeSurfaceTileProvider.prototype.getLevelMaximumGeometricError = function (
   level
 ) {
+  if (!defined(this._terrainProvider)) {
+    return 0;
+  }
+
   return this._terrainProvider.getLevelMaximumGeometricError(level);
 };
 
@@ -2126,6 +2126,7 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
   const oceanNormalMap = tileProvider.oceanNormalMap;
   const showOceanWaves = showReflectiveOcean && defined(oceanNormalMap);
   const hasVertexNormals =
+    defined(tileProvider.terrainProvider) &&
     // ready is deprecated; This is here for backwards compatibility
     tileProvider.terrainProvider._ready &&
     tileProvider.terrainProvider.hasVertexNormals;

--- a/packages/engine/Source/Scene/ImageryLayer.js
+++ b/packages/engine/Source/Scene/ImageryLayer.js
@@ -511,7 +511,7 @@ ImageryLayer.prototype.getViewableRectangle = function () {
  * @private
  *
  * @param {Tile} tile The terrain tile.
- * @param {TerrainProvider} terrainProvider The terrain provider associated with the terrain tile.
+ * @param {TerrainProvider|undefined} terrainProvider The terrain provider associated with the terrain tile.
  * @param {Number} insertionPoint The position to insert new skeletons before in the tile's imagery list.
  * @returns {Boolean} true if this layer overlaps any portion of the terrain tile; otherwise, false.
  */
@@ -523,8 +523,9 @@ ImageryLayer.prototype._createTileImagerySkeletons = function (
   const surfaceTile = tile.data;
 
   if (
-    defined(this._minimumTerrainLevel) &&
-    tile.level < this._minimumTerrainLevel
+    !defined(terrainProvider) ||
+    (defined(this._minimumTerrainLevel) &&
+      tile.level < this._minimumTerrainLevel)
   ) {
     return false;
   }

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -4390,9 +4390,15 @@ function setTerrain(scene, terrain) {
     scene._removeTerrainProviderReadyListener &&
     scene._removeTerrainProviderReadyListener();
 
-  // Set a placeholder
+  // If the terrain is already loaded, set it immediately
+  if (terrain.ready) {
+    if (defined(scene.globe)) {
+      scene.globe.terrainProvider = terrain.provider;
+    }
+    return;
+  }
+  // Otherwise, set a placeholder
   scene.globe.terrainProvider = undefined;
-
   scene._removeTerrainProviderReadyListener = terrain.readyEvent.addEventListener(
     (provider) => {
       if (defined(scene) && defined(scene.globe)) {

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3,6 +3,7 @@ import BoundingSphere from "../Core/BoundingSphere.js";
 import BoxGeometry from "../Core/BoxGeometry.js";
 import Cartesian3 from "../Core/Cartesian3.js";
 import Cartographic from "../Core/Cartographic.js";
+import Check from "../Core/Check.js";
 import clone from "../Core/clone.js";
 import Color from "../Core/Color.js";
 import ColorGeometryInstanceAttribute from "../Core/ColorGeometryInstanceAttribute.js";
@@ -638,6 +639,7 @@ function Scene(options) {
     requestRenderAfterFrame(this)
   );
   this._removeGlobeCallbacks = [];
+  this._removeTerrainProviderReadyListener = undefined;
 
   const viewport = new BoundingRectangle(
     0,
@@ -1104,6 +1106,11 @@ Object.defineProperties(Scene.prototype, {
       return this.globe.terrainProvider;
     },
     set: function (terrainProvider) {
+      // Cancel any in-progress terrain update
+      this._removeTerrainProviderReadyListener =
+        this._removeTerrainProviderReadyListener &&
+        this._removeTerrainProviderReadyListener();
+
       if (defined(this.globe)) {
         this.globe.terrainProvider = terrainProvider;
       }
@@ -4377,6 +4384,55 @@ Scene.prototype.morphTo3D = function (duration) {
   this._transitioner.morphTo3D(duration, ellipsoid);
 };
 
+function setTerrain(scene, terrain) {
+  // Cancel any in-progress terrain update
+  scene._removeTerrainProviderReadyListener =
+    scene._removeTerrainProviderReadyListener &&
+    scene._removeTerrainProviderReadyListener();
+
+  // Set a placeholder
+  scene.globe.terrainProvider = undefined;
+
+  scene._removeTerrainProviderReadyListener = terrain.readyEvent.addEventListener(
+    (provider) => {
+      if (defined(scene) && defined(scene.globe)) {
+        scene.globe.terrainProvider = provider;
+      }
+
+      scene._removeTerrainProviderReadyListener();
+    }
+  );
+}
+
+/**
+ * Update the terrain providing surface geometry for the globe.
+ *
+ * @param {Terrain} terrain The terrain provider async helper
+ * @returns {Terrain} terrain The terrain provider async helper
+ *
+ * @example
+ * // Use Cesium World Terrain
+ * scene.setTerrain(Cesium.Terrain.fromWorldTerrain());
+ *
+ * @example
+ * // Use a custom terrain provider
+ * const terrain = new Cesium.Terrain(Cesium.CesiumTerrainProvider.fromUrl("https://myTestTerrain.com"));
+ * scene.setTerrain(terrain);
+ *
+ * terrain.errorEvent.addEventListener(error => {
+ *   alert(`Encountered an error while creating terrain! ${error}`);
+ * });
+ */
+Scene.prototype.setTerrain = function (terrain) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("terrain", terrain);
+  //>>includeEnd('debug');
+
+  setTerrain(this, terrain);
+
+  return terrain;
+};
+
 /**
  * Returns true if this object was destroyed; otherwise, false.
  * <br /><br />
@@ -4421,6 +4477,9 @@ Scene.prototype.destroy = function () {
   this._groundPrimitives =
     this._groundPrimitives && this._groundPrimitives.destroy();
   this._globe = this._globe && this._globe.destroy();
+  this._removeTerrainProviderReadyListener =
+    this._removeTerrainProviderReadyListener &&
+    this._removeTerrainProviderReadyListener();
   this.skyBox = this.skyBox && this.skyBox.destroy();
   this.skyAtmosphere = this.skyAtmosphere && this.skyAtmosphere.destroy();
   this._debugSphere = this._debugSphere && this._debugSphere.destroy();

--- a/packages/engine/Source/Scene/Terrain.js
+++ b/packages/engine/Source/Scene/Terrain.js
@@ -37,15 +37,16 @@ async function handlePromise(instance, promise) {
  * @example
  * // Create
  * const viewer = new Cesium.Viewer("cesiumContainer", {
- *   terrainProvider: new Cesium.Terrain(Cesium.CesiumTerrainProvider.fromUrl("https://myTestTerrain.com"));
+ *   terrain: new Cesium.Terrain(Cesium.CesiumTerrainProvider.fromUrl("https://myTestTerrain.com"));
  * });
  *
  * @example
  * // Handle loading events
  * const terrain = new Cesium.Terrain(Cesium.CesiumTerrainProvider.fromUrl("https://myTestTerrain.com"));
  *
+ * scene.setTerrain(terrain);
+ *
  * terrain.readyEvent.addEventListener(provider => {
- *   scene.terrainProvider = provider;
  *   scene.globe.enableLighting = true;
  *
  *   terrain.provider.errorEvent.addEventListener(error => {
@@ -57,27 +58,27 @@ async function handlePromise(instance, promise) {
  *   alert(`Encountered an error while creating terrain! ${error}`);
  * });
  *
- * @param {Promise<TerrainProvider>} A promise which resolves to a terrain provider
+ * @param {Promise<TerrainProvider>} terrainProviderPromise A promise which resolves to a terrain provider
  */
-function Terrain(providerPromise) {
+function Terrain(terrainProviderPromise) {
   //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("providerPromise", providerPromise);
+  Check.typeOf.object("terrainProviderPromise", terrainProviderPromise);
   //>>includeEnd('debug');
 
   this._provider = undefined;
   this._errorEvent = new Event();
   this._readyEvent = new Event();
 
-  handlePromise(this, providerPromise);
+  handlePromise(this, terrainProviderPromise);
 }
 
 Object.defineProperties(Terrain.prototype, {
   /**
    * Gets an event that is raised when the terrain provider encounters an asynchronous error.  By subscribing
    * to the event, you will be notified of the error and can potentially recover from it.  Event listeners
-   * are passed an instance of {@link TileProviderError}.
-   * @memberof TerrainProvider.prototype
-   * @type {Event<TerrainProvider.ErrorEvent>}
+   * are passed an instance of the thrown error.
+   * @memberof Terrain.prototype
+   * @type {Event<Terrain.ErrorEventCallback>}
    * @readonly
    */
   errorEvent: {
@@ -89,8 +90,8 @@ Object.defineProperties(Terrain.prototype, {
   /**
    * Gets an event that is raised when the terrain provider has been successfully created. Event listeners
    * are passed the created instance of {@link TerrainProvider}.
-   * @memberof TerrainProvider.prototype
-   * @type {Event<TerrainProvider.ReadyEvent>}
+   * @memberof Terrain.prototype
+   * @type {Event<Terrain.ReadyEventCallback>}
    * @readonly
    */
   readyEvent: {
@@ -120,7 +121,7 @@ Object.defineProperties(Terrain.prototype, {
  * @param {Object} [options] Object with the following properties:
  * @param {Boolean} [options.requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server if available.
  * @param {Boolean} [options.requestWaterMask=false] Flag that indicates if the client should request per tile water masks from the server if available.
- * @returns {<Terrain>} A promise that resolves to the created CesiumTerrainProvider
+ * @returns {Terrain} An asynchronous helper object for a CesiumTerrainProvider
  *
  * @see Ion
  * @see createWorldTerrainAsync
@@ -128,13 +129,13 @@ Object.defineProperties(Terrain.prototype, {
  * @example
  * // Create Cesium World Terrain with default settings
  * const viewer = new Cesium.Viewer("cesiumContainer", {
- *   terrainProvider: Cesium.Terrain.fromWorldTerrain()
+ *   terrain: Cesium.Terrain.fromWorldTerrain()
  * });
  *
  * @example
  * // Create Cesium World Terrain with water and normals.
  * const viewer1 = new Cesium.Viewer("cesiumContainer", {
- *   terrainProvider: Cesium.Terrain.fromWorldTerrain({
+ *   terrain: Cesium.Terrain.fromWorldTerrain({
  *      requestWaterMask: true,
  *      requestVertexNormals: true
  *    });
@@ -142,18 +143,19 @@ Object.defineProperties(Terrain.prototype, {
  *
  * @example
  * // Handle loading events
- * const providerManager = Cesium.Terrain.fromWorldTerrain();
+ * const terrain = Cesium.Terrain.fromWorldTerrain();
  *
- * providerManager.readyEvent.addEventListener(provider => {
- *   viewer.terrainProvider = provider;
- *   viewer.scene.globe.enableLighting = true;
+ * scene.setTerrain(terrain);
  *
- *   providerManager.provider.errorEvent.addEventListener(error => {
+ * terrain.readyEvent.addEventListener(provider => {
+ *   scene.globe.enableLighting = true;
+ *
+ *   terrain.provider.errorEvent.addEventListener(error => {
  *     alert(`Encountered an error while loading terrain tiles! ${error}`);
  *   });
  * });
  *
- * providerManager.errorEvent.addEventListener(error => {
+ * terrain.errorEvent.addEventListener(error => {
  *   alert(`Encountered an error while creating terrain! ${error}`);
  * });
  */
@@ -161,9 +163,11 @@ Terrain.fromWorldTerrain = function (options) {
   return new Terrain(createWorldTerrainAsync(options));
 };
 
+export default Terrain;
+
 /**
  * A function that is called when an error occurs.
- * @callback Terrain.ErrorEvent
+ * @callback Terrain.ErrorEventCallback
  *
  * @this Terrain
  * @param {Error} err An object holding details about the error that occurred.
@@ -171,10 +175,8 @@ Terrain.fromWorldTerrain = function (options) {
 
 /**
  * A function that is called when the provider has been created
- * @callback Terrain.ReadyEvent
+ * @callback Terrain.ReadyEventCallback
  *
  * @this Terrain
  * @param {TerrainProvider} provider The created terrain provider.
  */
-
-export default Terrain;

--- a/packages/engine/Source/Scene/Terrain.js
+++ b/packages/engine/Source/Scene/Terrain.js
@@ -44,6 +44,7 @@ function Terrain(terrainProviderPromise) {
   Check.typeOf.object("terrainProviderPromise", terrainProviderPromise);
   //>>includeEnd('debug');
 
+  this._ready = false;
   this._provider = undefined;
   this._errorEvent = new Event();
   this._readyEvent = new Event();
@@ -76,6 +77,19 @@ Object.defineProperties(Terrain.prototype, {
   readyEvent: {
     get: function () {
       return this._readyEvent;
+    },
+  },
+
+  /**
+   * Returns true when the terrain provider has been successfully created. Otherwise, returns false.
+   * @memberof Viewer.prototype
+   *
+   * @type {boolean}
+   * @readonly
+   */
+  ready: {
+    get: function () {
+      return this._ready;
     },
   },
 
@@ -155,12 +169,12 @@ async function handlePromise(instance, promise) {
   let provider;
   try {
     provider = await Promise.resolve(promise);
+    instance._provider = provider;
+    instance._ready = true;
+    instance._readyEvent.raiseEvent(provider);
   } catch (error) {
     handleError(instance._errorEvent, error);
   }
-
-  instance._provider = provider;
-  instance._readyEvent.raiseEvent(provider);
 }
 
 export default Terrain;

--- a/packages/engine/Source/Scene/Terrain.js
+++ b/packages/engine/Source/Scene/Terrain.js
@@ -2,27 +2,6 @@ import Check from "../Core/Check.js";
 import Event from "../Core/Event.js";
 import createWorldTerrainAsync from "../Core/createWorldTerrainAsync.js";
 
-function handleError(errorEvent, error) {
-  if (errorEvent.numberOfListeners > 0) {
-    errorEvent.raiseEvent(error);
-  } else {
-    // Default handler is to log to the console
-    console.error(error);
-  }
-}
-
-async function handlePromise(instance, promise) {
-  let provider;
-  try {
-    provider = await Promise.resolve(promise);
-  } catch (error) {
-    handleError(instance._errorEvent, error);
-  }
-
-  instance._provider = provider;
-  instance._readyEvent.raiseEvent(provider);
-}
-
 /**
  * A helper to manage async operations of a terrain provider.
  *
@@ -162,6 +141,27 @@ Object.defineProperties(Terrain.prototype, {
 Terrain.fromWorldTerrain = function (options) {
   return new Terrain(createWorldTerrainAsync(options));
 };
+
+function handleError(errorEvent, error) {
+  if (errorEvent.numberOfListeners > 0) {
+    errorEvent.raiseEvent(error);
+  } else {
+    // Default handler is to log to the console
+    console.error(error);
+  }
+}
+
+async function handlePromise(instance, promise) {
+  let provider;
+  try {
+    provider = await Promise.resolve(promise);
+  } catch (error) {
+    handleError(instance._errorEvent, error);
+  }
+
+  instance._provider = provider;
+  instance._readyEvent.raiseEvent(provider);
+}
 
 export default Terrain;
 

--- a/packages/engine/Source/Scene/Terrain.js
+++ b/packages/engine/Source/Scene/Terrain.js
@@ -1,0 +1,180 @@
+import Check from "../Core/Check.js";
+import Event from "../Core/Event.js";
+import createWorldTerrainAsync from "../Core/createWorldTerrainAsync.js";
+
+function handleError(errorEvent, error) {
+  if (errorEvent.numberOfListeners > 0) {
+    errorEvent.raiseEvent(error);
+  } else {
+    // Default handler is to log to the console
+    console.error(error);
+  }
+}
+
+async function handlePromise(instance, promise) {
+  let provider;
+  try {
+    provider = await Promise.resolve(promise);
+  } catch (error) {
+    handleError(instance._errorEvent, error);
+  }
+
+  instance._provider = provider;
+  instance._readyEvent.raiseEvent(provider);
+}
+
+/**
+ * A helper to manage async operations of a terrain provider.
+ *
+ * @alias Terrain
+ * @constructor
+ *
+ * @see Terrain.fromWorldTerrain
+ * @see CesiumTerrainProvider
+ * @see VRTheWorldTerrainProvider
+ * @see GoogleEarthEnterpriseTerrainProvider
+ *
+ * @example
+ * // Create
+ * const viewer = new Cesium.Viewer("cesiumContainer", {
+ *   terrainProvider: new Cesium.Terrain(Cesium.CesiumTerrainProvider.fromUrl("https://myTestTerrain.com"));
+ * });
+ *
+ * @example
+ * // Handle loading events
+ * const terrain = new Cesium.Terrain(Cesium.CesiumTerrainProvider.fromUrl("https://myTestTerrain.com"));
+ *
+ * terrain.readyEvent.addEventListener(provider => {
+ *   scene.terrainProvider = provider;
+ *   scene.globe.enableLighting = true;
+ *
+ *   terrain.provider.errorEvent.addEventListener(error => {
+ *     alert(`Encountered an error while loading terrain tiles! ${error}`);
+ *   });
+ * });
+ *
+ * terrain.errorEvent.addEventListener(error => {
+ *   alert(`Encountered an error while creating terrain! ${error}`);
+ * });
+ *
+ * @param {Promise<TerrainProvider>} A promise which resolves to a terrain provider
+ */
+function Terrain(providerPromise) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("providerPromise", providerPromise);
+  //>>includeEnd('debug');
+
+  this._provider = undefined;
+  this._errorEvent = new Event();
+  this._readyEvent = new Event();
+
+  handlePromise(this, providerPromise);
+}
+
+Object.defineProperties(Terrain.prototype, {
+  /**
+   * Gets an event that is raised when the terrain provider encounters an asynchronous error.  By subscribing
+   * to the event, you will be notified of the error and can potentially recover from it.  Event listeners
+   * are passed an instance of {@link TileProviderError}.
+   * @memberof TerrainProvider.prototype
+   * @type {Event<TerrainProvider.ErrorEvent>}
+   * @readonly
+   */
+  errorEvent: {
+    get: function () {
+      return this._errorEvent;
+    },
+  },
+
+  /**
+   * Gets an event that is raised when the terrain provider has been successfully created. Event listeners
+   * are passed the created instance of {@link TerrainProvider}.
+   * @memberof TerrainProvider.prototype
+   * @type {Event<TerrainProvider.ReadyEvent>}
+   * @readonly
+   */
+  readyEvent: {
+    get: function () {
+      return this._readyEvent;
+    },
+  },
+
+  /**
+   * The terrain provider providing surface geometry to a globe. Do not use until {@link Terrain.readyEvent} is raised.
+   * @memberof Viewer.prototype
+   *
+   * @type {TerrainProvider}
+   * @readonly
+   */
+  provider: {
+    get: function () {
+      return this._provider;
+    },
+  },
+});
+/**
+ * Creates a {@link Terrain} instance for {@link https://cesium.com/content/#cesium-world-terrain|Cesium World Terrain}.
+ *
+ * @function
+ *
+ * @param {Object} [options] Object with the following properties:
+ * @param {Boolean} [options.requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server if available.
+ * @param {Boolean} [options.requestWaterMask=false] Flag that indicates if the client should request per tile water masks from the server if available.
+ * @returns {<Terrain>} A promise that resolves to the created CesiumTerrainProvider
+ *
+ * @see Ion
+ * @see createWorldTerrainAsync
+ *
+ * @example
+ * // Create Cesium World Terrain with default settings
+ * const viewer = new Cesium.Viewer("cesiumContainer", {
+ *   terrainProvider: Cesium.Terrain.fromWorldTerrain()
+ * });
+ *
+ * @example
+ * // Create Cesium World Terrain with water and normals.
+ * const viewer1 = new Cesium.Viewer("cesiumContainer", {
+ *   terrainProvider: Cesium.Terrain.fromWorldTerrain({
+ *      requestWaterMask: true,
+ *      requestVertexNormals: true
+ *    });
+ * });
+ *
+ * @example
+ * // Handle loading events
+ * const providerManager = Cesium.Terrain.fromWorldTerrain();
+ *
+ * providerManager.readyEvent.addEventListener(provider => {
+ *   viewer.terrainProvider = provider;
+ *   viewer.scene.globe.enableLighting = true;
+ *
+ *   providerManager.provider.errorEvent.addEventListener(error => {
+ *     alert(`Encountered an error while loading terrain tiles! ${error}`);
+ *   });
+ * });
+ *
+ * providerManager.errorEvent.addEventListener(error => {
+ *   alert(`Encountered an error while creating terrain! ${error}`);
+ * });
+ */
+Terrain.fromWorldTerrain = function (options) {
+  return new Terrain(createWorldTerrainAsync(options));
+};
+
+/**
+ * A function that is called when an error occurs.
+ * @callback Terrain.ErrorEvent
+ *
+ * @this Terrain
+ * @param {Error} err An object holding details about the error that occurred.
+ */
+
+/**
+ * A function that is called when the provider has been created
+ * @callback Terrain.ReadyEvent
+ *
+ * @this Terrain
+ * @param {TerrainProvider} provider The created terrain provider.
+ */
+
+export default Terrain;

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -125,6 +125,7 @@ function configureCameraFrustum(widget) {
  * @param {Clock} [options.clock=new Clock()] The clock to use to control current time.
  * @param {ImageryProvider | false} [options.imageryProvider=createWorldImagery()] The imagery provider to serve as the base layer. If set to <code>false</code>, no imagery provider will be added.
  * @param {TerrainProvider} [options.terrainProvider=new EllipsoidTerrainProvider] The terrain provider.
+ * @param {Terrain} [options.terrain] A terrain object which handles asynchronous terrain provider. Can only specify if options.terrainProvider is undefined.
  * @param {SkyBox| false} [options.skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used. If set to <code>false</code>, no skyBox, Sun, or Moon will be added.
  * @param {SkyAtmosphere | false} [options.skyAtmosphere] Blue sky, and the glow around the Earth's limb.  Set to <code>false</code> to turn it off.
  * @param {SceneMode} [options.sceneMode=SceneMode.SCENE3D] The initial scene mode.
@@ -163,7 +164,7 @@ function configureCameraFrustum(widget) {
  * try {
  *   const widget2 = new Cesium.CesiumWidget("cesiumContainer", {
  *     imageryProvider: Cesium.createWorldImagery(),
- *     terrainProvider: await Cesium.createWorldTerrainAsync(),
+ *     terrain: Cesium.Terrain.fromWorldTerrain()
  *     skyBox: new Cesium.SkyBox({
  *       sources: {
  *         positiveX: "stars/TychoSkymapII.t3_08192x04096_80_px.jpg",
@@ -358,6 +359,18 @@ function CesiumWidget(container, options) {
     //Set the terrain provider if one is provided.
     if (defined(options.terrainProvider) && options.globe !== false) {
       scene.terrainProvider = options.terrainProvider;
+    }
+
+    if (defined(options.terrain) && options.globe !== false) {
+      //>>includeStart('debug', pragmas.debug);
+      if (defined(options.terrainProvider)) {
+        throw new DeveloperError(
+          "Specify either options.terrainProvider or options.terrain."
+        );
+      }
+      //>>includeEnd('debug')
+
+      scene.setTerrain(options.terrain);
     }
 
     this._screenSpaceEventHandler = new ScreenSpaceEventHandler(canvas);

--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -41,6 +41,7 @@ import {
   SunLight,
   TweenCollection,
   Sun,
+  Terrain,
   GroundPrimitive,
   PerInstanceColorAppearance,
   ColorGeometryInstanceAttribute,
@@ -1495,33 +1496,71 @@ describe(
       scene.destroyForSpecs();
     });
 
-    it("Sets terrainProvider", function () {
+    it("Sets terrainProvider", async function () {
       returnQuantizedMeshTileJson();
 
       const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
-      scene.terrainProvider = new CesiumTerrainProvider({
-        url: "//terrain/tiles",
+      scene.terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "//terrain/tiles"
+      );
+
+      expect(scene.terrainProvider).toBe(globe.terrainProvider);
+      scene.globe = undefined;
+
+      const newProvider = await CesiumTerrainProvider.fromUrl(
+        "//newTerrain/tiles"
+      );
+      expect(function () {
+        scene.terrainProvider = newProvider;
+      }).not.toThrow();
+
+      scene.destroyForSpecs();
+      Resource._Implementations.loadWithXhr =
+        Resource._DefaultImplementations.loadWithXhr;
+    });
+
+    it("setTerrain updates terrain provider", async function () {
+      returnQuantizedMeshTileJson();
+
+      const scene = createScene();
+      const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
+      const promise = CesiumTerrainProvider.fromUrl("//terrain/tiles");
+      scene.setTerrain(new Terrain(promise));
+
+      const originalProvider = scene.terrainProvider;
+      let terrainWasChanged = false;
+      scene.terrainProviderChanged.addEventListener((terrainProvider) => {
+        expect(terrainProvider).not.toBe(originalProvider);
+        expect(scene.terrainProvider).toBe(terrainProvider);
+        expect(scene.terrainProvider).toBe(globe.terrainProvider);
+        terrainWasChanged = true;
       });
 
-      return scene.terrainProvider.readyPromise
-        .then(() => {
-          expect(scene.terrainProvider).toBe(globe.terrainProvider);
-          scene.globe = undefined;
-          const newProvider = new CesiumTerrainProvider({
-            url: "//newTerrain/tiles",
-          });
-          return newProvider.readyPromise.then(() => {
-            expect(function () {
-              scene.terrainProvider = newProvider;
-            }).not.toThrow();
-          });
-        })
-        .finally(() => {
-          scene.destroyForSpecs();
-          Resource._Implementations.loadWithXhr =
-            Resource._DefaultImplementations.loadWithXhr;
-        });
+      await promise;
+
+      expect(terrainWasChanged).toBeTrue();
+
+      scene.destroyForSpecs();
+      Resource._Implementations.loadWithXhr =
+        Resource._DefaultImplementations.loadWithXhr;
+    });
+
+    it("setTerrain handles destroy", async function () {
+      returnQuantizedMeshTileJson();
+
+      const scene = createScene();
+      scene.globe = new Globe(Ellipsoid.UNIT_SPHERE);
+
+      const promise = CesiumTerrainProvider.fromUrl("//newTerrain/tiles");
+      scene.setTerrain(new Terrain(promise));
+      scene.destroyForSpecs();
+
+      await expectAsync(promise).toBeResolved();
+      expect(scene.isDestroyed()).toBeTrue();
+
+      Resource._Implementations.loadWithXhr =
+        Resource._DefaultImplementations.loadWithXhr;
     });
 
     it("Gets terrainProviderChanged", function () {

--- a/packages/engine/Specs/Scene/TerrainSpec.js
+++ b/packages/engine/Specs/Scene/TerrainSpec.js
@@ -1,0 +1,57 @@
+import { Terrain, EllipsoidTerrainProvider } from "../../index.js";
+
+describe("Scene/Terrain", function () {
+  it("constructor throws without terrain promise", function () {
+    expect(() => new Terrain()).toThrowDeveloperError();
+  });
+
+  it("does not throw on error", function () {
+    expect(() => {
+      // eslint-disable-next-line no-unused-vars
+      const terrain = new Terrain(Promise.reject(new Error("Fail")));
+    }).not.toThrow();
+  });
+
+  it("readyEvent handles terrain promise success", async function () {
+    let resolve;
+    const promise = new Promise((r) => {
+      resolve = r;
+    });
+
+    const terrain = new Terrain(promise);
+    const terrainProvider = new EllipsoidTerrainProvider();
+
+    let wasCalled = false;
+    terrain.readyEvent.addEventListener((provider) => {
+      expect(provider).toBe(terrainProvider);
+      wasCalled = true;
+    });
+
+    resolve(terrainProvider);
+
+    await promise;
+    expect(wasCalled).toBeTrue();
+    expect(terrain.provider).toBe(terrainProvider);
+  });
+
+  it("errorEvent handles terrain promise failure", async function () {
+    let reject;
+    const promise = new Promise((resolve, r) => {
+      reject = r;
+    });
+
+    const terrain = new Terrain(promise);
+    const error = new Error("Fail");
+
+    let wasCalled = false;
+    terrain.errorEvent.addEventListener((e) => {
+      expect(e).toBe(error);
+      wasCalled = true;
+    });
+
+    reject(error);
+
+    await expectAsync(promise).toBeRejected();
+    expect(wasCalled).toBeTrue();
+  });
+});

--- a/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -3,6 +3,7 @@ import {
   defined,
   DeveloperError,
   EllipsoidTerrainProvider,
+  Terrain,
 } from "@cesium/engine";
 import knockout from "../ThirdParty/knockout.js";
 import createCommand from "../createCommand.js";
@@ -181,7 +182,7 @@ function BaseLayerPickerViewModel(options) {
     get: function () {
       return selectedImageryViewModel();
     },
-    set: async function (value) {
+    set: function (value) {
       if (selectedImageryViewModel() === value) {
         this.dropDownVisible = false;
         return;
@@ -253,31 +254,19 @@ function BaseLayerPickerViewModel(options) {
         newProvider = value.creationCommand();
       }
 
-      selectedTerrainViewModel(value);
-
-      const updateTerrainProvider = async () => {
-        try {
-          const provider = await Promise.resolve(newProvider);
-
-          if (!defined(provider) || this._globe.isDestroyed()) {
-            this.dropDownVisible = false;
-            return;
-          }
-
+      const terrain = new Terrain(Promise.resolve(newProvider));
+      const removeEventListener = terrain.readyEvent.addEventListener(
+        (terrainProvider) => {
           this._globe.depthTestAgainstTerrain = !(
-            provider instanceof EllipsoidTerrainProvider
+            terrainProvider instanceof EllipsoidTerrainProvider
           );
-          this._globe.terrainProvider = provider;
-        } catch (error) {
-          console.log(
-            `An error occurred while creating the terrain provider: ${error}`
-          );
+          this._globe.terrainProvider = terrainProvider;
+          removeEventListener();
         }
+      );
 
-        this.dropDownVisible = false;
-      };
-
-      updateTerrainProvider();
+      selectedTerrainViewModel(value);
+      this.dropDownVisible = false;
     },
   });
 
@@ -290,12 +279,9 @@ function BaseLayerPickerViewModel(options) {
     options.selectedImageryProviderViewModel,
     imageryProviderViewModels[0]
   );
-
-  selectedTerrainViewModel(
-    defaultValue(
-      options.selectedTerrainProviderViewModel,
-      terrainProviderViewModels[0]
-    )
+  this.selectedTerrain = defaultValue(
+    options.selectedTerrainProviderViewModel,
+    terrainProviderViewModels[0]
   );
 }
 
@@ -303,6 +289,7 @@ Object.defineProperties(BaseLayerPickerViewModel.prototype, {
   /**
    * Gets the command to toggle the visibility of the drop down.
    * @memberof BaseLayerPickerViewModel.prototype
+   *
    * @type {Command}
    */
   toggleDropDown: {
@@ -314,6 +301,7 @@ Object.defineProperties(BaseLayerPickerViewModel.prototype, {
   /**
    * Gets the globe.
    * @memberof BaseLayerPickerViewModel.prototype
+   *
    * @type {Globe}
    */
   globe: {

--- a/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -254,9 +254,21 @@ function BaseLayerPickerViewModel(options) {
         newProvider = value.creationCommand();
       }
 
+      let cancelUpdate = false;
+      const removeCancelListener = this._globe.terrainProviderChanged.addEventListener(
+        () => {
+          cancelUpdate = true;
+          removeCancelListener();
+        }
+      );
       const terrain = new Terrain(Promise.resolve(newProvider));
       const removeEventListener = terrain.readyEvent.addEventListener(
         (terrainProvider) => {
+          if (cancelUpdate) {
+            // Early return in case something has outside of the picker.
+            return;
+          }
+
           this._globe.depthTestAgainstTerrain = !(
             terrainProvider instanceof EllipsoidTerrainProvider
           );

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -315,6 +315,7 @@ function enableVRUI(viewer, enabled) {
  * @property {ProviderViewModel[]} [terrainProviderViewModels=createDefaultTerrainProviderViewModels()] The array of ProviderViewModels to be selectable from the BaseLayerPicker.  This value is only valid if `baseLayerPicker` is set to true.
  * @property {ImageryProvider} [imageryProvider=createWorldImagery()] The imagery provider to use.  This value is only valid if `baseLayerPicker` is set to false.
  * @property {TerrainProvider} [terrainProvider=new EllipsoidTerrainProvider()] The terrain provider to use
+ * @param {Terrain} [options.terrain] A terrain object which handles asynchronous terrain provider. Can only specify if options.terrainProvider is undefined.
  * @property {SkyBox|false} [skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used. If set to <code>false</code>, no skyBox, Sun, or Moon will be added.
  * @property {SkyAtmosphere|false} [skyAtmosphere] Blue sky, and the glow around the Earth's limb.  Set to <code>false</code> to turn it off.
  * @property {Element|String} [fullscreenElement=document.body] The element or id to be placed into fullscreen mode when the full screen button is pressed.
@@ -375,7 +376,7 @@ function enableVRUI(viewer, enabled) {
  *     // Start in Columbus Viewer
  *     sceneMode: Cesium.SceneMode.COLUMBUS_VIEW,
  *     // Use Cesium World Terrain
- *     terrainProvider: await Cesium.createWorldTerrainAsync(),
+ *     terrain: Cesium.Terrain.fromWorldTerrain(),
  *     // Hide the base layer picker
  *     baseLayerPicker: false,
  *     // Use OpenStreetMaps
@@ -688,6 +689,22 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
       baseLayerPicker.viewModel.selectedTerrain = undefined;
     }
     scene.terrainProvider = options.terrainProvider;
+  }
+
+  if (defined(options.terrain)) {
+    //>>includeStart('debug', pragmas.debug);
+    if (defined(options.terrainProvider)) {
+      throw new DeveloperError(
+        "Specify either options.terrainProvider or options.terrain."
+      );
+    }
+    //>>includeEnd('debug')
+
+    if (createBaseLayerPicker) {
+      baseLayerPicker.viewModel.selectedTerrain = undefined;
+    }
+
+    scene.setTerrain(options.terrain);
   }
 
   // Navigation Help Button

--- a/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -1,5 +1,6 @@
 import {
   EllipsoidTerrainProvider,
+  Event,
   ImageryLayerCollection,
 } from "@cesium/engine";
 
@@ -9,6 +10,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
   function MockGlobe() {
     this.imageryLayers = new ImageryLayerCollection();
     this.terrainProvider = new EllipsoidTerrainProvider();
+    this.terrainProviderChanged = new Event();
   }
   MockGlobe.prototype.isDestroyed = () => false;
 
@@ -255,6 +257,23 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     viewModel.selectedTerrain = testProviderViewModelAsync;
     await testProviderViewModelAsync.creationCommand();
     expect(globe.terrainProvider).toBe(testProvider);
+  });
+
+  it("selectedTerrain cancels update if terrainProvider is set externally", async function () {
+    const terrainProviderViewModels = [
+      testProviderViewModel,
+      testProviderViewModelAsync,
+    ];
+    const globe = new MockGlobe();
+    const viewModel = new BaseLayerPickerViewModel({
+      globe: globe,
+      terrainProviderViewModels: terrainProviderViewModels,
+    });
+
+    viewModel.selectedTerrain = testProviderViewModelAsync;
+    globe.terrainProviderChanged.raiseEvent();
+    await testProviderViewModelAsync.creationCommand();
+    expect(globe.terrainProvider).not.toBe(testProvider);
   });
 
   it("settings selectedImagery only removes layers added by view model", function () {


### PR DESCRIPTION
[We are deprecating `readyPromises` throughout the API and making a move towards an API which makes better use of `async/await` type patterns](https://github.com/CesiumGS/cesium/pull/11059).

However, based on discussion in https://github.com/CesiumGS/cesium/pull/11033, it would be convenient for most users to have a simpler API, while still preserving the .fromXYZ-style factory functions for those users who may prefer using async/await and simplifying code further down the stack.

In this approach, `Terrain` is a new object that handles the async error handling and exposes an error event and a ready event. One plus here is that this is more in line with event-driven UIs then `readyPromise` was. `Viewer` and `CesiumWidget` now take `terrain` options, which is then handled by `Scene`.  The result is behavior much like what exists now in `main`, and prevents some common race conditions that could arise if use async/await.
* Passing config values to a `Viewer` or `CesiumWidget` constructors can begin rendering the globe immediately while waiting on a terrain provider promise in the background
* By default, errors are caught and logged to the console, but the user can subscribe to `errorEvent` to override this behavior
 * The existing terrain immediately disappears when setting the new `Terrain` object, so that it's obvious that the update process has started
 * Handles "competing" values, like when setting a terrain provider and then immediately setting another, or a `terrainProvider` directly
 * Handles `Viewer`, `CesiumWidget`, or `Scene` being destroyed while a terrain update in in progress

One downside of this approach is that (without TypeScript) it's not possible to confirm that a promise resolves to the expected type during object creation. However, there are many other areas of the code where this is the case, and hopefully won't be a concern if/when we move to TypeScript.

TODO:
- [x] Sweep other Sandcastle examples and update the API where applicable