### PR TITLE
CreditDisplay.js: appendCss() : add styles to shadowRoot if found

### DIFF
--- a/packages/engine/Source/Scene/CreditDisplay.js
+++ b/packages/engine/Source/Scene/CreditDisplay.js
@@ -174,7 +174,7 @@ function addStyle(selector, styles) {
   return style;
 }
 
-function appendCss() {
+function appendCss(container) {
   let style = "";
   style += addStyle(".cesium-credit-lightbox-overlay", {
     display: "none",
@@ -270,10 +270,23 @@ function appendCss() {
     }
   );
 
-  const head = document.head;
+  function getShadowRoot(container) {
+    if (container.shadowRoot) {
+      return container.shadowRoot;
+    }
+    if (container.getRootNode) {
+      const root = container.getRootNode();
+      if (root instanceof ShadowRoot) {
+        return root;
+      }
+    }
+    return undefined;
+  }
+
+  const shadowRootOrDocumentHead = getShadowRoot(container) || document.head;
   const css = document.createElement("style");
   css.innerHTML = style;
-  head.insertBefore(css, head.firstChild);
+  shadowRootOrDocumentHead.appendChild(css);
 }
 
 /**
@@ -343,7 +356,7 @@ function CreditDisplay(container, delimiter, viewport) {
   expandLink.textContent = "Data attribution";
   container.appendChild(expandLink);
 
-  appendCss();
+  appendCss(container);
   const cesiumCredit = Credit.clone(CreditDisplay.cesiumCredit);
 
   this._delimiter = defaultValue(delimiter, " • ");


### PR DESCRIPTION
This PR solves the issue #10907 "Cesium.Viewer instantiated inside my lit component: CreditDisplay is missing its styles".

It adds the argument `container` to the existing `function appendCss()`.
The modified function checks if the container is a child of a `shadowRoot` and appends styles to it if so, otherwise it appends styles to the `document.head`, as before the change.

Builds and tests:

1. `build` and `build-release` run successfully.

2. `test` runs almost successfully except that, before the change and after the change, I get 3 to 5 failures similar to these:

```
Chrome 110.0.0.0 (Mac OS 10.15.7): Executed 13854 of 13922 (4 FAILED) (skipped 68) (3 mins 1.928 secs / 2 mins 44.378 secs)
TOTAL: 4 FAILED, 13850 SUCCESS
1) 2D
     Scene/GeometryRenderingSpec SimplePolylineGeometry
2) renders
     Scene/ParticleSystem
3) night vision
     Scene/PostProcessStageLibrary
4) renders pnts with point size style
     Scene/Model/Model3DTileContent pnts


TOTAL: 4 FAILED, 13850 SUCCESS
```

3. Sandcastle apps are unaffected by the change, and the `Data Attribution` box opens on click.

4. The local build of my [cesium-lit-demo](https://github.com/rudifa/cesium-lit-demo), using the modified cesium code, confirms that the problem the CreditDisplay missing styles is solved.


