### PR TITLE
JulianDate.toIso8601 builds a non compliant string with very small milliseconds

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -366,3 +366,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [hongfaqiu](https://github.com/hongfaqiu)
 - [KOBAYASHI Ittoku](https://github.com/kittoku)
 - [王康](https://github.com/yieryi)
+- [Jérôme Fayot](https://github.com/jfayot)

--- a/packages/engine/Source/Core/JulianDate.js
+++ b/packages/engine/Source/Core/JulianDate.js
@@ -784,8 +784,13 @@ JulianDate.toIso8601 = function (julianDate, precision) {
   let millisecondStr;
 
   if (!defined(precision) && millisecond !== 0) {
-    //Forces milliseconds into a number with at least 3 digits to whatever the default toString() precision is.
-    millisecondStr = (millisecond * 0.01).toString().replace(".", "");
+    // This works only for milliseconds expressed numerically or with negative exponential notation,
+    // which is OK because milliseconds are lower than 999 by design.
+    const milliHundreds = millisecond * 0.01;
+    const expFactor = +(milliHundreds.toString().split("e-")[1] || 0);
+    millisecondStr = expFactor
+      ? milliHundreds.toFixed(expFactor).replace(".", "")
+      : milliHundreds.toString().replace(".", "");
     return `${year.toString().padStart(4, "0")}-${month
       .toString()
       .padStart(2, "0")}-${day

--- a/packages/engine/Specs/Core/JulianDateSpec.js
+++ b/packages/engine/Specs/Core/JulianDateSpec.js
@@ -878,6 +878,31 @@ describe("Core/JulianDate", function () {
     expect(date).toEqual("0950-01-02T03:04:05.0123450Z");
   });
 
+  function roundtripTest(expectedDate) {
+    const date = JulianDate.fromIso8601(expectedDate);
+    const dateStr = JulianDate.toIso8601(JulianDate.fromIso8601(expectedDate));
+    const roundtripDate = JulianDate.fromIso8601(dateStr);
+    // There are situations where numerical precision introduces a very small difference in the milliseconds,
+    // in which case the ISO8601 dates will differ and we have to compare dates with epsilon
+    expect(
+      dateStr === expectedDate ||
+        roundtripDate.equalsEpsilon(date, CesiumMath.EPSILON12)
+    ).toEqual(true);
+  }
+
+  it("toIso8601 works with very small milliseconds", function () {
+    roundtripTest("0950-01-02T03:04:05.001Z");
+    roundtripTest("0950-01-02T03:04:05.0001Z");
+    roundtripTest("0950-01-02T03:04:05.00001Z");
+    roundtripTest("0950-01-02T03:04:05.000001Z");
+    roundtripTest("0950-01-02T03:04:05.0000001Z");
+    roundtripTest("0950-01-02T03:04:05.00000001Z");
+    roundtripTest("0950-01-02T03:04:05.000000001Z");
+    roundtripTest("0950-01-02T03:04:05.0000000001Z");
+    roundtripTest("0950-01-02T03:04:05.00000000001Z");
+    roundtripTest("0950-01-02T03:04:05.000000000001Z");
+  });
+
   it("can format Iso8601.MINIMUM_VALUE and MAXIMUM_VALUE to ISO strings", function () {
     const minString = Iso8601.MINIMUM_VALUE.toString();
     expect(minString).toEqual("0000-01-01T00:00:00Z");


### PR DESCRIPTION
fixes #11507