### PR TITLE
Workspace dependencies now use caret versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -587,7 +587,7 @@ export const postversion = async function () {
       return;
     }
     // Update the version for the updated workspace.
-    packageJson.dependencies[workspace] = version;
+    packageJson.dependencies[workspace] = `^${version}`;
     await writeFile(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
   });
   return Promise.all(promises);

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "./Specs/**/*"
   ],
   "dependencies": {
-    "@cesium/engine": "2.4.1",
-    "@cesium/widgets": "2.3.1"
+    "@cesium/engine": "^2.4.1",
+    "@cesium/widgets": "^2.3.1"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.342.0",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -28,7 +28,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@cesium/engine": "2.4.1",
+    "@cesium/engine": "^2.4.1",
     "nosleep.js": "^0.12.0"
   },
   "type": "module",


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11336

Marks workspace dependencies with caret versioning to ensure non-conflicting versions of @cesium/engine and @cesium/widgets are ever installed.

This also updates the `postversion` command so that incrementing the version takes the caret versioning into account.