### PR TITLE
Make build-watch compatible with new esbuild rebuild API

### DIFF
--- a/build.js
+++ b/build.js
@@ -145,9 +145,9 @@ export async function getFilesFromWorkspaceGlobs(workspaceGlobs) {
 
 /**
  * @typedef {object} CesiumBundles
- * @property {object} esmBundle The ESM bundle.
- * @property {object} iifeBundle The IIFE bundle, for use in browsers.
- * @property {object} nodeBundle The CommonJS bundle, for use in NodeJS.
+ * @property {object} esm The ESM bundle.
+ * @property {object} iife The IIFE bundle, for use in browsers.
+ * @property {object} node The CommonJS bundle, for use in NodeJS.
  */
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -178,21 +178,22 @@ export const buildWatch = gulp.series(build, async function () {
     sourcemap: sourcemap,
     incremental: true,
   });
-  let esmResult = bundles.esmBundle;
-  let cjsResult = bundles.nodeBundle;
-  let iifeResult = bundles.iifeBundle;
-  let specResult = bundles.specsBundle;
+
+  const esm = bundles.esm;
+  const cjs = bundles.node;
+  const iife = bundles.iife;
+  const specs = bundles.specs;
 
   gulp.watch(shaderFiles, async () => {
     glslToJavaScript(minify, "Build/minifyShaders.state", "engine");
-    esmResult = await esmResult.rebuild();
+    await esm.rebuild();
 
-    if (iifeResult) {
-      iifeResult = await iifeResult.rebuild();
+    if (iife) {
+      await iife.rebuild();
     }
 
-    if (cjsResult) {
-      cjsResult = await cjsResult.rebuild();
+    if (cjs) {
+      await cjs.rebuild();
     }
   });
 
@@ -204,14 +205,14 @@ export const buildWatch = gulp.series(build, async function () {
     ],
     async () => {
       createJsHintOptions();
-      esmResult = await esmResult.rebuild();
+      await esm.rebuild();
 
-      if (iifeResult) {
-        iifeResult = await iifeResult.rebuild();
+      if (iife) {
+        await iife.rebuild();
       }
 
-      if (cjsResult) {
-        cjsResult = await cjsResult.rebuild();
+      if (cjs) {
+        await cjs.rebuild();
       }
     }
   );
@@ -223,7 +224,7 @@ export const buildWatch = gulp.series(build, async function () {
     },
     async () => {
       createCombinedSpecList();
-      specResult = await specResult.rebuild();
+      await specs.rebuild();
     }
   );
 
@@ -233,7 +234,7 @@ export const buildWatch = gulp.series(build, async function () {
       events: ["change"],
     },
     async () => {
-      specResult = await specResult.rebuild();
+      await specs.rebuild();
     }
   );
 
@@ -248,17 +249,17 @@ export const buildWatch = gulp.series(build, async function () {
 
   process.on("SIGINT", () => {
     // Free up resources
-    esmResult.rebuild.dispose();
+    esm.dispose();
 
-    if (iifeResult) {
-      iifeResult.rebuild.dispose();
+    if (iife) {
+      iife.dispose();
     }
 
-    if (cjsResult) {
-      cjsResult.rebuild.dispose();
+    if (cjs) {
+      cjs.dispose();
     }
 
-    specResult.rebuild.dispose();
+    specs.dispose();
     process.exit(0);
   });
 });


### PR DESCRIPTION
I think in #11100 the `build-watch` command was overlooked. 🙂  
At least for me it didn't run properly anymore. According to the new rebuild API of esbuild (as linked in #11100: https://esbuild.github.io/api/#rebuild) some changes were needed to make `build-watch` compatible again.

I only really tested rebuilds of `esm` and changed `cjs`, `iife` and `specs` accordingly. Maybe someone can test these, too? 😅  
I guess especially @ggetz should have a look on this.