### PR TITLE
Fix crash with hidden 3D Tileset in CZML

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed crash in `CzmlDataSource` when a 3D Tileset entity is hidden. [#11357](https://github.com/CesiumGS/cesium/issues/11357)
 - Fixed `PostProcessStage` crash affecting point clouds rendered with attenuation. [#11339](https://github.com/CesiumGS/cesium/issues/11339)
 
 ##### Deprecated :hourglass_flowing_sand:

--- a/packages/engine/Source/DataSources/Cesium3DTilesetVisualizer.js
+++ b/packages/engine/Source/DataSources/Cesium3DTilesetVisualizer.js
@@ -79,16 +79,17 @@ Cesium3DTilesetVisualizer.prototype.update = function (time) {
       );
     }
 
+    const tileset = defined(tilesetData)
+      ? tilesetData.tilesetPrimitive
+      : undefined;
+
     if (!show) {
-      if (defined(tilesetData)) {
-        tilesetData.tilesetPrimitive.show = false;
+      if (defined(tileset)) {
+        tileset.show = false;
       }
       continue;
     }
 
-    const tileset = defined(tilesetData)
-      ? tilesetData.tilesetPrimitive
-      : undefined;
     if (!defined(tilesetData) || resource.url !== tilesetData.url) {
       if (defined(tileset)) {
         primitives.removeAndDestroy(tileset);

--- a/packages/engine/Specs/DataSources/Cesium3DTilesetVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/Cesium3DTilesetVisualizerSpec.js
@@ -211,6 +211,102 @@ describe(
       expect(tilesetPrimitive.id).toEqual(testObject);
     });
 
+    it("Visualizer does not create tileset primitive when show is false.", async function () {
+      const time = JulianDate.now();
+      const entityCollection = new EntityCollection();
+      visualizer = new Cesium3DTilesetVisualizer(scene, entityCollection);
+
+      const tileset = new Cesium3DTilesetGraphics();
+      tileset.show = new ConstantProperty(false);
+      tileset.uri = new ConstantProperty(
+        new Resource({
+          url: tilesetUrl,
+        })
+      );
+
+      const testObject = entityCollection.getOrCreateEntity("test");
+      testObject.position = new ConstantPositionProperty(
+        Cartesian3.fromDegrees(1, 2, 3)
+      );
+      testObject.tileset = tileset;
+
+      spyOn(Cesium3DTileset, "fromUrl").and.callThrough();
+
+      visualizer.update(time);
+
+      expect(Cesium3DTileset.fromUrl).not.toHaveBeenCalled();
+
+      tileset.show = new ConstantProperty(true);
+
+      visualizer.update(time);
+
+      expect(Cesium3DTileset.fromUrl).toHaveBeenCalled();
+
+      await pollToPromise(function () {
+        return defined(scene.primitives.get(0));
+      });
+
+      expect(scene.primitives.length).toEqual(1);
+      expect(scene.primitives.get(0)).toBeInstanceOf(Cesium3DTileset);
+      expect(scene.primitives.get(0).show).toEqual(true);
+    });
+
+    it("Visualizer does not create tileset primitive when show is false.", async function () {
+      const time = JulianDate.now();
+      const entityCollection = new EntityCollection();
+      visualizer = new Cesium3DTilesetVisualizer(scene, entityCollection);
+
+      const tileset = new Cesium3DTilesetGraphics();
+      tileset.show = new ConstantProperty(true);
+      tileset.uri = new ConstantProperty(
+        new Resource({
+          url: tilesetUrl,
+        })
+      );
+
+      const testObject = entityCollection.getOrCreateEntity("test");
+      testObject.position = new ConstantPositionProperty(
+        Cartesian3.fromDegrees(1, 2, 3)
+      );
+      testObject.tileset = tileset;
+
+      spyOn(Cesium3DTileset, "fromUrl");
+      visualizer.update(time);
+
+      tileset.show = new ConstantProperty(false);
+
+      expect(() => visualizer.update(time)).not.toThrow();
+    });
+
+    it("Visualizer sets show property.", async function () {
+      const entityCollection = new EntityCollection();
+      visualizer = new Cesium3DTilesetVisualizer(scene, entityCollection);
+
+      const time = JulianDate.now();
+      const testObject = entityCollection.getOrCreateEntity("test");
+      const tileset = new Cesium3DTilesetGraphics();
+      testObject.tileset = tileset;
+
+      testObject.position = new ConstantProperty(
+        new Cartesian3(5678, 1234, 1101112)
+      );
+      tileset.uri = new ConstantProperty(tilesetUrl);
+      visualizer.update(time);
+
+      await pollToPromise(function () {
+        return defined(scene.primitives.get(0));
+      });
+
+      const tilesetPrimitive = scene.primitives.get(0);
+      expect(tilesetPrimitive.show).toEqual(true);
+
+      tileset.show = new ConstantProperty(false);
+
+      visualizer.update(time);
+
+      expect(tilesetPrimitive.show).toEqual(false);
+    });
+
     it("Computes bounding sphere.", async function () {
       const entityCollection = new EntityCollection();
       visualizer = new Cesium3DTilesetVisualizer(scene, entityCollection);


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11357

There was a race condition when a 3D tileset embedded in a CZML data source was loaded and the visibility was set to false.