### PR TITLE
Make TS definition of `defined` use type predicate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.109 - 2023-09-01
+
+#### @cesium/engine
+
+##### Additions :tada:
+
+- The TypeScript definition of `defined` now uses type predicates to allow TypeScript to use the result during compliation.
+
 ### 1.108 - 2023-08-01
 
 #### Major Announcements :loudspeaker:
@@ -81,7 +89,7 @@ try {
 - `GoogleEarthEnterpriseMapsProvider` constructor parameters `options.url` and `options.channel`, `GoogleEarthEnterpriseMapsProvider.ready`, and `GoogleEarthEnterpriseMapsProvider.readyPromise` have been removed. Use `GoogleEarthEnterpriseMapsProvider.fromUrl` instead.
 - `GridImageryProvider.ready` and `GridImageryProvider.readyPromise` have been removed.
 - `IonImageryProvider` constructor parameter `assetId`,`BIonImageryProvider.ready`, and `IonImageryProvider.readyPromise` have been removed. Use `IonImageryProvider.fromAssetId` instead.
-- `MapboxImageryProvider.ready` and `MapboxImageryProvider.readyPromise` have been removed.
+- `MapboxImageryProvider.ready` and `MapboxImageryProvider.readyPromise` have been removed.``
 - `MapboxStyleImageryProvider.ready` and `MapboxStyleImageryProvider.readyPromise` have been removed.
 - `OpenStreetMapImageryProvider.ready` and `OpenStreetMapImageryProvider.readyPromise` have been removed.
 - `SingleTileImageryProvider` constructor parameters `options.tileHeight` and `options.tileWidth` became required in CesiumJS 1.104. Omitting these properties will result in an error in 1.107. Provide `options.tileHeight` and `options.tileWidth`, or use `SingleTileImageryProvider.fromUrl` instead.

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -27,6 +27,7 @@ import {
   CylinderOutlineGeometry,
   CzmlDataSource,
   DataSource,
+  defined,
   EllipseGeometry,
   EllipseOutlineGeometry,
   EllipsoidGeometry,
@@ -387,3 +388,9 @@ const canvas: HTMLCanvasElement | undefined = writeTextToCanvas("test");
 let pb = new PropertyBag();
 let hasProp: boolean = pb.hasProperty("xyz");
 property = pb.xyz;
+
+// Validate overridden defined with type predicate
+let pos: Cartesian3 | undefined | null;
+if (defined(pos)) {
+  pos.clone();
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1925,7 +1925,12 @@ function createTypeScriptDefinitions() {
       (match, p1) => `= WebGLConstants.${p1}`
     )
     // Strip const enums which can cause errors - https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls
-    .replace(/^(\s*)(export )?const enum (\S+) {(\s*)$/gm, "$1$2enum $3 {$4");
+    .replace(/^(\s*)(export )?const enum (\S+) {(\s*)$/gm, "$1$2enum $3 {$4")
+    // Replace JSDoc generation version of defined with an improved version using TS type predicates
+    .replace(
+      /defined\(value: any\): boolean/gm,
+      "defined<Type>(value: Type | undefined | null): value is Type"
+    );
 
   // Wrap the source to actually be inside of a declared cesium module
   // and add any workaround and private utility types.


### PR DESCRIPTION
This is a simple fix for #11419 and overrides the TypeScript definition of `defined` to include a better but manually maintained version using Type predicates.

It also adds a test to ensure that if the code that creates the custom definition ever breaks, the test will break.

There are probably other places Cesium could improve it's type definitions, and the same strategy could be used to replace others as well. Longer term, it would be nice to have a custom JSDoc tag to allow for overriding the definition inline with the JSDoc that generates it.

Fixes #11419