### PR TITLE
Fix rendering of emissive model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 ##### Fixes :wrench:
 
 - Fixed missing `ContextOptions` in generated TypeScript definitions. [10963](https://github.com/CesiumGS/cesium/issues/10963)
+- Fixed model rendering when emissiveTexture is defined and emissiveFactor is not. [#11215](https://github.com/CesiumGS/cesium/pull/11215)
 
 ### 1.104 - 2023-04-03
 
@@ -44,7 +45,6 @@ try {
 - Fixed ion URL in `RequestScheduler` throttling overrides. [#11193](https://github.com/CesiumGS/cesium/pull/11193)
 - Fixed `SingleTileImageryProvider` fetching image when `show` is `false` by allowing lazy-loading for `SingleTileImageryProvider` if `tileWidth` and `tileHeight` are provided to the constructor. [#9529](https://github.com/CesiumGS/cesium/issues/9529)
 - Fixed various race conditions from async operations. [#10909](https://github.com/CesiumGS/cesium/issues/10909)
-- Fixed model rendering when emissiveTexture is defined and emissiveFactor is not. [#11215](https://github.com/CesiumGS/cesium/pull/11215)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ try {
 - Fixed ion URL in `RequestScheduler` throttling overrides. [#11193](https://github.com/CesiumGS/cesium/pull/11193)
 - Fixed `SingleTileImageryProvider` fetching image when `show` is `false` by allowing lazy-loading for `SingleTileImageryProvider` if `tileWidth` and `tileHeight` are provided to the constructor. [#9529](https://github.com/CesiumGS/cesium/issues/9529)
 - Fixed various race conditions from async operations. [#10909](https://github.com/CesiumGS/cesium/issues/10909)
+- Fixed model rendering when emissiveTexture is defined and emissiveFactor is not. [#11215](https://github.com/CesiumGS/cesium/pull/11215)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/packages/engine/Source/Scene/Model/MaterialPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/MaterialPipelineStage.js
@@ -245,18 +245,6 @@ function processMaterialUniforms(
   defaultEmissiveTexture,
   disableTextures
 ) {
-  const emissiveTexture = material.emissiveTexture;
-  if (defined(emissiveTexture) && !disableTextures) {
-    processTexture(
-      shaderBuilder,
-      uniformMap,
-      emissiveTexture,
-      "u_emissiveTexture",
-      "EMISSIVE",
-      defaultEmissiveTexture
-    );
-  }
-
   const emissiveFactor = material.emissiveFactor;
   if (
     defined(emissiveFactor) &&
@@ -275,6 +263,18 @@ function processMaterialUniforms(
       undefined,
       ShaderDestination.FRAGMENT
     );
+
+    const emissiveTexture = material.emissiveTexture;
+    if (defined(emissiveTexture) && !disableTextures) {
+      processTexture(
+        shaderBuilder,
+        uniformMap,
+        emissiveTexture,
+        "u_emissiveTexture",
+        "EMISSIVE",
+        defaultEmissiveTexture
+      );
+    }
   }
 
   const normalTexture = material.normalTexture;

--- a/packages/engine/Specs/Scene/Model/MaterialPipelineStageSpec.js
+++ b/packages/engine/Specs/Scene/Model/MaterialPipelineStageSpec.js
@@ -12,6 +12,7 @@ import {
   ModelAlphaOptions,
   ModelStatistics,
   ModelLightingOptions,
+  ModelComponents,
   Pass,
   RenderState,
   Resource,
@@ -252,6 +253,59 @@ describe(
             metallicRoughness.metallicRoughnessTexture.texture,
           u_metallicFactor: metallicRoughness.metallicFactor,
           u_roughnessFactor: metallicRoughness.roughnessFactor,
+        };
+        expectUniformMap(uniformMap, expectedUniforms);
+      });
+    });
+
+    it("doesn't add emissive uniforms when emissive factor is default", function () {
+      return loadGltf(boomBox).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const primitive = components.nodes[0].primitives[0];
+
+        const material = primitive.material;
+        material.emissiveFactor = Cartesian3.clone(
+          ModelComponents.Material.DEFAULT_EMISSIVE_FACTOR
+        );
+        const metallicRoughness = material.metallicRoughness;
+
+        const renderResources = mockRenderResources();
+        const shaderBuilder = renderResources.shaderBuilder;
+        const uniformMap = renderResources.uniformMap;
+
+        MaterialPipelineStage.process(
+          renderResources,
+          primitive,
+          mockFrameState
+        );
+
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
+          "uniform sampler2D u_baseColorTexture;",
+          "uniform sampler2D u_metallicRoughnessTexture;",
+          "uniform sampler2D u_normalTexture;",
+          "uniform sampler2D u_occlusionTexture;",
+        ]);
+
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_BASE_COLOR_TEXTURE",
+          "HAS_METALLIC_ROUGHNESS_TEXTURE",
+          "HAS_NORMAL_TEXTURE",
+          "HAS_OCCLUSION_TEXTURE",
+          "TEXCOORD_BASE_COLOR v_texCoord_0",
+          "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
+          "TEXCOORD_OCCLUSION v_texCoord_0",
+          "USE_METALLIC_ROUGHNESS",
+        ]);
+
+        const expectedUniforms = {
+          u_normalTexture: material.normalTexture.texture,
+          u_occlusionTexture: material.occlusionTexture.texture,
+          u_baseColorTexture: metallicRoughness.baseColorTexture.texture,
+          u_metallicRoughnessTexture:
+            metallicRoughness.metallicRoughnessTexture.texture,
         };
         expectUniformMap(uniformMap, expectedUniforms);
       });


### PR DESCRIPTION
When `emissiveFactor` does not exist, there is no need to process `emissiveTexture` because `emissiveFactor` defaults to [0.0, 0.0, 0.0], and it can also reduce one texture sample in the shader

Also fix #11209 