### PR TITLE
Fix scope of proxy definition

### DIFF
--- a/packages/engine/Source/Scene/IonImageryProvider.js
+++ b/packages/engine/Source/Scene/IonImageryProvider.js
@@ -296,18 +296,18 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       return this._imageryProvider.hasAlphaChannel;
     },
+  },
 
-    /**
-     * Gets the proxy used by this provider.
-     * @memberof IonImageryProvider.prototype
-     * @type {Proxy}
-     * @readonly
-     * @default undefined
-     */
-    proxy: {
-      get: function () {
-        return undefined;
-      },
+  /**
+   * Gets the proxy used by this provider.
+   * @memberof IonImageryProvider.prototype
+   * @type {Proxy}
+   * @readonly
+   * @default undefined
+   */
+  proxy: {
+    get: function () {
+      return undefined;
     },
   },
 


### PR DESCRIPTION
The `proxy` was defined in the `hasAlphaChannel` scope.
