### PR TITLE
Primitive collection events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 #### @cesium/engine
 
+##### Additions :tada:
+
+- Adds events to `PrimitiveCollection` for primitive added/removed. [#11531](https://github.com/CesiumGS/cesium/pull/11531)
+
 ##### Fixes :wrench:
 
 - Fix bug in `Cesium3DTilePass` affecting the `PRELOAD` pass. [#11525](https://github.com/CesiumGS/cesium/pull/11525)

--- a/packages/engine/Source/Scene/PrimitiveCollection.js
+++ b/packages/engine/Source/Scene/PrimitiveCollection.js
@@ -104,6 +104,9 @@ Object.defineProperties(PrimitiveCollection.prototype, {
   /**
    * An event that is raised when a primitive is removed from the collection.
    * Event handlers are passed the primitive that was removed.
+   * <p>
+   * Note: Depending on the destroyPrimitives constructor option, the primitive may already be destroyed.
+   * </p>
    * @memberof PrimitiveCollection.prototype
    * @type {Event}
    * @readonly
@@ -224,10 +227,12 @@ PrimitiveCollection.prototype.removeAll = function () {
   const length = primitives.length;
   for (let i = 0; i < length; ++i) {
     delete primitives[i]._external._composites[this._guid];
-    this._primitiveRemoved.raiseEvent(primitives[i]);
+
     if (this.destroyPrimitives) {
       primitives[i].destroy();
     }
+
+    this._primitiveRemoved.raiseEvent(primitives[i]);
   }
   this._primitives = [];
 };

--- a/packages/engine/Specs/Scene/PrimitiveCollectionSpec.js
+++ b/packages/engine/Specs/Scene/PrimitiveCollectionSpec.js
@@ -651,13 +651,14 @@ describe(
     });
 
     it("fires an event on primitive added", function () {
+      const p = createLabels();
       const primitiveAdded = primitives.primitiveAdded;
 
       const onPrimitiveAddedSpy = jasmine.createSpy("event");
       primitiveAdded.addEventListener(onPrimitiveAddedSpy);
       expect(onPrimitiveAddedSpy).not.toHaveBeenCalled();
-      primitives.add(createLabels());
-      expect(onPrimitiveAddedSpy).toHaveBeenCalled();
+      primitives.add(p);
+      expect(onPrimitiveAddedSpy).toHaveBeenCalledOnceWith(p);
     });
 
     it("fires an event on primitive removed", function () {
@@ -670,20 +671,28 @@ describe(
       primitives.add(p);
       expect(onPrimitiveRemovedSpy).not.toHaveBeenCalled();
       primitives.remove(p);
-      expect(onPrimitiveRemovedSpy).toHaveBeenCalled();
+      expect(onPrimitiveRemovedSpy).toHaveBeenCalledOnceWith(p);
     });
 
-    it("fires an event on primitive remove all", function () {
-      const primitiveRemoved = primitives.primitiveRemoved;
-
+    it("fires events on primitive remove all", function () {
+      const collection = new PrimitiveCollection({ destroyPrimitives: false });
+      const p1 = createLabels();
+      const p2 = createLabels();
+      const primitiveRemoved = collection.primitiveRemoved;
       const onPrimitiveRemovedSpy = jasmine.createSpy("event");
       primitiveRemoved.addEventListener(onPrimitiveRemovedSpy);
       expect(onPrimitiveRemovedSpy).not.toHaveBeenCalled();
-      primitives.add(createLabels());
-      primitives.add(createLabels());
+      collection.add(p1);
+      collection.add(p2);
       expect(onPrimitiveRemovedSpy).not.toHaveBeenCalled();
-      primitives.removeAll();
+      collection.removeAll();
+      expect(onPrimitiveRemovedSpy).toHaveBeenCalledWith(p1);
+      expect(onPrimitiveRemovedSpy).toHaveBeenCalledWith(p2);
       expect(onPrimitiveRemovedSpy).toHaveBeenCalledTimes(2);
+
+      collection.destroy();
+      p1.destroy();
+      p2.destroy();
     });
   },
   "WebGL"

--- a/packages/engine/Specs/Scene/PrimitiveCollectionSpec.js
+++ b/packages/engine/Specs/Scene/PrimitiveCollectionSpec.js
@@ -649,6 +649,42 @@ describe(
         primitives.lowerToBottom(p);
       }).toThrowDeveloperError();
     });
+
+    it("fires an event on primitive added", function () {
+      const primitiveAdded = primitives.primitiveAdded;
+
+      const onPrimitiveAddedSpy = jasmine.createSpy("event");
+      primitiveAdded.addEventListener(onPrimitiveAddedSpy);
+      expect(onPrimitiveAddedSpy).not.toHaveBeenCalled();
+      primitives.add(createLabels());
+      expect(onPrimitiveAddedSpy).toHaveBeenCalled();
+    });
+
+    it("fires an event on primitive removed", function () {
+      const p = createLabels();
+      const primitiveRemoved = primitives.primitiveRemoved;
+
+      const onPrimitiveRemovedSpy = jasmine.createSpy("event");
+      primitiveRemoved.addEventListener(onPrimitiveRemovedSpy);
+      expect(onPrimitiveRemovedSpy).not.toHaveBeenCalled();
+      primitives.add(p);
+      expect(onPrimitiveRemovedSpy).not.toHaveBeenCalled();
+      primitives.remove(p);
+      expect(onPrimitiveRemovedSpy).toHaveBeenCalled();
+    });
+
+    it("fires an event on primitive remove all", function () {
+      const primitiveRemoved = primitives.primitiveRemoved;
+
+      const onPrimitiveRemovedSpy = jasmine.createSpy("event");
+      primitiveRemoved.addEventListener(onPrimitiveRemovedSpy);
+      expect(onPrimitiveRemovedSpy).not.toHaveBeenCalled();
+      primitives.add(createLabels());
+      primitives.add(createLabels());
+      expect(onPrimitiveRemovedSpy).not.toHaveBeenCalled();
+      primitives.removeAll();
+      expect(onPrimitiveRemovedSpy).toHaveBeenCalledTimes(2);
+    });
   },
   "WebGL"
 );


### PR DESCRIPTION
This adds `primitiveAdded` and `primitiveRemoved` events to `PrimitiveCollection` as discussed in #9815 .  The implementation is similar to [`DataSourceCollection`](https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/DataSources/DataSourceCollection.js#L33-L57).

This change has been in our fork for some time.