### PR TITLE
fix camera go througth building in zoom

### DIFF
--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -224,6 +224,12 @@ function ScreenSpaceCameraController(scene) {
   this.minimumPickingTerrainHeight = 150000.0;
   this._minimumPickingTerrainHeight = this.minimumPickingTerrainHeight;
   /**
+   * The minimum distance the camera must be before testing for collision with terrain when zoom with inertia.
+   * @type {number}
+   * @default 4000.0
+   */
+  this.minimumPickingTerrainDistanceWithInertia = 4000.0;
+  /**
    * The minimum height the camera must be before testing for collision with terrain.
    * @type {number}
    * @default 15000.0
@@ -2191,7 +2197,9 @@ function zoom3D(controller, startPosition, movement) {
     zoom3DCartographic
   ).height;
 
-  const approachingCollision = Math.abs(preIntersectionDistance) < 4000;
+  const approachingCollision =
+    Math.abs(preIntersectionDistance) <
+    controller.minimumPickingTerrainDistanceWithInertia;
 
   const needPickGlobe = inertiaMovement
     ? approachingCollision

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -2191,7 +2191,7 @@ function zoom3D(controller, startPosition, movement) {
     zoom3DCartographic
   ).height;
 
-  const approachingCollision = Math.abs(preIntersectionDistance) < 100;
+  const approachingCollision = Math.abs(preIntersectionDistance) < 4000;
 
   const needPickGlobe = inertiaMovement
     ? approachingCollision

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -2158,6 +2158,8 @@ function pan3D(controller, startPosition, movement, ellipsoid) {
 const zoom3DUnitPosition = new Cartesian3();
 const zoom3DCartographic = new Cartographic();
 
+let preIntersectionDistance = 0;
+
 function zoom3D(controller, startPosition, movement) {
   if (defined(movement.distance)) {
     movement = movement.distance;
@@ -2189,10 +2191,10 @@ function zoom3D(controller, startPosition, movement) {
     zoom3DCartographic
   ).height;
 
-  const inertiaMovementApproachingGround = Math.abs(height) < 50;
+  const approachingCollision = Math.abs(preIntersectionDistance) < 100;
 
   const needPickGlobe = inertiaMovement
-    ? inertiaMovementApproachingGround
+    ? approachingCollision
     : height < controller._minimumPickingTerrainHeight;
   if (needPickGlobe) {
     intersection = pickGlobe(controller, windowPosition, zoomCVIntersection);
@@ -2201,6 +2203,7 @@ function zoom3D(controller, startPosition, movement) {
   let distance;
   if (defined(intersection)) {
     distance = Cartesian3.distance(ray.origin, intersection);
+    preIntersectionDistance = distance;
   }
 
   if (cameraUnderground) {


### PR DESCRIPTION
from issue #11107  fix camera go througth building in zoom by changing approaching condition