### PR TITLE
Fixed `depthTestAgainstTerrain` value being overridden when using the base layer picker widget

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,8 @@
 
 ##### Fixes :wrench:
 
-- Fixed the error report "rectanglePromise.then is not a function" that occurred when using `viewer.flyTo` to navigate to an ImageryLayer. [#11392](https://github.com/CesiumGS/cesium/pull/11392)
+- Fixed promise return value when using `viewer.flyTo` to navigate to an ImageryLayer. [#11392](https://github.com/CesiumGS/cesium/pull/11392)
+- Fixed `depthTestAgainstTerrain` value being overridden when using the base layer picker widget. [#11393](https://github.com/CesiumGS/cesium/issues/11393)
 
 ### 1.107 - 2023-07-03
 

--- a/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -13,6 +13,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     this.imageryLayers = new ImageryLayerCollection();
     this.terrainProvider = new EllipsoidTerrainProvider();
     this.terrainProviderChanged = new Event();
+    this.depthTestAgainstTerrain = false;
   }
   MockGlobe.prototype.isDestroyed = () => false;
 
@@ -25,6 +26,15 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
   const testProvider3 = {
     tilingScheme: new GeographicTilingScheme(),
   };
+
+  const testEllipsoidProviderViewModel = new ProviderViewModel({
+    name: "name",
+    tooltip: "tooltip",
+    iconUrl: "url",
+    creationFunction: function () {
+      return new EllipsoidTerrainProvider();
+    },
+  });
 
   const testProviderViewModel = new ProviderViewModel({
     name: "name",
@@ -268,13 +278,41 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     viewModel.selectedTerrain = testProviderViewModelAsync;
     await testProviderViewModelAsync.creationCommand();
     expect(globe.terrainProvider).toBe(testProvider);
+    expect(globe.depthTestAgainstTerrain).toBeTrue();
+  });
+
+  it("selectedTerrain sets ellipsoid terrain provider", async function () {
+    const terrainProviderViewModels = [testEllipsoidProviderViewModel];
+    const globe = new MockGlobe();
+    const viewModel = new BaseLayerPickerViewModel({
+      globe: globe,
+      terrainProviderViewModels: terrainProviderViewModels,
+    });
+
+    viewModel.selectedTerrain = testEllipsoidProviderViewModel;
+    await testProviderViewModelAsync.creationCommand();
+    expect(globe.terrainProvider).toBeInstanceOf(EllipsoidTerrainProvider);
+    expect(globe.depthTestAgainstTerrain).toBeFalse();
+  });
+
+  it("default does not override default value of depthTestAgainstTerrain", async function () {
+    const terrainProviderViewModels = [testEllipsoidProviderViewModel];
+    const globe = new MockGlobe();
+    // eslint-disable-next-line no-unused-vars
+    const viewModel = new BaseLayerPickerViewModel({
+      globe: globe,
+      terrainProviderViewModels: terrainProviderViewModels,
+    });
+
+    globe.depthTestAgainstTerrain = true;
+
+    await testEllipsoidProviderViewModel.creationCommand();
+    expect(globe.terrainProvider).toBeInstanceOf(EllipsoidTerrainProvider);
+    expect(globe.depthTestAgainstTerrain).toBeTrue();
   });
 
   it("selectedTerrain cancels update if terrainProvider is set externally", async function () {
-    const terrainProviderViewModels = [
-      testProviderViewModel,
-      testProviderViewModelAsync,
-    ];
+    const terrainProviderViewModels = [testProviderViewModel3];
     const globe = new MockGlobe();
     const viewModel = new BaseLayerPickerViewModel({
       globe: globe,


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11393, given https://github.com/CesiumGS/cesium/issues/6991

Until https://github.com/CesiumGS/cesium/issues/6991 is addressed (which would be breaking behavior), I added a few unit tests to ensure it doesn't get broken.