### PR TITLE
Terrain & imagery provider ready deprecation fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Fixes :wrench:
 
 - Fixed a race condition when loading cut-out terrain. [#11296](https://github.com/CesiumGS/cesium/pull/11296)
+- Fixed async behavior for custom terrain and imagery providers. [#11274](https://github.com/CesiumGS/cesium/issues/11274)
 
 ### 1.105.2 - 2023-05-15
 

--- a/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -261,7 +261,7 @@ function ArcGISTiledElevationTerrainProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "ArcGISTiledElevationTerrainProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
     );
 
     const that = this;
@@ -345,7 +345,7 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGISTiledElevationTerrainProvider.ready",
-        "ArcGISTiledElevationTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
+        "ArcGISTiledElevationTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
       );
       return this._ready;
     },
@@ -362,7 +362,7 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGISTiledElevationTerrainProvider.readyPromise",
-        "ArcGISTiledElevationTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
+        "ArcGISTiledElevationTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
       );
       return this._readyPromise;
     },

--- a/packages/engine/Source/Core/CesiumTerrainProvider.js
+++ b/packages/engine/Source/Core/CesiumTerrainProvider.js
@@ -535,7 +535,7 @@ function CesiumTerrainProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "CesiumTerrainProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use CesiumTerrainProvider.fromIonAssetId or CesiumTerrainProvider.fromUrl instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use CesiumTerrainProvider.fromIonAssetId or CesiumTerrainProvider.fromUrl instead."
     );
     this._readyPromise = CesiumTerrainProvider._initializeReadyPromise(
       options,
@@ -1087,7 +1087,7 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "CesiumTerrainProvider.ready",
-        "CesiumTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use CesiumTerrainProvider.fromIonAssetId or CesiumTerrainProvider.fromUrl instead."
+        "CesiumTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use CesiumTerrainProvider.fromIonAssetId or CesiumTerrainProvider.fromUrl instead."
       );
       return this._ready;
     },
@@ -1104,7 +1104,7 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "CesiumTerrainProvider.readyPromise",
-        "CesiumTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use CesiumTerrainProvider.fromIonAssetId or CesiumTerrainProvider.fromUrl instead."
+        "CesiumTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use CesiumTerrainProvider.fromIonAssetId or CesiumTerrainProvider.fromUrl instead."
       );
       return this._readyPromise;
     },

--- a/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
+++ b/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
@@ -145,7 +145,7 @@ Object.defineProperties(CustomHeightmapTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "CustomHeightmapTerrainProvider.ready",
-        "CustomHeightmapTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "CustomHeightmapTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return true;
     },
@@ -162,7 +162,7 @@ Object.defineProperties(CustomHeightmapTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "CustomHeightmapTerrainProvider.readyPromise",
-        "CustomHeightmapTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "CustomHeightmapTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._readyPromise;
     },

--- a/packages/engine/Source/Core/EllipsoidTerrainProvider.js
+++ b/packages/engine/Source/Core/EllipsoidTerrainProvider.js
@@ -98,7 +98,7 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "EllipsoidTerrainProvider.ready",
-        "EllipsoidTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "EllipsoidTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return true;
     },
@@ -115,7 +115,7 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "EllipsoidTerrainProvider.readyPromise",
-        "EllipsoidTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "EllipsoidTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._readyPromise;
     },

--- a/packages/engine/Source/Core/GoogleEarthEnterpriseMetadata.js
+++ b/packages/engine/Source/Core/GoogleEarthEnterpriseMetadata.js
@@ -105,7 +105,7 @@ function GoogleEarthEnterpriseMetadata(resourceOrUrl) {
   if (defined(resourceOrUrl)) {
     deprecationWarning(
       "GoogleEarthEnterpriseMetadata options.url",
-      "GoogleEarthEnterpriseMetadata constructor parmeter resourceOrUrl was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use GoogleEarthEnterpriseMetadata.fromUrl instead."
+      "GoogleEarthEnterpriseMetadata constructor parmeter resourceOrUrl was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use GoogleEarthEnterpriseMetadata.fromUrl instead."
     );
 
     let url = resourceOrUrl;
@@ -183,7 +183,7 @@ Object.defineProperties(GoogleEarthEnterpriseMetadata.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMetadata.readyPromise",
-        "GoogleEarthEnterpriseMetadata.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use GoogleEarthEnterpriseMetadata.fromUrl instead."
+        "GoogleEarthEnterpriseMetadata.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use GoogleEarthEnterpriseMetadata.fromUrl instead."
       );
       return this._readyPromise;
     },

--- a/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -135,7 +135,7 @@ function GoogleEarthEnterpriseTerrainProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "GoogleEarthEnterpriseTerrainProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use GoogleEarthEnterpriseTerrainProvider.fromMetadata instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use GoogleEarthEnterpriseTerrainProvider.fromMetadata instead."
     );
     const resource = Resource.createIfNeeded(options.url);
     const that = this;
@@ -172,7 +172,7 @@ function GoogleEarthEnterpriseTerrainProvider(options) {
   } else if (defined(options.metadata)) {
     deprecationWarning(
       "GoogleEarthEnterpriseTerrainProvider options.metadata",
-      "options.metadata was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use GoogleEarthEnterpriseTerrainProvider.fromMetadata instead."
+      "options.metadata was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use GoogleEarthEnterpriseTerrainProvider.fromMetadata instead."
     );
     const metadata = options.metadata;
     this._metadata = metadata;
@@ -253,7 +253,7 @@ Object.defineProperties(GoogleEarthEnterpriseTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseTerrainProvider.ready",
-        "GoogleEarthEnterpriseTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "GoogleEarthEnterpriseTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._ready;
     },
@@ -270,7 +270,7 @@ Object.defineProperties(GoogleEarthEnterpriseTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseTerrainProvider.readyPromise",
-        "GoogleEarthEnterpriseTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "GoogleEarthEnterpriseTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._readyPromise;
     },

--- a/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
+++ b/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
@@ -185,7 +185,7 @@ function VRTheWorldTerrainProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "VRTheWorldTerrainProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  VRTheWorldTerrainProvider.fromUrl instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  VRTheWorldTerrainProvider.fromUrl instead."
     );
     const that = this;
     const terrainProviderBuilder = new TerrainProviderBuilder(options);
@@ -255,7 +255,7 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "VRTheWorldTerrainProvider.ready",
-        "VRTheWorldTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use VRTheWorldTerrainProvider.fromUrl instead."
+        "VRTheWorldTerrainProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use VRTheWorldTerrainProvider.fromUrl instead."
       );
       return this._ready;
     },
@@ -272,7 +272,7 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
     get: function () {
       deprecationWarning(
         "VRTheWorldTerrainProvider.readyPromise",
-        "VRTheWorldTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use VRTheWorldTerrainProvider.fromUrl instead."
+        "VRTheWorldTerrainProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use VRTheWorldTerrainProvider.fromUrl instead."
       );
       return this._readyPromise;
     },

--- a/packages/engine/Source/Core/createWorldTerrain.js
+++ b/packages/engine/Source/Core/createWorldTerrain.js
@@ -7,6 +7,7 @@ import IonResource from "./IonResource.js";
  * Creates a {@link CesiumTerrainProvider} instance for the {@link https://cesium.com/content/#cesium-world-terrain|Cesium World Terrain}.
  *
  * @function
+ * @deprecated
  *
  * @param {object} [options] Object with the following properties:
  * @param {boolean} [options.requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server if available.
@@ -34,7 +35,7 @@ import IonResource from "./IonResource.js";
 function createWorldTerrain(options) {
   deprecationWarning(
     "createWorldTerrain",
-    "createWorldTerrain was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use createWorldTerrainAsync instead."
+    "createWorldTerrain was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use createWorldTerrainAsync instead."
   );
 
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/packages/engine/Source/Core/sampleTerrain.js
+++ b/packages/engine/Source/Core/sampleTerrain.js
@@ -43,7 +43,11 @@ async function sampleTerrain(terrainProvider, level, positions) {
   //>>includeEnd('debug');
 
   // readyPromise has been deprecated; This is here for backwards compatibility
-  await terrainProvider._readyPromise;
+  if (defined(terrainProvider._readyPromise)) {
+    await terrainProvider._readyPromise;
+  } else if (defined(terrainProvider.readyPromise)) {
+    await terrainProvider.readyPromise;
+  }
 
   return doSampling(terrainProvider, level, positions);
 }

--- a/packages/engine/Source/Core/sampleTerrainMostDetailed.js
+++ b/packages/engine/Source/Core/sampleTerrainMostDetailed.js
@@ -40,7 +40,11 @@ async function sampleTerrainMostDetailed(terrainProvider, positions) {
   const maxLevels = [];
 
   // readyPromise has been deprecated; This is here for backwards compatibility
-  await terrainProvider._readyPromise;
+  if (defined(terrainProvider._readyPromise)) {
+    await terrainProvider._readyPromise;
+  } else if (defined(terrainProvider.readyPromise)) {
+    await terrainProvider.readyPromise;
+  }
 
   const availability = terrainProvider.availability;
 

--- a/packages/engine/Source/DataSources/ModelVisualizer.js
+++ b/packages/engine/Source/DataSources/ModelVisualizer.js
@@ -454,7 +454,12 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
     // We cannot query the availability of the terrain provider till its ready, so the
     // bounding sphere state will remain pending till the terrain provider is ready.
     // ready is deprecated. This is here for backwards compatibility
-    if (!terrainProvider._ready) {
+    if (
+      defined(terrainProvider) &&
+      (defined(terrainProvider._ready)
+        ? !terrainProvider._ready
+        : defined(terrainProvider.ready) && !terrainProvider.ready)
+    ) {
       return BoundingSphereState.PENDING;
     }
 

--- a/packages/engine/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/packages/engine/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -371,7 +371,7 @@ function ArcGisMapServerImageryProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "ArcGisMapServerImageryProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ArcGisMapServerImageryProvider.fromUrl instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ArcGisMapServerImageryProvider.fromUrl instead."
     );
     const resource = Resource.createIfNeeded(options.url);
     resource.appendForwardSlash();
@@ -706,7 +706,7 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.ready",
-        "ArcGisMapServerImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ArcGisMapServerImageryProvider.fromUrl instead."
+        "ArcGisMapServerImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ArcGisMapServerImageryProvider.fromUrl instead."
       );
       return this._ready;
     },
@@ -723,7 +723,7 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.readyPromise",
-        "ArcGisMapServerImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ArcGisMapServerImageryProvider.fromUrl instead."
+        "ArcGisMapServerImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ArcGisMapServerImageryProvider.fromUrl instead."
       );
       return this._readyPromise;
     },
@@ -798,14 +798,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultAlpha",
-        "ArcGisMapServerImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "ArcGisMapServerImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultAlpha",
-        "ArcGisMapServerImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "ArcGisMapServerImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -822,14 +822,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultNightAlpha",
-        "ArcGisMapServerImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "ArcGisMapServerImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this._defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultNightAlpha",
-        "ArcGisMapServerImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "ArcGisMapServerImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this._defaultNightAlpha = value;
     },
@@ -846,14 +846,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultDayAlpha",
-        "ArcGisMapServerImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "ArcGisMapServerImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultDayAlpha",
-        "ArcGisMapServerImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "ArcGisMapServerImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -870,14 +870,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultBrightness",
-        "ArcGisMapServerImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "ArcGisMapServerImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultBrightness",
-        "ArcGisMapServerImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "ArcGisMapServerImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -894,14 +894,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultContrast",
-        "ArcGisMapServerImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "ArcGisMapServerImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultContrast",
-        "ArcGisMapServerImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "ArcGisMapServerImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -917,14 +917,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultHue",
-        "ArcGisMapServerImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "ArcGisMapServerImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultHue",
-        "ArcGisMapServerImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "ArcGisMapServerImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -941,14 +941,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultSaturation",
-        "ArcGisMapServerImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "ArcGisMapServerImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultSaturation",
-        "ArcGisMapServerImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "ArcGisMapServerImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -964,14 +964,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultGamma",
-        "ArcGisMapServerImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "ArcGisMapServerImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultGamma",
-        "ArcGisMapServerImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "ArcGisMapServerImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -987,14 +987,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultMinificationFilter",
-        "ArcGisMapServerImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "ArcGisMapServerImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultMinificationFilter",
-        "ArcGisMapServerImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "ArcGisMapServerImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -1010,14 +1010,14 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultMagnificationFilter",
-        "ArcGisMapServerImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "ArcGisMapServerImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "ArcGisMapServerImageryProvider.defaultMagnificationFilter",
-        "ArcGisMapServerImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "ArcGisMapServerImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/BingMapsImageryProvider.js
+++ b/packages/engine/Source/Scene/BingMapsImageryProvider.js
@@ -245,7 +245,7 @@ function BingMapsImageryProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "BingMapsImageryProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use BingMapsImageryProvider.fromUrl instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use BingMapsImageryProvider.fromUrl instead."
     );
 
     //>>includeStart('debug', pragmas.debug);
@@ -467,7 +467,7 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.ready",
-        "BingMapsImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use BingMapsImageryProvider.fromUrl instead."
+        "BingMapsImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use BingMapsImageryProvider.fromUrl instead."
       );
       return this._ready;
     },
@@ -484,7 +484,7 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.readyPromise",
-        "BingMapsImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use BingMapsImageryProvider.fromUrl instead."
+        "BingMapsImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use BingMapsImageryProvider.fromUrl instead."
       );
       return this._readyPromise;
     },
@@ -530,14 +530,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultAlpha",
-        "BingMapsImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "BingMapsImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultAlpha",
-        "BingMapsImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "BingMapsImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -554,14 +554,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultNightAlpha",
-        "BingMapsImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "BingMapsImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this.defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultNightAlpha",
-        "BingMapsImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "BingMapsImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this.defaultNightAlpha = value;
     },
@@ -578,14 +578,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultDayAlpha",
-        "BingMapsImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "BingMapsImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultDayAlpha",
-        "BingMapsImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "BingMapsImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -602,14 +602,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultBrightness",
-        "BingMapsImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "BingMapsImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultBrightness",
-        "BingMapsImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "BingMapsImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -626,14 +626,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultContrast",
-        "BingMapsImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "BingMapsImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultContrast",
-        "BingMapsImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "BingMapsImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -649,14 +649,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultHue",
-        "BingMapsImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "BingMapsImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultHue",
-        "BingMapsImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "BingMapsImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -673,14 +673,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultSaturation",
-        "BingMapsImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "BingMapsImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultSaturation",
-        "BingMapsImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "BingMapsImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -696,14 +696,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultGamma",
-        "BingMapsImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "BingMapsImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultGamma",
-        "BingMapsImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "BingMapsImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -719,14 +719,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultMinificationFilter",
-        "BingMapsImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "BingMapsImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultMinificationFilter",
-        "BingMapsImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "BingMapsImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -742,14 +742,14 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "BingMapsImageryProvider.defaultMagnificationFilter",
-        "BingMapsImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "BingMapsImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "BingMapsImageryProvider.defaultMagnificationFilter",
-        "BingMapsImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "BingMapsImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -983,12 +983,16 @@ Globe.prototype.beginFrame = function (frameState) {
   const surface = this._surface;
   const tileProvider = surface.tileProvider;
   const terrainProvider = this.terrainProvider;
+  // ready is deprecated; This is here for backwards compatibility
+  const terrainReady =
+    defined(terrainProvider) &&
+    (defined(terrainProvider._ready)
+      ? terrainProvider._ready
+      : !defined(terrainProvider.ready) || terrainProvider.ready);
   const hasWaterMask =
     this.showWaterEffect &&
-    defined(terrainProvider) &&
+    terrainReady &&
     terrainProvider.hasWaterMask &&
-    // ready is deprecated; This is here for backwards compatibility
-    terrainProvider._ready &&
     terrainProvider.hasWaterMask;
 
   if (hasWaterMask && this._oceanNormalMapResourceDirty) {

--- a/packages/engine/Source/Scene/GlobeSurfaceTile.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTile.js
@@ -346,7 +346,13 @@ GlobeSurfaceTile.prototype.processImagery = function (
     if (tileImagery.loadingImagery.state === ImageryState.PLACEHOLDER) {
       const imageryLayer = tileImagery.loadingImagery.imageryLayer;
       // ImageryProvider.ready is deprecated. This is here for backwards compatibility
-      if (imageryLayer.ready && imageryLayer.imageryProvider._ready) {
+      const imageryProvider = imageryLayer.imageryProvider;
+      if (
+        imageryLayer.ready &&
+        (defined(imageryProvider._ready)
+          ? imageryProvider._ready
+          : !defined(imageryProvider.ready) || imageryProvider.ready)
+      ) {
         // Remove the placeholder and add the actual skeletons (if any)
         // at the same position.  Then continue the loop at the same index.
         tileImagery.freeResources();

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -237,15 +237,32 @@ Object.defineProperties(GlobeSurfaceTileProvider.prototype, {
    */
   ready: {
     get: function () {
-      return (
-        defined(this._terrainProvider) &&
+      const terrainProvider = this._terrainProvider;
+      if (
+        !defined(terrainProvider) ||
         // TerrainProvider.ready is deprecated; This is here for backwards compatibility
-        this._terrainProvider._ready &&
-        (this._imageryLayers.length === 0 ||
-          // ImageryProvider.ready is deprecated; This is here for backwards compatibility
-          (this._imageryLayers.get(0).ready &&
-            this._imageryLayers.get(0).imageryProvider._ready))
-      );
+        (defined(terrainProvider._ready)
+          ? !terrainProvider._ready
+          : defined(terrainProvider.ready) && !terrainProvider.ready)
+      ) {
+        return false;
+      }
+
+      if (this._imageryLayers.length === 0) {
+        return true;
+      }
+
+      const imageryLayer = this._imageryLayers.get(0);
+      if (!imageryLayer.ready) {
+        return false;
+      }
+
+      // ImageryProvider.ready is deprecated; This is here for backwards compatibility
+      const imageryProvider = imageryLayer.imageryProvider;
+      const imageryProviderReady = defined(imageryProvider._ready)
+        ? imageryProvider._ready
+        : !defined(imageryProvider.ready) || imageryProvider.ready;
+      return imageryProviderReady;
     },
   },
 
@@ -346,25 +363,30 @@ GlobeSurfaceTileProvider.prototype.update = function (frameState) {
 
 function updateCredits(surface, frameState) {
   const creditDisplay = frameState.creditDisplay;
+  const terrainProvider = surface._terrainProvider;
   if (
-    defined(surface._terrainProvider) &&
+    defined(terrainProvider) &&
     // ready is deprecated; This is here for backwards compatibility
-    surface._terrainProvider._ready &&
-    defined(surface._terrainProvider.credit)
+    (defined(terrainProvider._ready)
+      ? terrainProvider._ready
+      : !defined(terrainProvider.ready) || terrainProvider.ready) &&
+    defined(terrainProvider.credit)
   ) {
-    creditDisplay.addCreditToNextFrame(surface._terrainProvider.credit);
+    creditDisplay.addCreditToNextFrame(terrainProvider.credit);
   }
 
   const imageryLayers = surface._imageryLayers;
   for (let i = 0, len = imageryLayers.length; i < len; ++i) {
     const layer = imageryLayers.get(i);
-    // ImageryProvider.ready is deprecated; This is here for backwards compatibility
-    if (
-      layer.ready &&
-      layer.imageryProvider._ready &&
-      defined(layer.imageryProvider.credit)
-    ) {
-      creditDisplay.addCreditToNextFrame(layer.imageryProvider.credit);
+    if (layer.ready) {
+      // ImageryProvider.ready is deprecated; This is here for backwards compatibility
+      const imageryProvider = layer.imageryProvider;
+      const imageryProviderReady = defined(imageryProvider._ready)
+        ? imageryProvider._ready
+        : !defined(imageryProvider.ready) || imageryProvider.ready;
+      if (imageryProviderReady && defined(layer.imageryProvider.credit)) {
+        creditDisplay.addCreditToNextFrame(layer.imageryProvider.credit);
+      }
     }
   }
 }
@@ -2144,10 +2166,13 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
     tileProvider.hasWaterMask && defined(waterMaskTexture);
   const oceanNormalMap = tileProvider.oceanNormalMap;
   const showOceanWaves = showReflectiveOcean && defined(oceanNormalMap);
+  const terrainProvider = tileProvider.terrainProvider;
   const hasVertexNormals =
-    defined(tileProvider.terrainProvider) &&
+    defined(terrainProvider) &&
     // ready is deprecated; This is here for backwards compatibility
-    tileProvider.terrainProvider._ready &&
+    (defined(terrainProvider._ready)
+      ? terrainProvider._ready
+      : !defined(terrainProvider.ready) || terrainProvider.ready) &&
     tileProvider.terrainProvider.hasVertexNormals;
   const enableFog =
     frameState.fog.enabled && frameState.fog.renderable && !cameraUnderground;

--- a/packages/engine/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
+++ b/packages/engine/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
@@ -141,7 +141,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "GoogleEarthEnterpriseImageryProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
     );
     const resource = Resource.createIfNeeded(options.url);
     metadata = new GoogleEarthEnterpriseMetadata(resource);
@@ -150,7 +150,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
   if (defined(options.metadata)) {
     deprecationWarning(
       "GoogleEarthEnterpriseImageryProvider options.metadata",
-      "options.metadata was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
+      "options.metadata was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
     );
     metadata = options.metadata;
   }
@@ -332,7 +332,7 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.ready",
-        "GoogleEarthEnterpriseImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107. Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
+        "GoogleEarthEnterpriseImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107. Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
       );
       return this._ready;
     },
@@ -349,7 +349,7 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.readyPromise",
-        "GoogleEarthEnterpriseImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107. Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
+        "GoogleEarthEnterpriseImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107. Use GoogleEarthEnterpriseImageryProvider.fromMetadata instead."
       );
       return this._readyPromise;
     },
@@ -395,14 +395,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultAlpha",
-        "GoogleEarthEnterpriseImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultAlpha",
-        "GoogleEarthEnterpriseImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -419,14 +419,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultNightAlpha",
-        "GoogleEarthEnterpriseImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this.defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultNightAlpha",
-        "GoogleEarthEnterpriseImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this.defaultNightAlpha = value;
     },
@@ -443,14 +443,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultDayAlpha",
-        "GoogleEarthEnterpriseImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultDayAlpha",
-        "GoogleEarthEnterpriseImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -467,14 +467,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultBrightness",
-        "GoogleEarthEnterpriseImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultBrightness",
-        "GoogleEarthEnterpriseImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -491,14 +491,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultContrast",
-        "GoogleEarthEnterpriseImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultContrast",
-        "GoogleEarthEnterpriseImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -514,14 +514,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultHue",
-        "GoogleEarthEnterpriseImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultHue",
-        "GoogleEarthEnterpriseImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -538,14 +538,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultSaturation",
-        "GoogleEarthEnterpriseImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultSaturation",
-        "GoogleEarthEnterpriseImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -561,14 +561,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultGamma",
-        "GoogleEarthEnterpriseImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultGamma",
-        "GoogleEarthEnterpriseImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -584,14 +584,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultMinificationFilter",
-        "GoogleEarthEnterpriseImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultMinificationFilter",
-        "GoogleEarthEnterpriseImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -607,14 +607,14 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultMagnificationFilter",
-        "GoogleEarthEnterpriseImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseImageryProvider.defaultMagnificationFilter",
-        "GoogleEarthEnterpriseImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "GoogleEarthEnterpriseImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/packages/engine/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -469,7 +469,7 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.ready",
-        "GoogleEarthEnterpriseMapsProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107. Use GoogleEarthEnterpriseMapsProvider.fromUrl instead."
+        "GoogleEarthEnterpriseMapsProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107. Use GoogleEarthEnterpriseMapsProvider.fromUrl instead."
       );
       return this._ready;
     },
@@ -486,7 +486,7 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.readyPromise",
-        "GoogleEarthEnterpriseMapsProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107. Use GoogleEarthEnterpriseMapsProvider.fromUrl instead."
+        "GoogleEarthEnterpriseMapsProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107. Use GoogleEarthEnterpriseMapsProvider.fromUrl instead."
       );
       return this._readyPromise;
     },
@@ -532,14 +532,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultAlpha",
-        "GoogleEarthEnterpriseMapsProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultAlpha",
-        "GoogleEarthEnterpriseMapsProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -556,14 +556,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultNightAlpha",
-        "GoogleEarthEnterpriseMapsProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this.defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultNightAlpha",
-        "GoogleEarthEnterpriseMapsProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this.defaultNightAlpha = value;
     },
@@ -580,14 +580,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultDayAlpha",
-        "GoogleEarthEnterpriseMapsProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultDayAlpha",
-        "GoogleEarthEnterpriseMapsProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -604,14 +604,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultBrightness",
-        "GoogleEarthEnterpriseMapsProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultBrightness",
-        "GoogleEarthEnterpriseMapsProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -628,14 +628,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultContrast",
-        "GoogleEarthEnterpriseMapsProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultContrast",
-        "GoogleEarthEnterpriseMapsProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -651,14 +651,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultHue",
-        "GoogleEarthEnterpriseMapsProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultHue",
-        "GoogleEarthEnterpriseMapsProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -675,14 +675,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultSaturation",
-        "GoogleEarthEnterpriseMapsProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultSaturation",
-        "GoogleEarthEnterpriseMapsProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -698,14 +698,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultGamma",
-        "GoogleEarthEnterpriseMapsProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultGamma",
-        "GoogleEarthEnterpriseMapsProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -721,14 +721,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultMinificationFilter",
-        "GoogleEarthEnterpriseMapsProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultMinificationFilter",
-        "GoogleEarthEnterpriseMapsProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -744,14 +744,14 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultMagnificationFilter",
-        "GoogleEarthEnterpriseMapsProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "GoogleEarthEnterpriseMapsProvider.defaultMagnificationFilter",
-        "GoogleEarthEnterpriseMapsProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "GoogleEarthEnterpriseMapsProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/GridImageryProvider.js
+++ b/packages/engine/Source/Scene/GridImageryProvider.js
@@ -202,7 +202,7 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.ready",
-        "GridImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "GridImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return true;
     },
@@ -219,7 +219,7 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.readyPromise",
-        "GridImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "GridImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._readyPromise;
     },
@@ -265,14 +265,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultAlpha",
-        "GridImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "GridImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultAlpha",
-        "GridImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "GridImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -289,14 +289,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultNightAlpha",
-        "GridImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "GridImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this.defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultNightAlpha",
-        "GridImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "GridImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this.defaultNightAlpha = value;
     },
@@ -313,14 +313,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultDayAlpha",
-        "GridImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "GridImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultDayAlpha",
-        "GridImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "GridImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -337,14 +337,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultBrightness",
-        "GridImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "GridImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultBrightness",
-        "GridImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "GridImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -361,14 +361,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultContrast",
-        "GridImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "GridImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultContrast",
-        "GridImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "GridImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -384,14 +384,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultHue",
-        "GridImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "GridImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultHue",
-        "GridImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "GridImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -408,14 +408,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultSaturation",
-        "GridImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "GridImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultSaturation",
-        "GridImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "GridImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -431,14 +431,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultGamma",
-        "GridImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "GridImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultGamma",
-        "GridImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "GridImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -454,14 +454,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultMinificationFilter",
-        "GridImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "GridImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultMinificationFilter",
-        "GridImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "GridImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -477,14 +477,14 @@ Object.defineProperties(GridImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "GridImageryProvider.defaultMagnificationFilter",
-        "GridImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "GridImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "GridImageryProvider.defaultMagnificationFilter",
-        "GridImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "GridImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/Imagery.js
+++ b/packages/engine/Source/Scene/Imagery.js
@@ -34,11 +34,14 @@ function Imagery(imageryLayer, x, y, level, rectangle) {
   this.credits = undefined;
   this.referenceCount = 0;
 
-  // imageryProvider._ready is deprecated; This is here for backward compatibility
+  const imageryProvider = imageryLayer.imageryProvider;
   if (
     !defined(rectangle) &&
     imageryLayer.ready &&
-    imageryLayer.imageryProvider._ready
+    // imageryProvider._ready is deprecated; This is here for backward compatibility
+    (defined(imageryProvider._ready)
+      ? imageryProvider._ready
+      : !defined(imageryProvider.ready) || imageryProvider.ready)
   ) {
     const tilingScheme = imageryLayer.imageryProvider.tilingScheme;
     rectangle = tilingScheme.tileXYToRectangle(x, y, level);

--- a/packages/engine/Source/Scene/ImageryLayer.js
+++ b/packages/engine/Source/Scene/ImageryLayer.js
@@ -690,7 +690,12 @@ ImageryLayer.prototype.getViewableRectangle = async function () {
   const imageryProvider = this._imageryProvider;
   const rectangle = this._rectangle;
   // readyPromise has been deprecated. This is here for backward compatibility and can be removed with readyPromise.
-  await imageryProvider._readyPromise;
+  if (defined(imageryProvider._readyPromise)) {
+    await imageryProvider._readyPromise;
+  } else if (defined(imageryProvider.readyPromise)) {
+    await imageryProvider.readyPromise;
+  }
+
   return Rectangle.intersection(imageryProvider.rectangle, rectangle);
 };
 
@@ -751,8 +756,13 @@ ImageryLayer.prototype._createTileImagerySkeletons = function (
   }
 
   const imageryProvider = this._imageryProvider;
-  // ready is deprecated. This is here for backwards compatibility
-  if (!this.ready || !imageryProvider._ready) {
+  if (
+    !this.ready ||
+    // ready is deprecated. This is here for backwards compatibility
+    (defined(imageryProvider._ready)
+      ? !imageryProvider._ready
+      : defined(imageryProvider.ready) && !imageryProvider.ready)
+  ) {
     // The imagery provider is not ready, so we can't create skeletons, yet.
     // Instead, add a placeholder so that we'll know to create
     // the skeletons once the provider is ready.

--- a/packages/engine/Source/Scene/IonImageryProvider.js
+++ b/packages/engine/Source/Scene/IonImageryProvider.js
@@ -123,7 +123,7 @@ function IonImageryProvider(options) {
   if (defined(assetId)) {
     deprecationWarning(
       "IonImageryProvider options.assetId",
-      "options.assetId was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use IonImageryProvider.fromAssetId instead."
+      "options.assetId was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use IonImageryProvider.fromAssetId instead."
     );
 
     IonImageryProvider._initialize(this, assetId, options);
@@ -142,7 +142,7 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.ready",
-        "IonImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use IonImageryProvider.fromAssetId instead."
+        "IonImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use IonImageryProvider.fromAssetId instead."
       );
       return this._ready;
     },
@@ -159,7 +159,7 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.readyPromise",
-        "IonImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use IonImageryProvider.fromAssetId instead."
+        "IonImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use IonImageryProvider.fromAssetId instead."
       );
       return this._readyPromise;
     },
@@ -322,14 +322,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultAlpha",
-        "IonImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "IonImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultAlpha",
-        "IonImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "IonImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -346,14 +346,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultNightAlpha",
-        "IonImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "IonImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this.defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultNightAlpha",
-        "IonImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "IonImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this.defaultNightAlpha = value;
     },
@@ -370,14 +370,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultDayAlpha",
-        "IonImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "IonImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultDayAlpha",
-        "IonImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "IonImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -394,14 +394,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultBrightness",
-        "IonImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "IonImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultBrightness",
-        "IonImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "IonImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -418,14 +418,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultContrast",
-        "IonImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "IonImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultContrast",
-        "IonImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "IonImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -441,14 +441,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultHue",
-        "IonImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "IonImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultHue",
-        "IonImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "IonImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -465,14 +465,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultSaturation",
-        "IonImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "IonImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultSaturation",
-        "IonImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "IonImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -488,14 +488,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultGamma",
-        "IonImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "IonImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultGamma",
-        "IonImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "IonImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -511,14 +511,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultMinificationFilter",
-        "IonImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "IonImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultMinificationFilter",
-        "IonImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "IonImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -534,14 +534,14 @@ Object.defineProperties(IonImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "IonImageryProvider.defaultMagnificationFilter",
-        "IonImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "IonImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "IonImageryProvider.defaultMagnificationFilter",
-        "IonImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "IonImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/MapboxImageryProvider.js
+++ b/packages/engine/Source/Scene/MapboxImageryProvider.js
@@ -146,7 +146,7 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.ready",
-        "MapboxImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "MapboxImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._imageryProvider.ready;
     },
@@ -163,7 +163,7 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.readyPromise",
-        "MapboxImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "MapboxImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._imageryProvider._readyPromise;
     },
@@ -325,14 +325,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultAlpha",
-        "MapboxImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "MapboxImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultAlpha",
-        "MapboxImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "MapboxImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -349,14 +349,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultNightAlpha",
-        "MapboxImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "MapboxImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this.defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultNightAlpha",
-        "MapboxImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "MapboxImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this.defaultNightAlpha = value;
     },
@@ -373,14 +373,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultDayAlpha",
-        "MapboxImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "MapboxImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultDayAlpha",
-        "MapboxImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "MapboxImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -397,14 +397,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultBrightness",
-        "MapboxImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "MapboxImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultBrightness",
-        "MapboxImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "MapboxImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -421,14 +421,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultContrast",
-        "MapboxImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "MapboxImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultContrast",
-        "MapboxImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "MapboxImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -444,14 +444,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultHue",
-        "MapboxImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "MapboxImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultHue",
-        "MapboxImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "MapboxImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -468,14 +468,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultSaturation",
-        "MapboxImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "MapboxImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultSaturation",
-        "MapboxImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "MapboxImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -491,14 +491,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultGamma",
-        "MapboxImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "MapboxImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultGamma",
-        "MapboxImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "MapboxImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -514,14 +514,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultMinificationFilter",
-        "MapboxImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "MapboxImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultMinificationFilter",
-        "MapboxImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "MapboxImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -537,14 +537,14 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxImageryProvider.defaultMagnificationFilter",
-        "MapboxImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "MapboxImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxImageryProvider.defaultMagnificationFilter",
-        "MapboxImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "MapboxImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/MapboxStyleImageryProvider.js
+++ b/packages/engine/Source/Scene/MapboxStyleImageryProvider.js
@@ -150,7 +150,7 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.ready",
-        "MapboxStyleImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "MapboxStyleImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._imageryProvider.ready;
     },
@@ -167,7 +167,7 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.readyPromise",
-        "MapboxStyleImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "MapboxStyleImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._imageryProvider.readyPromise;
     },
@@ -329,14 +329,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultAlpha",
-        "MapboxStyleImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "MapboxStyleImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultAlpha",
-        "MapboxStyleImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "MapboxStyleImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -353,14 +353,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultNightAlpha",
-        "MapboxStyleImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "MapboxStyleImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this._defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultNightAlpha",
-        "MapboxStyleImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "MapboxStyleImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this._defaultNightAlpha = value;
     },
@@ -377,14 +377,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultDayAlpha",
-        "MapboxStyleImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "MapboxStyleImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultDayAlpha",
-        "MapboxStyleImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "MapboxStyleImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -401,14 +401,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultBrightness",
-        "MapboxStyleImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "MapboxStyleImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultBrightness",
-        "MapboxStyleImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "MapboxStyleImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -425,14 +425,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultContrast",
-        "MapboxStyleImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "MapboxStyleImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultContrast",
-        "MapboxStyleImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "MapboxStyleImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -448,14 +448,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultHue",
-        "MapboxStyleImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "MapboxStyleImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultHue",
-        "MapboxStyleImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "MapboxStyleImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -472,14 +472,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultSaturation",
-        "MapboxStyleImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "MapboxStyleImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultSaturation",
-        "MapboxStyleImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "MapboxStyleImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -495,14 +495,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultGamma",
-        "MapboxStyleImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "MapboxStyleImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultGamma",
-        "MapboxStyleImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "MapboxStyleImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -518,14 +518,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultMinificationFilter",
-        "MapboxStyleImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "MapboxStyleImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultMinificationFilter",
-        "MapboxStyleImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "MapboxStyleImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -541,14 +541,14 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultMagnificationFilter",
-        "MapboxStyleImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "MapboxStyleImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "MapboxStyleImageryProvider.defaultMagnificationFilter",
-        "MapboxStyleImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "MapboxStyleImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/SingleTileImageryProvider.js
+++ b/packages/engine/Source/Scene/SingleTileImageryProvider.js
@@ -253,7 +253,7 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.ready",
-        "SingleTileImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107. Use SingleTileImageryProvider.fromUrl instead."
+        "SingleTileImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107. Use SingleTileImageryProvider.fromUrl instead."
       );
       return this._ready;
     },
@@ -270,7 +270,7 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.readyPromise",
-        "SingleTileImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107. Use SingleTileImageryProvider.fromUrl instead."
+        "SingleTileImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107. Use SingleTileImageryProvider.fromUrl instead."
       );
       return this._readyPromise;
     },
@@ -316,14 +316,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultAlpha",
-        "SingleTileImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "SingleTileImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultAlpha",
-        "SingleTileImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "SingleTileImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -340,14 +340,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultNightAlpha",
-        "SingleTileImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "SingleTileImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this._defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultNightAlpha",
-        "SingleTileImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "SingleTileImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this._defaultNightAlpha = value;
     },
@@ -364,14 +364,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultDayAlpha",
-        "SingleTileImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "SingleTileImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultDayAlpha",
-        "SingleTileImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "SingleTileImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -388,14 +388,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultBrightness",
-        "SingleTileImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "SingleTileImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultBrightness",
-        "SingleTileImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "SingleTileImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -412,14 +412,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultContrast",
-        "SingleTileImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "SingleTileImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultContrast",
-        "SingleTileImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "SingleTileImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -435,14 +435,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultHue",
-        "SingleTileImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "SingleTileImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultHue",
-        "SingleTileImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "SingleTileImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -459,14 +459,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultSaturation",
-        "SingleTileImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "SingleTileImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultSaturation",
-        "SingleTileImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "SingleTileImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -482,14 +482,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultGamma",
-        "SingleTileImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "SingleTileImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultGamma",
-        "SingleTileImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "SingleTileImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -505,14 +505,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultMinificationFilter",
-        "SingleTileImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "SingleTileImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultMinificationFilter",
-        "SingleTileImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "SingleTileImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -528,14 +528,14 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "SingleTileImageryProvider.defaultMagnificationFilter",
-        "SingleTileImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "SingleTileImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "SingleTileImageryProvider.defaultMagnificationFilter",
-        "SingleTileImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "SingleTileImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/packages/engine/Source/Scene/TileCoordinatesImageryProvider.js
@@ -178,7 +178,7 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.ready",
-        "TileCoordinatesImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "TileCoordinatesImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return true;
     },
@@ -195,7 +195,7 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.readyPromise",
-        "TileCoordinatesImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "TileCoordinatesImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._readyPromise;
     },
@@ -241,14 +241,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultAlpha",
-        "TileCoordinatesImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "TileCoordinatesImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultAlpha",
-        "TileCoordinatesImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "TileCoordinatesImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -265,14 +265,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultNightAlpha",
-        "TileCoordinatesImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "TileCoordinatesImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this._defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultNightAlpha",
-        "TileCoordinatesImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "TileCoordinatesImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this._defaultNightAlpha = value;
     },
@@ -289,14 +289,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultDayAlpha",
-        "TileCoordinatesImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "TileCoordinatesImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultDayAlpha",
-        "TileCoordinatesImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "TileCoordinatesImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -313,14 +313,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultBrightness",
-        "TileCoordinatesImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "TileCoordinatesImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultBrightness",
-        "TileCoordinatesImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "TileCoordinatesImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -337,14 +337,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultContrast",
-        "TileCoordinatesImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "TileCoordinatesImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultContrast",
-        "TileCoordinatesImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "TileCoordinatesImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -360,14 +360,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultHue",
-        "TileCoordinatesImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "TileCoordinatesImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultHue",
-        "TileCoordinatesImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "TileCoordinatesImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -384,14 +384,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultSaturation",
-        "TileCoordinatesImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "TileCoordinatesImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultSaturation",
-        "TileCoordinatesImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "TileCoordinatesImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -407,14 +407,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultGamma",
-        "TileCoordinatesImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "TileCoordinatesImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultGamma",
-        "TileCoordinatesImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "TileCoordinatesImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -430,14 +430,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultMinificationFilter",
-        "TileCoordinatesImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "TileCoordinatesImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultMinificationFilter",
-        "TileCoordinatesImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "TileCoordinatesImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -453,14 +453,14 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultMagnificationFilter",
-        "TileCoordinatesImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "TileCoordinatesImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "TileCoordinatesImageryProvider.defaultMagnificationFilter",
-        "TileCoordinatesImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "TileCoordinatesImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/TileMapServiceImageryProvider.js
+++ b/packages/engine/Source/Scene/TileMapServiceImageryProvider.js
@@ -81,7 +81,7 @@ function TileMapServiceImageryProvider(options) {
   if (defined(options.url)) {
     deprecationWarning(
       "TileMapServiceImageryProvider options.url",
-      "options.url was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use TileMapServiceImageryProvider.fromUrl instead."
+      "options.url was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use TileMapServiceImageryProvider.fromUrl instead."
     );
 
     this._metadataError = undefined;

--- a/packages/engine/Source/Scene/UrlTemplateImageryProvider.js
+++ b/packages/engine/Source/Scene/UrlTemplateImageryProvider.js
@@ -493,7 +493,7 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.ready",
-        "UrlTemplateImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "UrlTemplateImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._ready && defined(this._resource);
     },
@@ -510,7 +510,7 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.readyPromise",
-        "UrlTemplateImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "UrlTemplateImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._readyPromise;
     },
@@ -558,14 +558,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultAlpha",
-        "UrlTemplateImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "UrlTemplateImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultAlpha",
-        "UrlTemplateImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "UrlTemplateImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -582,14 +582,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultNightAlpha",
-        "UrlTemplateImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "UrlTemplateImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this._defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultNightAlpha",
-        "UrlTemplateImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "UrlTemplateImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this._defaultNightAlpha = value;
     },
@@ -606,14 +606,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultDayAlpha",
-        "UrlTemplateImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "UrlTemplateImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultDayAlpha",
-        "UrlTemplateImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "UrlTemplateImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -630,14 +630,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultBrightness",
-        "UrlTemplateImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "UrlTemplateImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultBrightness",
-        "UrlTemplateImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "UrlTemplateImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -654,14 +654,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultContrast",
-        "UrlTemplateImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "UrlTemplateImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultContrast",
-        "UrlTemplateImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "UrlTemplateImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -677,14 +677,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultHue",
-        "UrlTemplateImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "UrlTemplateImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultHue",
-        "UrlTemplateImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "UrlTemplateImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -701,14 +701,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultSaturation",
-        "UrlTemplateImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "UrlTemplateImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultSaturation",
-        "UrlTemplateImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "UrlTemplateImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -724,14 +724,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultGamma",
-        "UrlTemplateImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "UrlTemplateImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultGamma",
-        "UrlTemplateImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "UrlTemplateImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -747,14 +747,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultMinificationFilter",
-        "UrlTemplateImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "UrlTemplateImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultMinificationFilter",
-        "UrlTemplateImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "UrlTemplateImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -770,14 +770,14 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultMagnificationFilter",
-        "UrlTemplateImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "UrlTemplateImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "UrlTemplateImageryProvider.defaultMagnificationFilter",
-        "UrlTemplateImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "UrlTemplateImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },
@@ -794,7 +794,7 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
 UrlTemplateImageryProvider.prototype.reinitialize = function (options) {
   deprecationWarning(
     "UrlTemplateImageryProvider.reinitialize",
-    "UrlTemplateImageryProvider.reinitialize was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+    "UrlTemplateImageryProvider.reinitialize was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
   );
 
   return this._reinitialize(options);

--- a/packages/engine/Source/Scene/WebMapServiceImageryProvider.js
+++ b/packages/engine/Source/Scene/WebMapServiceImageryProvider.js
@@ -449,7 +449,7 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.ready",
-        "WebMapServiceImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "WebMapServiceImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._tileProvider.ready;
     },
@@ -466,7 +466,7 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.readyPromise",
-        "WebMapServiceImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "WebMapServiceImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._tileProvider.readyPromise;
     },
@@ -572,14 +572,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultAlpha",
-        "WebMapServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "WebMapServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultAlpha",
-        "WebMapServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "WebMapServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -596,14 +596,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultNightAlpha",
-        "WebMapServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "WebMapServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this._defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultNightAlpha",
-        "WebMapServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "WebMapServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this._defaultNightAlpha = value;
     },
@@ -620,14 +620,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultDayAlpha",
-        "WebMapServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "WebMapServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultDayAlpha",
-        "WebMapServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "WebMapServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -644,14 +644,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultBrightness",
-        "WebMapServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "WebMapServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultBrightness",
-        "WebMapServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "WebMapServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -668,14 +668,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultContrast",
-        "WebMapServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "WebMapServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultContrast",
-        "WebMapServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "WebMapServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -691,14 +691,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultHue",
-        "WebMapServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "WebMapServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultHue",
-        "WebMapServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "WebMapServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -715,14 +715,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultSaturation",
-        "WebMapServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "WebMapServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultSaturation",
-        "WebMapServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "WebMapServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -738,14 +738,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultGamma",
-        "WebMapServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "WebMapServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultGamma",
-        "WebMapServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "WebMapServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -761,14 +761,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultMinificationFilter",
-        "WebMapServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "WebMapServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultMinificationFilter",
-        "WebMapServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "WebMapServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -784,14 +784,14 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultMagnificationFilter",
-        "WebMapServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "WebMapServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapServiceImageryProvider.defaultMagnificationFilter",
-        "WebMapServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "WebMapServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/packages/engine/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -461,7 +461,7 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.ready",
-        "WebMapTileServiceImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "WebMapTileServiceImageryProvider.ready was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return true;
     },
@@ -478,7 +478,7 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.readyPromise",
-        "WebMapTileServiceImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107."
+        "WebMapTileServiceImageryProvider.readyPromise was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107."
       );
       return this._readyPromise;
     },
@@ -570,14 +570,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultAlpha",
-        "WebMapTileServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "WebMapTileServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       return this._defaultAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultAlpha",
-        "WebMapTileServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
+        "WebMapTileServiceImageryProvider.defaultAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.alpha instead."
       );
       this._defaultAlpha = value;
     },
@@ -594,14 +594,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultNightAlpha",
-        "WebMapTileServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "WebMapTileServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       return this._defaultNightAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultNightAlpha",
-        "WebMapTileServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
+        "WebMapTileServiceImageryProvider.defaultNightAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.nightAlpha instead."
       );
       this._defaultNightAlpha = value;
     },
@@ -618,14 +618,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultDayAlpha",
-        "WebMapTileServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "WebMapTileServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       return this._defaultDayAlpha;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultDayAlpha",
-        "WebMapTileServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
+        "WebMapTileServiceImageryProvider.defaultDayAlpha was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.dayAlpha instead."
       );
       this._defaultDayAlpha = value;
     },
@@ -642,14 +642,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultBrightness",
-        "WebMapTileServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "WebMapTileServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       return this._defaultBrightness;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultBrightness",
-        "WebMapTileServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
+        "WebMapTileServiceImageryProvider.defaultBrightness was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.brightness instead."
       );
       this._defaultBrightness = value;
     },
@@ -666,14 +666,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultContrast",
-        "WebMapTileServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "WebMapTileServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       return this._defaultContrast;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultContrast",
-        "WebMapTileServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
+        "WebMapTileServiceImageryProvider.defaultContrast was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.contrast instead."
       );
       this._defaultContrast = value;
     },
@@ -689,14 +689,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultHue",
-        "WebMapTileServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "WebMapTileServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       return this._defaultHue;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultHue",
-        "WebMapTileServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.hue instead."
+        "WebMapTileServiceImageryProvider.defaultHue was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.hue instead."
       );
       this._defaultHue = value;
     },
@@ -713,14 +713,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultSaturation",
-        "WebMapTileServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "WebMapTileServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       return this._defaultSaturation;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultSaturation",
-        "WebMapTileServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
+        "WebMapTileServiceImageryProvider.defaultSaturation was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.saturation instead."
       );
       this._defaultSaturation = value;
     },
@@ -736,14 +736,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultGamma",
-        "WebMapTileServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "WebMapTileServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       return this._defaultGamma;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultGamma",
-        "WebMapTileServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
+        "WebMapTileServiceImageryProvider.defaultGamma was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.gamma instead."
       );
       this._defaultGamma = value;
     },
@@ -759,14 +759,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultMinificationFilter",
-        "WebMapTileServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "WebMapTileServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       return this._defaultMinificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultMinificationFilter",
-        "WebMapTileServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
+        "WebMapTileServiceImageryProvider.defaultMinificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.minificationFilter instead."
       );
       this._defaultMinificationFilter = value;
     },
@@ -782,14 +782,14 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
     get: function () {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultMagnificationFilter",
-        "WebMapTileServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "WebMapTileServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       return this._defaultMagnificationFilter;
     },
     set: function (value) {
       deprecationWarning(
         "WebMapTileServiceImageryProvider.defaultMagnificationFilter",
-        "WebMapTileServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
+        "WebMapTileServiceImageryProvider.defaultMagnificationFilter was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use ImageryLayer.magnificationFilter instead."
       );
       this._defaultMagnificationFilter = value;
     },

--- a/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
+++ b/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
@@ -32,7 +32,11 @@ async function computeFlyToLocationForRectangle(rectangle, scene) {
   }
 
   // readyPromise has been deprecated; This is here for backwards compatibility
-  await terrainProvider._readyPromise;
+  if (defined(terrainProvider._readyPromise)) {
+    await terrainProvider._readyPromise;
+  } else if (defined(terrainProvider.readyPromise)) {
+    await terrainProvider.readyPromise;
+  }
   const availability = terrainProvider.availability;
 
   if (!defined(availability) || scene.mode === SceneMode.SCENE2D) {

--- a/packages/engine/Source/Scene/createOsmBuildings.js
+++ b/packages/engine/Source/Scene/createOsmBuildings.js
@@ -13,6 +13,7 @@ import Cesium3DTileStyle from "./Cesium3DTileStyle.js";
  * tileset.
  *
  * @function
+ *  @deprecated
  *
  * @param {object} [options] Construction options. Any options allowed by the {@link Cesium3DTileset} constructor
  *        may be specified here. In addition to those, the following properties are supported:
@@ -52,7 +53,7 @@ import Cesium3DTileStyle from "./Cesium3DTileStyle.js";
 function createOsmBuildings(options) {
   deprecationWarning(
     "createOsmBuildings",
-    "createOsmBuildings was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use createOsmBuildingsAsync instead."
+    "createOsmBuildings was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use createOsmBuildingsAsync instead."
   );
 
   options = combine(options, {

--- a/packages/engine/Source/Scene/createWorldImagery.js
+++ b/packages/engine/Source/Scene/createWorldImagery.js
@@ -33,7 +33,7 @@ import IonWorldImageryStyle from "./IonWorldImageryStyle.js";
 function createWorldImagery(options) {
   deprecationWarning(
     "createWorldImagery",
-    "createWorldImagery was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use createWorldImageryAsync instead."
+    "createWorldImagery was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use createWorldImageryAsync instead."
   );
 
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -346,7 +346,7 @@ function CesiumWidget(container, options) {
     if (defined(options.imageryProvider)) {
       deprecationWarning(
         "CesiumWidget options.imageryProvider",
-        "options.imageryProvider was deprecated in CesiumJS 1.104.  It will be in CesiumJS 1.107.  Use options.baseLayer instead."
+        "options.imageryProvider was deprecated in CesiumJS 1.104.  It will be removed in CesiumJS 1.107.  Use options.baseLayer instead."
       );
     }
 

--- a/packages/engine/Specs/Scene/ImageryLayerCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ImageryLayerCollectionSpec.js
@@ -22,9 +22,7 @@ describe(
   "Scene/ImageryLayerCollection",
   function () {
     const fakeProvider = {
-      isReady: function () {
-        return false;
-      },
+      ready: false,
     };
 
     it("tracks the base layer on add", function () {

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -2154,7 +2154,7 @@ function zoomToOrFly(that, zoomTarget, options, isFlight) {
       if (defined(zoomTarget.imageryProvider)) {
         // This is here for backward compatibility. It can be removed when readyPromise is removed.
         let promise = Promise.resolve();
-        if (defined(zoomTarget.imageryProvider)) {
+        if (defined(zoomTarget.imageryProvider._readyPromise)) {
           promise = zoomTarget.imageryProvider._readyPromise;
         } else if (defined(zoomTarget.imageryProvider.readyPromise)) {
           promise = zoomTarget.imageryProvider.readyPromise;

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -2153,7 +2153,13 @@ function zoomToOrFly(that, zoomTarget, options, isFlight) {
 
       if (defined(zoomTarget.imageryProvider)) {
         // This is here for backward compatibility. It can be removed when readyPromise is removed.
-        rectanglePromise = zoomTarget.imageryProvider._readyPromise.then(() => {
+        let promise = Promise.resolve();
+        if (defined(zoomTarget.imageryProvider)) {
+          promise = zoomTarget.imageryProvider._readyPromise;
+        } else if (defined(zoomTarget.imageryProvider.readyPromise)) {
+          promise = zoomTarget.imageryProvider.readyPromise;
+        }
+        rectanglePromise = promise.then(() => {
           return zoomTarget.getImageryRectangle();
         });
       } else {

--- a/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -15,9 +15,15 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
   }
   MockGlobe.prototype.isDestroyed = () => false;
 
-  const testProvider = {};
-  const testProvider2 = {};
-  const testProvider3 = {};
+  const testProvider = {
+    ready: false,
+  };
+  const testProvider2 = {
+    ready: false,
+  };
+  const testProvider3 = {
+    ready: false,
+  };
 
   const testProviderViewModel = new ProviderViewModel({
     name: "name",

--- a/packages/widgets/Specs/Viewer/ViewerSpec.js
+++ b/packages/widgets/Specs/Viewer/ViewerSpec.js
@@ -58,12 +58,7 @@ describe(
   function () {
     const readyPromise = Promise.resolve(true);
     const testProvider = {
-      isReady: function () {
-        return false;
-      },
-      _ready: true,
       ready: true,
-      _readyPromise: readyPromise,
       readyPromise: readyPromise,
       tilingScheme: {
         tileXYToRectangle: function () {


### PR DESCRIPTION
* Fixes https://github.com/CesiumGS/cesium/issues/11274 
    * This is resolved by ensuring the existence of either `_ready` or `ready` before checking the value.
    * The logic is a bit more complicated in these checks as we don't want to check `ready` unless completely necessary. Otherwise an unneeded deprecation warning is thrown when accessing `ready` for our build-in providers.
* Fixes deprecation warning typo reported in https://github.com/CesiumGS/cesium/issues/11195#issuecomment-1555937605
* Fixes https://github.com/CesiumGS/cesium/issues/11303#issuecomment-1558379153

For testing, here's a [local sandcastle with custom terrain and imagery providers](http://localhost:8080/Apps/Sandcastle/index.html#c=5Vdpb9s2GP4rhD/Jg0vHWXMscYJ5rtsGcJeiyZZuMGDQ0mubK0VqJOXUG/zfx0O3lcXZ9m0BAkPk897HI4WCK402FB5BoivE4RGNQdE0xj+7s2DWCd3zWHBNKAc56/TQnzOO0IIomJItyItc5CYmK5Bbd4iXUsQPQrIoOw2cEEJKbxmUIoJXQXf2Eo8mn25G0/nDzf37+XT0w2R617Oyu26vZvcjDb9Y60vCFJirXfdyxkMXELP3ygTkI8MqBA6YVvxTBpujF4yEXz4QuWBgRJ4K5qMUGxqBHKktDwPrSRlDBs4hDj9SCvRNFHx7Pjjuzrh1rmIIE5asiTF3hE8aNwtJV2vNQdkAjvGRufbxYBJFQQXZdTEsUx5qKjgap0qLuOEKCrooy7xeU4XnmjLKV3fhGmKoV/wdiJUkyZqG9xVMXjcJoSZ8Vandp/zEhfsGVhJABR5t/16dneCjXvl8fF57fHV6Vr/+Dp+d5I/d7IKn8QLk7XIKG2C/ghTGNVCfL9DgbwG/lABgjCZK0Kjwe5Kf4Id3d+evfWu5VOY5AimFnGyA63qG3FFgsTsLnvHbxW8mCTiCpRkNk/IEpKYmCa2lwIkUWuhtAtkESSDR9iIvzwr0ha3W1TVKudcYoX4fCYm0TMG52fNmM1GjOKYKDtGQQbEEJdgGAquxW1dZbYy6yqLDbC8Z0zqVvKWbLtGu6WTRMv9AHS7E9xQbGDzQSK/bQkcng+N9+BrsUB2Gj8lXGqexa6k2iaMGnPKXwO1/2WAHp6YU2UvHmqiR3SbjNeG83Yeig7I16QWfaVNTgd9TUNoBzCSU3n3toW0PMRtxD2WoYs9kbtf3aKGdCeK3fcBTZqRnHYz7bjOrvheZT8VKzMUGpFl7OOGrWce7vDvYcRO53QNjCRHVquZ6081iUl5oIjHs8xaI0QFVAwfoz2knyVd0tmPaDAYlp3ketrmpL6UqUQW5zm6dNErZVs64N81lyH2PMw7dhv+WWw7f0bkllq/7D35Wjf4YtKThxDpbsngjMtsYE6VNu2mICsqoC78VcvTebYuYJMFT1IkLnzOeOX3dexJrrP6Y8dRnx08j7YwHR24HZ4TyHJ00Y/m/0Ml/vjUztn8mq/n2swXLOmTbtkn8dD5aOjLXg9PL8tCTTnmaudbMXvYmU05L0X6Zc2+IJvmsmBfgdLm0771W4CfK9fnIgLaB9+CbzGi3eLN69ETpforDnA79b3a8K7vxoASZ5Ls2fmoGy1RZvW5kzXtw3qyVKj0zzX0UDNBw6DWU7h3koK2eTd9oQygj/g1/r4Qtq/qwDFgya1gwHay3LzJS+0bRjVVc5YaGH271dnqdofukus5L+z2NEyE1SiULDLVqiBNm1p3qL1LzvaRxqJTfpAgN+1XRYUQ3iEZXLZ98KGREKXOzNJx9R/+AWed62Df4PVGbETPCt569LWw9uJ76Q4zxsG8e2yW1EGxBZEPzXw). Sandcastles related to terrain or imagery should also be verified.