### PR TITLE
Fix type of SingleTileImageryProvider.fromUrl return type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,5 @@
 # Change Log
 
-### Unreleased
-
-#### @cesium/engine
-
-##### Fixes :wrench:
-
-- The return type of `SingleTileImageryProvider.fromUrl` has been fixed to be `Promise.<SingleTileImageryProvider>` (was `void`). [#11432](https://github.com/CesiumGS/cesium/pull/11432)
-
 ### 1.109 - 2023-09-01
 
 #### @cesium/engine
@@ -15,6 +7,10 @@
 ##### Additions :tada:
 
 - The TypeScript definition of `defined` now uses type predicates to allow TypeScript to use the result during compliation.
+
+##### Fixes :wrench:
+
+- The return type of `SingleTileImageryProvider.fromUrl` has been fixed to be `Promise.<SingleTileImageryProvider>` (was `void`). [#11432](https://github.com/CesiumGS/cesium/pull/11432)
 
 #### @cesium/widgets
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### Unreleased
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- The return type of `SingleTileImageryProvider.fromUrl` has been fixed to be `Promise.<SingleTileImageryProvider>` (was `void`). [#11432](https://github.com/CesiumGS/cesium/pull/11432)
+
 ### 1.107.1 - 2023-07-13
 
 #### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -182,6 +182,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Jussi Hirvonen](https://github.com/VsKatshuma)
 - [Sierra Nevada Corp](https://www.sncorp.com/)
   - [Robert Irving](https://github.com/robert-irving-snc)
+- [General Atomics CCRi](https://www.ga-ccri.com/)
+  - [matthias-ccri](https://github.com/matthias-ccri)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/packages/engine/Source/Scene/SingleTileImageryProvider.js
+++ b/packages/engine/Source/Scene/SingleTileImageryProvider.js
@@ -295,6 +295,7 @@ async function doRequest(resource, provider, previousError) {
  * Creates a provider for a single, top-level imagery tile.  The single image is assumed to use a
  * @param {Resource|String} url The url for the tile
  * @param {SingleTileImageryProvider.fromUrlOptions} [options] Object describing initialization options.
+ * @returns {Promise.<SingleTileImageryProvider>} The resolved SingleTileImageryProvider.
  *
  * @example
  * const provider = await SingleTileImageryProvider.fromUrl("https://yoururl.com/image.png");


### PR DESCRIPTION
Fixed the type of `SingleTileImageryProvider.fromUrl`.

The current type has a return type of `void` but the return type should be `Promise<SingleTileImageryProvider>`

![Selection_034](https://github.com/CesiumGS/cesium/assets/18034092/38aa0d8d-7eb9-4efe-8d6d-638d590f144b)
(from `Cesium.d.ts`)