### PR TITLE
Fix 3D Tiles debug label rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed `PostProcessStage` crash affecting point clouds rendered with attenuation. [#11339](https://github.com/CesiumGS/cesium/issues/11339)
+- Fixed debug label rendering in `Cesium3dTilesInspector`. [#11355](https://github.com/CesiumGS/cesium/issues/11355)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -1181,6 +1181,13 @@ Billboard.prototype._loadImage = function () {
     return;
   }
 
+  // If the promise has already successfully resolved, we can return immediately without waiting a frame
+  const index = atlas.getImageIndex(imageId);
+  if (defined(index) && !defined(imageSubRegion)) {
+    completeImageLoad(index);
+    return;
+  }
+
   imageIndexPromise.then(completeImageLoad).catch(function (error) {
     console.error(`Error loading image for billboard: ${error}`);
     that._imageIndexPromise = undefined;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11355.

The issue was introduced in https://github.com/CesiumGS/cesium/pull/11293, but this should ensure both cases are now working. 

The debug labels are destroyed at the beginning of every frame-- Which doesn't leave any time for the promise in `Billboard.js` to resolve. This can be worked around by skipping the promise chain under specific conditions.