### PR TITLE
Replace calls to deprecated methods in Sandcastles

### DIFF
--- a/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
+++ b/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
@@ -42,7 +42,8 @@
           terrain: Cesium.Terrain.fromWorldTerrain(),
         });
 
-        viewer.scene.primitives.add(Cesium.createOsmBuildings());
+        const osmBuildingsTileset = await Cesium.createOsmBuildingsAsync();
+        viewer.scene.primitives.add(osmBuildingsTileset);
 
         viewer.scene.camera.flyTo({
           destination: Cesium.Cartesian3.fromDegrees(-74.019, 40.6912, 750),

--- a/Apps/Sandcastle/gallery/Clouds.html
+++ b/Apps/Sandcastle/gallery/Clouds.html
@@ -39,7 +39,8 @@
         });
 
         const scene = viewer.scene;
-        scene.primitives.add(Cesium.createOsmBuildings());
+        const osmBuildingsTileset = await Cesium.createOsmBuildingsAsync();
+        scene.primitives.add(osmBuildingsTileset);
 
         ///////////////////////////
         // Create clouds

--- a/packages/engine/Source/Scene/ImageryLayer.js
+++ b/packages/engine/Source/Scene/ImageryLayer.js
@@ -684,7 +684,7 @@ const terrainRectangleScratch = new Rectangle();
 ImageryLayer.prototype.getViewableRectangle = async function () {
   deprecationWarning(
     "ImageryLayer.getViewableRectangle",
-    "ImageryLayer.getViewableRectangle was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.getImageryRectangle instead."
+    "ImageryLayer.getViewableRectangle was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.getImageryRectangle instead."
   );
 
   const imageryProvider = this._imageryProvider;

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -2137,8 +2137,22 @@ function zoomToOrFly(that, zoomTarget, options, isFlight) {
 
     //If the zoom target is a rectangular imagery in an ImageLayer
     if (zoomTarget instanceof ImageryLayer) {
-      zoomTarget
-        .getViewableRectangle()
+      let rectanglePromise;
+
+      if (defined(zoomTarget.imageryProvider)) {
+        // This is here for backward compatibility. It can be removed when readyPromise is removed.
+        rectanglePromise = zoomTarget.imageryProvider._readyPromise.then(() => {
+          return zoomTarget.getImageryRectangle();
+        });
+      } else {
+        rectanglePromise = new Promise((resolve) => {
+          const removeListener = zoomTarget.readyEvent.addEventListener(() => {
+            removeListener();
+            resolve(zoomTarget.getImageryRectangle());
+          });
+        });
+      }
+      rectanglePromise
         .then(function (rectangle) {
           return computeFlyToLocationForRectangle(rectangle, that.scene);
         })


### PR DESCRIPTION
A couple Sandcastles were still using methods that were deprecated in https://github.com/CesiumGS/cesium/pull/11059