### PR TITLE
Use alpha from rendered scene in AmbientOcclusionModulate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Fixed a crash when Cesium3DTileStyle's scaleByDistance, translucencyByDistance or distanceDisplayCondition set to StyleExpression
   which returns `undefined`. [#11228](https://github.com/CesiumGS/cesium/pull/11228)
 - Fixed handling of `out_FragColor` layout declarations when translating shaders to WebGL1. [#11230](https://github.com/CesiumGS/cesium/pull/11230)
+- Fixed a problem with Ambient Occlusion that affected some MacOS hardware. [#10106](https://github.com/CesiumGS/cesium/issues/10106)
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
+++ b/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
@@ -58,7 +58,7 @@ void main(void)
     float gapAngle = 90.0 * czm_radiansPerDegree;
 
     // RandomNoise
-    float randomVal = texture(randomTexture, v_textureCoordinates).x;
+    float randomVal = texture(randomTexture, v_textureCoordinates / pixelSize / 255.0).x;
 
     //Loop for each direction
     for (int i = 0; i < 4; i++)

--- a/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionModulate.glsl
+++ b/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionModulate.glsl
@@ -5,7 +5,7 @@ in vec2 v_textureCoordinates;
 
 void main(void)
 {
-    vec3 color = texture(colorTexture, v_textureCoordinates).rgb;
-    vec3 ao = texture(ambientOcclusionTexture, v_textureCoordinates).rgb;
-    out_FragColor.rgb = ambientOcclusionOnly ? ao : ao * color;
+    vec4 color = texture(colorTexture, v_textureCoordinates);
+    vec4 ao = texture(ambientOcclusionTexture, v_textureCoordinates);
+    out_FragColor = ambientOcclusionOnly ? ao : ao * color;
 }


### PR DESCRIPTION
Partially addresses #10106. `AmbientOcclusionModulate.glsl` was not setting an output alpha, which broke ambient occlusion on some hardware.

Thanks @shotamatsuda for tracking down the problem!