### PR TITLE
Add willReadFrequently option to 2d contexts where applicable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fixed Primitive.getGeometryInstanceAttributes cache acquisition speed. [#11066](https://github.com/CesiumGS/cesium/issues/11066)
 - Fixed requestWebgl1 hint error in context. [#11082](https://github.com/CesiumGS/cesium/issues/11082)
 - Replace constructor types with primitive types in JSDoc. [#11080](https://github.com/CesiumGS/cesium/pull/11080)
+- Fixed browser warning for `willReadFrequently` option. [#11025](https://github.com/CesiumGS/cesium/issues/11025)
 
 ### 1.102 - 2023-02-01
 

--- a/packages/engine/Source/Core/getImagePixels.js
+++ b/packages/engine/Source/Core/getImagePixels.js
@@ -32,7 +32,8 @@ function getImagePixels(image, width, height) {
     const canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;
-    context2d = canvas.getContext("2d");
+    // Since we re-use contexts, use the willReadFrequently option – See https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently
+    context2d = canvas.getContext("2d", { willReadFrequently: true });
     context2d.globalCompositeOperation = "copy";
     context2DsByHeight[height] = context2d;
   }

--- a/packages/engine/Source/Core/writeTextToCanvas.js
+++ b/packages/engine/Source/Core/writeTextToCanvas.js
@@ -143,7 +143,8 @@ function writeTextToCanvas(text, options) {
   canvas.width = 1;
   canvas.height = 1;
   canvas.style.font = font;
-  const context2D = canvas.getContext("2d");
+  // Since multiple read-back operations are expected for labels, use the willReadFrequently option – See https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently
+  const context2D = canvas.getContext("2d", { willReadFrequently: true });
 
   if (!defined(imageSmoothingEnabledName)) {
     if (defined(context2D.imageSmoothingEnabled)) {

--- a/packages/engine/Source/Scene/LabelCollection.js
+++ b/packages/engine/Source/Scene/LabelCollection.js
@@ -226,6 +226,7 @@ function rebindAllGlyphs(labelCollection, label) {
           radius: SDFSettings.RADIUS,
         });
 
+        // Context is originally created in writeTextToCanvas()
         const ctx = canvas.getContext("2d");
         const canvasWidth = canvas.width;
         const canvasHeight = canvas.height;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11025 

Selectively apply `willReadFrequently` option based on discussion in https://github.com/CesiumGS/cesium/pull/10873. This only applies the option to the place where the context is initially created, and adds some inline comments where this may be a bit obscure or non-obvious.