### PR TITLE
Enforce memory limit for `Cesium3DTilesetCache`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Additions :tada:
 
-- Added `Cesium3DTileset.cacheBytes` and `Cesium3DTileset.maximumCacheOverflowBytes` to better control memory usage. To replicate previous behavior, change `maximumMemoryUsage` to `cacheBytes`, and set `maximumCacheOverflowBytes = Number.MAX_VALUE`
+- Added `Cesium3DTileset.cacheBytes` and `Cesium3DTileset.maximumCacheOverflowBytes` to better control memory usage. To replicate previous behavior, convert `maximumMemoryUsage` from MB to bytes, assign the value to `cacheBytes`, and set `maximumCacheOverflowBytes = Number.MAX_VALUE`
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Change Log
 
+### 1.107 - 2023-07-01
+
+##### Additions :tada:
+
+- Added `Cesium3DTileset.cacheBytes` and `Cesium3DTileset.maximumCacheOverflowBytes` to better control memory usage. To replicate previous behavior, change `maximumMemoryUsage` to `cacheBytes`, and set `maximumCacheOverflowBytes = Number.MAX_VALUE`
+
+##### Fixes :wrench:
+
+##### Deprecated :hourglass_flowing_sand:
+
+- `Cesium3DTileset.maximumMemoryUsage` has been deprecated in CesiumJS 1.107. It will be removed in 1.110. Use `Cesium3DTileset.cacheBytes` and `Cesium3DTileset.maximumCacheOverflowBytes` instead. [#11310](https://github.com/CesiumGS/cesium/pull/11310)
+
 ### 1.106 - 2023-06-01
 
 #### @cesium/engine

--- a/packages/engine/Source/Scene/Cesium3DTile.js
+++ b/packages/engine/Source/Scene/Cesium3DTile.js
@@ -870,7 +870,7 @@ function isPriorityDeferred(tile, frameState) {
   );
   const sseRelaxation = tileset.foveatedInterpolationCallback(
     tileset.foveatedMinimumScreenSpaceErrorRelaxation,
-    tileset.maximumScreenSpaceError,
+    tileset.memoryAdjustedScreenSpaceError,
     normalizedFoveatedFactor
   );
   const sse =
@@ -878,7 +878,7 @@ function isPriorityDeferred(tile, frameState) {
       ? tile.parent._screenSpaceError * 0.5
       : tile._screenSpaceError;
 
-  return tileset.maximumScreenSpaceError - sseRelaxation <= sse;
+  return tileset.memoryAdjustedScreenSpaceError - sseRelaxation <= sse;
 }
 
 const scratchJulianDate = new JulianDate();
@@ -957,12 +957,11 @@ function isPriorityProgressiveResolution(tileset, tile) {
     return false;
   }
 
+  const maximumScreenSpaceError = tileset.memoryAdjustedScreenSpaceError;
   let isProgressiveResolutionTile =
-    tile._screenSpaceErrorProgressiveResolution >
-    tileset._maximumScreenSpaceError; // Mark non-SSE leaves
+    tile._screenSpaceErrorProgressiveResolution > maximumScreenSpaceError; // Mark non-SSE leaves
   tile._priorityProgressiveResolutionScreenSpaceErrorLeaf = false; // Needed for skipLOD
   const parent = tile.parent;
-  const maximumScreenSpaceError = tileset._maximumScreenSpaceError;
   const tilePasses =
     tile._screenSpaceErrorProgressiveResolution <= maximumScreenSpaceError;
   const parentFails =

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -225,18 +225,18 @@ function Cesium3DTileset(options) {
   );
   this._memoryAdjustedScreenSpaceError = this._maximumScreenSpaceError;
 
-  let defaultCachedBytes = 512 * 1024 * 1024;
+  let defaultCacheBytes = 512 * 1024 * 1024;
   if (defined(options.maximumMemoryUsage)) {
     deprecationWarning(
       "Cesium3DTileset.maximumMemoryUsage",
       "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.106.  It will be removed in CesiumJS 1.109. Use Cesium3DTileset.cacheBytes instead."
     );
-    defaultCachedBytes = options.maximumMemoryUsage * 1024 * 1024;
+    defaultCacheBytes = options.maximumMemoryUsage * 1024 * 1024;
   }
-  this._cacheBytes = defaultValue(options.cacheBytes, defaultCachedBytes);
+  this._cacheBytes = defaultValue(options.cacheBytes, defaultCacheBytes);
   this._cacheHeadroomBytes = defaultValue(
     options.cacheHeadroomBytes,
-    defaultCachedBytes
+    defaultCacheBytes
   );
 
   this._styleEngine = new Cesium3DTileStyleEngine();

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -69,8 +69,8 @@ import Cesium3DTilesetSkipTraversal from "./Cesium3DTilesetSkipTraversal.js";
  * @property {ShadowMode} [shadows=ShadowMode.ENABLED] Determines whether the tileset casts or receives shadows from light sources.
  * @property {number} [maximumScreenSpaceError=16] The maximum screen space error used to drive level of detail refinement.
  * @property {number} [maximumMemoryUsage=512] The maximum amount of memory in MB that can be used by the tileset. Deprecated.
- * @property {number} [cacheBytes=536870912] The size (in bytes) to which the tile cache will be trimmed, if the cache contains tiles not needed for the current view
- * @property {number} [cacheHeadroomBytes=536870912] The maximum additional memory (in bytes) to allow for cache headroom, if more than {@link Cesium3DTileset#cacheBytes} are needed for the current view
+ * @property {number} [cacheBytes=536870912] The size (in bytes) to which the tile cache will be trimmed, if the cache contains tiles not needed for the current view.
+ * @property {number} [cacheHeadroomBytes=536870912] The maximum additional memory (in bytes) to allow for cache headroom, if more than {@link Cesium3DTileset#cacheBytes} are needed for the current view. Must be at least 10 * 1024 * 1024.
  * @property {boolean} [cullWithChildrenBounds=true] Optimization option. Whether to cull tiles using the union of their children bounding volumes.
  * @property {boolean} [cullRequestsWhileMoving=true] Optimization option. Don't request tiles that will likely be unused when they come back because of the camera's movement. This optimization only applies to stationary tilesets.
  * @property {number} [cullRequestsWhileMovingMultiplier=60.0] Optimization option. Multiplier used in culling requests while moving. Larger is more aggressive culling, smaller less aggressive culling.
@@ -234,9 +234,9 @@ function Cesium3DTileset(options) {
     defaultCacheBytes = options.maximumMemoryUsage * 1024 * 1024;
   }
   this._cacheBytes = defaultValue(options.cacheBytes, defaultCacheBytes);
-  this._cacheHeadroomBytes = defaultValue(
-    options.cacheHeadroomBytes,
-    defaultCacheBytes
+  this._cacheHeadroomBytes = Math.max(
+    10 * 1024 * 1024,
+    defaultValue(options.cacheHeadroomBytes, defaultCacheBytes)
   );
 
   this._styleEngine = new Cesium3DTileStyleEngine();
@@ -1637,6 +1637,9 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * until the tiles required to meet the adjusted screen space error use less
    * than <code>cacheBytes</code> plus <code>cacheHeadroomBytes</code>.
    * </p>
+   * <p>
+   * Must be at least 10 * 1024 * 1024.
+   * </p>
    *
    * @memberof Cesium3DTileset.prototype
    *
@@ -1655,7 +1658,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
       Check.typeOf.number.greaterThanOrEquals("value", value, 0);
       //>>includeEnd('debug');
 
-      this._cacheHeadroomBytes = value;
+      this._cacheHeadroomBytes = Math.max(10 * 1024 * 1024, value);
     },
   },
 

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -69,8 +69,8 @@ import Cesium3DTilesetSkipTraversal from "./Cesium3DTilesetSkipTraversal.js";
  * @property {ShadowMode} [shadows=ShadowMode.ENABLED] Determines whether the tileset casts or receives shadows from light sources.
  * @property {number} [maximumScreenSpaceError=16] The maximum screen space error used to drive level of detail refinement.
  * @property {number} [maximumMemoryUsage=512] The maximum amount of memory in MB that can be used by the tileset. Deprecated.
- * @property {number} [cachedBytes=536870912] The size (in bytes) to which the tile cache will be trimmed
- * @property {number} [maximumCachedBytes=1073741824] The maximum amount of memory in bytes to use for the cache. Must be larger than {@link Cesium3DTileset#cachedBytes}
+ * @property {number} [cacheBytes=536870912] The size (in bytes) to which the tile cache will be trimmed, if the cache contains tiles not needed for the current view
+ * @property {number} [cacheHeadroomBytes=536870912] The maximum additional memory (in bytes) to allow for cache headroom, if more than {@link Cesium3DTileset#cacheBytes} are needed for the current view
  * @property {boolean} [cullWithChildrenBounds=true] Optimization option. Whether to cull tiles using the union of their children bounding volumes.
  * @property {boolean} [cullRequestsWhileMoving=true] Optimization option. Don't request tiles that will likely be unused when they come back because of the camera's movement. This optimization only applies to stationary tilesets.
  * @property {number} [cullRequestsWhileMovingMultiplier=60.0] Optimization option. Multiplier used in culling requests while moving. Larger is more aggressive culling, smaller less aggressive culling.
@@ -229,14 +229,14 @@ function Cesium3DTileset(options) {
   if (defined(options.maximumMemoryUsage)) {
     deprecationWarning(
       "Cesium3DTileset.maximumMemoryUsage",
-      "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.106.  It will be removed in CesiumJS 1.109. Use Cesium3DTileset.cachedBytes instead."
+      "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.106.  It will be removed in CesiumJS 1.109. Use Cesium3DTileset.cacheBytes instead."
     );
     defaultCachedBytes = options.maximumMemoryUsage * 1024 * 1024;
   }
-  this._cachedBytes = defaultValue(options.cachedBytes, defaultCachedBytes);
-  this._maximumCachedBytes = defaultValue(
-    options.maximumCachedBytes,
-    this._cachedBytes * 2.0
+  this._cacheBytes = defaultValue(options.cacheBytes, defaultCachedBytes);
+  this._cacheHeadroomBytes = defaultValue(
+    options.cacheHeadroomBytes,
+    defaultCachedBytes
   );
 
   this._styleEngine = new Cesium3DTileStyleEngine();
@@ -606,7 +606,7 @@ function Cesium3DTileset(options) {
    *     console.log('A tile was unloaded from the cache.');
    * });
    *
-   * @see Cesium3DTileset#cachedBytes
+   * @see Cesium3DTileset#cacheBytes
    * @see Cesium3DTileset#trimLoadedTiles
    */
   this.tileUnload = new Event();
@@ -1569,26 +1569,26 @@ Object.defineProperties(Cesium3DTileset.prototype, {
     get: function () {
       deprecationWarning(
         "Cesium3DTileset.maximumMemoryUsage",
-        "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.106.  It will be removed in CesiumJS 1.109. Use Cesium3DTileset.cachedBytes instead."
+        "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.106.  It will be removed in CesiumJS 1.109. Use Cesium3DTileset.cacheBytes instead."
       );
       return this._maximumMemoryUsage;
     },
     set: function (value) {
       deprecationWarning(
         "Cesium3DTileset.maximumMemoryUsage",
-        "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.106.  It will be removed in CesiumJS 1.109. Use Cesium3DTileset.cachedBytes instead."
+        "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.106.  It will be removed in CesiumJS 1.109. Use Cesium3DTileset.cacheBytes instead."
       );
       //>>includeStart('debug', pragmas.debug);
       Check.typeOf.number.greaterThanOrEquals("value", value, 0);
       //>>includeEnd('debug');
 
       this._maximumMemoryUsage = value;
-      this._cachedBytes = value * 1024 * 1024;
+      this._cacheBytes = value * 1024 * 1024;
     },
   },
 
   /**
-   * The amount of GPU memory (in MB) used to cache tiles. This memory usage is estimated from
+   * The amount of GPU memory (in bytes) used to cache tiles. This memory usage is estimated from
    * geometry, textures, and batch table textures of loaded tiles. For point clouds, this value also
    * includes per-point metadata.
    * <p>
@@ -1598,10 +1598,10 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * If decreasing this value results in unloading tiles, the tiles are unloaded the next frame.
    * </p>
    * <p>
-   * If tiles sized more than <code>cachedBytes</code> are needed to meet the
+   * If tiles sized more than <code>cacheBytes</code> are needed to meet the
    * desired screen space error, determined by {@link Cesium3DTileset#maximumScreenSpaceError},
    * for the current view, then the memory usage of the tiles loaded will exceed
-   * <code>cachedBytes</code>.  For example, if the maximum is 256 MB, but 300 MB
+   * <code>cacheBytes</code>.  For example, if the maximum is 256 MB, but 300 MB
    * of tiles are needed to meet the screen space error, then 300 MB of tiles may
    * be loaded. When these tiles go out of view, they will be unloaded.
    * </p>
@@ -1611,54 +1611,60 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * @type {number}
    * @default 536870912
    *
-   * @exception {DeveloperError} <code>cachedBytes</code> must be typeof 'number' and greater than or equal to 0
+   * @exception {DeveloperError} <code>cacheBytes</code> must be typeof 'number' and greater than or equal to 0
    * @see Cesium3DTileset#totalMemoryUsageInBytes
    */
-  cachedBytes: {
+  cacheBytes: {
     get: function () {
-      return this._cachedBytes;
+      return this._cacheBytes;
     },
     set: function (value) {
       //>>includeStart('debug', pragmas.debug);
       Check.typeOf.number.greaterThanOrEquals("value", value, 0);
       //>>includeEnd('debug');
 
-      this._cachedBytes = value;
-      this._maximumCachedBytes = Math.max(
-        this._maximumCachedBytes,
-        value * 1.1
-      );
+      this._cacheBytes = value;
     },
   },
 
   /**
-   * The maximum amount of GPU memory (in MB) that will be used to cache tiles.
+   * The maximum additional amount of GPU memory (in bytes) that will be used to cache tiles.
    * <p>
-   * If tiles sized more than <code>maximumCachedBytes</code> are needed to meet the
-   * desired screen space error, determined by {@link Cesium3DTileset#maximumScreenSpaceError},
-   * for the current view, then {@link Cesium3DTileset#memoryAdjustedScreenSpaceError}
-   * will be adjusted until the tiles required to meet the adjusted screen space error
-   * are sized less than <code>maximumCachedBytes</code>.
+   * If tiles sized more than <code>cacheBytes</code> plus <code>cacheHeadroomBytes</code>
+   * are needed to meet the desired screen space error, determined by
+   * {@link Cesium3DTileset#maximumScreenSpaceError} for the current view, then
+   * {@link Cesium3DTileset#memoryAdjustedScreenSpaceError} will be adjusted
+   * until the tiles required to meet the adjusted screen space error use less
+   * than <code>cacheBytes</code> plus <code>cacheHeadroomBytes</code>.
    * </p>
    *
    * @memberof Cesium3DTileset.prototype
    *
    * @type {number}
-   * @readonly
+   * @default 536870912
    *
+   * @exception {DeveloperError} <code>cacheHeadroomBytes</code> must be typeof 'number' and greater than or equal to 0
    * @see Cesium3DTileset#totalMemoryUsageInBytes
    */
-  maximumCachedBytes: {
+  cacheHeadroomBytes: {
     get: function () {
-      return this._maximumCachedBytes;
+      return this._cacheHeadroomBytes;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      Check.typeOf.number.greaterThanOrEquals("value", value, 0);
+      //>>includeEnd('debug');
+
+      this._cacheHeadroomBytes = value;
     },
   },
 
   /**
    * If loading the level of detail required by @{link Cesium3DTileset#maximumScreenSpaceError}
-   * results in the memory usage exceeding @{link Cesium3DTileset#maximumCachedBytes},
-   * level of detail refinement will instead use this (larger) adjusted screen space error
-   * to achieve the best possible visual quality within the available memory
+   * results in the memory usage exceeding @{link Cesium3DTileset#cacheBytes}
+   * plus @{link Cesium3DTileset#cacheHeadroomBytes}, level of detail refinement
+   * will instead use this (larger) adjusted screen space error to achieve the
+   * best possible visual quality within the available memory
    *
    * @memberof Cesium3DTileset.prototype
    *
@@ -1779,7 +1785,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * @type {number}
    * @readonly
    *
-   * @see Cesium3DTileset#cachedBytes
+   * @see Cesium3DTileset#cacheBytes
    */
   totalMemoryUsageInBytes: {
     get: function () {
@@ -2789,7 +2795,8 @@ function processTiles(tileset, frameState) {
   );
   tileset._processingQueue = tiles;
 
-  const { cachedBytes, maximumCachedBytes, statistics } = tileset;
+  const { cacheBytes, cacheHeadroomBytes, statistics } = tileset;
+  const cacheByteLimit = cacheBytes + cacheHeadroomBytes;
 
   let memoryExceeded = false;
   for (let i = 0; i < tiles.length; ++i) {
@@ -2806,13 +2813,13 @@ function processTiles(tileset, frameState) {
       handleTileFailure(error, tileset, tile);
     }
 
-    if (tileset.totalMemoryUsageInBytes > maximumCachedBytes) {
+    if (tileset.totalMemoryUsageInBytes > cacheByteLimit) {
       memoryExceeded = true;
       break;
     }
   }
 
-  if (tileset.totalMemoryUsageInBytes < cachedBytes) {
+  if (tileset.totalMemoryUsageInBytes < cacheBytes) {
     decreaseScreenSpaceError(tileset);
   } else if (memoryExceeded && tiles.length > 1) {
     increaseScreenSpaceError(tileset);
@@ -3180,7 +3187,7 @@ function destroyTile(tileset, tile) {
 /**
  * Unloads all tiles that weren't selected the previous frame.  This can be used to
  * explicitly manage the tile cache and reduce the total number of tiles loaded below
- * {@link Cesium3DTileset#cachedBytes}.
+ * {@link Cesium3DTileset#cacheBytes}.
  * <p>
  * Tile unloads occur at the next frame to keep all the WebGL delete calls
  * within the render loop.

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -2544,7 +2544,7 @@ function requestContent(tileset, tile) {
   tileset._requestedTilesInFlight.push(tile);
 }
 
-function sortRequestByPriority(a, b) {
+function sortTilesByPriority(a, b) {
   return a._priority - b._priority;
 }
 
@@ -2647,7 +2647,7 @@ function cancelOutOfViewRequests(tileset, frameState) {
  */
 function requestTiles(tileset) {
   const requestedTiles = tileset._requestedTiles;
-  requestedTiles.sort(sortRequestByPriority);
+  requestedTiles.sort(sortTilesByPriority);
   for (let i = 0; i < requestedTiles.length; ++i) {
     requestContent(tileset, requestedTiles[i]);
   }
@@ -2731,6 +2731,11 @@ function increaseScreenSpaceError(tileset) {
   console.log(
     `tileset.totalMemoryUsageInBytes = ${tileset.totalMemoryUsageInBytes}. memoryAdjustedScreenSpaceError increased to ${tileset.memoryAdjustedScreenSpaceError}`
   );
+  const tiles = tileset._processingQueue;
+  for (let i = 0; i < tiles.length; ++i) {
+    tiles[i].updatePriority();
+  }
+  tiles.sort(sortTilesByPriority);
 }
 
 function decreaseScreenSpaceError(tileset) {

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -1532,6 +1532,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
       //>>includeEnd('debug');
 
       this._maximumScreenSpaceError = value;
+      this._memoryAdjustedScreenSpaceError = value;
     },
   },
 
@@ -1582,6 +1583,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
       //>>includeEnd('debug');
 
       this._maximumMemoryUsage = value;
+      this._cachedBytes = value * 1024 * 1024;
     },
   },
 
@@ -2819,9 +2821,6 @@ function processTiles(tileset, frameState) {
 
 function increaseScreenSpaceError(tileset) {
   tileset._memoryAdjustedScreenSpaceError *= 1.01;
-  console.log(
-    `tileset.totalMemoryUsageInBytes = ${tileset.totalMemoryUsageInBytes}. memoryAdjustedScreenSpaceError increased to ${tileset.memoryAdjustedScreenSpaceError}`
-  );
   const tiles = tileset._processingQueue;
   for (let i = 0; i < tiles.length; ++i) {
     tiles[i].updatePriority();
@@ -2833,9 +2832,6 @@ function decreaseScreenSpaceError(tileset) {
   tileset._memoryAdjustedScreenSpaceError = Math.max(
     tileset.memoryAdjustedScreenSpaceError / 1.01,
     tileset.maximumScreenSpaceError
-  );
-  console.log(
-    `memoryAdjustedScreenSpaceError decreased to ${tileset.memoryAdjustedScreenSpaceError}`
   );
 }
 

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -2821,13 +2821,13 @@ function processTiles(tileset, frameState) {
 
   if (tileset.totalMemoryUsageInBytes < cacheBytes) {
     decreaseScreenSpaceError(tileset);
-  } else if (memoryExceeded && tiles.length > 1) {
+  } else if (memoryExceeded && tiles.length > 0) {
     increaseScreenSpaceError(tileset);
   }
 }
 
 function increaseScreenSpaceError(tileset) {
-  tileset._memoryAdjustedScreenSpaceError *= 1.01;
+  tileset._memoryAdjustedScreenSpaceError *= 1.02;
   const tiles = tileset._processingQueue;
   for (let i = 0; i < tiles.length; ++i) {
     tiles[i].updatePriority();
@@ -2837,7 +2837,7 @@ function increaseScreenSpaceError(tileset) {
 
 function decreaseScreenSpaceError(tileset) {
   tileset._memoryAdjustedScreenSpaceError = Math.max(
-    tileset.memoryAdjustedScreenSpaceError / 1.01,
+    tileset.memoryAdjustedScreenSpaceError / 1.02,
     tileset.maximumScreenSpaceError
   );
 }

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -53,7 +53,7 @@ Cesium3DTilesetBaseTraversal.selectTiles = function (tileset, frameState) {
 
   if (
     root.getScreenSpaceError(frameState, true) <=
-    tileset._maximumScreenSpaceError
+    tileset.memoryAdjustedScreenSpaceError
   ) {
     return;
   }

--- a/packages/engine/Source/Scene/Cesium3DTilesetCache.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetCache.js
@@ -58,8 +58,6 @@ Cesium3DTilesetCache.prototype.unloadTiles = function (
 
   const list = this._list;
 
-  const maximumMemoryUsageInBytes = tileset.maximumMemoryUsage * 1024 * 1024;
-
   // Traverse the list only to the sentinel since tiles/nodes to the
   // right of the sentinel were used this frame.
   //
@@ -68,8 +66,7 @@ Cesium3DTilesetCache.prototype.unloadTiles = function (
   let node = list.head;
   while (
     node !== sentinel &&
-    (tileset.totalMemoryUsageInBytes > maximumMemoryUsageInBytes * 0.7 ||
-      trimTiles)
+    (tileset.totalMemoryUsageInBytes > tileset.cachedBytes || trimTiles)
   ) {
     const tile = node.item;
     node = node.next;

--- a/packages/engine/Source/Scene/Cesium3DTilesetCache.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetCache.js
@@ -68,7 +68,8 @@ Cesium3DTilesetCache.prototype.unloadTiles = function (
   let node = list.head;
   while (
     node !== sentinel &&
-    (tileset.totalMemoryUsageInBytes > maximumMemoryUsageInBytes || trimTiles)
+    (tileset.totalMemoryUsageInBytes > maximumMemoryUsageInBytes * 0.7 ||
+      trimTiles)
   ) {
     const tile = node.item;
     node = node.next;

--- a/packages/engine/Source/Scene/Cesium3DTilesetCache.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetCache.js
@@ -66,7 +66,7 @@ Cesium3DTilesetCache.prototype.unloadTiles = function (
   let node = list.head;
   while (
     node !== sentinel &&
-    (tileset.totalMemoryUsageInBytes > tileset.cachedBytes || trimTiles)
+    (tileset.totalMemoryUsageInBytes > tileset.cacheBytes || trimTiles)
   ) {
     const tile = node.item;
     node = node.next;

--- a/packages/engine/Source/Scene/Cesium3DTilesetSkipTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetSkipTraversal.js
@@ -267,7 +267,10 @@ function executeTraversal(root, frameState) {
   const { tileset } = root;
   const baseScreenSpaceError = tileset.immediatelyLoadDesiredLevelOfDetail
     ? Number.MAX_VALUE
-    : Math.max(tileset.baseScreenSpaceError, tileset.maximumScreenSpaceError);
+    : Math.max(
+        tileset.baseScreenSpaceError,
+        tileset.memoryAdjustedScreenSpaceError
+      );
   const {
     canTraverse,
     loadTile,

--- a/packages/engine/Source/Scene/Cesium3DTilesetSkipTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetSkipTraversal.js
@@ -61,7 +61,7 @@ Cesium3DTilesetSkipTraversal.selectTiles = function (tileset, frameState) {
 
   if (
     root.getScreenSpaceError(frameState, true) <=
-    tileset._maximumScreenSpaceError
+    tileset.memoryAdjustedScreenSpaceError
   ) {
     return;
   }

--- a/packages/engine/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetTraversal.js
@@ -64,7 +64,7 @@ Cesium3DTilesetTraversal.canTraverse = function (tile) {
     // Don't traverse if the subtree is expired because it will be destroyed
     return !tile.contentExpired;
   }
-  return tile._screenSpaceError > tile.tileset._maximumScreenSpaceError;
+  return tile._screenSpaceError > tile.tileset.memoryAdjustedScreenSpaceError;
 };
 
 /**
@@ -260,7 +260,7 @@ function meetsScreenSpaceErrorEarly(tile, frameState) {
   // Use parent's geometric error with child's box to see if the tile already meet the SSE
   return (
     tile.getScreenSpaceError(frameState, true) <=
-    tileset._maximumScreenSpaceError
+    tileset.memoryAdjustedScreenSpaceError
   );
 }
 

--- a/packages/engine/Source/Scene/Model/PointCloudStylingPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/PointCloudStylingPipelineStage.js
@@ -161,7 +161,7 @@ PointCloudStylingPipelineStage.process = function (
     if (is3DTiles) {
       defaultPointSize = usesAddRefinement
         ? 5.0
-        : content.tileset.maximumScreenSpaceError;
+        : content.tileset.memoryAdjustedScreenSpaceError;
     }
     vec4.x = defaultValue(
       pointCloudShading.maximumAttenuation,

--- a/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
+++ b/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
@@ -38,6 +38,11 @@ async function createGooglePhotorealistic3DTileset(key, options) {
 
   options = defaultValue(options, {});
   options.showCreditsOnScreen = true;
+  options.cacheBytes = defaultValue(options.cacheBytes, 1536 * 1024 * 1024);
+  options.cacheHeadroomBytes = defaultValue(
+    options.cacheHeadroomBytes,
+    1024 * 1024 * 1024
+  );
 
   const resource = new Resource({
     url: `${GoogleMaps.mapTilesApiEndpoint}3dtiles/root.json`,

--- a/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
+++ b/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
@@ -39,8 +39,8 @@ async function createGooglePhotorealistic3DTileset(key, options) {
   options = defaultValue(options, {});
   options.showCreditsOnScreen = true;
   options.cacheBytes = defaultValue(options.cacheBytes, 1536 * 1024 * 1024);
-  options.cacheHeadroomBytes = defaultValue(
-    options.cacheHeadroomBytes,
+  options.maximumCacheOverflowBytes = defaultValue(
+    options.maximumCacheOverflowBytes,
     1024 * 1024 * 1024
   );
 

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3434,6 +3434,77 @@ describe(
     ///////////////////////////////////////////////////////////////////////////
     // Cache replacement tests
 
+    it("Unload all cached tiles not required to meet SSE using maximumMemoryUsage", function () {
+      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
+        tileset
+      ) {
+        tileset.maximumMemoryUsage = 0;
+
+        // Render parent and four children (using additive refinement)
+        viewAllTiles();
+        scene.renderForSpecs();
+
+        const statistics = tileset._statistics;
+        expect(statistics.numberOfCommands).toEqual(5);
+        expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
+        expect(tileset.totalMemoryUsageInBytes).toEqual(37200); // Specific to this tileset
+
+        // Zoom out so only root tile is needed to meet SSE.  This unloads
+        // the four children since the maximum memory usage is zero.
+        viewRootOnly();
+        scene.renderForSpecs();
+
+        expect(statistics.numberOfCommands).toEqual(1);
+        expect(statistics.numberOfTilesWithContentReady).toEqual(1);
+        expect(tileset.totalMemoryUsageInBytes).toEqual(7440); // Specific to this tileset
+
+        // Zoom back in so all four children are re-requested.
+        viewAllTiles();
+
+        return Cesium3DTilesTester.waitForTilesLoaded(scene, tileset).then(
+          function () {
+            expect(statistics.numberOfCommands).toEqual(5);
+            expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
+            expect(tileset.totalMemoryUsageInBytes).toEqual(37200); // Specific to this tileset
+          }
+        );
+      });
+    });
+
+    it("Unload some cached tiles not required to meet SSE using maximumMemoryUsage", function () {
+      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
+        tileset
+      ) {
+        tileset.maximumMemoryUsage = 0.025; // Just enough memory to allow 3 tiles to remain
+        // Render parent and four children (using additive refinement)
+        viewAllTiles();
+        scene.renderForSpecs();
+
+        const statistics = tileset._statistics;
+        expect(statistics.numberOfCommands).toEqual(5);
+        expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
+
+        // Zoom out so only root tile is needed to meet SSE.  This unloads
+        // two of the four children so three tiles are still loaded (the
+        // root and two children) since the maximum memory usage is sufficient.
+        viewRootOnly();
+        scene.renderForSpecs();
+
+        expect(statistics.numberOfCommands).toEqual(1);
+        expect(statistics.numberOfTilesWithContentReady).toEqual(3);
+
+        // Zoom back in so the two children are re-requested.
+        viewAllTiles();
+
+        return Cesium3DTilesTester.waitForTilesLoaded(scene, tileset).then(
+          function () {
+            expect(statistics.numberOfCommands).toEqual(5);
+            expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
+          }
+        );
+      });
+    });
+
     it("Unload all cached tiles not required to meet SSE using cacheBytes", function () {
       return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
         tileset

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3510,7 +3510,7 @@ describe(
         tileset
       ) {
         tileset.cacheBytes = 0.025 * 1024 * 1024; // Just enough memory to allow 3 tiles to remain
-        tileset._maximumCacheOverflowBytes = 0;
+        tileset.maximumCacheOverflowBytes = 0;
         expect(tileset.memoryAdjustedScreenSpaceError).toEqual(16);
 
         // Zoom out so only root tile is needed to meet SSE.
@@ -3753,10 +3753,10 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("maximumCacheOverflowBytes throws if less than 10 MB", async function () {
+    it("maximumCacheOverflowBytes throws when negative", async function () {
       const tileset = await Cesium3DTileset.fromUrl(tilesetUrl, options);
       expect(function () {
-        tileset.maximumCacheOverflowBytes = 10000000;
+        tileset.maximumCacheOverflowBytes = -1;
       }).toThrowDeveloperError();
     });
 

--- a/packages/engine/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
+++ b/packages/engine/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
@@ -764,6 +764,7 @@ describe(
           },
           tileset: {
             maximumScreenSpaceError: 16,
+            memoryAdjustedScreenSpaceError: 16,
           },
         },
       });


### PR DESCRIPTION
Resolves #6226.

This PR deprecates the  `Cesium3DTileset` constructor option `maximumMemoryUsage`, and replaces it with two new options:

1. `cacheBytes`: The size (in bytes) to which the tile cache will be trimmed, if the cache contains tiles not needed for the current view.
2. `maximumCacheOverflowBytes`: The maximum _additional_ memory (in bytes) to allow for cache overflow, if more than `cacheBytes` are needed for the current view.

If the tileset's `totalMemoryUsageInBytes` exceeds `cacheBytes + maximumCacheOverflowBytes`, processing of new tiles will be interrupted, and the target screen-space error used to drive level-of-detail refinement will be adjusted higher. When the camera moves to an area where `totalMemoryUsageInBytes` drops below `cacheBytes`, the target screen-space error will be adjusted back down toward the user-provided value in `maximumScreenSpaceError`.

The adjusted screen-space error is exposed as a new read-only property `memoryAdjustedScreenSpaceError` 

Here is a [hosted Sandcastle](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/tileset-cache/Apps/Sandcastle/index.html#c=zVftbxo3GP9XPDRVMAUfCSFpCGQLCdWihTUqabYPSK25M+DGZ1PbR0Kj/O977PO9EUq6fZqQOM5+nt/z/kIohTZoxegDVaiPBH1AF1SzJMZ37qw+qYXu/UIKQ5igalLbQ08TgRCLyZyq9Y2SKxZR1UUzwjXds1dTouk1WVN1w8L76hURwGeYFOVDw2LKAbw4e26cTsREhE69J6RDKugeCklMFYEnl+E9egaFU81PC0ojP5CIEaHdtbdlRMyihJfC3EgNFM4UTkwXHbbw8eHRyfH+285Jq+304mLeRc3jNj457hwcHRwedU7cOeV05Y1ot45x+607XTITLoB+v+NeFxQUsQAta48THwRoTDP5aCk1syCgljvAmhrr9brTKaLaMOGleDsuiDLwi4g2nikZX9K5olTXLTkqrMKg9t6LM2JenOVm2IuGu5aKUQh0KvUpZcgNyX1bLzD8ZcODex9so3RXGZ2SnINncMu9PxcRBxddMk2mnCKzoC6TIDyQSvbKpQGeczmlWC/kA8TPJUwptlySaAwGJDa4kQyTGOzBc2qGnNqfg/VVBEldkE1qjTx9llRYYz7Qrwl4fzfCBm0ZxjBONdQFVI4Gkp0wG7RlmJCECzpm3+hOgJyqzKohtKGh0a1F38leoSxDxDSWav1RQ5HvBCjRldlJ9CXRgDseD3eyl+hSdg4Fog0k+i00Bf/O9LV0aVYJOKTKeRSh9iVKzXSupAZPRFYu7tG+vPUXtmY+Ku7qZVJbGLPU3SCwbHgu5ZxTsmQahzIOVvtBO3J4gZLS4C9ail/v6bp/fvWNjNeD4fAmvgvF36uj4U3SUcO/RneSnY/Cd38MFo9fbkJoklaILyCbqheKRszo92IcQs1CcRmVUF8MQRDRaTIfA9lAJi6t7iQHh1WoXKAHa2gAXdTZP0C/oP3WwaF/eJqYPLIYmrUlfb+iasYBMmU56BxtYXmeiMZEYCg1Uff+Q/2zVPG02paKxdCmVlRjEkUZkY0Uyj1uqwlyGLqRdlTDFQT4mkFcYWDUZ4kIbUNBvlGJJJ5S9X52U62gvert7UZh2BaVOXSj9jATIOf329G1HWHb0U9Tzo1y28q5Idlzshmqfwcb9ft91EJv3nwPIiXI1Yf2R02ihEd+LgT8lGd6iTivBtBxCTGVKiYipFjIh3rjNKMq14jNmvyiaHUVayc1T48xntTKqjxXg8sEhJ9wZ5JlodGuEOd6F+0YZHjt6/UX+qNmYV8DBZCZLZgKDWzkO/ZIo3o7s/A7Zny+StVL1XVUNEJMoJ+fSrKfoSOCQpH+fLrFQsL/t9b9CQvZv7EMbe2VucVuccJS3MJe9mN2ZtOlolbmuE/uGn/igIA5FXO3ZrmcLY+V7bxVkgp3aYyOBtazGZORhvBRMXGuhOtuzrPQ2NJH4d79zL2lIfVSmdHAU5Vm0VaVU5TzjMo18vGShHSolFS51ING4XL4qu3VetqsOT2zp7+xeCmVQQnMIYwDQ+MlrGYwZ6YJrMoGh1qn7F6aTQqd9z2/MXYRmWqYECar8ikJ7+fKzo5mKLmEjVvNp/UWsp8A1qyjzBEzWOObGuLZha1Kzd3q7MseBl8iDPwN8MIipkG1dRdSzu7mzanNHQ/zwCIDa95hmEXM0EfTJJzNQTfF5guTOR6EMNF0R7As5/ROjxmJGQcBCWvGUkhtXVnRx270P6zM0avKvCq0F2SB6kVshVjU3/L3B4qIaA03s4TzdPE66wVAX2HzJWqHMOhtSRb7Z0XH7QXw+pLLSMmnRG0iZhJLKQEkVuleSmWt64EpohCebbeAZC9S6iAjL/H5YQYzKZ1m3TLSiy0318VnCwholSQgv4st89lXgXux7b4Ct1XhVAI0Qtd9KvilZfhVRce+/6TlXYHZWIr/i5Jpk0KJbTkV7Mq+XELWpgSLRoNXkJtZs4I1zfYh5BIZUduJKvIqC/amvC1WpM9/AA) demonstrating the interaction between memory usage and adjusted screen-space error.