### PR TITLE
Fix many layer terrain loading order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fixed dimensions of `tangentEC` in custom shaders [#11394](https://github.com/CesiumGS/cesium/pull/11394).
 - Fixed a bug where `Model` would not respond to different alpha values in a `Cesium3DTileStyle`. [#11399](https://github.com/CesiumGS/cesium/pull/11399)
+- Fixed issue where terrain with multiple layers was loading higher LOD tiles inconsistently. [#11312](https://github.com/CesiumGS/cesium/issues/11312)
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/Core/CesiumTerrainProvider.js
+++ b/packages/engine/Source/Core/CesiumTerrainProvider.js
@@ -867,7 +867,8 @@ CesiumTerrainProvider.prototype.requestTileGeometry = function (
     // Optimized path for single layers
     layerToUse = layers[0];
   } else {
-    for (let i = 0; i < layerCount; ++i) {
+    // Use the last layer where terrain data is available as it should be the most up-to-date
+    for (let i = layerCount - 1; i >= 0; --i) {
       const layer = layers[i];
       if (
         !defined(layer.availability) ||


### PR DESCRIPTION
Fixes #11312

Terrain with multiple layers was loading higher LOD tiles inconsistently, both for rendering and when calling sampleTerrainMostDetailed.

I believe we are iterating through the nested layer in reverse of the intended order, meaning the *oldest* layer has priority rather than the more recent subsequent layers.

Here's a [up-to-date Sandcastle example](https://sandcastle.cesium.com/#c=3VR/b9owEP0qFv8QNGYc0pC2o9VQ2k1hTboWSveDaXKTIzg1NrMNFKZ99zmErqzrJ5gVKfblvfO7d6eEoNlihiMpcAYTuuCml6ag9VDeg0AnqA7r/vTufcouWT+62URuwiIdiWs/DaNOdD//NAr7R9iCfmTv7y0o8pOC83iTr74M3CIprsjF8IokRWouz7JpsiYPn9v9WVxEXlLE7eQ2Yhdhf/7FJks25368XjF6+45EhXxIis9ectYj8TB9mFzhD4OCRa8vozC6ScTt3fd8cxGPqLf6NAiuyfR2obybQ0pHJozP62/GYixSKbRBSwYrULYQASsUVsWOtjFnXEu351AKQ5kANa41LLNiYANK2ehHJZcs22agK8rMY47qNfwbhCdKzqyVPa3BRJnjdoIj76DdRD/HAiEFPxagzQiUgYdEqhnl+hgZtYCx+NX4o1lywFzmVp6xaCZytJOCMa4UcjBI09mcg34uqwrvZMVSmzOwtXHInJfLaqKve8aEVBmZKzqfstQhmBwdugE5IIFLXN93SbtJcHDYCbwgIJ5/dOj5XqfxrVS0r7s+l0wYBByW1DApENOojl6hmJopnnAplbMT/5V8w1Ng+dQ07Pf6rF6ZsKQKGapyW+XJrn8YhGGGgcY0y5ytm9WaS83KS473S7A7KrxtM84gVwDa8XGnfRD4TXTgYxJ0yp1PCGk0n1IB52yuJcuO0U/0FC6Xohljx+iZU9U1jttE5bOfqlwzaq1mlD8pk1wqPLzuJYOPvevzZPiE/7Xj7qag6uiu8glfD6VT+fHvkNQfZ4Tm1YRsPfxPh6PWrHW1WXM4fbTuLZvNpTJoobiDccuApVrfdetukd6DwanWpYIS2m3tU7sZWyKWnbzwD0App1rbL5MF5wO2gXHttNuy+H+oXNq5EPnlEhSn6xI2dU8vqqBtRbdljy8zjZT8jqpnmX8D) for testing. You'll see in `main` that 1) The results reported are mismatched, and 2) the terrain tiles flash in and out as you navigate around the scene. In this branch, both of these problems should be resolved.