### PR TITLE
update MapboxImageryProvider example mapId

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -348,3 +348,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Tengfei](https://github.com/i-tengfei)
 - [Rudolf Farkas](https://github.com/rudifa)
 - [Nick Noce](https://github.com/nnoce14)
+- [L](https://github.com/L-hikari)

--- a/packages/engine/Source/Scene/MapboxImageryProvider.js
+++ b/packages/engine/Source/Scene/MapboxImageryProvider.js
@@ -39,7 +39,7 @@ const defaultCredit = new Credit(
  * @example
  * // Mapbox tile provider
  * const mapbox = new Cesium.MapboxImageryProvider({
- *     mapId: 'mapbox.streets',
+ *     mapId: 'mapbox.mapbox-terrain-v2',
  *     accessToken: 'thisIsMyAccessToken'
  * });
  *


### PR DESCRIPTION
Hi~ I have signed the individual CLA.
When I used MapboxImageryProvider the mapId "mapbox.streets" got the message "Classic styles are no longer supported; see https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4 for more information", so i updated the
MapboxImageryProvider example.
This is my first contribute for cesiumjs, if I was something wrong, I'm sorry to bring extra works for yours.