### PR TITLE
Fixed Insufficient buffer size thrown by rendering 3dtiles.

### DIFF
--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -1340,7 +1340,14 @@ function continueDraw(context, drawCommand, shaderProgram, uniformMap) {
 
   if (defined(indexBuffer)) {
     offset = offset * indexBuffer.bytesPerIndex; // offset in vertices to offset in bytes
-    count = defaultValue(count, indexBuffer.numberOfIndices);
+    if (count) {
+      count =
+        count < indexBuffer.numberOfIndices
+          ? count
+          : indexBuffer.numberOfIndices;
+    } else {
+      count = indexBuffer.numberOfIndices;
+    }
     if (instanceCount === 0) {
       context._gl.drawElements(
         primitiveType,
@@ -1358,7 +1365,11 @@ function continueDraw(context, drawCommand, shaderProgram, uniformMap) {
       );
     }
   } else {
-    count = defaultValue(count, va.numberOfVertices);
+    if (count) {
+      count = count < va.numberOfIndices ? count : va.numberOfIndices;
+    } else {
+      count = va.numberOfIndices;
+    }
     if (instanceCount === 0) {
       context._gl.drawArrays(primitiveType, offset, count);
     } else {


### PR DESCRIPTION
Before repair
![image](https://github.com/CesiumGS/cesium/assets/17905150/f2dbe655-f9ae-4a74-8f3c-f7cc3887cab7)

After repair
![image](https://github.com/CesiumGS/cesium/assets/17905150/e8a37a27-9b54-492e-918a-3467bd187745)

This is the test data. (Data needs to be published independently.)
[test_data.zip](https://github.com/CesiumGS/cesium/files/11767969/test_data.zip)

This is the test code.
```js
const viewer = new Cesium.Viewer("cesiumContainer");

try {
  const tileset = await Cesium.Cesium3DTileset.fromUrl('http://127.0.0.1:9092/63b0f42c-c5ef-4874-bbdc-21e9d6e3ee56/tileset.json');
  viewer.scene.primitives.add(tileset);
  viewer.zoomTo(tileset);
} catch (error) {
  console.log(`Error loading tileset: ${error}`);
} 
```
