### PR TITLE
Fix check for style translucency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,13 +7,13 @@
 ##### Fixes :wrench:
 
 - Fixed dimensions of `tangentEC` in custom shaders [#11394](https://github.com/CesiumGS/cesium/pull/11394).
+- Fixed a bug where `Model` would not respond to different alpha values in a `Cesium3DTileStyle`. [#11399](https://github.com/CesiumGS/cesium/pull/11399)
 
 #### @cesium/widgets
 
 ##### Fixes :wrench:
 
 - Fixed the error report "rectanglePromise.then is not a function" that occurred when using `viewer.flyTo` to navigate to an ImageryLayer. [#11392](https://github.com/CesiumGS/cesium/pull/11392)
-- Fixed a bug where `Model` would not respond to different alpha values in a `Cesium3DTileStyle`. [#11399](https://github.com/CesiumGS/cesium/pull/11399)
 
 ### 1.107 - 2023-07-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Fixes :wrench:
 
 - Fixed the error report "rectanglePromise.then is not a function" that occurred when using `viewer.flyTo` to navigate to an ImageryLayer. [#11392](https://github.com/CesiumGS/cesium/pull/11392)
+- Fixed a bug where `Model` would not respond to different alpha values in a `Cesium3DTileStyle`. [#11399](https://github.com/CesiumGS/cesium/pull/11399)
 
 ### 1.107 - 2023-07-03
 

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -2902,11 +2902,13 @@ Model.fromGeoJson = async function (options) {
   return model;
 };
 
+const scratchColor = new Color();
+
 /**
  * @private
  */
 Model.prototype.applyColorAndShow = function (style) {
-  const previousColor = this._color;
+  const previousColor = Color.clone(this._color, scratchColor);
   const hasColorStyle = defined(style) && defined(style.color);
   const hasShowStyle = defined(style) && defined(style.show);
 


### PR DESCRIPTION
Fixes #11300.

This PR corrects the check in `Model.applyColorAndShow`. The specs didn't catch it because there wasn't a unit test for models without feature tables, so one such unit test was added.

[Local sandcastle for testing.](http://localhost:8080/Apps/Sandcastle/index.html#c=lVNNb9swDP0rRLCDDQRK99FiyJJga7dDgQE7JOguPkSRGUeYLAYSnSAt/N8nSw7ibN1hFxvk4+Mj+WxF1jMcNB7RwRwsHuEBvW5q8RRzWTFSMX4gy1JbdMVoDC+FBWB0LmSmZ8IqxWLrqP5JzpR9IssL2+afCltYgwysDXrkS+yk9Xvp0HIYYCuNx4ixO/U6iRBAeZSaz3Lp9f7rKsFR9pHsFx+CxzL7cPPx7q5TBRg0ESVummq5o2O3T5C8p8aW2lZPZJoagwa7BiMr3UR4hRbF3ulasz6gF7Iss75bPix8JqpXdA0NlT2fDF6feLjCsoOzM60FJVntIAsnJJenQ6jgFRkUhqps/a0DwJDspj+LTOHNS2S0665TC90hC7uUtlTSc+CG6VdUVQbvG2aywd5lOO3q4kFnbzRhDJnaofqFZQ7zRW/FlVc9HEfW20F5rP3PzXtOt6UhN4W1qzYye3d7O4bL40bc5utU2KZTtYBh1n8pBm9xGz7aNGMbv8PReDSL+OKs+FnXe3IMjTOZEBPGem8ko59smrAPC+V9EgOYTYbUWakPoMv5K/8IKCO9D8i2MWapn7EYLWaTUP8XtbfwxwGdkaeubPd28T0lhRCzSQhfZzKR2Uj3R+ff)