### PR TITLE
Remove CartographicGeocoderService from default geocoder services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ##### Fixes :wrench:
 
+- Fixed conflicting geocoder suggestions for latitude and longitude pairs by removing `CartographicGeocoderService` from the default geocoder services in `GeocoderViewModel`. [#11433](https://github.com/CesiumGS/cesium/issues/11433).
+
 ### 1.107.2 - 2023-07-13
 
 This is an npm-only release to fix a dependency issue published in 1.107.1

--- a/packages/widgets/Source/Geocoder/GeocoderViewModel.js
+++ b/packages/widgets/Source/Geocoder/GeocoderViewModel.js
@@ -1,5 +1,4 @@
 import {
-  CartographicGeocoderService,
   computeFlyToLocationForRectangle,
   defaultValue,
   defined,
@@ -44,10 +43,7 @@ function GeocoderViewModel(options) {
   if (defined(options.geocoderServices)) {
     this._geocoderServices = options.geocoderServices;
   } else {
-    this._geocoderServices = [
-      new CartographicGeocoderService(),
-      new IonGeocoderService({ scene: options.scene }),
-    ];
+    this._geocoderServices = [new IonGeocoderService({ scene: options.scene })];
   }
 
   this._viewContainer = options.container;

--- a/packages/widgets/Specs/Viewer/ViewerSpec.js
+++ b/packages/widgets/Specs/Viewer/ViewerSpec.js
@@ -372,7 +372,7 @@ describe(
         geocoder: true,
       });
       expect(viewer.geocoder).toBeDefined();
-      expect(viewer.geocoder.viewModel._geocoderServices.length).toBe(2);
+      expect(viewer.geocoder.viewModel._geocoderServices.length).toBe(1);
     });
 
     it("constructs geocoder with geocoder service option", function () {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11433

There were conflicting suggestions from Cesium ion's geocoder service and CesiumJS's internal `CartographicGeocoderService`. Since Cesium ion's geocoder service supports latitude and longitude pairs directly, this PR removes the redundant `CartographicGeocoderService` by default.