### PR TITLE
Fix type qualifier in ShadowMapShader

### DIFF
--- a/packages/engine/Source/Scene/ShadowMapShader.js
+++ b/packages/engine/Source/Scene/ShadowMapShader.js
@@ -39,7 +39,7 @@ ShadowMapShader.createShadowCastVertexShader = function (
     }
 
     const shadowVS =
-      "in vec3 v_positionEC; \n" +
+      "out vec3 v_positionEC; \n" +
       "void main() \n" +
       "{ \n" +
       "    czm_shadow_cast_main(); \n" +


### PR DESCRIPTION
This PR fixes a typo in the conversion to es300 syntax (see #10894). 

The `v_positionEC` variable is an _output_ of the vertex shader