### PR TITLE
Doc Issue #10303 Fix in screenSpaceCameraController 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -348,3 +348,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Tengfei](https://github.com/i-tengfei)
 - [Rudolf Farkas](https://github.com/rudifa)
 - [Nick Noce](https://github.com/nnoce14)
+- [Jacob Van Dine](https://github.com/JacobVanDine)

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -245,7 +245,7 @@ function ScreenSpaceCameraController(scene) {
   this.minimumTrackBallHeight = 7500000.0;
   this._minimumTrackBallHeight = this.minimumTrackBallHeight;
   /**
-   * Enables or disables camera collision detection with terrain. When enabled, the camera's maximumZoomDistance and minimumZoomDistance become locked.
+   * When disabled, the values of <code>maximumZoomDistance</code> and <code>minimumZoomDistance</code> are ignored.
    * @type {boolean}
    * @default true
    */

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -245,7 +245,7 @@ function ScreenSpaceCameraController(scene) {
   this.minimumTrackBallHeight = 7500000.0;
   this._minimumTrackBallHeight = this.minimumTrackBallHeight;
   /**
-   * Enables or disables camera collision detection with terrain.
+   * Enables or disables camera collision detection with terrain. When enabled, the camera's maximumZoomDistance and minimumZoomDistance become locked.
    * @type {boolean}
    * @default true
    */


### PR DESCRIPTION
This is my first issue and PR for Cesium, so please let me know how I did! I signed the individual CLA 

Resolving issue #10303 : "screenSpaceCameraController.maximumZoomDistance not work,when I set enableCollisionDetection to false."

Added more documentation to screenSpaceCameraController.enableCollisionDetection to specify that maximumZoomDistance and minimumZoomDistance are both locked when enabled.