### PR TITLE
Fix built viewer after esbuild update

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -1,6 +1,7 @@
-if (window.CESIUM_BASE_URL === undefined) {
-  window.CESIUM_BASE_URL = "../../Build/CesiumUnminified/";
-}
+// eslint-disable-next-line no-undef
+window.CESIUM_BASE_URL = window.CESIUM_BASE_URL
+  ? window.CESIUM_BASE_URL
+  : "../../Build/CesiumUnminified/";
 
 import {
   Cartesian3,

--- a/Apps/CesiumViewer/index.js
+++ b/Apps/CesiumViewer/index.js
@@ -1,1 +1,0 @@
-window.CESIUM_BASE_URL = ".";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2230,7 +2230,8 @@ async function buildCesiumViewer() {
     ".png": "text",
   };
   config.format = "iife";
-  config.inject = ["Apps/CesiumViewer/index.js"];
+  // Configure Cesium base path to use built
+  config.define = { CESIUM_BASE_URL: `"."` };
   config.external = ["https", "http", "url", "zlib"];
   config.outdir = cesiumViewerOutputDirectory;
   config.outbase = "Apps/CesiumViewer";
@@ -2247,7 +2248,7 @@ async function buildCesiumViewer() {
       ".gif": "text",
       ".png": "text",
     },
-    outdir: cesiumViewerOutputDirectory,
+    outdir: join(cesiumViewerOutputDirectory, "Widgets"),
     outbase: "packages/widgets/Source/",
   });
 


### PR DESCRIPTION
I believe this broke after https://github.com/CesiumGS/cesium/pull/11100. Instead of using `inject` to insert a bit of code to define the `window.CESIUM_BASE_URL` variable, this simplifies things a bit by using the `define` option directly.

To test, run `build-apps` and `npm start -- --production` and navigate to http://localhost:8080/Build/Apps/CesiumViewer/index.html. In main, it will be broken, but it should be working after this fix.