### PR TITLE
10957 zoom to entities without globe fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Fixed an issue when zooming in an orthographic frustum. [#11206](https://github.com/CesiumGS/cesium/pull/11206)
 - Fixed atmosphere rendering performance issue. [10510](https://github.com/CesiumGS/cesium/issues/10510)
 - Fixed model rendering when emissiveTexture is defined and emissiveFactor is not. [#11215](https://github.com/CesiumGS/cesium/pull/11215)
+- Fixed crashing when zooming to an entity without globe present. [#10957](https://github.com/CesiumGS/cesium/pull/11226)
 
 #### @cesium/widgets
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -354,3 +354,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Michael Cabana](https://github.com/mikecabana)
 - [Joseph Stanton](https://github.com/romejoe)
 - [Zehua Hu](https://github.com/lanvada)
+- [Jason Summercamp](https://github.com/fullstacc)

--- a/packages/engine/Source/DataSources/ModelVisualizer.js
+++ b/packages/engine/Source/DataSources/ModelVisualizer.js
@@ -18,7 +18,6 @@ import BoundingSphereState from "./BoundingSphereState.js";
 import Property from "./Property.js";
 import sampleTerrainMostDetailed from "../Core/sampleTerrainMostDetailed.js";
 import Cartographic from "../Core/Cartographic.js";
-import Ellipsoid from "../Core/Ellipsoid.js";
 
 const defaultScale = 1.0;
 const defaultMinimumPixelSize = 0.0;
@@ -446,13 +445,13 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
 
   const scene = this._scene;
   const globe = scene.globe;
-  // Check if the globe is undefined and use a substitute ellipsoid if it is not
-  const ellipsoid = globe ? globe.ellipsoid : Ellipsoid.WGS84;
+
   // cannot access a terrainprovider if there is not one; formally set to undefined
   const terrainProvider = globe ? globe.terrainProvider : undefined;
 
   const hasHeightReference = model.heightReference !== HeightReference.NONE;
-  if (hasHeightReference) {
+  if (globe !== undefined && hasHeightReference) {
+    const ellipsoid = globe.ellipsoid;
     // We cannot query the availability of the terrain provider till its ready, so the
     // bounding sphere state will remain pending till the terrain provider is ready.
     // ready is deprecated. This is here for backwards compatibility

--- a/packages/engine/Source/DataSources/ModelVisualizer.js
+++ b/packages/engine/Source/DataSources/ModelVisualizer.js
@@ -18,6 +18,7 @@ import BoundingSphereState from "./BoundingSphereState.js";
 import Property from "./Property.js";
 import sampleTerrainMostDetailed from "../Core/sampleTerrainMostDetailed.js";
 import Cartographic from "../Core/Cartographic.js";
+import Ellipsoid from "../Core/Ellipsoid.js";
 
 const defaultScale = 1.0;
 const defaultMinimumPixelSize = 0.0;
@@ -63,6 +64,7 @@ function ModelVisualizer(scene, entityCollection) {
   this._entityCollection = entityCollection;
   this._modelHash = {};
   this._entitiesToVisualize = new AssociativeArray();
+
   this._onCollectionChanged(entityCollection, entityCollection.values, [], []);
 }
 
@@ -444,8 +446,10 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
 
   const scene = this._scene;
   const globe = scene.globe;
-  const ellipsoid = globe.ellipsoid;
-  const terrainProvider = globe.terrainProvider;
+  // Check if the globe is undefined and use a substitute ellipsoid if it is not
+  const ellipsoid = globe ? globe.ellipsoid : Ellipsoid.WGS84;
+  // cannot access a terrainprovider if there is not one; formally set to undefined
+  const terrainProvider = globe ? globe.terrainProvider : undefined;
 
   const hasHeightReference = model.heightReference !== HeightReference.NONE;
   if (hasHeightReference) {

--- a/packages/engine/Source/DataSources/ModelVisualizer.js
+++ b/packages/engine/Source/DataSources/ModelVisualizer.js
@@ -450,7 +450,7 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
   const terrainProvider = globe ? globe.terrainProvider : undefined;
 
   const hasHeightReference = model.heightReference !== HeightReference.NONE;
-  if (globe !== undefined && hasHeightReference) {
+  if (defined(globe) && hasHeightReference) {
     const ellipsoid = globe.ellipsoid;
     // We cannot query the availability of the terrain provider till its ready, so the
     // bounding sphere state will remain pending till the terrain provider is ready.

--- a/packages/engine/Source/DataSources/ModelVisualizer.js
+++ b/packages/engine/Source/DataSources/ModelVisualizer.js
@@ -446,9 +446,8 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
   const scene = this._scene;
   const globe = scene.globe;
 
-  // cannot access a terrainprovider if there is not one; formally set to undefined
-  const terrainProvider = globe ? globe.terrainProvider : undefined;
-
+  // cannot access a terrain provider if there is no globe; formally set to undefined
+  const terrainProvider = defined(globe) ? globe.terrainProvider : undefined;
   const hasHeightReference = model.heightReference !== HeightReference.NONE;
   if (defined(globe) && hasHeightReference) {
     const ellipsoid = globe.ellipsoid;

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -28,7 +28,7 @@ import {
 } from "../../index.js";
 import createScene from "../../../../Specs/createScene.js";
 import pollToPromise from "../../../../Specs/pollToPromise.js";
-import { Viewer } from "../../Source/Widgets/Viewer/Viewer.js";
+import createViewer from "../../../../Specs/createViewer.js";
 
 describe(
   "DataSources/ModelVisualizer",
@@ -759,7 +759,7 @@ describe(
       document.body.appendChild(container);
 
       // Create viewer with globe disabled
-      const viewer = new Viewer(container, {
+      const viewer = createViewer(container, {
         globe: false,
         infoBox: false,
         selectionIndicator: false,

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -750,8 +750,10 @@ describe(
     });
 
     it("does not throw error when globe is not present while zooming to entity", async function () {
-      // Disable the globe
-      scene.globe = undefined;
+      // Create a mock globe object with an undefined terrainProvider
+      const originalGlobe = scene.globe;
+      const mockGlobe = { terrainProvider: undefined };
+      scene.globe = mockGlobe;
 
       // Create a new entity with position and model
       const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000);
@@ -772,6 +774,9 @@ describe(
       } catch (error) {
         errorOccurred = true;
       }
+
+      // Restore the original globe
+      scene.globe = originalGlobe;
 
       // If no error occurred while getting the bounding sphere, the test case passes
       expect(errorOccurred).toBe(false);

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -751,12 +751,13 @@ describe(
 
     it("does not throw error when globe is not present while zooming to entity", async function () {
       // Create a custom viewer object without a globe
+      const customEntityCollection = new EntityCollection();
       const customViewer = {
         scene: {
           ...scene,
           globe: undefined,
         },
-        entities: entityCollection,
+        entities: customEntityCollection,
       };
 
       // Create a new ModelVisualizer using the custom viewer

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -748,6 +748,34 @@ describe(
         visualizer.getBoundingSphere(testObject, undefined);
       }).toThrowDeveloperError();
     });
+
+    it("does not throw error when globe is not present while zooming to entity", async function () {
+      // Disable the globe
+      scene.globe = undefined;
+
+      // Create a new entity with position and model
+      const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000);
+      const testObject = entityCollection.getOrCreateEntity("test");
+      const model = new ModelGraphics();
+      testObject.model = model;
+      testObject.position = new ConstantProperty(position);
+      model.uri = new ConstantProperty(boxUrl);
+
+      // Update the visualizer
+      visualizer.update(JulianDate.now());
+
+      // Try to get the bounding sphere
+      const result = new BoundingSphere();
+      let errorOccurred = false;
+      try {
+        visualizer.getBoundingSphere(testObject, result);
+      } catch (error) {
+        errorOccurred = true;
+      }
+
+      // If no error occurred while getting the bounding sphere, the test case passes
+      expect(errorOccurred).toBe(false);
+    });
   },
   "WebGL"
 );

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -764,7 +764,7 @@ describe(
 
       // Create a new entity with position and model
       const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000);
-      const testObject = entityCollection.getOrCreateEntity("test");
+      const testObject = customViewer.entities.getOrCreateEntity("test");
       const model = new ModelGraphics();
       testObject.model = model;
       testObject.position = new ConstantProperty(position);

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -750,10 +750,17 @@ describe(
     });
 
     it("does not throw error when globe is not present while zooming to entity", async function () {
-      // Create a mock globe object with an undefined terrainProvider
-      const originalGlobe = scene.globe;
-      const mockGlobe = { terrainProvider: undefined };
-      scene.globe = mockGlobe;
+      // Create a custom viewer object without a globe
+      const customViewer = {
+        scene: {
+          ...scene,
+          globe: undefined,
+        },
+        entities: entityCollection,
+      };
+
+      // Create a new ModelVisualizer using the custom viewer
+      const customVisualizer = new ModelVisualizer(customViewer);
 
       // Create a new entity with position and model
       const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000);
@@ -763,22 +770,15 @@ describe(
       testObject.position = new ConstantProperty(position);
       model.uri = new ConstantProperty(boxUrl);
 
-      // Update the visualizer
-      visualizer.update(JulianDate.now());
-
-      // Try to get the bounding sphere
-      const result = new BoundingSphere();
+      // Try to update the custom visualizer
       let errorOccurred = false;
       try {
-        visualizer.getBoundingSphere(testObject, result);
+        customVisualizer.update(JulianDate.now());
       } catch (error) {
         errorOccurred = true;
       }
 
-      // Restore the original globe
-      scene.globe = originalGlobe;
-
-      // If no error occurred while getting the bounding sphere, the test case passes
+      // If no error occurred while updating the custom visualizer, the test case passes
       expect(errorOccurred).toBe(false);
     });
   },

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -749,46 +749,31 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("does not throw error when globe is not present while zooming to entity", function () {
-      // Create a custom viewer object without a globe
-      const customEntityCollection = new EntityCollection();
-      const customViewer = {
-        scene: {
-          ...scene,
-          globe: undefined,
-        },
-        entities: customEntityCollection,
-      };
-
-      // Create a new ModelVisualizer using the custom viewer
-      const customVisualizer = new ModelVisualizer(customViewer);
+    it("does not throw error when globe is not present while zooming to entity", async function () {
+      // Temporarily remove the globe
+      const originalGlobe = scene.globe;
+      scene.globe = undefined;
 
       // Create a new entity with position and model
       const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000);
-      const testObject = customViewer.entities.getOrCreateEntity("test");
+      const testObject = entityCollection.getOrCreateEntity("test");
       const model = new ModelGraphics();
       testObject.model = model;
       testObject.position = new ConstantProperty(position);
       model.uri = new ConstantProperty(boxUrl);
 
-      // Set the camera view to simulate zooming to the entity
-      const heading = 0.0;
-      const pitch = -CesiumMath.PI_OVER_TWO;
-      const roll = 0.0;
-      customViewer.scene.camera.setView({
-        destination: position,
-        orientation: { heading, pitch, roll },
-      });
-
-      // Try to update the custom visualizer
+      // Update the visualizer
       let errorOccurred = false;
       try {
-        customVisualizer.update(JulianDate.now());
+        visualizer.update(JulianDate.now());
       } catch (error) {
         errorOccurred = true;
       }
 
-      // If no error occurred while updating the custom visualizer, the test case passes
+      // Restore the original globe
+      scene.globe = originalGlobe;
+
+      // If no error occurred while updating the visualizer, the test case passes
       expect(errorOccurred).toBe(false);
     });
   },

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -750,36 +750,43 @@ describe(
     });
 
     it("does not throw error when globe is not present while zooming to entity", async function () {
-      // Create a custom viewer object without a globe
-      const customEntityCollection = new EntityCollection();
-      const customViewer = {
-        scene: {
-          ...scene,
-          globe: undefined,
-        },
-        entities: customEntityCollection,
-      };
+      // Set the scene's globe to undefined
+      scene.globe = undefined;
 
-      // Create a new ModelVisualizer using the custom viewer
-      const customVisualizer = new ModelVisualizer(customViewer);
+      // Create a new ModelVisualizer using the scene
+      const customVisualizer = new ModelVisualizer(scene);
 
       // Create a new entity with position and model
       const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000);
-      const testObject = customViewer.entities.getOrCreateEntity("test");
-      const model = new ModelGraphics();
-      testObject.model = model;
-      testObject.position = new ConstantProperty(position);
-      model.uri = new ConstantProperty(boxUrl);
+      scene.entities.add({
+        position: position,
+        model: {
+          uri: boxUrl,
+        },
+      });
 
-      // Try to update the custom visualizer
+      // Update the custom visualizer
+      customVisualizer.update(JulianDate.now());
+
+      // Zoom to the entity
       let errorOccurred = false;
       try {
-        customVisualizer.update(JulianDate.now());
+        await scene.camera.flyTo({
+          destination: position,
+          orientation: {
+            heading: 0,
+            pitch: -Math.PI / 2,
+            roll: 0,
+          },
+          duration: 0,
+        });
+
+        await scene.zoomTo(scene.entities);
       } catch (error) {
         errorOccurred = true;
       }
 
-      // If no error occurred while updating the custom visualizer, the test case passes
+      // If no error occurred while zooming to the entity, the test case passes
       expect(errorOccurred).toBe(false);
     });
   },

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -749,7 +749,7 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("does not throw error when globe is not present while zooming to entity", async function () {
+    it("does not throw error when globe is not present while zooming to entity", function () {
       // Create a custom viewer object without a globe
       const customEntityCollection = new EntityCollection();
       const customViewer = {
@@ -760,6 +760,9 @@ describe(
         entities: customEntityCollection,
       };
 
+      // Create a new ModelVisualizer using the custom viewer
+      const customVisualizer = new ModelVisualizer(customViewer);
+
       // Create a new entity with position and model
       const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000);
       const testObject = customViewer.entities.getOrCreateEntity("test");
@@ -768,29 +771,24 @@ describe(
       testObject.position = new ConstantProperty(position);
       model.uri = new ConstantProperty(boxUrl);
 
-      // Set the custom viewer's camera view to the entity's position (looking straight down)
-      const camera = customViewer.scene.camera;
-      const heading = 0;
+      // Set the camera view to simulate zooming to the entity
+      const heading = 0.0;
       const pitch = -CesiumMath.PI_OVER_TWO;
-      camera.setView({
+      const roll = 0.0;
+      customViewer.scene.camera.setView({
         destination: position,
-        orientation: {
-          heading: heading,
-          pitch: pitch,
-          roll: 0.0,
-        },
+        orientation: { heading, pitch, roll },
       });
 
-      // Try to update the scene
+      // Try to update the custom visualizer
       let errorOccurred = false;
       try {
-        customViewer.scene.initializeFrame();
-        customViewer.scene.render(JulianDate.now());
+        customVisualizer.update(JulianDate.now());
       } catch (error) {
         errorOccurred = true;
       }
 
-      // If no error occurred while updating the custom viewer's scene, the test case passes
+      // If no error occurred while updating the custom visualizer, the test case passes
       expect(errorOccurred).toBe(false);
     });
   },

--- a/packages/widgets/Specs/Viewer/ViewerSpec.js
+++ b/packages/widgets/Specs/Viewer/ViewerSpec.js
@@ -47,7 +47,7 @@ import {
   Timeline,
 } from "../../index.js";
 
-import createViewer from "../../../../Specs/createViewer.js";
+import createViewer from "../createViewer.js";
 import DomEventSimulator from "../../../../Specs/DomEventSimulator.js";
 import MockDataSource from "../../../../Specs/MockDataSource.js";
 import pollToPromise from "../../../../Specs/pollToPromise.js";
@@ -1549,6 +1549,34 @@ describe(
       return promise.then(function () {
         expect(wasCompleted).toEqual(true);
       });
+    });
+
+    it("zoomTo zooms to entity when globe is disabled", async function () {
+      // Create viewer with globe disabled
+      const viewer = createViewer(container, {
+        globe: false,
+        infoBox: false,
+        selectionIndicator: false,
+        shadows: true,
+        shouldAnimate: true,
+      });
+
+      // Create position variable
+      const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 1000.0);
+
+      // Add entity to viewer
+      const entity = viewer.entities.add({
+        position: position,
+        model: {
+          uri: "../SampleData/models/CesiumAir/Cesium_Air.glb",
+        },
+      });
+
+      await viewer.zoomTo(entity);
+
+      // Verify that no errors occurred
+      expect(viewer.scene).toBeDefined();
+      expect(viewer.scene.errorEvent).toBeUndefined();
     });
 
     it("flyTo throws if target is not defined", function () {

--- a/packages/widgets/Specs/Viewer/viewerDragDropMixinSpec.js
+++ b/packages/widgets/Specs/Viewer/viewerDragDropMixinSpec.js
@@ -2,7 +2,7 @@ import { defined, TimeInterval } from "@cesium/engine";
 
 import { viewerDragDropMixin } from "../../index.js";
 
-import createViewer from "../../../../Specs/createViewer.js";
+import createViewer from "../createViewer.js";
 import DomEventSimulator from "../../../../Specs/DomEventSimulator.js";
 import pollToPromise from "../../../../Specs/pollToPromise.js";
 

--- a/packages/widgets/Specs/Viewer/viewerPerformanceWatchdogMixinSpec.js
+++ b/packages/widgets/Specs/Viewer/viewerPerformanceWatchdogMixinSpec.js
@@ -2,7 +2,7 @@ import {
   PerformanceWatchdog,
   viewerPerformanceWatchdogMixin,
 } from "../../index.js";
-import createViewer from "../../../../Specs/createViewer.js";
+import createViewer from "../createViewer.js";
 
 describe(
   "Widgets/Viewer/viewerPerformanceWatchdogMixin",

--- a/packages/widgets/Specs/createViewer.js
+++ b/packages/widgets/Specs/createViewer.js
@@ -1,7 +1,7 @@
 import { defaultValue } from "@cesium/engine";
-import { Viewer } from "@cesium/widgets";
+import { Viewer } from "../index.js";
 
-import getWebGLStub from "./getWebGLStub.js";
+import getWebGLStub from "../../../Specs/getWebGLStub.js";
 
 function createViewer(container, options) {
   options = defaultValue(options, {});


### PR DESCRIPTION
Fixes #10957 .
- Added 2 lines which check for the presence of a globe & terrain provider and adds a substitute ellipsoid if globe doesn't exist.
- Based on the description for the issue, I looked at the other visualizers and didn't see this needed in any of the others

<img width="952" alt="Screenshot 2023-04-12 070841" src="https://user-images.githubusercontent.com/5422043/231467384-1e0047fc-f1b8-457d-8852-e858c300eb30.png">

The behavior noted from the issue is fixed