### PR TITLE
Fix TILE_BOUNDING_VOLUME handling for implicit tiling

### DIFF
--- a/packages/engine/Source/Scene/Implicit3DTileContent.js
+++ b/packages/engine/Source/Scene/Implicit3DTileContent.js
@@ -536,8 +536,21 @@ function deriveChildTile(
   // user specified such as extras or extensions.
   const deep = true;
   const rootHeader = clone(implicitTileset.tileHeader, deep);
+  // The bounding volume was computed above since it may come from metadata
+  // in the subtree file.
   delete rootHeader.boundingVolume;
+  // Copying the transform to all the transcoded tiles would cause the transform
+  // to be applied multiple times. Removing it from the header avoids this issue.
   delete rootHeader.transform;
+  // The implicit tiling spec does not specify what should happen if explicit
+  // tile metadata is added to the placeholder tile. Since implicit tile
+  // metadata comes from the subtree file, ignore the explicit version.
+  //
+  // Also, when a property with the semantic TILE_BOUNDING_VOLUME is added to
+  // the placeholder tile to set a tight bounding volume (See Cesium3DTile.js)
+  // propagating it to transcoded tiles causes transcoded tiles to use the
+  // wrong bounding volume, this can lead to loading far too many tiles.
+  delete rootHeader.metadata;
   const combinedTileJson = combine(tileJson, rootHeader, deep);
 
   const childTile = makeTile(

--- a/packages/engine/Source/Scene/ImplicitTileset.js
+++ b/packages/engine/Source/Scene/ImplicitTileset.js
@@ -60,6 +60,11 @@ function ImplicitTileset(baseResource, tileJson, metadataSchema) {
    */
   this.metadataSchema = metadataSchema;
 
+  // Due to using explicit tile metadata to store a tight bounding box
+  // in some cases (see https://github.com/CesiumGS/cesium/pull/11365)
+  // it's important that this bounding volume is computed from the tile JSON
+  // (which is the original, possibly loose bounding volume) rather than
+  // tile.boundingVolume which is the tigher one.
   const boundingVolume = tileJson.boundingVolume;
   if (
     !defined(boundingVolume.box) &&

--- a/packages/engine/Source/Scene/ImplicitTileset.js
+++ b/packages/engine/Source/Scene/ImplicitTileset.js
@@ -64,7 +64,7 @@ function ImplicitTileset(baseResource, tileJson, metadataSchema) {
   // in some cases (see https://github.com/CesiumGS/cesium/pull/11365)
   // it's important that this bounding volume is computed from the tile JSON
   // (which is the original, possibly loose bounding volume) rather than
-  // tile.boundingVolume which is the tigher one.
+  // tile.boundingVolume which is the tighter one.
   const boundingVolume = tileJson.boundingVolume;
   if (
     !defined(boundingVolume.box) &&

--- a/packages/engine/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/Implicit3DTileContentSpec.js
@@ -158,6 +158,13 @@ describe(
           box: [0, 0, 0, 256, 0, 0, 0, 256, 0, 0, 0, 256],
         },
         transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 0, 0, 1],
+        // For testing that tile metadata is ignored by transcoded children
+        metadata: {
+          class: "tile",
+          properties: {
+            tightBoundingVolume: [0, 0, 0, 64, 0, 0, 0, 64, 0, 0, 0, 64],
+          },
+        },
       });
       mockPlaceholderTile.implicitCoordinates = rootCoordinates;
       mockPlaceholderTile.implicitTileset = implicitTileset;
@@ -318,6 +325,23 @@ describe(
         0
       );
       expect(mockPlaceholderTile.children.length).toEqual(1);
+    });
+
+    it("does not propagate explicit tile metadata", async function () {
+      await Implicit3DTileContent.fromSubtreeJson(
+        mockTileset,
+        mockPlaceholderTile,
+        tilesetResource,
+        undefined,
+        quadtreeBuffer,
+        0
+      );
+      const tiles = [];
+      const subtreeRootTile = mockPlaceholderTile.children[0];
+      gatherTilesPreorder(subtreeRootTile, 0, 4, tiles);
+      for (let i = 0; i < tiles.length; i++) {
+        expect(tiles[i].metadata).not.toBeDefined();
+      }
     });
 
     it("preserves tile extras", async function () {


### PR DESCRIPTION
This fixes a problem I introduced in #11365.

When the `TILE_BOUNDING_VOLUME` semantic is added to an implicit root tile (to store a tight bounding volume), this value was being propagated to every transcoded tile. This causes a couple problems:

- Most critically, it results in all the tiles in a single LOD loading at the same time! this is because all the bounding volumes are the same, so the distance to camera in the screen-space error calculation is exactly the same for every tile at the same level (because they have the same geometric error based on how implicit tiling works)
- `debugShowBoundingVolume` and tile labels always show the root bounding volume in the inspector.

The fix: simply ignore explicit tile metadata before transcoding tiles. I think this makes sense in general since tile metadata for implicit tiling is supposed to come from the subtree file. @lilleyse let me know if this is a reasonable way to handle this from a 3D Tiles spec perspective (and do we need to make any clarifications in the spec?)

On Monday I want to do some more tests on more datasets and put together a sandcastle to help with the review, but otherwise the code is ready, I also included a unit test.