### PR TITLE
Fix crash due to terrain loading race condition

### DIFF
--- a/packages/engine/Source/Scene/GlobeSurfaceTile.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTile.js
@@ -686,6 +686,11 @@ function upsample(surfaceTile, tile, frameState, terrainProvider, x, y, level) {
 
   Promise.resolve(terrainDataPromise)
     .then(function (terrainData) {
+      if (!defined(terrainData)) {
+        // The upsample request has been deferred - try again later.
+        return;
+      }
+
       surfaceTile.terrainData = terrainData;
       surfaceTile.terrainState = TerrainState.RECEIVED;
     })
@@ -696,6 +701,13 @@ function upsample(surfaceTile, tile, frameState, terrainProvider, x, y, level) {
 
 function requestTileGeometry(surfaceTile, terrainProvider, x, y, level) {
   function success(terrainData) {
+    if (!defined(terrainData)) {
+      // Throttled due to low priority - try again later.
+      surfaceTile.terrainState = TerrainState.UNLOADED;
+      surfaceTile.request = undefined;
+      return;
+    }
+
     surfaceTile.terrainData = terrainData;
     surfaceTile.terrainState = TerrainState.RECEIVED;
     surfaceTile.request = undefined;


### PR DESCRIPTION
Follow up from https://github.com/CesiumGS/cesium/pull/11296

Technically after that change, due to [this line](https://github.com/CesiumGS/cesium/pull/11296/files#diff-39e084694ee46ce76a00b042bb4e510d79af3f07440a23a2248952da9757b182R941), it was possible to return a promise which resolves to undefined if a `requestTileGeometry` request gets throttled by the requestScheduler.

TODO:
- [ ] Unit test?