### PR TITLE
Fix credit display for hidden imagery layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed `PostProcessStage` crash affecting point clouds rendered with attenuation. [#11339](https://github.com/CesiumGS/cesium/issues/11339)
+- Fixed credits for imagery layer shows up even when layer is hidden [#11340](https://github.com/CesiumGS/cesium/issues/11340)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -378,7 +378,7 @@ function updateCredits(surface, frameState) {
   const imageryLayers = surface._imageryLayers;
   for (let i = 0, len = imageryLayers.length; i < len; ++i) {
     const layer = imageryLayers.get(i);
-    if (layer.ready) {
+    if (layer.ready && layer.show) {
       // ImageryProvider.ready is deprecated; This is here for backwards compatibility
       const imageryProvider = layer.imageryProvider;
       const imageryProviderReady = defined(imageryProvider._ready)


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11340

To test:

> Use this minimal Sandcastle:
> ```
> const viewer = new Cesium.Viewer("cesiumContainer", {geocoder: false});
> viewer.imageryLayers.get(0).show = false;
> ```
> The Bing maps logo still shows up in Attribution even though it's impossible for it to show up in the scene.