### PR TITLE
adds return type for .fromUrl

### DIFF
--- a/packages/engine/Source/Scene/SingleTileImageryProvider.js
+++ b/packages/engine/Source/Scene/SingleTileImageryProvider.js
@@ -295,7 +295,7 @@ async function doRequest(resource, provider, previousError) {
  * Creates a provider for a single, top-level imagery tile.  The single image is assumed to use a
  * @param {Resource|String} url The url for the tile
  * @param {SingleTileImageryProvider.fromUrlOptions} [options] Object describing initialization options.
- *
+ * @returns {Promise<SingleTileImageryProvider>}
  * @example
  * const provider = await SingleTileImageryProvider.fromUrl("https://yoururl.com/image.png");
  */


### PR DESCRIPTION
Adds a missing returns statement for `SingleTileImageryProvider.fromUrl`