### PR TITLE
Move playwright install from postinstall to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "yargs": "^17.0.1"
   },
   "scripts": {
-    "prepare": "gulp prepare && husky install",
+    "prepare": "gulp prepare && husky install && playwright install --with-deps",
     "start": "node server.js",
     "start-public": "node server.js --public",
     "build": "gulp build",
@@ -156,8 +156,7 @@
     "deploy-status": "gulp deployStatus",
     "deploy-set-version": "gulp deploySetVersion",
     "prettier": "prettier --write --no-config \"**/*\"",
-    "prettier-check": "prettier --check --no-config \"**/*\"",
-    "postinstall": "playwright install --with-deps"
+    "prettier-check": "prettier --check --no-config \"**/*\""
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
I had added the command `playwright install --with-deps` to `postinstall` which was incorrect-- This causes the release version to run the command despite `playwright` not being installed.

`prepare` is the correct script to use, as it is only run in dev, not in production. 

This can be tested using the following commands:
```
npm run pack
cp cesium-1.107.1.tgz ../<another external directory>
cd <another external directory>
npm install cesium-1.107.1.tgz
```

We're looking into adding a step to CI to catch any errors like this in the future.