### PR TITLE
Fix misleading warnings for OES_standard_derivatives

### DIFF
--- a/packages/engine/Source/Renderer/demodernizeShader.js
+++ b/packages/engine/Source/Renderer/demodernizeShader.js
@@ -56,6 +56,9 @@ function demodernizeShader(input, isFragmentShader) {
       // Replace gl_FragDepth with gl_FragDepthEXT.
       output = output.replaceAll(/gl_FragDepth/g, `gl_FragDepthEXT`);
     }
+
+    // Enable the OES_standard_derivatives extension
+    output = `#ifdef GL_OES_standard_derivatives\n#extension GL_OES_standard_derivatives : enable\n#endif\n${output}`;
   } else {
     // Replace the in with attribute.
     output = output.replaceAll(/(in)\s+(vec\d|mat\d|float)/g, `attribute $2`);

--- a/packages/engine/Source/Scene/Cesium3DTileBatchTable.js
+++ b/packages/engine/Source/Scene/Cesium3DTileBatchTable.js
@@ -1050,9 +1050,6 @@ function getLogDepthPolygonOffsetFragmentShaderProgram(context, shaderProgram) {
     fs.defines = defined(fs.defines) ? fs.defines.slice(0) : [];
     fs.defines.push("POLYGON_OFFSET");
 
-    fs.sources.unshift(
-      "#ifdef GL_OES_standard_derivatives\n#extension GL_OES_standard_derivatives : enable\n#endif\n"
-    );
     shader = context.shaderCache.createDerivedShaderProgram(
       shaderProgram,
       "zBackfaceLogDepth",

--- a/packages/engine/Source/Shaders/BillboardCollectionFS.glsl
+++ b/packages/engine/Source/Shaders/BillboardCollectionFS.glsl
@@ -1,7 +1,3 @@
-#ifdef GL_OES_standard_derivatives
-#extension GL_OES_standard_derivatives : enable
-#endif
-
 uniform sampler2D u_atlas;
 
 #ifdef VECTOR_TILE

--- a/packages/engine/Source/Shaders/Builtin/Functions/writeLogDepth.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/writeLogDepth.glsl
@@ -3,9 +3,6 @@ in float v_depthFromNearPlusOne;
 
 #ifdef POLYGON_OFFSET
 uniform vec2 u_polygonOffset;
-#ifdef GL_OES_standard_derivatives
-#extension GL_OES_standard_derivatives : enable
-#endif
 #endif
 
 #endif

--- a/packages/engine/Source/Shaders/Materials/ElevationContourMaterial.glsl
+++ b/packages/engine/Source/Shaders/Materials/ElevationContourMaterial.glsl
@@ -1,7 +1,3 @@
-#ifdef GL_OES_standard_derivatives
-    #extension GL_OES_standard_derivatives : enable
-#endif
-
 uniform vec4 color;
 uniform float spacing;
 uniform float width;

--- a/packages/engine/Source/Shaders/Materials/GridMaterial.glsl
+++ b/packages/engine/Source/Shaders/Materials/GridMaterial.glsl
@@ -1,7 +1,3 @@
-#ifdef GL_OES_standard_derivatives
-    #extension GL_OES_standard_derivatives : enable
-#endif
-
 uniform vec4 color;
 uniform float cellAlpha;
 uniform vec2 lineCount;

--- a/packages/engine/Source/Shaders/Materials/PolylineArrowMaterial.glsl
+++ b/packages/engine/Source/Shaders/Materials/PolylineArrowMaterial.glsl
@@ -1,7 +1,3 @@
-#ifdef GL_OES_standard_derivatives
-#extension GL_OES_standard_derivatives : enable
-#endif
-
 uniform vec4 color;
 
 float getPointOnLine(vec2 p0, vec2 p1, float x)

--- a/packages/engine/Source/Shaders/Model/ModelFS.glsl
+++ b/packages/engine/Source/Shaders/Model/ModelFS.glsl
@@ -1,9 +1,3 @@
-#if defined(HAS_NORMALS) && !defined(HAS_TANGENTS) && !defined(LIGHTING_UNLIT)
-    #ifdef GL_OES_standard_derivatives
-    #extension GL_OES_standard_derivatives : enable
-    #endif
-#endif
-
 czm_modelMaterial defaultModelMaterial()
 {
     czm_modelMaterial material;


### PR DESCRIPTION
When a Custom Shader fails to compile, the error message begins with an irrelevant warning:

![image](https://github.com/CesiumGS/cesium/assets/41167620/f1ff233e-41c5-4652-ad85-12d8d78f47b7)

The [OES_standard_derivatives extension](https://developer.mozilla.org/en-US/docs/Web/API/OES_standard_derivatives) is only available in WebGL1 contexts. In a WebGL2 context, the derivatives functionality is available by default. However, several of our fragment shaders (written in ES300) still enabled this extension conditionally:

```glsl
#ifdef GL_OES_standard_derivatives
    #extension GL_OES_standard_derivatives : enable
#endif
```

The middle line was then [moved to the top of the file in `ShaderSource`](https://github.com/CesiumGS/cesium/blob/2cbe29610f77dd2eff33e10a0471aff315a5d337/packages/engine/Source/Renderer/ShaderSource.js#LL195C1-L201C28) _without_ the `#ifdef` block, resulting in a warning on WebGL2 contexts.

This PR simplifies our handling of the `OES_standard_derivatives` extension. Since it is very commonly used, but only needed in WebGL1, I removed all the code to enable the extension in individual shaders. I then _always_  enable the extension (if available) in `demodernizeShader`.

The above error message now becomes:

![image](https://github.com/CesiumGS/cesium/assets/41167620/9a1db1ac-c7c7-4504-ae08-86331c00f772)

which better emphasizes the relevant error.

The errors can be reproduced with this [local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVRra9swFP0rl2wfHEiVrEuhzdKy0G1QWCis2boPhkaRZEdUDyPJSZOS/74r2VmTtgIj3+eRzrk2s8YHWEmxFg4uwYg1XAsva03+JF+Wd1iyr60JVBrh8k4PnnMDEIRz6BntC2aNTQpn9b11ireOrNvLza77JTcsgXkmjECsBpQkE4NpJ6WyC0G4qMJyJnyYlNjAh7YTFhVU+ZidGyUCBKmEFwHt4DbNqfp9mE7+Tn7B7f0MprVnNNBQP0K1tMGWjmotYi5HN1bCWoYlVM5WwoUNXukp1E74thFr7ixNCUvr5DaaCqjhsMJ0ydCoDcNXTAqbxElzIDwoXVMZ9tQ02+dvsyacKLqxZuLRuOHZxeDsfHgeGYIjVkjlpJZBroQnlPOs7X6UuLVWz+xhaAd4Z7aEDEmzrtvQEqm3ShBly2z+PQZAWcrj1drSEXx8ThW7eeoSOW5DhNU+WH23pPz1lFwfRLKEVDhaamFC45shoyOY52ZlJf8fm8ax+NEaN6aqAxQ+7T2QxqLJtvpBWy7UlOKcSWRaty/d3CQcpPxAld8vOsQpaZoR1JpGpYn7zPXDgVYPTFwMfK0Tk/vOhMuiqH2aTcGGWYEMhexdjC704fTsjAwSVfP9gHd6nbEPGyWuYt+4vkpdWRegdiojpB+ErhTC+f6iZo+RWe8bOeP6EKxVC+oayZq1oOyxdLY2fASuXNBseNqD/TMg5y/VABUOCSo6gmH1dOBeWIdKnDiUu/bHwd0baJnUODjAftRPqJIlfu1acq7EW9STYKsRnB4h70MLG3BKjqMt9Lh/SNiYyxVIfvnOXweYot5jpKiVupNbkXeuxn3Mf1PaDvYtnlzRTUxbfrr62TgJIeM+mu9XtiS86vwP)