### PR TITLE
Fix typo in Cesium3DTilePass

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.110 - 2023-10-02
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Fix bug in `Cesium3DTilePass` affecting the `PRELOAD` pass. [#11525](https://github.com/CesiumGS/cesium/pull/11525)
+
 ### 1.109 - 2023-09-01
 
 #### @cesium/engine

--- a/packages/engine/Source/Scene/Cesium3DTilePass.js
+++ b/packages/engine/Source/Scene/Cesium3DTilePass.js
@@ -39,7 +39,7 @@ passOptions[Cesium3DTilePass.SHADOW] = Object.freeze({
 });
 
 passOptions[Cesium3DTilePass.PRELOAD] = Object.freeze({
-  pass: Cesium3DTilePass.SHADOW,
+  pass: Cesium3DTilePass.PRELOAD,
   isRender: false,
   requestTiles: true,
   ignoreCommands: true,


### PR DESCRIPTION
Fixes #11516. There was a copy-paste error in `Cesium3DTilePass` from #11167 which affected the `PRELOAD` pass.