### PR TITLE
update MapboxImageryProvider example

### DIFF
--- a/packages/engine/Source/Scene/MapboxImageryProvider.js
+++ b/packages/engine/Source/Scene/MapboxImageryProvider.js
@@ -39,7 +39,7 @@ const defaultCredit = new Credit(
  * @example
  * // Mapbox tile provider
  * const mapbox = new Cesium.MapboxImageryProvider({
- *     mapId: 'mapbox.streets',
+ *     mapId: 'mapbox.mapbox-terrain-v2',
  *     accessToken: 'thisIsMyAccessToken'
  * });
  *


### PR DESCRIPTION
Hi~ I have signed the individual CLA.
When I used the mapId "mapbox.streets" got the tip "Classic styles are no longer supported; see https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4 for more information", then I updated the 
MapboxImageryProvider example.
