### PR TITLE
ContextOptions TypeScript fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@
 
 - Fixed atmosphere rendering performance issue. [10510](https://github.com/CesiumGS/cesium/issues/10510)
 
+#### @cesium/widgets
+
+##### Fixes :wrench:
+
+- Fixed missing `ContextOptions` in generated TypeScript definitions. [10963](https://github.com/CesiumGS/cesium/issues/10963)
+
+
 ### 1.104 - 2023-04-03
 
 #### Major Announcements :loudspeaker:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,6 @@
 
 - Fixed missing `ContextOptions` in generated TypeScript definitions. [10963](https://github.com/CesiumGS/cesium/issues/10963)
 
-
 ### 1.104 - 2023-04-03
 
 #### Major Announcements :loudspeaker:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -351,3 +351,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [L](https://github.com/L-hikari)
 - [Jacob Van Dine](https://github.com/JacobVanDine)
 - [Michael Cabana](https://github.com/mikecabana)
+- [Joseph Stanton](https://github.com/romejoe)

--- a/packages/widgets/tsd-conf.json
+++ b/packages/widgets/tsd-conf.json
@@ -4,6 +4,7 @@
   },
   "source": {
     "include": [
+      "packages/engine/Source/Renderer/Context.js",
       "packages/widgets/Source"
     ],
     "exclude": [


### PR DESCRIPTION
Recent versions of the '@cesium/widgets' package have failed to build in TypeScript projects, as reported in #10963, because of a missing `ContextOptions` reference. This pull request fixes that by including `ContextOptions` and `WebGLOptions` in the type definitions.