### PR TITLE
Generate stricter type predicate for 'defined'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,7 +95,7 @@ try {
 - `GoogleEarthEnterpriseMapsProvider` constructor parameters `options.url` and `options.channel`, `GoogleEarthEnterpriseMapsProvider.ready`, and `GoogleEarthEnterpriseMapsProvider.readyPromise` have been removed. Use `GoogleEarthEnterpriseMapsProvider.fromUrl` instead.
 - `GridImageryProvider.ready` and `GridImageryProvider.readyPromise` have been removed.
 - `IonImageryProvider` constructor parameter `assetId`,`BIonImageryProvider.ready`, and `IonImageryProvider.readyPromise` have been removed. Use `IonImageryProvider.fromAssetId` instead.
-- `MapboxImageryProvider.ready` and `MapboxImageryProvider.readyPromise` have been removed.``
+- `MapboxImageryProvider.ready` and `MapboxImageryProvider.readyPromise` have been removed.
 - `MapboxStyleImageryProvider.ready` and `MapboxStyleImageryProvider.readyPromise` have been removed.
 - `OpenStreetMapImageryProvider.ready` and `OpenStreetMapImageryProvider.readyPromise` have been removed.
 - `SingleTileImageryProvider` constructor parameters `options.tileHeight` and `options.tileWidth` became required in CesiumJS 1.104. Omitting these properties will result in an error in 1.107. Provide `options.tileHeight` and `options.tileWidth`, or use `SingleTileImageryProvider.fromUrl` instead.

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -394,3 +394,10 @@ let pos: Cartesian3 | undefined | null;
 if (defined(pos)) {
   pos.clone();
 }
+function consumeDefined(pos: Cartesian3) {
+  pos.clone();
+}
+pos = undefined;
+if (defined(pos)) {
+  consumeDefined(pos);
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1929,7 +1929,7 @@ function createTypeScriptDefinitions() {
     // Replace JSDoc generation version of defined with an improved version using TS type predicates
     .replace(
       /defined\(value: any\): boolean/gm,
-      "defined<Type>(value: Type | undefined | null): value is Type"
+      "defined<Type>(value: Type): value is NonNullable<Type>"
     );
 
   // Wrap the source to actually be inside of a declared cesium module


### PR DESCRIPTION
A follow-up for https://github.com/CesiumGS/cesium/pull/11455 , with some details and an example described in https://github.com/CesiumGS/cesium/pull/11455#issuecomment-1668310430 : The previous type predicate that was added to `defined` did not work when the type already was `undefined`, because the type predicate would only result in `undefined` again. When using `NonNullable<Type>` in the type predicate, then `undefined` will be constrained to `never`, causing the compile-time error check that one might expect in this case.

