### PR TITLE
Fix fragment shader output variable in DerivedCommand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.107 - 2023-07-01
+
+##### Fixes :wrench:
+
+- Fixed `PostProcessStage` crash affecting point clouds rendered with attenuation. [#11339](https://github.com/CesiumGS/cesium/issues/11339)
+
 ### 1.106.1 - 2023-06-02
 
 This is an npm-only release to fix a dependency issue published in 1.106

--- a/packages/engine/Source/Scene/DerivedCommand.js
+++ b/packages/engine/Source/Scene/DerivedCommand.js
@@ -278,16 +278,21 @@ function getPickShaderProgram(context, shaderProgram, pickId) {
     const sources = fs.sources;
     const length = sources.length;
 
-    const newMain =
-      `${
-        "void main() \n" +
-        "{ \n" +
-        "    czm_non_pick_main(); \n" +
-        "    if (out_FragColor.a == 0.0) { \n" +
-        "        discard; \n" +
-        "    } \n" +
-        "    out_FragColor = "
-      }${pickId}; \n` + `} \n`;
+    const hasFragData = sources.some((source) =>
+      source.includes("out_FragData")
+    );
+    const outputColorVariable = hasFragData
+      ? "out_FragData_0"
+      : "out_FragColor";
+    const newMain = `void main () 
+{ 
+    czm_non_pick_main(); 
+    if (${outputColorVariable}.a == 0.0) { 
+        discard; 
+    } 
+    ${outputColorVariable} = ${pickId}; 
+} `;
+
     const newSources = new Array(length + 1);
     for (let i = 0; i < length; ++i) {
       newSources[i] = ShaderSource.replaceMain(sources[i], "czm_non_pick_main");


### PR DESCRIPTION
Fixes #11339. 

When deriving a pick shader, we do the following: 
1. Bundle the main shader code into a `czm_non_pick_main` function
2. Call it from a new `main` function
3. Check the value of the fragment alpha channel to decide whether to pick or discard the current fragment. 

Step 3 requires us to know the name of the output fragment variable: it could be either `out_FragColor` or `out_FragData_0`, depending on the structure of `czm_non_pick_main`.

This PR checks the name of the output variable, and uses the appropriate name in the pick shader, instead of assuming `out_FragColor`.