### PR TITLE
Improve SingleTileImageryProvider wording about projection expectations

### DIFF
--- a/packages/engine/Source/Scene/SingleTileImageryProvider.js
+++ b/packages/engine/Source/Scene/SingleTileImageryProvider.js
@@ -24,8 +24,9 @@ import ImageryProvider from "./ImageryProvider.js";
  */
 
 /**
- * Provides a single, top-level imagery tile.  The single image is assumed to use a
- * {@link GeographicTilingScheme}.
+ * Provides a single, top-level imagery tile.  The single image is assumed to be in 
+ * the Geographic projection (i.e. WGS84 / EPSG:4326), 
+ * and will be rendered using a {@link GeographicTilingScheme}.
  *
  * @alias SingleTileImageryProvider
  * @constructor

--- a/packages/engine/Source/Scene/SingleTileImageryProvider.js
+++ b/packages/engine/Source/Scene/SingleTileImageryProvider.js
@@ -24,8 +24,8 @@ import ImageryProvider from "./ImageryProvider.js";
  */
 
 /**
- * Provides a single, top-level imagery tile.  The single image is assumed to be in 
- * the Geographic projection (i.e. WGS84 / EPSG:4326), 
+ * Provides a single, top-level imagery tile.  The single image is assumed to be in
+ * the Geographic projection (i.e. WGS84 / EPSG:4326),
  * and will be rendered using a {@link GeographicTilingScheme}.
  *
  * @alias SingleTileImageryProvider


### PR DESCRIPTION
Motivated by: https://github.com/CesiumGS/cesium/issues/11428

To explain this wording change:

A `SingleTileImageryProvider` image is not a tile; it's a regular image. It does not need to snap to any tile grid; it can have an arbitrary rectange. So you wouldn't call the image a tile (if this reasoning is correct then the "tile" in `SingleTileImageryProvider` a bit of a misnomer too)

So the question is, where does the tiling come into play? Since the image itself is not a tile, does cesium request the image as tiles? Looking at the Network panel, no it does not. So the only thing left is on the cesium engine's end; maybe cesium renders the image internally using tiles.

If the tiling happens on the cesium engine side (which is not exposed to this API), then that makes it an implementation detail. 
So the tiling aspect is an implementation detail. It's still good to know for context, but I wanted to add the main point in clearer terms.

The expectation of `SingleTileImageryProvider` is that **the image must be in the `EPSG:4326` projection**. Mentioning `GeographicTilingScheme` hints at this fact, but I changed the wording to explicitly state it.