### PR TITLE
Use Matrix4.multiplyTransformation to update tile transforms

### DIFF
--- a/packages/engine/Source/Scene/Cesium3DTile.js
+++ b/packages/engine/Source/Scene/Cesium3DTile.js
@@ -1796,7 +1796,7 @@ Cesium3DTile.prototype.createBoundingVolume = function (
  */
 Cesium3DTile.prototype.updateTransform = function (parentTransform) {
   parentTransform = defaultValue(parentTransform, Matrix4.IDENTITY);
-  const computedTransform = Matrix4.multiply(
+  const computedTransform = Matrix4.multiplyTransformation(
     parentTransform,
     this.transform,
     scratchTransform


### PR DESCRIPTION
`Cesium3DTile.prototype.updateVisibility` is called for every tile in the scene, every pass of every frame. One of the most expensive operations within this call is the `Matrix4.multiply` in `updateTransform`.

This PR replaces `Matrix4.multiply` with the more efficient `Matrix4.multiplyTransformation`.