### PR TITLE
Fix some comments of Cesium3DTileset and Viewer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -353,3 +353,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jacob Van Dine](https://github.com/JacobVanDine)
 - [Michael Cabana](https://github.com/mikecabana)
 - [Joseph Stanton](https://github.com/romejoe)
+- [Zehua Hu](https://github.com/lanvada)

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -141,7 +141,7 @@ import Cesium3DTilesetSkipTraversal from "./Cesium3DTilesetSkipTraversal.js";
  * try {
  *   const tileset = await Cesium.Cesium3DTileset.fromUrl(
  *      "http://localhost:8002/tilesets/Seattle/tileset.json"
- *   });
+ *   );
  *   scene.primitives.add(tileset);
  * } catch (error) {
  *   console.error(`Error creating tileset: ${error}`);
@@ -2029,7 +2029,7 @@ Cesium3DTileset.fromIonAssetId = async function (assetId, options) {
  * used for streaming massive heterogeneous 3D geospatial datasets.
  *
  * @param {Resource|string} url The url to a tileset JSON file.
- * @param {Cesium3DTileset.ConstructorOptions} options An object describing initialization options
+ * @param {Cesium3DTileset.ConstructorOptions} [options] An object describing initialization options
  * @returns {Promise<Cesium3DTileset>}
  *
  * @exception {DeveloperError} The tileset must be 3D Tiles version 0.0 or 1.0.
@@ -2040,7 +2040,7 @@ Cesium3DTileset.fromIonAssetId = async function (assetId, options) {
  * try {
  *   const tileset = await Cesium.Cesium3DTileset.fromUrl(
  *      "http://localhost:8002/tilesets/Seattle/tileset.json"
- *   });
+ *   );
  *   scene.primitives.add(tileset);
  * } catch (error) {
  *   console.error(`Error creating tileset: ${error}`);

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -317,7 +317,7 @@ function enableVRUI(viewer, enabled) {
  * @property {ImageryProvider|false} [imageryProvider=createWorldImagery()] The imagery provider to use.  This value is only valid if `baseLayerPicker` is set to false. Deprecated.
  * @property {ImageryLayer|false} [baseLayer=ImageryLayer.fromWorldImagery()] The bottommost imagery layer applied to the globe. If set to <code>false</code>, no imagery provider will be added. This value is only valid if `baseLayerPicker` is set to false.
  * @property {TerrainProvider} [terrainProvider=new EllipsoidTerrainProvider()] The terrain provider to use
- * @property {Terrain} [options.terrain] A terrain object which handles asynchronous terrain provider. Can only specify if options.terrainProvider is undefined.
+ * @property {Terrain} [terrain] A terrain object which handles asynchronous terrain provider. Can only specify if options.terrainProvider is undefined.
  * @property {SkyBox|false} [skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used. If set to <code>false</code>, no skyBox, Sun, or Moon will be added.
  * @property {SkyAtmosphere|false} [skyAtmosphere] Blue sky, and the glow around the Earth's limb.  Set to <code>false</code> to turn it off.
  * @property {Element|string} [fullscreenElement=document.body] The element or id to be placed into fullscreen mode when the full screen button is pressed.


### PR DESCRIPTION
Comment of `Cesium3DTileset.fromUrl`
1. From the usage example, the `options` parameter should be optional.
2. Fix the syntax error of constructor examples

Comment of `Viewer.ConstructorOptions`
1. The terrain parameter should be `terrain` not `options.terrain`