### PR TITLE
Verify npm prod package in CI

### DIFF
--- a/travis/release.sh
+++ b/travis/release.sh
@@ -8,3 +8,15 @@ else
 fi
 
 npm --silent run build-apps
+
+if [ $TRAVIS_BRANCH != "cesium.com" ]; then
+  # verify prod package
+  mkdir ../test
+  cp cesium-*.tgz ../test
+  cp Specs/test.*js ../test
+  cd ../test
+  npm install cesium-*.tgz
+  NODE_ENV=development node test.cjs
+  NODE_ENV=production node test.cjs
+  node test.mjs
+fi


### PR DESCRIPTION
To avoid issues like what came up in https://github.com/CesiumGS/cesium/pull/11417#issuecomment-1634488269, this adds a few steps to CI to install the npm package as a production app would and runs a few smokescreen tests.