### PR TITLE
Fix invalid metadata type in `buildings-metadata.gltf`

### DIFF
--- a/Specs/Data/Models/glTF-2.0/BuildingsMetadata/glTF/buildings-metadata.gltf
+++ b/Specs/Data/Models/glTF-2.0/BuildingsMetadata/glTF/buildings-metadata.gltf
@@ -261,7 +261,8 @@
                 "required": false
               },
               "temperatureCelsius": {
-                "type": "UINT8",
+                "type": "SCALAR",
+                "componentType": "UINT8",
                 "normalized": true,
                 "scale": 100
               }


### PR DESCRIPTION
One of the test models had an incorrectly typed class property, which I caught while loading it in Cesium for Unreal. It doesn't seem like this was intentional, so I fixed it to conform to the 3D Tiles 1.1 spec.