### PR TITLE
Easier detection of sampleTerrain tile failure.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 #### @cesium/engine
 
+##### Additions :tada:
+
+- Adds an optional `rejectOnTileFail` parameter to `sampleTerrain()` to allow handling of tile request failures. [#11530](https://github.com/CesiumGS/cesium/pull/11530)
+
 ##### Fixes :wrench:
 
 - Fix bug in `Cesium3DTilePass` affecting the `PRELOAD` pass. [#11525](https://github.com/CesiumGS/cesium/pull/11525)

--- a/packages/engine/Source/Core/sampleTerrain.js
+++ b/packages/engine/Source/Core/sampleTerrain.js
@@ -20,7 +20,7 @@ import defined from "./defined.js";
  * @param {TerrainProvider} terrainProvider The terrain provider from which to query heights.
  * @param {number} level The terrain level-of-detail from which to query terrain heights.
  * @param {Cartographic[]} positions The positions to update with terrain heights.
- * @param {boolean} [rejectOnTileFail=false] If true, the promise will be rejected.  If false, returned heights will be undefined.
+ * @param {boolean} [rejectOnTileFail=false] If true, for a failed terrain tile request the promise will be rejected. If false, returned heights will be undefined.
  * @returns {Promise<Cartographic[]>} A promise that resolves to the provided list of positions when terrain the query has completed.
  *
  * @see sampleTerrainMostDetailed
@@ -35,6 +35,13 @@ import defined from "./defined.js";
  * const updatedPositions = await Cesium.sampleTerrain(terrainProvider, 11, positions);
  * // positions[0].height and positions[1].height have been updated.
  * // updatedPositions is just a reference to positions.
+ *
+ * // To handle tile errors, pass true for the rejectOnTileFail parameter.
+ * try {
+ *    const updatedPositions = await Cesium.sampleTerrain(terrainProvider, 11, positions, true);
+ * } catch (error) {
+ *   // A tile request error occurred.
+ * }
  */
 async function sampleTerrain(
   terrainProvider,

--- a/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
@@ -83,4 +83,18 @@ describe("Core/sampleTerrainMostDetailed", function () {
     await sampleTerrainMostDetailed(worldTerrain, positions);
     expect(positions[0].height).toBeDefined();
   });
+
+  it("rejects on tile error when rejectOnTileFail is set", async function () {
+    const terrainProvider = await createWorldTerrainAsync();
+
+    terrainProvider.requestTileGeometry = function (x, y, level) {
+      return Promise.reject();
+    };
+
+    const positions = [Cartographic.fromDegrees(0.0, 0.0, 0.0)];
+
+    return expectAsync(
+      sampleTerrainMostDetailed(terrainProvider, positions, true)
+    ).toBeRejected();
+  });
 });

--- a/packages/engine/Specs/Core/sampleTerrainSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainSpec.js
@@ -4,6 +4,7 @@ import {
   CesiumTerrainProvider,
   createWorldTerrainAsync,
   defined,
+  RequestErrorEvent,
   RequestScheduler,
   Resource,
   sampleTerrain,
@@ -55,6 +56,14 @@ describe("Core/sampleTerrain", function () {
 
     return sampleTerrain(worldTerrain, 18, positions).then(function () {
       expect(positions[0].height).toBeUndefined();
+    });
+  });
+
+  it("rejects if terrain data is not available and rejectOnTileFail is set", function () {
+    const positions = [Cartographic.fromDegrees(0.0, 0.0, 0.0)];
+
+    sampleTerrain(worldTerrain, 18, positions, true).catch(function (error) {
+      expect(error).toBeInstanceOf(RequestErrorEvent);
     });
   });
 

--- a/packages/engine/Specs/Core/sampleTerrainSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainSpec.js
@@ -4,7 +4,6 @@ import {
   CesiumTerrainProvider,
   createWorldTerrainAsync,
   defined,
-  RequestErrorEvent,
   RequestScheduler,
   Resource,
   sampleTerrain,
@@ -59,12 +58,12 @@ describe("Core/sampleTerrain", function () {
     });
   });
 
-  it("rejects if terrain data is not available and rejectOnTileFail is set", function () {
+  it("rejects if terrain data is not available and rejectOnTileFail is true", function () {
     const positions = [Cartographic.fromDegrees(0.0, 0.0, 0.0)];
 
-    sampleTerrain(worldTerrain, 18, positions, true).catch(function (error) {
-      expect(error).toBeInstanceOf(RequestErrorEvent);
-    });
+    return expectAsync(
+      sampleTerrain(worldTerrain, 18, positions, true)
+    ).toBeRejected();
   });
 
   it("fills in what it can when given a mix of positions with and without valid tiles", function () {


### PR DESCRIPTION
This change allows a less permissive Promise rejection in `sampleTerrain()` if a tile request fails.  This is code we have had in our fork of Cesium for a long time.  It helps to distinguish between a valid no data value vs a tile server failing to produce a tile.