### PR TITLE
Cleanups for 3D Tiles Feature Picking sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -33,6 +33,7 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+
         // A simple demo of 3D Tiles feature picking with hover and select behavior
         // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -90,6 +91,53 @@
           Cesium.ScreenSpaceEventType.LEFT_CLICK
         );
 
+        // Update the 'nameOverlay' for the given picked feature,
+        // at the given (screen) position.
+        function updateNameOverlay(pickedFeature, position) {
+          if (!Cesium.defined(pickedFeature)) {
+            nameOverlay.style.display = "none";
+            return;
+          }
+          // A feature was picked, so show its overlay content
+          nameOverlay.style.display = "block";
+          nameOverlay.style.bottom = `${
+            viewer.canvas.clientHeight - position.y
+          }px`;
+          nameOverlay.style.left = `${position.x}px`;
+          const name = pickedFeature.getProperty("BIN");
+          nameOverlay.textContent = name;
+        }
+
+        // Create the HTML that will be put into the info box that shows
+        // information about the currently selected feature
+        function createPickedFeatureDescription(pickedFeature) {
+          const description =
+            `${
+              '<table class="cesium-infoBox-defaultTable"><tbody>' +
+              "<tr><th>BIN</th><td>"
+            }${pickedFeature.getProperty("BIN")}</td></tr>` +
+            `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
+              "DOITT_ID"
+            )}</td></tr>` +
+            `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
+              "SOURCE_ID"
+            )}</td></tr>` +
+            `<tr><th>Longitude</th><td>${pickedFeature.getProperty(
+              "Longitude"
+            )}</td></tr>` +
+            `<tr><th>Latitude</th><td>${pickedFeature.getProperty(
+              "Latitude"
+            )}</td></tr>` +
+            `<tr><th>Height</th><td>${pickedFeature.getProperty(
+              "Height"
+            )}</td></tr>` +
+            `<tr><th>Terrain Height (Ellipsoid)</th><td>${pickedFeature.getProperty(
+              "TerrainHeight"
+            )}</td></tr>` +
+            `</tbody></table>`;
+          return description;
+        }
+
         // If silhouettes are supported, silhouette features in blue on mouse over and silhouette green on mouse click.
         // If silhouettes are not supported, change the feature color to yellow on mouse over and green on mouse click.
         if (
@@ -122,19 +170,12 @@
 
             // Pick a new feature
             const pickedFeature = viewer.scene.pick(movement.endPosition);
+
+            updateNameOverlay(pickedFeature, movement.endPosition);
+
             if (!Cesium.defined(pickedFeature)) {
-              nameOverlay.style.display = "none";
               return;
             }
-
-            // A feature was picked, so show it's overlay content
-            nameOverlay.style.display = "block";
-            nameOverlay.style.bottom = `${
-              viewer.canvas.clientHeight - movement.endPosition.y
-            }px`;
-            nameOverlay.style.left = `${movement.endPosition.x}px`;
-            const name = pickedFeature.getProperty("BIN");
-            nameOverlay.textContent = name;
 
             // Highlight the feature if it's not already selected.
             if (pickedFeature !== selected.feature) {
@@ -172,23 +213,10 @@
             silhouetteGreen.selected = [pickedFeature];
 
             // Set feature infobox description
-            const featureName = pickedFeature.getProperty("name");
-            selectedEntity.name = featureName;
-            selectedEntity.description =
-              'Loading <div class="cesium-infoBox-loading"></div>';
             viewer.selectedEntity = selectedEntity;
-            selectedEntity.description =
-              `${
-                '<table class="cesium-infoBox-defaultTable"><tbody>' +
-                "<tr><th>BIN</th><td>"
-              }${pickedFeature.getProperty("BIN")}</td></tr>` +
-              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
-                "DOITT_ID"
-              )}</td></tr>` +
-              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
-                "SOURCE_ID"
-              )}</td></tr>` +
-              `</tbody></table>`;
+            selectedEntity.description = createPickedFeatureDescription(
+              pickedFeature
+            );
           },
           Cesium.ScreenSpaceEventType.LEFT_CLICK);
         } else {
@@ -211,21 +239,12 @@
             }
             // Pick a new feature
             const pickedFeature = viewer.scene.pick(movement.endPosition);
+            updateNameOverlay(pickedFeature, movement.endPosition);
+
             if (!Cesium.defined(pickedFeature)) {
-              nameOverlay.style.display = "none";
               return;
             }
-            // A feature was picked, so show it's overlay content
-            nameOverlay.style.display = "block";
-            nameOverlay.style.bottom = `${
-              viewer.canvas.clientHeight - movement.endPosition.y
-            }px`;
-            nameOverlay.style.left = `${movement.endPosition.x}px`;
-            let name = pickedFeature.getProperty("name");
-            if (!Cesium.defined(name)) {
-              name = pickedFeature.getProperty("id");
-            }
-            nameOverlay.textContent = name;
+
             // Highlight the feature if it's not already selected.
             if (pickedFeature !== selected.feature) {
               highlighted.feature = pickedFeature;
@@ -270,36 +289,12 @@
             }
             // Highlight newly selected feature
             pickedFeature.color = Cesium.Color.LIME;
+
             // Set feature infobox description
-            const featureName = pickedFeature.getProperty("name");
-            selectedEntity.name = featureName;
-            selectedEntity.description =
-              'Loading <div class="cesium-infoBox-loading"></div>';
             viewer.selectedEntity = selectedEntity;
-            selectedEntity.description =
-              `${
-                '<table class="cesium-infoBox-defaultTable"><tbody>' +
-                "<tr><th>BIN</th><td>"
-              }${pickedFeature.getProperty("BIN")}</td></tr>` +
-              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
-                "DOITT_ID"
-              )}</td></tr>` +
-              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
-                "SOURCE_ID"
-              )}</td></tr>` +
-              `<tr><th>Longitude</th><td>${pickedFeature.getProperty(
-                "longitude"
-              )}</td></tr>` +
-              `<tr><th>Latitude</th><td>${pickedFeature.getProperty(
-                "latitude"
-              )}</td></tr>` +
-              `<tr><th>Height</th><td>${pickedFeature.getProperty(
-                "height"
-              )}</td></tr>` +
-              `<tr><th>Terrain Height (Ellipsoid)</th><td>${pickedFeature.getProperty(
-                "TerrainHeight"
-              )}</td></tr>` +
-              `</tbody></table>`;
+            selectedEntity.description = createPickedFeatureDescription(
+              pickedFeature
+            );
           },
           Cesium.ScreenSpaceEventType.LEFT_CLICK);
         }


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10905 

Further issues that are fixed here:

- At some places, `pickedFeature.getProperty("name")` was called, which is always `undefined` for the features here
- Specifically: In the non-silhouette-case, the overlay displayed this property when hovering a building - causing an empty overlay (small black square) to be displayed!
- At some places, `pickedFeature.getProperty("longitude")` was called, which must be `pickedFeature.getProperty("Longitude")` (capitalized) - otherwise, the info box showed a bunch of `undefined`s.
- At some places, the comments used `"it's"` (contraction) where they should have used `"its"` (possessive noun)

---

Note: A "pragmatic" way to check whether the non-silhouette case works is to change
`if (Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)) {`
to 
`if (false && Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)) {` 
when running it locally...



