### PR TITLE
Fix request render for model loading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ##### Fixes :wrench:
 
 - The return type of `SingleTileImageryProvider.fromUrl` has been fixed to be `Promise.<SingleTileImageryProvider>` (was `void`). [#11432](https://github.com/CesiumGS/cesium/pull/11432)
+- Fixed request render mode when models are loading without `incrementallyLoadTextures`. [#11486](https://github.com/CesiumGS/cesium/pull/11486)
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -1838,7 +1838,10 @@ Model.prototype.update = function (frameState) {
 };
 
 function processLoader(model, frameState) {
-  if (!model._resourcesLoaded || !model._texturesLoaded) {
+  if (
+    !model._resourcesLoaded ||
+    (model._loader.incrementallyLoadTextures && !model._texturesLoaded)
+  ) {
     // Ensures frames continue to render in requestRender mode while resources are processing
     frameState.afterRender.push(() => true);
     return model._loader.process(frameState);


### PR DESCRIPTION
A user brought to our attention that in request render mode, renders are being triggered when then are not needed.

As demonstrated in [this Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVNrb9MwFP0rVj+lUnHzfmxdxdSBqMRgWiMQUr64yW1r4djFdtoVxH/n5tFR2KRIzr3n3EfOcUoljSUHDkfQ5IZIOJIFGN7U9EuXc4pR2cULJS3jEnQxmpBfhSTEgtaYuToX5H1MN1rVX5UW1ZBwxpOWruFHA8Y+gqxA36sKrojVDXRYzZ543dQ9lvMaFjsmt8hYyg2X3J4K+Xt8Xciy29aUIAGX7bemXYhgd9IK1s12tVPH95rVYB5ArwDLKuS345B3Zm6FWrf8vd3luNjtFnc1dlj6kj7MKbGfZtSAbaVxOg0qLOSSWa5QhwvxFkxbfGMycFoaIZ7vxaEb0DQNoyiN/TSa9MCbMAniIEpomAVB5AXZGQjd1POzjCZeFGdpFmZtupdSaQ7oxoupH4BVXG4fuC13j0qIYXZI/TTzfS/Bjqmbpm58nu3SMMkyN3G9MIlcH58BiamfZEmaeUmShkHgBX+Ho0e5ZtJslK6fvb9nVvOnkC7v3n3Kl/m3yWDY2TLLBaBwqCo7Mm6fZeqO4C7v4e7qLJW8NRgsKwcliOO2zaXTdK95zS0/gKGsqpyh9fjSqp74z41zxtejyWhm7EnAvP9IQt7yeq+0JY0WDqVTC/VeMDRuum7K77hPaUzbt6XOppels4ofCK9uXvk7SCmYMYhsGiFW/CcUo/lsivwXpUJ1dn0+gBbs1NJ23vxjn6SUzqYYvl5plRJrpv/r/Ac), the FPS counter continues to display the running FPS. In request render mode, assuming no other operation are happening like camera movement, the FPS counter should display N/A, indicating no new frames are being rendered.

The cause was `Model.js`, which should only require rendering new frames when loading or processing resources.