### PR TITLE
Fix documented prototype class on Model.incrementallyLoadTextures

### DIFF
--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -682,7 +682,7 @@ Object.defineProperties(Model.prototype, {
   /**
    * Returns true if textures are loaded separately from the other glTF resources.
    *
-   * @memberof GltfLoader.prototype
+   * @memberof Model.prototype
    *
    * @type {boolean}
    * @readonly


### PR DESCRIPTION
This looks like just a copy-and-paste error on a member of `Model` that came over from `GltfLoader`.