### PR TITLE
Set depthTestAgainstTerrain when using the viewer with baseLayerPicker enabled

### DIFF
--- a/packages/engine/Source/Scene/DepthPlane.js
+++ b/packages/engine/Source/Scene/DepthPlane.js
@@ -125,7 +125,7 @@ DepthPlane.prototype.update = function (frameState) {
 
   const context = frameState.context;
 
-  // Allow offsetting the ellipsoid radius to address rendering artefacts below ellipsoid zero elevation.
+  // Allow offsetting the ellipsoid radius to address rendering artifacts below ellipsoid zero elevation.
   const radii = frameState.mapProjection.ellipsoid.radii;
   const ellipsoid = new Ellipsoid(
     radii.x + this._ellipsoidOffset,

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -720,6 +720,8 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
     if (createBaseLayerPicker) {
       baseLayerPicker.viewModel.selectedTerrain = undefined;
+      // Required as this is otherwise set by the baseLayerPicker
+      scene.globe.depthTestAgainstTerrain = true;
     }
 
     scene.setTerrain(options.terrain);


### PR DESCRIPTION
Due to https://github.com/CesiumGS/cesium/issues/6991, after changes in https://github.com/CesiumGS/cesium/pull/11059, it's required to set this value up front when the `terrain` viewer option is provided and `baseLayerPicker` is not set to `false` in order to not have any breaking behavior. This is because we are now bypassing the baseLayerPIcker entirely when setting the terrain provider on viewer creation.
