### PR TITLE
Use the no-config option with prettier to prevent conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,8 +147,8 @@
     "deploy-s3": "gulp deployS3",
     "deploy-status": "gulp deployStatus",
     "deploy-set-version": "gulp deploySetVersion",
-    "prettier": "prettier --write \"**/*\"",
-    "prettier-check": "prettier --check \"**/*\""
+    "prettier": "prettier --write --no-config \"**/*\"",
+    "prettier-check": "prettier --check --no-config \"**/*\""
   },
   "engines": {
     "node": ">=14.0.0"
@@ -156,11 +156,11 @@
   "lint-staged": {
     "*.{js,cjs,html}": [
       "eslint --cache --quiet",
-      "prettier --write"
+      "prettier --write --no-config"
     ],
     "*.md": [
       "markdownlint --ignore CHANGES.md --ignore \"./**/LICENSE.md\"",
-      "prettier --write"
+      "prettier --write --no-config"
     ]
   },
   "workspaces": [


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11135

Prevents conflicts from other user prettier configs that may be in a parent directory.