### PR TITLE
Improve voxel test coverage

### DIFF
--- a/packages/engine/Source/Scene/SpatialNode.js
+++ b/packages/engine/Source/Scene/SpatialNode.js
@@ -103,6 +103,33 @@ SpatialNode.prototype.computeBoundingVolumes = function (
 };
 
 /**
+ * Compute the [level, x, y, z] coordinates of the children of a node
+ * @returns {Array[]} Child coordinate arrays
+ * @private
+ */
+SpatialNode.prototype.getChildCoordinates = function () {
+  const { level, x, y, z } = this;
+  const xMin = x * 2;
+  const yMin = y * 2;
+  const zMin = z * 2;
+  const yMax = yMin + 1;
+  const xMax = xMin + 1;
+  const zMax = zMin + 1;
+  const childLevel = level + 1;
+
+  return [
+    [childLevel, xMin, yMin, zMin],
+    [childLevel, xMax, yMin, zMin],
+    [childLevel, xMin, yMax, zMin],
+    [childLevel, xMax, yMax, zMin],
+    [childLevel, xMin, yMin, zMax],
+    [childLevel, xMax, yMin, zMax],
+    [childLevel, xMin, yMax, zMax],
+    [childLevel, xMax, yMax, zMax],
+  ];
+};
+
+/**
  * @param {FrameState} frameState
  * @param {Number} visibilityPlaneMask
  * @returns {Number} A plane mask as described in {@link CullingVolume#computeVisibilityWithPlaneMask}.
@@ -173,66 +200,43 @@ SpatialNode.prototype.computeSurroundingRenderableKeyframeNodes = function (
   let minimumDistanceNext = +Number.MAX_VALUE;
 
   while (defined(spatialNode)) {
-    const renderableKeyframeNodes = spatialNode.renderableKeyframeNodes;
+    const { renderableKeyframeNodes } = spatialNode;
 
     if (renderableKeyframeNodes.length >= 1) {
-      let keyframeNodeIndexPrev = findKeyframeIndex(
+      const indexPrev = getKeyframeIndexPrev(
         targetKeyframePrev,
         renderableKeyframeNodes
       );
-      if (keyframeNodeIndexPrev < 0) {
-        keyframeNodeIndexPrev = CesiumMath.clamp(
-          ~keyframeNodeIndexPrev - 1,
-          0,
-          renderableKeyframeNodes.length - 1
-        );
-      }
-      const keyframeNodePrev = renderableKeyframeNodes[keyframeNodeIndexPrev];
-      const keyframePrev = keyframeNodePrev.keyframe;
+      const keyframeNodePrev = renderableKeyframeNodes[indexPrev];
 
-      let keyframeNodeNext;
-      if (
+      const indexNext =
         targetKeyframeNext === targetKeyframePrev ||
-        targetKeyframePrev < keyframePrev
-      ) {
-        keyframeNodeNext = keyframeNodePrev;
-      } else {
-        const keyframeNodeIndexNext = Math.min(
-          keyframeNodeIndexPrev + 1,
-          renderableKeyframeNodes.length - 1
-        );
-        keyframeNodeNext = renderableKeyframeNodes[keyframeNodeIndexNext];
-      }
-      const keyframeNext = keyframeNodeNext.keyframe;
+        targetKeyframePrev < keyframeNodePrev.keyframe
+          ? indexPrev
+          : Math.min(indexPrev + 1, renderableKeyframeNodes.length - 1);
+      const keyframeNodeNext = renderableKeyframeNodes[indexNext];
 
-      const keyframeDistancePrev = targetKeyframePrev - keyframePrev;
-      const keyframeDistanceNext = keyframeNext - targetKeyframeNext;
-      const levelDistance = startLevel - spatialNode.level;
-
-      // Balance temporal and visual quality
-      const levelWeight = Math.exp(levelDistance * 4.0);
-      const normalKeyframeWeight = 1.0;
-      const reverseKeyframeWeight = 200.0; // Keyframes on the opposite of the desired direction are deprioritized.
-      const distancePrev =
-        levelDistance * levelWeight +
-        (keyframeDistancePrev >= 0
-          ? keyframeDistancePrev * normalKeyframeWeight
-          : -keyframeDistancePrev * reverseKeyframeWeight);
-      const distanceNext =
-        levelDistance * levelWeight +
-        (keyframeDistanceNext >= 0
-          ? keyframeDistanceNext * normalKeyframeWeight
-          : -keyframeDistanceNext * reverseKeyframeWeight);
-
-      if (distancePrev < minimumDistancePrev) {
-        minimumDistancePrev = distancePrev;
+      const distancePrev = targetKeyframePrev - keyframeNodePrev.keyframe;
+      const weightedDistancePrev = getWeightedKeyframeDistance(
+        startLevel - spatialNode.level,
+        distancePrev
+      );
+      if (weightedDistancePrev < minimumDistancePrev) {
+        minimumDistancePrev = weightedDistancePrev;
         bestKeyframeNodePrev = keyframeNodePrev;
       }
-      if (distanceNext < minimumDistanceNext) {
-        minimumDistanceNext = distanceNext;
+
+      const distanceNext = keyframeNodeNext.keyframe - targetKeyframeNext;
+      const weightedDistanceNext = getWeightedKeyframeDistance(
+        startLevel - spatialNode.level,
+        distanceNext
+      );
+      if (weightedDistanceNext < minimumDistanceNext) {
+        minimumDistanceNext = weightedDistanceNext;
         bestKeyframeNodeNext = keyframeNodeNext;
       }
-      if (keyframeDistancePrev === 0 && keyframeDistanceNext === 0) {
+
+      if (distancePrev === 0 && distanceNext === 0) {
         // Nothing higher up will be better, so break early.
         break;
       }
@@ -243,20 +247,38 @@ SpatialNode.prototype.computeSurroundingRenderableKeyframeNodes = function (
 
   this.renderableKeyframeNodePrevious = bestKeyframeNodePrev;
   this.renderableKeyframeNodeNext = bestKeyframeNodeNext;
-  if (defined(bestKeyframeNodePrev) && defined(bestKeyframeNodeNext)) {
-    const bestKeyframePrev = bestKeyframeNodePrev.keyframe;
-    const bestKeyframeNext = bestKeyframeNodeNext.keyframe;
-    this.renderableKeyframeNodeLerp =
-      bestKeyframePrev === bestKeyframeNext
-        ? 0.0
-        : CesiumMath.clamp(
-            (keyframeLocation - bestKeyframePrev) /
-              (bestKeyframeNext - bestKeyframePrev),
-            0.0,
-            1.0
-          );
+
+  if (!defined(bestKeyframeNodePrev) || !defined(bestKeyframeNodeNext)) {
+    return;
   }
+
+  const bestKeyframePrev = bestKeyframeNodePrev.keyframe;
+  const bestKeyframeNext = bestKeyframeNodeNext.keyframe;
+  this.renderableKeyframeNodeLerp =
+    bestKeyframePrev === bestKeyframeNext
+      ? 0.0
+      : CesiumMath.clamp(
+          (keyframeLocation - bestKeyframePrev) /
+            (bestKeyframeNext - bestKeyframePrev),
+          0.0,
+          1.0
+        );
 };
+
+function getKeyframeIndexPrev(targetKeyframe, keyframeNodes) {
+  const keyframeIndex = findKeyframeIndex(targetKeyframe, keyframeNodes);
+  return keyframeIndex < 0
+    ? CesiumMath.clamp(~keyframeIndex - 1, 0, keyframeNodes.length - 1)
+    : keyframeIndex;
+}
+
+function getWeightedKeyframeDistance(levelDistance, keyframeDistance) {
+  // Balance quality between visual (levelDistance) and temporal (keyframeDistance)
+  const levelWeight = Math.exp(levelDistance * 4.0);
+  // Keyframes on the opposite of the desired direction are deprioritized.
+  const keyframeWeight = keyframeDistance >= 0 ? 1.0 : -200.0;
+  return levelDistance * levelWeight + keyframeDistance * keyframeWeight;
+}
 
 /**
  * @param {Number} frameNumber

--- a/packages/engine/Source/Scene/SpatialNode.js
+++ b/packages/engine/Source/Scene/SpatialNode.js
@@ -65,16 +65,6 @@ function SpatialNode(level, x, y, z, parent, shape, voxelDimensions) {
   this.computeBoundingVolumes(shape, voxelDimensions);
 }
 
-/**
- * @param {SpatialNode} a
- * @param {SpatialNode} b
- * @returns {Boolean}
- */
-SpatialNode.spatialComparator = function (a, b) {
-  // The higher of the two screen space errors is prioritized
-  return b.screenSpaceError - a.screenSpaceError;
-};
-
 const scratchObbHalfScale = new Cartesian3();
 
 /**

--- a/packages/engine/Source/Scene/SpatialNode.js
+++ b/packages/engine/Source/Scene/SpatialNode.js
@@ -16,7 +16,7 @@ import OrientedBoundingBox from "../Core/OrientedBoundingBox.js";
  * @param {Number} y
  * @param {Number} z
  * @param {SpatialNode} parent
- * @param {VoxelShapeType} shape
+ * @param {VoxelShape} shape
  * @param {Cartesian3} voxelDimensions
  *
  * @private
@@ -93,11 +93,11 @@ SpatialNode.prototype.computeBoundingVolumes = function (
 };
 
 /**
- * Compute the [level, x, y, z] coordinates of the children of a node
- * @returns {Array[]} Child coordinate arrays
+ * @param {VoxelShape} shape The shape of the parent VoxelPrimitive
+ * @param {Cartesian3} voxelDimensions
  * @private
  */
-SpatialNode.prototype.getChildCoordinates = function () {
+SpatialNode.prototype.constructChildNodes = function (shape, voxelDimensions) {
   const { level, x, y, z } = this;
   const xMin = x * 2;
   const yMin = y * 2;
@@ -107,7 +107,7 @@ SpatialNode.prototype.getChildCoordinates = function () {
   const zMax = zMin + 1;
   const childLevel = level + 1;
 
-  return [
+  const childCoords = [
     [childLevel, xMin, yMin, zMin],
     [childLevel, xMax, yMin, zMin],
     [childLevel, xMin, yMax, zMin],
@@ -117,6 +117,10 @@ SpatialNode.prototype.getChildCoordinates = function () {
     [childLevel, xMin, yMax, zMax],
     [childLevel, xMax, yMax, zMax],
   ];
+
+  this.children = childCoords.map(([level, x, y, z]) => {
+    return new SpatialNode(level, x, y, z, this, shape, voxelDimensions);
+  });
 };
 
 /**

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -145,16 +145,6 @@ function VoxelTraversal(
    */
   this._binaryTreeKeyframeWeighting = new Array(keyframeCount);
 
-  function binaryTreeWeightingRecursive(arr, start, end, depth) {
-    if (start > end) {
-      return;
-    }
-    const mid = Math.floor((start + end) / 2);
-    arr[mid] = depth;
-    binaryTreeWeightingRecursive(arr, start, mid - 1, depth + 1);
-    binaryTreeWeightingRecursive(arr, mid + 1, end, depth + 1);
-  }
-
   const binaryTreeKeyframeWeighting = this._binaryTreeKeyframeWeighting;
   binaryTreeKeyframeWeighting[0] = 0;
   binaryTreeKeyframeWeighting[keyframeCount - 1] = 0;
@@ -226,6 +216,16 @@ function VoxelTraversal(
    * @readonly
    */
   this.leafNodeTexelSizeUv = new Cartesian2();
+}
+
+function binaryTreeWeightingRecursive(arr, start, end, depth) {
+  if (start > end) {
+    return;
+  }
+  const mid = Math.floor((start + end) / 2);
+  arr[mid] = depth;
+  binaryTreeWeightingRecursive(arr, start, mid - 1, depth + 1);
+  binaryTreeWeightingRecursive(arr, mid + 1, end, depth + 1);
 }
 
 VoxelTraversal.simultaneousRequestCountMaximum = 50;

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -93,25 +93,12 @@ function VoxelTraversal(
   this._frameNumber = 0;
 
   const shape = primitive._shape;
-  const rootLevel = 0;
-  const rootX = 0;
-  const rootY = 0;
-  const rootZ = 0;
-  const rootParent = undefined;
 
   /**
    * @type {SpatialNode}
    * @readonly
    */
-  this.rootNode = new SpatialNode(
-    rootLevel,
-    rootX,
-    rootY,
-    rootZ,
-    rootParent,
-    shape,
-    dimensions
-  );
+  this.rootNode = new SpatialNode(0, 0, 0, 0, undefined, shape, dimensions);
 
   /**
    * @type {DoubleEndedPriorityQueue}
@@ -425,12 +412,6 @@ function requestData(that, keyframeNode) {
 
   const primitive = that._primitive;
   const provider = primitive._provider;
-  const keyframe = keyframeNode.keyframe;
-  const spatialNode = keyframeNode.spatialNode;
-  const tileLevel = spatialNode.level;
-  const tileX = spatialNode.x;
-  const tileY = spatialNode.y;
-  const tileZ = spatialNode.z;
 
   function postRequestSuccess(result) {
     that._simultaneousRequestCount--;
@@ -469,11 +450,12 @@ function requestData(that, keyframeNode) {
     keyframeNode.state = KeyframeNode.LoadState.FAILED;
   }
 
+  const { keyframe, spatialNode } = keyframeNode;
   const promise = provider.requestData({
-    tileLevel: tileLevel,
-    tileX: tileX,
-    tileY: tileY,
-    tileZ: tileZ,
+    tileLevel: spatialNode.level,
+    tileX: spatialNode.x,
+    tileY: spatialNode.y,
+    tileZ: spatialNode.z,
     keyframe: keyframe,
   });
 
@@ -510,18 +492,41 @@ function loadAndUnload(that, frameState) {
   const frameNumber = that._frameNumber;
   const primitive = that._primitive;
   const shape = primitive._shape;
-  const voxelDimensions = primitive._provider.dimensions;
-  const targetScreenSpaceError = primitive._screenSpaceError;
+  const { dimensions } = primitive;
+  const targetScreenSpaceError = primitive.screenSpaceError;
   const priorityQueue = that._priorityQueue;
   const keyframeLocation = that._keyframeLocation;
   const keyframeCount = that._keyframeCount;
   const rootNode = that.rootNode;
 
-  const cameraPosition = frameState.camera.positionWC;
-  const screenSpaceErrorDenominator = frameState.camera.frustum.sseDenominator;
-  const screenHeight =
-    frameState.context.drawingBufferHeight / frameState.pixelRatio;
-  const screenSpaceErrorMultiplier = screenHeight / screenSpaceErrorDenominator;
+  const { camera, context, pixelRatio } = frameState;
+  const { positionWC, frustum } = camera;
+  const screenHeight = context.drawingBufferHeight / pixelRatio;
+  const screenSpaceErrorMultiplier = screenHeight / frustum.sseDenominator;
+
+  function keyframePriority(previousKeyframe, keyframe, nextKeyframe) {
+    const keyframeDifference = Math.min(
+      Math.abs(keyframe - previousKeyframe),
+      Math.abs(keyframe - nextKeyframe)
+    );
+    const maxKeyframeDifference = Math.max(
+      previousKeyframe,
+      keyframeCount - nextKeyframe - 1,
+      1
+    );
+    const keyframeFactor = Math.pow(
+      1.0 - keyframeDifference / maxKeyframeDifference,
+      4.0
+    );
+    const binaryTreeFactor = Math.exp(
+      -that._binaryTreeKeyframeWeighting[keyframe]
+    );
+    return CesiumMath.lerp(
+      binaryTreeFactor,
+      keyframeFactor,
+      0.15 + 0.85 * keyframeFactor
+    );
+  }
 
   /**
    * @ignore
@@ -529,10 +534,7 @@ function loadAndUnload(that, frameState) {
    * @param {Number} visibilityPlaneMask
    */
   function addToQueueRecursive(spatialNode, visibilityPlaneMask) {
-    spatialNode.computeScreenSpaceError(
-      cameraPosition,
-      screenSpaceErrorMultiplier
-    );
+    spatialNode.computeScreenSpaceError(positionWC, screenSpaceErrorMultiplier);
 
     visibilityPlaneMask = spatialNode.visibility(
       frameState,
@@ -565,31 +567,10 @@ function loadAndUnload(that, frameState) {
     const keyframeNodes = spatialNode.keyframeNodes;
     for (let i = 0; i < keyframeNodes.length; i++) {
       const keyframeNode = keyframeNodes[i];
-      const keyframe = keyframeNode.keyframe;
 
-      // Balanced prioritization
-      const keyframeDifference = Math.min(
-        Math.abs(keyframe - previousKeyframe),
-        Math.abs(keyframe - nextKeyframe)
-      );
-      const maxKeyframeDifference = Math.max(
-        previousKeyframe,
-        keyframeCount - nextKeyframe - 1,
-        1
-      );
-      const keyframeFactor = Math.pow(
-        1.0 - keyframeDifference / maxKeyframeDifference,
-        4.0
-      );
-      const binaryTreeFactor = Math.exp(
-        -that._binaryTreeKeyframeWeighting[keyframe]
-      );
-      keyframeNode.priority = 10.0 * ssePriority;
-      keyframeNode.priority += CesiumMath.lerp(
-        binaryTreeFactor,
-        keyframeFactor,
-        0.15 + 0.85 * keyframeFactor
-      );
+      keyframeNode.priority =
+        10.0 * ssePriority +
+        keyframePriority(previousKeyframe, keyframeNode.keyframe, nextKeyframe);
 
       if (
         keyframeNode.state !== KeyframeNode.LoadState.UNAVAILABLE &&
@@ -612,18 +593,9 @@ function loadAndUnload(that, frameState) {
     }
 
     if (!defined(spatialNode.children)) {
-      const childCoords = getChildCoords(spatialNode);
-      const childLevel = spatialNode.level + 1;
-      spatialNode.children = childCoords.map(([x, y, z]) => {
-        return new SpatialNode(
-          childLevel,
-          x,
-          y,
-          z,
-          spatialNode,
-          shape,
-          voxelDimensions
-        );
+      const childCoords = spatialNode.getChildCoordinates();
+      spatialNode.children = childCoords.map(([level, x, y, z]) => {
+        return new SpatialNode(level, x, y, z, spatialNode, shape, dimensions);
       });
     }
     for (let childIndex = 0; childIndex < 8; childIndex++) {
@@ -704,33 +676,6 @@ function loadAndUnload(that, frameState) {
       keyframeNodesInMegatexture[addNodeIndex] = highPriorityKeyframeNode;
     }
   }
-}
-
-/**
- * Compute the X, Y, Z coordinates of the children of a node
- * @param {SpatialNode} spatialNode The parent node
- * @returns {Array[]} Child coordinate arrays
- * @private
- */
-function getChildCoords(spatialNode) {
-  const { x, y, z } = spatialNode;
-  const xMin = x * 2;
-  const yMin = y * 2;
-  const zMin = z * 2;
-  const yMax = yMin + 1;
-  const xMax = xMin + 1;
-  const zMax = zMin + 1;
-
-  return [
-    [xMin, yMin, zMin],
-    [xMax, yMin, zMin],
-    [xMin, yMax, zMin],
-    [xMax, yMax, zMin],
-    [xMin, yMin, zMax],
-    [xMax, yMin, zMax],
-    [xMin, yMax, zMax],
-    [xMax, yMax, zMax],
-  ];
 }
 
 /**

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -593,10 +593,7 @@ function loadAndUnload(that, frameState) {
     }
 
     if (!defined(spatialNode.children)) {
-      const childCoords = spatialNode.getChildCoordinates();
-      spatialNode.children = childCoords.map(([level, x, y, z]) => {
-        return new SpatialNode(level, x, y, z, spatialNode, shape, dimensions);
-      });
+      spatialNode.constructChildNodes(shape, dimensions);
     }
     for (let childIndex = 0; childIndex < 8; childIndex++) {
       const child = spatialNode.children[childIndex];

--- a/packages/engine/Specs/Scene/SpatialNodeSpec.js
+++ b/packages/engine/Specs/Scene/SpatialNodeSpec.js
@@ -42,6 +42,9 @@ describe("Scene/SpatialNode", function () {
     const dimensions = new Cartesian3(2, 3, 4);
 
     const node = new SpatialNode(level, x, y, z, parent, shape, dimensions);
+    expect(node.children).toBeUndefined();
+    node.constructChildNodes(shape, dimensions);
+    expect(node.children.length).toBe(8);
 
     const expectedChildCoordinates = [
       [3, 2, 4, 6],
@@ -53,8 +56,14 @@ describe("Scene/SpatialNode", function () {
       [3, 2, 5, 7],
       [3, 3, 5, 7],
     ];
+    const actualChildCoordinates = node.children.map((child) => [
+      child.level,
+      child.x,
+      child.y,
+      child.z,
+    ]);
 
-    expect(node.getChildCoordinates()).toEqual(expectedChildCoordinates);
+    expect(actualChildCoordinates).toEqual(expectedChildCoordinates);
   });
 
   it("computes screen space error", function () {

--- a/packages/engine/Specs/Scene/SpatialNodeSpec.js
+++ b/packages/engine/Specs/Scene/SpatialNodeSpec.js
@@ -6,14 +6,19 @@ import {
 } from "../../index.js";
 
 describe("Scene/SpatialNode", function () {
-  it("constructs", function () {
+  function getBasicBoxShape() {
     const shape = new VoxelBoxShape();
     const modelMatrix = Matrix4.IDENTITY.clone();
     const minBounds = VoxelBoxShape.DefaultMinBounds.clone();
     const maxBounds = VoxelBoxShape.DefaultMaxBounds.clone();
     shape.update(modelMatrix, minBounds, maxBounds);
+    return shape;
+  }
 
-    const level = 0;
+  it("constructs", function () {
+    const shape = getBasicBoxShape();
+
+    const level = 2;
     const x = 1;
     const y = 2;
     const z = 3;
@@ -22,7 +27,63 @@ describe("Scene/SpatialNode", function () {
 
     const node = new SpatialNode(level, x, y, z, parent, shape, dimensions);
 
-    expect(node.level).toEqual(0);
+    expect(node.level).toEqual(2);
     expect(node.screenSpaceError).toEqual(0.0);
+  });
+
+  it("returns coordinates of child", function () {
+    const shape = getBasicBoxShape();
+
+    const level = 2;
+    const x = 1;
+    const y = 2;
+    const z = 3;
+    const parent = undefined;
+    const dimensions = new Cartesian3(2, 3, 4);
+
+    const node = new SpatialNode(level, x, y, z, parent, shape, dimensions);
+
+    const expectedChildCoordinates = [
+      [3, 2, 4, 6],
+      [3, 3, 4, 6],
+      [3, 2, 5, 6],
+      [3, 3, 5, 6],
+      [3, 2, 4, 7],
+      [3, 3, 4, 7],
+      [3, 2, 5, 7],
+      [3, 3, 5, 7],
+    ];
+
+    expect(node.getChildCoordinates()).toEqual(expectedChildCoordinates);
+  });
+
+  it("computes screen space error", function () {
+    const shape = getBasicBoxShape();
+
+    const level = 0;
+    const x = 0;
+    const y = 0;
+    const z = 0;
+    const parent = undefined;
+    const dimensions = new Cartesian3(2, 3, 4);
+
+    const node = new SpatialNode(level, x, y, z, parent, shape, dimensions);
+
+    const cameraPosition = new Cartesian3(0.0, 0.0, 2.0);
+    node.computeScreenSpaceError(cameraPosition, 1.0);
+
+    expect(node.screenSpaceError).toEqual(1.0);
+  });
+
+  it("adds a keyframe node", function () {
+    const shape = getBasicBoxShape();
+
+    const parent = undefined;
+    const dimensions = new Cartesian3(2, 3, 4);
+    const node = new SpatialNode(0, 0, 0, 0, parent, shape, dimensions);
+
+    const numberOfStartingKeyframes = node.keyframeNodes.length;
+    node.createKeyframeNode(0);
+    expect(node.keyframeNodes.length - numberOfStartingKeyframes).toEqual(1);
   });
 });

--- a/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
@@ -41,23 +41,23 @@ describe(
       expect(primitive.show).toEqual(true);
     });
 
-    it("constructs with options", function () {
+    it("constructs with options", async function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);
       scene.renderForSpecs();
 
       expect(primitive.provider).toBe(provider);
-      return primitive.readyPromise.then(function () {
-        expect(primitive.shape._type).toBe(provider.shape._type);
-        expect(primitive.dimensions.equals(provider.dimensions)).toBe(true);
-        expect(primitive._tileCount).toBe(provider._tileCount);
-        expect(primitive._traversal).toBeDefined();
-        expect(primitive.minimumValues).toBe(provider.minimumValues);
-        expect(primitive.maximumValues).toBe(provider.maximumValues);
-      });
+      await primitive.readyPromise;
+
+      expect(primitive.shape._type).toBe(provider.shape._type);
+      expect(primitive.dimensions.equals(provider.dimensions)).toBe(true);
+      expect(primitive._tileCount).toBe(provider._tileCount);
+      expect(primitive._traversal).toBeDefined();
+      expect(primitive.minimumValues).toBe(provider.minimumValues);
+      expect(primitive.maximumValues).toBe(provider.maximumValues);
     });
 
-    it("toggles render options that require shader rebuilds", function () {
+    it("toggles render options that require shader rebuilds", async function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);
 
@@ -70,18 +70,18 @@ describe(
         expect(primitive._shaderDirty).toBe(false);
       }
 
-      return pollToPromise(function () {
+      await pollToPromise(function () {
         scene.renderForSpecs();
         const traversal = primitive._traversal;
         return traversal.isRenderable(traversal.rootNode);
-      }).then(function () {
-        toggleOption("depthTest", true, false);
-        toggleOption("jitter", true, false);
-        toggleOption("nearestSampling", false, true);
       });
+
+      toggleOption("depthTest", true, false);
+      toggleOption("jitter", true, false);
+      toggleOption("nearestSampling", false, true);
     });
 
-    it("sets render parameters", function () {
+    it("sets render parameters", async function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);
 
@@ -92,16 +92,16 @@ describe(
         expect(primitive[parameter]).toBe(newValue);
       }
 
-      return pollToPromise(function () {
+      await pollToPromise(function () {
         scene.renderForSpecs();
         const traversal = primitive._traversal;
         return traversal.isRenderable(traversal.rootNode);
-      }).then(function () {
-        setParameter("levelBlendFactor", 0.0, 0.5);
-        setParameter("screenSpaceError", 4.0, 2.0);
-        setParameter("stepSize", 1.0, 0.5);
-        setParameter("debugDraw", false, true);
       });
+
+      setParameter("levelBlendFactor", 0.0, 0.5);
+      setParameter("screenSpaceError", 4.0, 2.0);
+      setParameter("stepSize", 1.0, 0.5);
+      setParameter("debugDraw", false, true);
     });
 
     it("sets clipping range extrema when given valid range between 0 and 1", function () {
@@ -126,65 +126,64 @@ describe(
       expect(primitive.style).toBe(VoxelPrimitive.DefaultStyle);
     });
 
-    it("updates step size", function () {
+    it("updates step size", async function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);
       scene.renderForSpecs();
 
       const shape = primitive._shape;
       shape.translation = new Cartesian3(2.382, -3.643, 1.084);
-      return primitive.readyPromise.then(function () {
-        primitive.update(scene.frameState);
-        const stepSizeUv = shape.computeApproximateStepSize(
-          primitive.dimensions
-        );
-        expect(primitive._stepSizeUv).toBe(stepSizeUv);
-      });
+
+      await primitive.readyPromise;
+
+      primitive.update(scene.frameState);
+      const stepSizeUv = shape.computeApproximateStepSize(primitive.dimensions);
+      expect(primitive._stepSizeUv).toBe(stepSizeUv);
     });
 
-    it("accepts a new Custom Shader", function () {
+    it("accepts a new Custom Shader", async function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);
       scene.renderForSpecs();
 
-      return primitive.readyPromise.then(function () {
-        expect(primitive.customShader).toBe(VoxelPrimitive.DefaultCustomShader);
+      await primitive.readyPromise;
 
-        // If new shader is undefined, we should get DefaultCustomShader again
-        primitive.customShader = undefined;
-        scene.renderForSpecs();
-        expect(primitive.customShader).toBe(VoxelPrimitive.DefaultCustomShader);
+      expect(primitive.customShader).toBe(VoxelPrimitive.DefaultCustomShader);
 
-        const modifiedShader = new CustomShader({
-          fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+      // If new shader is undefined, we should get DefaultCustomShader again
+      primitive.customShader = undefined;
+      scene.renderForSpecs();
+      expect(primitive.customShader).toBe(VoxelPrimitive.DefaultCustomShader);
+
+      const modifiedShader = new CustomShader({
+        fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
 {
     material.diffuse = vec3(1.0, 1.0, 0.0);
     material.alpha = 0.8;
 }`,
-        });
-        primitive.customShader = modifiedShader;
-        scene.renderForSpecs();
-        expect(primitive.customShader).toBe(modifiedShader);
       });
+      primitive.customShader = modifiedShader;
+      scene.renderForSpecs();
+      expect(primitive.customShader).toBe(modifiedShader);
     });
 
-    it("destroys", function () {
+    it("destroys", async function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);
       scene.renderForSpecs();
       expect(primitive.isDestroyed()).toBe(false);
 
-      return primitive.readyPromise.then(function () {
-        primitive.update(scene.frameState);
-        expect(primitive.isDestroyed()).toBe(false);
-        expect(primitive._pickId).toBeDefined();
-        expect(primitive._traversal).toBeDefined();
+      await primitive.readyPromise;
 
-        scene.primitives.remove(primitive);
-        expect(primitive.isDestroyed()).toBe(true);
-        expect(primitive._pickId).toBeUndefined();
-        expect(primitive._traversal).toBeUndefined();
-      });
+      primitive.update(scene.frameState);
+      expect(primitive.isDestroyed()).toBe(false);
+      expect(primitive._pickId).toBeDefined();
+      expect(primitive._traversal).toBeDefined();
+
+      scene.primitives.remove(primitive);
+      expect(primitive.isDestroyed()).toBe(true);
+      expect(primitive._pickId).toBeUndefined();
+      expect(primitive._traversal).toBeUndefined();
     });
   },
   "WebGL"

--- a/packages/engine/Specs/Scene/VoxelTraversalSpec.js
+++ b/packages/engine/Specs/Scene/VoxelTraversalSpec.js
@@ -22,7 +22,7 @@ function turnCameraAround(scene) {
 describe(
   "Scene/VoxelTraversal",
   function () {
-    const keyframeCount = 1;
+    const keyframeCount = 3;
     const textureMemory = 500;
 
     let scene;
@@ -30,6 +30,7 @@ describe(
     let camera;
     let primitive;
     let traversal;
+
     beforeEach(function () {
       scene = createScene();
       provider = new Cesium3DTilesVoxelProvider({
@@ -162,7 +163,6 @@ describe(
       const tileInQueueWhenLookingAtRoot = tilesInMegatextureCount === 1;
       expect(tileInQueueWhenLookingAtRoot).toBe(true);
 
-      traversal.megatexture.remove(0);
       turnCameraAround(scene);
       traversal.update(
         scene.frameState,


### PR DESCRIPTION
Resolves #11012. Key changes:

- Added a pollToPromise call in VoxelPrimitiveSpec to make sure tiles actually load. Without this, the `traversal.isRenderable(...)` check in `VoxelTraversal` never returned true, so larges sections of code were not covered.
- Used smaller functions in SpatialNode and VoxelTraversal
- Added specs for SpatialNode

Some things not addressed by this PR:
- Untested code in `VoxelBoxShape`. This code is removed in #11050 
- The `printDebugInformation` function in `VoxelTraversal`. This prints load times to the console, which is not easily testable
- Code for time-dynamic voxels and LOD blending. See #11006