### PR TITLE
fix: rectanglePromise.then is not a function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.108 - 2023-08-01
+
+#### @cesium/widgets
+
+##### Fixes :wrench:
+
+- Fixed the error report "rectanglePromise.then is not a function" that occurred when using `viewer.flyTo` to navigate to an ImageryLayer. [#11392](https://github.com/CesiumGS/cesium/pull/11392)
+
 ### 1.107 - 2023-07-03
 
 #### Major Announcements :loudspeaker:
@@ -95,7 +103,6 @@ try {
 - Fixed debug label rendering in `Cesium3dTilesInspector`. [#11355](https://github.com/CesiumGS/cesium/issues/11355)
 - Fixed credits for imagery layer shows up even when layer is hidden. [#11340](https://github.com/CesiumGS/cesium/issues/11340)
 - Fixed Insufficient buffer size thrown by rendering 3dtiles. [#11358](https://github.com/CesiumGS/cesium/pull/11358)
-- Fixed the error report "rectanglePromise.then is not a function" that occurred when using ``viewer.flyTo`` to navigate to an ImageryLayer. [#11392](https://github.com/CesiumGS/cesium/pull/11392)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,7 @@ try {
 - Fixed debug label rendering in `Cesium3dTilesInspector`. [#11355](https://github.com/CesiumGS/cesium/issues/11355)
 - Fixed credits for imagery layer shows up even when layer is hidden. [#11340](https://github.com/CesiumGS/cesium/issues/11340)
 - Fixed Insufficient buffer size thrown by rendering 3dtiles. [#11358](https://github.com/CesiumGS/cesium/pull/11358)
+- Fixed the error report "rectanglePromise.then is not a function" that occurred when using ``viewer.flyTo`` to navigate to an ImageryLayer. [#11392](https://github.com/CesiumGS/cesium/pull/11392)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -361,3 +361,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [IKangXu](https://github.com/IKangXu)
 - [e3dio](https://github.com/e3dio)
 - [Dphalos](https://github.com/Dphalos)
+- [hongfaqiu](https://github.com/hongfaqiu)

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -2137,7 +2137,7 @@ function zoomToOrFly(that, zoomTarget, options, isFlight) {
       let rectanglePromise;
 
       if (defined(zoomTarget.imageryProvider)) {
-        rectanglePromise = zoomTarget.getImageryRectangle();
+        rectanglePromise = Promise.resolve(zoomTarget.getImageryRectangle());
       } else {
         rectanglePromise = new Promise((resolve) => {
           const removeListener = zoomTarget.readyEvent.addEventListener(() => {

--- a/packages/widgets/Specs/Viewer/ViewerSpec.js
+++ b/packages/widgets/Specs/Viewer/ViewerSpec.js
@@ -62,6 +62,7 @@ describe(
           return new Rectangle();
         },
       },
+      rectangle: Rectangle.MAX_VALUE,
     };
 
     const testProviderViewModel = new ProviderViewModel({
@@ -1867,6 +1868,20 @@ describe(
       return promise.then(function () {
         expect(wasCompleted).toEqual(true);
       });
+    });
+
+    it("flyTo flies to imagery layer with default offset when options are not defined", async function () {
+      viewer = createViewer(container);
+
+      const imageryLayer = new ImageryLayer(testProvider);
+
+      const promise = viewer.flyTo(imageryLayer, {
+        duration: 0,
+      });
+
+      viewer._postRender();
+
+      await expectAsync(promise).toBeResolved();
     });
 
     it("flyTo flies to VoxelPrimitive with default offset when options not defined", function () {


### PR DESCRIPTION
In the latest Cesium version, v1.107.0, an issue has occurred when using ``viewer.flyTo`` to navigate to an ImageryLayer.