### PR TITLE
Fix deploy by accounting for possibly undefined property after AWS SDK update

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1186,6 +1186,10 @@ async function listAll(s3Client, bucketName, prefix, files, marker) {
   });
   const data = await s3Client.send(listObjectsCommand);
   const items = data.Contents;
+  if (!items) {
+    return;
+  }
+
   for (let i = 0; i < items.length; i++) {
     files.push(items[i].Key);
   }


### PR DESCRIPTION
After [the AWS SDK version udpate](https://github.com/CesiumGS/cesium/pull/11104), it [appears that it's possible for the response from the list command to not contain a `Contents` array property](https://app.travis-ci.com/github/CesiumGS/cesium/jobs/596868422). This adds an early return in that case.