### PR TITLE
Fix issue #10576 Viewer.destroy not checking if ScreenSpaceEventHandl…

### DIFF
--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -1720,7 +1720,7 @@ Viewer.prototype.destroy = function () {
   let i;
 
   // Check if Event handler is exist
-  if(define(this.screenSpaceEventHandler)){
+  if(defined(this.screenSpaceEventHandler)){
     this.screenSpaceEventHandler.removeInputAction(
       ScreenSpaceEventType.LEFT_CLICK
     );

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -1719,12 +1719,18 @@ Viewer.prototype.isDestroyed = function () {
 Viewer.prototype.destroy = function () {
   let i;
 
-  this.screenSpaceEventHandler.removeInputAction(
-    ScreenSpaceEventType.LEFT_CLICK
-  );
-  this.screenSpaceEventHandler.removeInputAction(
-    ScreenSpaceEventType.LEFT_DOUBLE_CLICK
-  );
+  // Check if Event handler is exist
+  if(define(this.screenSpaceEventHandler)){
+    this.screenSpaceEventHandler.removeInputAction(
+      ScreenSpaceEventType.LEFT_CLICK
+    );
+    this.screenSpaceEventHandler.removeInputAction(
+      ScreenSpaceEventType.LEFT_DOUBLE_CLICK
+    );
+
+    // Destroy the handler
+    this.screenSpaceEventHandler.destroy(); 
+  }
 
   // Unsubscribe from data sources
   const dataSources = this.dataSources;


### PR DESCRIPTION
Fixes #10576 

- Check if Screen Space Event Handler is defined or exists if yes then destroy it.