### PR TITLE
Update to the latest version of cesium eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "draco3d": "^1.5.1",
     "esbuild": "^0.16.7",
     "eslint": "^8.29.0",
-    "eslint-config-cesium": "^9.0.0",
+    "eslint-config-cesium": "^9.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-html": "^7.1.0",


### PR DESCRIPTION
Bumps cesium's eslint config version to the latest. [The update](https://github.com/CesiumGS/eslint-config-cesium/pull/4) enables new language features as of the latest version Node 18 LTS. No code updates are needed.