### PR TITLE
Update GeometryPipeline.js

### DIFF
--- a/packages/engine/Source/Core/GeometryPipeline.js
+++ b/packages/engine/Source/Core/GeometryPipeline.js
@@ -2127,7 +2127,11 @@ function generateBarycentricInterpolateFunction(
     CartesianType.add(value, v2, value);
 
     if (normalize) {
-      CartesianType.normalize(value, value);
+      try {
+        CartesianType.normalize(value, value);
+      } catch (e) {
+        throw new DeveloperError(e);
+      }
     }
 
     CartesianType.pack(


### PR DESCRIPTION
This should be a DeveloperError; certain complex geometries fail to normalize for edge-cases, should not stop rendering.