### PR TITLE
Update requestsByServer defaults

### DIFF
--- a/packages/engine/Source/Core/RequestScheduler.js
+++ b/packages/engine/Source/Core/RequestScheduler.js
@@ -65,18 +65,23 @@ RequestScheduler.maximumRequests = 50;
 RequestScheduler.maximumRequestsPerServer = 6;
 
 /**
- * A per server key list of overrides to use for throttling instead of <code>maximumRequestsPerServer</code>
+ * A per server key list of overrides to use for throttling instead of <code>maximumRequestsPerServer</code>.
+ * Useful when streaming data from a known HTTP/2 or HTTP/3 server.
  * @type {object}
  *
  * @example
+ * RequestScheduler.requestsByServer["myserver.com:443"] = 18;
+ *
+ * @example
  * RequestScheduler.requestsByServer = {
- *   'api.cesium.com:443': 18,
- *   'assets.cesium.com:443': 18
+ *   "api.cesium.com:443": 18,
+ *   "assets.cesium.com:443": 18,
  * };
  */
 RequestScheduler.requestsByServer = {
   "api.cesium.com:443": 18,
   "assets.ion.cesium.com:443": 18,
+  "ibasemaps-api.arcgis.com:443": 18,
 };
 
 /**


### PR DESCRIPTION
Improves baseline performance for the default urls included in https://github.com/CesiumGS/cesium/pull/11098.

This also updates the doc to add a bit more explanation about when setting this value is useful.