### PR TITLE
Initial WebXR display support for Scene

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added `Cesium3DTileset.cacheBytes` and `Cesium3DTileset.maximumCacheOverflowBytes` to better control memory usage. To replicate previous behavior, convert `maximumMemoryUsage` from MB to bytes, assign the value to `cacheBytes`, and set `maximumCacheOverflowBytes = Number.MAX_VALUE`
+- Added `Cesium.Scene.webXRContext` and initial support for integrating Cesium into the WebXR redering cycle.
 
 ##### Fixes :wrench:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -360,3 +360,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Alexander Popoff](https://github.com/aerialist7)
 - [IKangXu](https://github.com/IKangXu)
 - [e3dio](https://github.com/e3dio)
+- [Arturo Espinosa](https://github.com/pupitetris)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -360,4 +360,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Alexander Popoff](https://github.com/aerialist7)
 - [IKangXu](https://github.com/IKangXu)
 - [e3dio](https://github.com/e3dio)
-- [Arturo Espinosa](https://github.com/pupitetris)
+- [Arturo Espinosa Aldama](https://github.com/pupitetris)

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -2875,18 +2875,13 @@ function executeWebXRCommands(scene, passState, backgroundColor) {
   const renderTranslucentDepthForPick =
     environmentState.renderTranslucentDepthForPick;
 
-  const xr = scene.xr;
-  const xrFrame = xr.frame;
-  const xrPose = xrFrame.getViewerPose(xr.refSpace);
-  if (!defined(xrPose)) {
-    return; // TODO: we should handle gracefully.
-  }
-
   updateAndClearFramebuffers(scene, passState, backgroundColor);
 
   updateAndRenderPrimitives(scene);
 
   view.createPotentiallyVisibleSet(scene);
+
+  executeComputeCommands(scene);
 
   if (!renderTranslucentDepthForPick) {
     executeShadowMapCastCommands(scene);
@@ -2907,6 +2902,13 @@ function executeWebXRCommands(scene, passState, backgroundColor) {
   );
 
   const offset = (0.5 * eyeSeparation * near) / fo;
+
+  const xr = scene.xr;
+  const xrFrame = xr.frame;
+  const xrPose = xrFrame.getViewerPose(xr.refSpace);
+  if (!defined(xrPose)) {
+    return; // TODO: we should handle gracefully.
+  }
 
   const xrLayer = xrFrame.session.renderState.baseLayer;
   for (const xrView of xrPose.views) {
@@ -2938,6 +2940,8 @@ function executeWebXRCommands(scene, passState, backgroundColor) {
 
   // Now manually blit into the framebuffer provided by WebXR, which
   // is the framebuffer for the HMD's displays.
+
+  // When the WebXR Emulator is used, xrLayer has no framebuffer.
   if (defined(xrLayer.framebuffer)) {
     const srcFb = passState.framebuffer;
     const gl = srcFb._gl;

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -2970,6 +2970,8 @@ function executeWebVRCommands(scene, passState, backgroundColor) {
 
   for (const eye of Object.keys(pose.viewports)) {
     const viewport = pose.viewports[eye];
+    passState.viewport = viewport;
+
     camera.frustum.aspectRatio = viewport.width / viewport.height;
 
     if (eye === "left") {

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -594,6 +594,7 @@ function Scene(options) {
   this._useWebVR = false;
   this._cameraVR = undefined;
   this._aspectRatioVR = undefined;
+  this._poseVR = undefined;
 
   /**
    * When <code>true</code>, rendering a frame will only occur when needed as determined by changes within the scene.
@@ -2865,14 +2866,14 @@ Scene.prototype.updateAndExecuteCommands = function (
 };
 
 function prepareWebVRPose(scene, viewport) {
-  let pose = scene._webVRPose;
+  let pose = scene._poseVR;
 
   if (!defined(pose)) {
     pose = {
       xrLayer: null,
       viewports: {},
     };
-    scene._webVRPose = pose;
+    scene._poseVR = pose;
   }
 
   if (defined(scene.xr)) {


### PR DESCRIPTION
This PR will be limited to making CesiumJS work with WebXR-enabled UAs at the Scene level, and it is considered as a Proof Of Concept due to its caveats, which may be worked on to make it acceptable for merging. The idea is to have a base to continue the discussion regarding WebXR support.

For a demo on how to use this proposal, check the [cesium-vr demo](https://github.com/pupitetris/cesium-vr). The most imprtant file is [htdocs/index.js](https://github.com/pupitetris/cesium-vr/blob/pupitetris/htdocs/index.js). This was initially a fork from a NICTA experiment, but most of the code originally found there is not in use by my demo.

## TO-DO:

  - [ ] Currently to achieve display on the Head Mounted Display (HMD) hardware, as a final stage in `Scene:executeWebVRCommands`, I am doing a low-level GL blit operation from the provided passState GL framebuffer to the GL framebuffer provided by WebXR.
    - This should be done at a Render level, using `Context` and something like `Renderer/MultisampleFramebuffer`.
    - The current method additionaly has the limitation that antialiasing cannot be activated in the WebGL context or the Blit will fail, and this is specially bad for HMDs due to the low resolution of the displays. Here the error that is produced:
    ```
    [WebGL-0x20036ff00]GL ERROR :GL_INVALID_OPERATION : glBlitFramebufferCHROMIUM: destination framebuffer is multisampled
    ```
  - [ ] Also on `executeWebVRCommands`, make use of the transform and projection matrix that WebXR provides to calculate camera offsets, frustum, etc. Right now we are using the method that was already in place for WebVR, but the parameters provided by WebXR are supposed to be the ideal ones and are provided by the HMD. For example, the Meta Quest 2 is aware of the IPD the user is phisically setting inside the device, and the transform+projection parameters probably obay such adjustment. The WebXR documentation strongly recommends using these params to avoid discomfort for the users.
  - [ ] Establish a mechanism to allow the containing app to know if pose information from the HMD was not available at a given frame (probably due to lost tracking). Maybe an event handler.

## Next steps

After the issues of this POC are resolved, it would be interesting to work on `Viewer`, where device and API discovery, scene configuration and WebXR session handling would be taking place. Discussion would be necessary regarding HUD widget display inside the VR session, since it is a WebGL pure view and also a default controller scheme that adapts/degrades according to the different VR sets capabilities. Also camera handling, beyond the trivial direct mapping of HMD orientation to camera orientation.