### PR TITLE
Support `Color.fromCssColorString` parsing `rgb(a)`/`hsl(a)` CSS colors with modern "space-separated" syntax

### DIFF
--- a/packages/engine/Source/Core/Color.js
+++ b/packages/engine/Source/Core/Color.js
@@ -352,9 +352,9 @@ const rgbaMatcher = /^#([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])?$/i;
 //#rrggbbaa
 const rrggbbaaMatcher = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?$/i;
 //rgb(), rgba(), or rgb%()
-const rgbParenthesesMatcher = /^rgba?\(\s*([0-9.]+%?)\s*,\s*([0-9.]+%?)\s*,\s*([0-9.]+%?)(?:\s*,\s*([0-9.]+))?\s*\)$/i;
+const rgbParenthesesMatcher = /^rgba?\(\s*([0-9.]+%?)\s*[,\s]\s*([0-9.]+%?)\s*[,\s]\s*([0-9.]+%?)(?:\s*[,\s/]\s*([0-9.]+))?\s*\)$/i;
 //hsl() or hsla()
-const hslParenthesesMatcher = /^hsla?\(\s*([0-9.]+)\s*,\s*([0-9.]+%)\s*,\s*([0-9.]+%)(?:\s*,\s*([0-9.]+))?\s*\)$/i;
+const hslParenthesesMatcher = /^hsla?\(\s*([0-9.]+)\s*[,\s]\s*([0-9.]+%)\s*[,\s]\s*([0-9.]+%)(?:\s*[,\s/]\s*([0-9.]+))?\s*\)$/i;
 
 /**
  * Creates a Color instance from a CSS color value.

--- a/packages/engine/Specs/Core/ColorSpec.js
+++ b/packages/engine/Specs/Core/ColorSpec.js
@@ -244,11 +244,29 @@ describe("Core/Color", function () {
     );
   });
 
+  it("fromCssColorString supports the rgb() format with absolute values (space-separated)", function () {
+    expect(Color.fromCssColorString("rgb(255 0 0)")).toEqual(Color.RED);
+    expect(Color.fromCssColorString("rgb(0 255 0)")).toEqual(Color.LIME);
+    expect(Color.fromCssColorString("rgb(0 0 255)")).toEqual(Color.BLUE);
+    expect(Color.fromCssColorString("rgb(51 102 204)")).toEqual(
+      new Color(0.2, 0.4, 0.8, 1.0)
+    );
+  });
+
   it("fromCssColorString supports the rgb() format with percentages", function () {
     expect(Color.fromCssColorString("rgb(100%, 0, 0)")).toEqual(Color.RED);
     expect(Color.fromCssColorString("rgb(0, 100%, 0)")).toEqual(Color.LIME);
     expect(Color.fromCssColorString("rgb(0, 0, 100%)")).toEqual(Color.BLUE);
     expect(Color.fromCssColorString("rgb(20%, 40%, 80%)")).toEqual(
+      new Color(0.2, 0.4, 0.8, 1.0)
+    );
+  });
+
+  it("fromCssColorString supports the rgb() format with percentages (space-separated)", function () {
+    expect(Color.fromCssColorString("rgb(100% 0 0)")).toEqual(Color.RED);
+    expect(Color.fromCssColorString("rgb(0 100% 0)")).toEqual(Color.LIME);
+    expect(Color.fromCssColorString("rgb(0 0 100%)")).toEqual(Color.BLUE);
+    expect(Color.fromCssColorString("rgb(20% 40% 80%)")).toEqual(
       new Color(0.2, 0.4, 0.8, 1.0)
     );
   });
@@ -266,6 +284,19 @@ describe("Core/Color", function () {
     );
   });
 
+  it("fromCssColorString supports the rgba() format with absolute values (space-separated)", function () {
+    expect(Color.fromCssColorString("rgba(255 0 0 / 1.0)")).toEqual(Color.RED);
+    expect(Color.fromCssColorString("rgba(0 255 0 / 1.0)")).toEqual(
+      Color.LIME
+    );
+    expect(Color.fromCssColorString("rgba(0 0 255 / 1.0)")).toEqual(
+      Color.BLUE
+    );
+    expect(Color.fromCssColorString("rgba(51 102 204 / 0.6)")).toEqual(
+      new Color(0.2, 0.4, 0.8, 0.6)
+    );
+  });
+
   it("fromCssColorString supports the rgba() format with percentages", function () {
     expect(Color.fromCssColorString("rgba(100%, 0, 0, 1.0)")).toEqual(
       Color.RED
@@ -277,6 +308,21 @@ describe("Core/Color", function () {
       Color.BLUE
     );
     expect(Color.fromCssColorString("rgba(20%, 40%, 80%, 0.6)")).toEqual(
+      new Color(0.2, 0.4, 0.8, 0.6)
+    );
+  });
+
+  it("fromCssColorString supports the rgba() format with percentages (space-separated)", function () {
+    expect(Color.fromCssColorString("rgba(100% 0 0 / 1.0)")).toEqual(
+      Color.RED
+    );
+    expect(Color.fromCssColorString("rgba(0 100% 0 / 1.0)")).toEqual(
+      Color.LIME
+    );
+    expect(Color.fromCssColorString("rgba(0 0 100% / 1.0)")).toEqual(
+      Color.BLUE
+    );
+    expect(Color.fromCssColorString("rgba(20% 40% 80% / 0.6)")).toEqual(
       new Color(0.2, 0.4, 0.8, 0.6)
     );
   });
@@ -297,6 +343,16 @@ describe("Core/Color", function () {
     );
   });
 
+  it("fromCssColorString supports the hsl() format (space-separated)", function () {
+    expect(Color.fromCssColorString("hsl(0 100% 50%)")).toEqual(Color.RED);
+    expect(Color.fromCssColorString("hsl(120 100% 50%)")).toEqual(Color.LIME);
+    expect(Color.fromCssColorString("hsl(240 100% 50%)")).toEqual(Color.BLUE);
+    expect(Color.fromCssColorString("hsl(220 60% 50%)")).toEqualEpsilon(
+      new Color(0.2, 0.4, 0.8),
+      CesiumMath.EPSILON15
+    );
+  });
+
   it("fromCssColorString supports the hsla() format", function () {
     expect(Color.fromCssColorString("hsla(0, 100%, 50%, 1.0)")).toEqual(
       Color.RED
@@ -308,6 +364,22 @@ describe("Core/Color", function () {
       Color.BLUE
     );
     expect(Color.fromCssColorString("hsla(220, 60%, 50%, 0.6)")).toEqualEpsilon(
+      new Color(0.2, 0.4, 0.8, 0.6),
+      CesiumMath.EPSILON15
+    );
+  });
+
+  it("fromCssColorString supports the hsla() format (space-separated)", function () {
+    expect(Color.fromCssColorString("hsla(0 100% 50% / 1.0)")).toEqual(
+      Color.RED
+    );
+    expect(Color.fromCssColorString("hsla(120 100% 50% / 1.0)")).toEqual(
+      Color.LIME
+    );
+    expect(Color.fromCssColorString("hsla(240 100% 50% / 1.0)")).toEqual(
+      Color.BLUE
+    );
+    expect(Color.fromCssColorString("hsla(220 60% 50% / 0.6)")).toEqualEpsilon(
       new Color(0.2, 0.4, 0.8, 0.6),
       CesiumMath.EPSILON15
     );


### PR DESCRIPTION
Closes #11264