### PR TITLE
Update ion URL in RequestScheduler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fixed issue where passing `children` in the Entity constructor options will override children. [#11101](https://github.com/CesiumGS/cesium/issues/11101)
 - Fixed error type to be `RequestErrorEvent` in `Resource.retryCallback`. [#11177](https://github.com/CesiumGS/cesium/pull/11177)
+- Fixed ion URL in `RequestScheduler` throttling overrides. [#11193](https://github.com/CesiumGS/cesium/pull/11193)
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/Core/RequestScheduler.js
+++ b/packages/engine/Source/Core/RequestScheduler.js
@@ -76,7 +76,7 @@ RequestScheduler.maximumRequestsPerServer = 6;
  */
 RequestScheduler.requestsByServer = {
   "api.cesium.com:443": 18,
-  "assets.cesium.com:443": 18,
+  "assets.ion.cesium.com:443": 18,
 };
 
 /**


### PR DESCRIPTION
One of the throttling overrides in `RequestScheduler` was set for `assets.cesium.com` which is no longer used. This PR replaces it with the new URL, `assets.ion.cesium.com`