### PR TITLE
Don't create contexts in the global scope in specs

### DIFF
--- a/packages/engine/Specs/Renderer/BufferSpec.js
+++ b/packages/engine/Specs/Renderer/BufferSpec.js
@@ -1,23 +1,17 @@
 import { IndexDatatype, Buffer, BufferUsage } from "../../index.js";
 
+import createWebglVersionHelper from "../createWebglVersionHelper.js";
 import createContext from "../../../../Specs/createContext.js";
 
 describe(
   "Renderer/Buffer",
   function () {
-    createBufferSpecs({});
-    const c = createContext({});
-    // Don't repeat WebGL 1 tests when WebGL 2 is not supported
-    if (c.webgl2) {
-      createBufferSpecs({});
-    }
-    c.destroyForSpecs();
+    createWebglVersionHelper(createBufferSpecs);
 
     function createBufferSpecs(contextOptions) {
-      let context;
       let buffer;
       let buffer2;
-      const webglMessage = contextOptions.requestWebgl1 ? "" : ": WebGL 2";
+      let context;
 
       beforeAll(function () {
         context = createContext(contextOptions);
@@ -36,7 +30,7 @@ describe(
         }
       });
 
-      it(`throws when creating a vertex buffer with no context${webglMessage}`, function () {
+      it(`throws when creating a vertex buffer with no context`, function () {
         expect(function () {
           buffer = Buffer.createVertexBuffer({
             sizeInBytes: 4,
@@ -45,7 +39,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating a vertex buffer with an invalid typed array${webglMessage}`, function () {
+      it(`throws when creating a vertex buffer with an invalid typed array`, function () {
         expect(function () {
           buffer = Buffer.createVertexBuffer({
             context: context,
@@ -55,7 +49,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating a vertex buffer with both a typed array and size in bytes${webglMessage}`, function () {
+      it(`throws when creating a vertex buffer with both a typed array and size in bytes`, function () {
         expect(function () {
           buffer = Buffer.createVertexBuffer({
             context: context,
@@ -66,7 +60,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating a vertex buffer without a typed array or size in bytes${webglMessage}`, function () {
+      it(`throws when creating a vertex buffer without a typed array or size in bytes`, function () {
         expect(function () {
           buffer = Buffer.createVertexBuffer({
             context: context,
@@ -75,7 +69,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating a vertex buffer with invalid usage${webglMessage}`, function () {
+      it(`throws when creating a vertex buffer with invalid usage`, function () {
         expect(function () {
           buffer = Buffer.createVertexBuffer({
             context: context,
@@ -85,7 +79,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating a vertex buffer with size of zero${webglMessage}`, function () {
+      it(`throws when creating a vertex buffer with size of zero`, function () {
         expect(function () {
           buffer = Buffer.createVertexBuffer({
             context: context,
@@ -95,7 +89,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`creates vertex buffer${webglMessage}`, function () {
+      it(`creates vertex buffer`, function () {
         buffer = Buffer.createVertexBuffer({
           context: context,
           sizeInBytes: 16,
@@ -106,7 +100,7 @@ describe(
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
       });
 
-      it(`copies array to a vertex buffer${webglMessage}`, function () {
+      it(`copies array to a vertex buffer`, function () {
         const sizeInBytes = 3 * Float32Array.BYTES_PER_ELEMENT;
         const vertices = new ArrayBuffer(sizeInBytes);
         const positions = new Float32Array(vertices);
@@ -122,7 +116,7 @@ describe(
         buffer.copyFromArrayView(vertices);
       });
 
-      it(`can create a vertex buffer from a typed array${webglMessage}`, function () {
+      it(`can create a vertex buffer from a typed array`, function () {
         const typedArray = new Float32Array(3);
         typedArray[0] = 1.0;
         typedArray[1] = 2.0;
@@ -137,7 +131,7 @@ describe(
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
       });
 
-      it(`can create a vertex buffer from a size in bytes${webglMessage}`, function () {
+      it(`can create a vertex buffer from a size in bytes`, function () {
         buffer = Buffer.createVertexBuffer({
           context: context,
           sizeInBytes: 4,
@@ -147,7 +141,7 @@ describe(
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
       });
 
-      it(`throws when creating an index buffer with no context${webglMessage}`, function () {
+      it(`throws when creating an index buffer with no context`, function () {
         expect(function () {
           buffer = Buffer.createIndexBuffer({
             sizeInBytes: 4,
@@ -157,7 +151,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating an index buffer with an invalid typed array${webglMessage}`, function () {
+      it(`throws when creating an index buffer with an invalid typed array`, function () {
         expect(function () {
           buffer = Buffer.createIndexBuffer({
             context: context,
@@ -168,7 +162,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating an index buffer with both a typed array and size in bytes${webglMessage}`, function () {
+      it(`throws when creating an index buffer with both a typed array and size in bytes`, function () {
         expect(function () {
           buffer = Buffer.createIndexBuffer({
             context: context,
@@ -180,7 +174,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating an index buffer without a typed array or size in bytes${webglMessage}`, function () {
+      it(`throws when creating an index buffer without a typed array or size in bytes`, function () {
         expect(function () {
           buffer = Buffer.createIndexBuffer({
             context: context,
@@ -190,7 +184,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating an index buffer with invalid usage${webglMessage}`, function () {
+      it(`throws when creating an index buffer with invalid usage`, function () {
         expect(function () {
           buffer = Buffer.createIndexBuffer({
             context: context,
@@ -201,7 +195,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating an index buffer with invalid index data type${webglMessage}`, function () {
+      it(`throws when creating an index buffer with invalid index data type`, function () {
         expect(function () {
           buffer = Buffer.createIndexBuffer({
             context: context,
@@ -212,7 +206,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`throws when creating an index buffer with size of zero${webglMessage}`, function () {
+      it(`throws when creating an index buffer with size of zero`, function () {
         expect(function () {
           buffer = Buffer.createIndexBuffer({
             context: context,
@@ -223,7 +217,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`creates index buffer${webglMessage}`, function () {
+      it(`creates index buffer`, function () {
         buffer = Buffer.createIndexBuffer({
           context: context,
           sizeInBytes: 6,
@@ -239,7 +233,7 @@ describe(
         expect(buffer.numberOfIndices).toEqual(3);
       });
 
-      it(`copies array to an index buffer${webglMessage}`, function () {
+      it(`copies array to an index buffer`, function () {
         const sizeInBytes = 3 * Uint16Array.BYTES_PER_ELEMENT;
         const elements = new ArrayBuffer(sizeInBytes);
         const indices = new Uint16Array(elements);
@@ -256,7 +250,7 @@ describe(
         buffer.copyFromArrayView(elements);
       });
 
-      it(`can create an index buffer from a typed array${webglMessage}`, function () {
+      it(`can create an index buffer from a typed array`, function () {
         const typedArray = new Uint16Array(3);
         typedArray[0] = 1;
         typedArray[1] = 2;
@@ -273,7 +267,7 @@ describe(
         expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
       });
 
-      it(`can create an index buffer from a size in bytes${webglMessage}`, function () {
+      it(`can create an index buffer from a size in bytes`, function () {
         buffer = Buffer.createIndexBuffer({
           context: context,
           sizeInBytes: 6,
@@ -285,7 +279,7 @@ describe(
         expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
       });
 
-      it(`getBufferData throws without WebGL 2${webglMessage}`, function () {
+      it(`getBufferData throws without WebGL 2`, function () {
         if (context.webgl2) {
           return;
         }
@@ -302,7 +296,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`getBufferData throws without arrayView${webglMessage}`, function () {
+      it(`getBufferData throws without arrayView`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -318,7 +312,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`getBufferData throws with invalid sourceOffset${webglMessage}`, function () {
+      it(`getBufferData throws with invalid sourceOffset`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -338,7 +332,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`getBufferData throws with invalid destinationOffset${webglMessage}`, function () {
+      it(`getBufferData throws with invalid destinationOffset`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -358,7 +352,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`getBufferData throws with invalid length${webglMessage}`, function () {
+      it(`getBufferData throws with invalid length`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -378,7 +372,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`getBufferData reads from vertex buffer${webglMessage}`, function () {
+      it(`getBufferData reads from vertex buffer`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -401,7 +395,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it(`getBufferData reads from index buffer${webglMessage}`, function () {
+      it(`getBufferData reads from index buffer`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -423,7 +417,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it(`copyFromBuffer throws without WebGL 2${webglMessage}`, function () {
+      it(`copyFromBuffer throws without WebGL 2`, function () {
         if (context.webgl2) {
           return;
         }
@@ -444,7 +438,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`copyFromBuffer throws without readBuffer${webglMessage}`, function () {
+      it(`copyFromBuffer throws without readBuffer`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -460,7 +454,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`copyFromBuffer throws with invalid readOffset${webglMessage}`, function () {
+      it(`copyFromBuffer throws with invalid readOffset`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -487,7 +481,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`copyFromBuffer throws with invalid writeOffset${webglMessage}`, function () {
+      it(`copyFromBuffer throws with invalid writeOffset`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -514,7 +508,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`copyFromBuffer throws with invalid sizeInBytes${webglMessage}`, function () {
+      it(`copyFromBuffer throws with invalid sizeInBytes`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -544,7 +538,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`copyFromBuffer throws with one index buffer and the other is not an index buffer${webglMessage}`, function () {
+      it(`copyFromBuffer throws with one index buffer and the other is not an index buffer`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -568,7 +562,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`copyFromBuffer throws when readBuffer is the same buffer and copy range overlaps${webglMessage}`, function () {
+      it(`copyFromBuffer throws when readBuffer is the same buffer and copy range overlaps`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -587,7 +581,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`copyFromBuffer with vertex buffers${webglMessage}`, function () {
+      it(`copyFromBuffer with vertex buffers`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -616,7 +610,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it(`copyFromBuffer with index buffers${webglMessage}`, function () {
+      it(`copyFromBuffer with index buffers`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -647,7 +641,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it(`destroys${webglMessage}`, function () {
+      it(`destroys`, function () {
         const b = Buffer.createIndexBuffer({
           context: context,
           sizeInBytes: 3,
@@ -659,7 +653,7 @@ describe(
         expect(b.isDestroyed()).toEqual(true);
       });
 
-      it(`fails to provide an array view${webglMessage}`, function () {
+      it(`fails to provide an array view`, function () {
         buffer = Buffer.createVertexBuffer({
           context: context,
           sizeInBytes: 3,
@@ -670,7 +664,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`fails to copy a large array view${webglMessage}`, function () {
+      it(`fails to copy a large array view`, function () {
         buffer = Buffer.createVertexBuffer({
           context: context,
           sizeInBytes: 3,
@@ -683,7 +677,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(`fails to destroy${webglMessage}`, function () {
+      it(`fails to destroy`, function () {
         const b = Buffer.createIndexBuffer({
           context: context,
           sizeInBytes: 3,

--- a/packages/engine/Specs/Scene/Vector3DTileGeometrySpec.js
+++ b/packages/engine/Specs/Scene/Vector3DTileGeometrySpec.js
@@ -22,24 +22,16 @@ import {
   Vector3DTileGeometry,
 } from "../../index.js";
 
-import createContext from "../../../../Specs/createContext.js";
+import createWebglVersionHelper from "../createWebglVersionHelper.js";
 import createScene from "../../../../Specs/createScene.js";
 import pollToPromise from "../../../../Specs/pollToPromise.js";
 
 describe(
   "Scene/Vector3DTileGeometry",
   function () {
-    createGeometrySpecs({});
-    const c = createContext({});
-    // Don't repeat WebGL 1 tests when WebGL 2 is not supported
-    if (c.webgl2) {
-      createGeometrySpecs({});
-    }
-    c.destroyForSpecs();
+    createWebglVersionHelper(createGeometrySpecs);
 
     function createGeometrySpecs(contextOptions) {
-      const webglMessage = contextOptions.requestWebgl1 ? "" : "WebGL 2";
-
       let scene;
       let rectangle;
       let geometry;
@@ -330,7 +322,7 @@ describe(
         });
       }
 
-      it(`renders a single box${webglMessage}`, function () {
+      it(`renders a single box`, function () {
         const dimensions = new Cartesian3(1000000.0, 1000000.0, 1000000.0);
         const boxes = packBoxes([
           {
@@ -350,7 +342,7 @@ describe(
         });
       });
 
-      it(`renders multiple boxes${webglMessage}`, function () {
+      it(`renders multiple boxes`, function () {
         const dimensions = new Cartesian3(500000.0, 500000.0, 500000.0);
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
@@ -378,7 +370,7 @@ describe(
         });
       });
 
-      it(`renders a single cylinder${webglMessage}`, function () {
+      it(`renders a single cylinder`, function () {
         const radius = 1000000.0;
         const length = 1000000.0;
         const cylinders = packCylinders([
@@ -400,7 +392,7 @@ describe(
         });
       });
 
-      it(`renders multiple cylinders${webglMessage}`, function () {
+      it(`renders multiple cylinders`, function () {
         const radius = 500000.0;
         const length = 500000.0;
         const modelMatrices = [
@@ -431,7 +423,7 @@ describe(
         });
       });
 
-      it(`renders a single ellipsoid${webglMessage}`, function () {
+      it(`renders a single ellipsoid`, function () {
         const radii = new Cartesian3(500000.0, 500000.0, 500000.0);
         const ellipsoid = packEllipsoids([
           {
@@ -451,7 +443,7 @@ describe(
         });
       });
 
-      it(`renders multiple ellipsoids${webglMessage}`, function () {
+      it(`renders multiple ellipsoids`, function () {
         const radii = new Cartesian3(500000.0, 500000.0, 500000.0);
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(radii.x, 0.0, 0.0)),
@@ -479,7 +471,7 @@ describe(
         });
       });
 
-      it(`renders a single sphere${webglMessage}`, function () {
+      it(`renders a single sphere`, function () {
         const radius = 500000.0;
         const sphere = packSpheres([
           {
@@ -496,7 +488,7 @@ describe(
         });
       });
 
-      it(`renders multiple spheres${webglMessage}`, function () {
+      it(`renders multiple spheres`, function () {
         const radius = 500000.0;
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
@@ -521,7 +513,7 @@ describe(
         });
       });
 
-      it(`renders with multiple types of each geometry${webglMessage}`, function () {
+      it(`renders with multiple types of each geometry`, function () {
         const dimensions = new Cartesian3(125000.0, 125000.0, 125000.0);
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
@@ -607,7 +599,7 @@ describe(
         });
       });
 
-      it(`renders multiple geometries after a re-batch${webglMessage}`, function () {
+      it(`renders multiple geometries after a re-batch`, function () {
         const dimensions = new Cartesian3(125000.0, 125000.0, 125000.0);
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
@@ -701,7 +693,7 @@ describe(
         });
       });
 
-      it(`renders with inverted classification${webglMessage}`, function () {
+      it(`renders with inverted classification`, function () {
         const radii = new Cartesian3(100.0, 100.0, 1000.0);
         const ellipsoids = packEllipsoids([
           {
@@ -756,7 +748,7 @@ describe(
         });
       });
 
-      it(`renders wireframe${webglMessage}`, function () {
+      it(`renders wireframe`, function () {
         const origin = Rectangle.center(rectangle);
         const center = ellipsoid.cartographicToCartesian(origin);
         const modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
@@ -796,7 +788,7 @@ describe(
         });
       });
 
-      it(`renders based on classificationType${webglMessage}`, function () {
+      it(`renders based on classificationType`, function () {
         const radii = new Cartesian3(100.0, 100.0, 1000.0);
         const ellipsoids = packEllipsoids([
           {
@@ -866,7 +858,7 @@ describe(
         });
       });
 
-      it(`picks geometry${webglMessage}`, function () {
+      it(`picks geometry`, function () {
         const origin = Rectangle.center(rectangle);
         const center = ellipsoid.cartographicToCartesian(origin);
         const modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
@@ -914,7 +906,7 @@ describe(
         });
       });
 
-      it(`isDestroyed${webglMessage}`, function () {
+      it(`isDestroyed`, function () {
         geometry = new Vector3DTileGeometry({});
         expect(geometry.isDestroyed()).toEqual(false);
         geometry.destroy();

--- a/packages/engine/Specs/Scene/Vector3DTilePolygonsSpec.js
+++ b/packages/engine/Specs/Scene/Vector3DTilePolygonsSpec.js
@@ -6,6 +6,7 @@ import {
   destroyObject,
   Ellipsoid,
   GeometryInstance,
+  Math as CesiumMath,
   Rectangle,
   RectangleGeometry,
   Pass,
@@ -19,31 +20,19 @@ import {
   Vector3DTilePolygons,
 } from "../../index.js";
 
-import { Math as CesiumMath } from "../../index.js";
-
-import createContext from "../../../../Specs/createContext.js";
 import createScene from "../../../../Specs/createScene.js";
 import pollToPromise from "../../../../Specs/pollToPromise.js";
-
-// Testing of this feature in WebGL is currently disabled due to test
-// failures that started in https://github.com/CesiumGS/cesium/pull/8600.
-// Classification does NOT work reliably in WebGL2 anyway, see
-// https://github.com/CesiumGS/cesium/issues/8629
-const testInWebGL2 = false;
 
 describe(
   "Scene/Vector3DTilePolygons",
   function () {
     createPolygonSpecs({});
 
-    if (testInWebGL2) {
-      const c = createContext({});
-      // Don't repeat WebGL 1 tests when WebGL 2 is not supported
-      if (c.webgl2) {
-        createPolygonSpecs({});
-      }
-      c.destroyForSpecs();
-    }
+    // Testing of this feature in WebGL is currently disabled due to test
+    // failures that started in https://github.com/CesiumGS/cesium/pull/8600.
+    // Classification does NOT work reliably in WebGL2 anyway, see
+    // https://github.com/CesiumGS/cesium/issues/8629
+    //createWebglVersionHelper(createPolygonSpecs);
 
     function createPolygonSpecs(contextOptions) {
       const webglMessage = contextOptions.requestWebgl1 ? "" : "WebGL 2";

--- a/packages/engine/Specs/createWebglVersionHelper.js
+++ b/packages/engine/Specs/createWebglVersionHelper.js
@@ -1,0 +1,25 @@
+/**
+ * Repeats a block of specs in Webgl1 and Webgl2, if supported
+ * @param {createSpecCallback} createSpecs
+ */
+export default function createWebglVersionHelper(createSpecs) {
+  describe("with WebGL 1", function () {
+    createSpecs({
+      requestWebgl1: true,
+    });
+  });
+
+  describe("with WebGL 2", function () {
+    // Don't repeat tests unless WebGL 2 is supported
+    if (typeof WebGL2RenderingContext !== "undefined") {
+      createSpecs();
+    }
+  });
+}
+
+/**
+ * @callback createSpecCallback
+ *
+ * @param {ContextOptions} [contextOptions] options used to initialize context
+ *
+ */


### PR DESCRIPTION
Creating a context in the global scope has some background side effects, namely requesting some data files, which could cause side effects even in standalone tests.

* Remove any code which created context in the global state
* Create helper to test code in WebGL1/WebGL2, which was the offending reason the context was being created
* Updated testing guide to call out these cases, as well as how to use the helper function