### PR TITLE
Fix Credit Show on Screen Behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Fixes :wrench:
 
 - Fix bug in `Cesium3DTilePass` affecting the `PRELOAD` pass. [#11525](https://github.com/CesiumGS/cesium/pull/11525)
+- Fixed `showOnScreen` behavior for `Model` and `Cesium3DTileset` credits. [#11538](https://github.com/CesiumGS/cesium/pull/11538)
 - Remove reading of `import.meta` meta-property because webpack does not support it. [#11511](https://github.com/CesiumGS/cesium/pull/11511)
 
 ### 1.109 - 2023-09-01

--- a/packages/engine/Source/Core/Credit.js
+++ b/packages/engine/Source/Core/Credit.js
@@ -140,6 +140,13 @@ Credit.prototype.equals = function (credit) {
 
 /**
  * @private
+ */
+Credit.prototype.isIon = function () {
+  return this.html.indexOf("ion-credit.png") !== -1;
+};
+
+/**
+ * @private
  * @param attribution
  * @return {Credit}
  */
@@ -148,7 +155,6 @@ Credit.getIonCredit = function (attribution) {
     defined(attribution.collapsible) && !attribution.collapsible;
   const credit = new Credit(attribution.html, showOnScreen);
 
-  credit._isIon = credit.html.indexOf("ion-credit.png") !== -1;
   return credit;
 };
 

--- a/packages/engine/Source/Core/GoogleMaps.js
+++ b/packages/engine/Source/Core/GoogleMaps.js
@@ -48,7 +48,6 @@ GoogleMaps.getDefaultApiKeyCredit = function (providedKey) {
             with <a href="https://developers.google.com/maps/documentation/embed/get-api-key">your API key for the Google Maps Platform</a>.</b>';
 
     defaultKeyCredit = new Credit(defaultKeyMessage, true);
-    defaultKeyCredit._isDefaultToken = true;
   }
 
   return defaultKeyCredit;

--- a/packages/engine/Source/Core/Ion.js
+++ b/packages/engine/Source/Core/Ion.js
@@ -49,7 +49,6 @@ Ion.getDefaultTokenCredit = function (providedKey) {
             You can sign up for a free ion account at <a href="https://cesium.com">https://cesium.com</a>.</b>';
 
     defaultTokenCredit = new Credit(defaultTokenMessage, true);
-    defaultTokenCredit._isDefaultToken = true;
   }
 
   return defaultTokenCredit;

--- a/packages/engine/Source/Scene/ArcGisMapService.js
+++ b/packages/engine/Source/Scene/ArcGisMapService.js
@@ -76,7 +76,6 @@ ArcGisMapService.getDefaultTokenCredit = function (providedKey) {
             You can sign up for a free ArcGIS Developer account at <a href="https://developers.arcgis.com/">https://developers.arcgis.com/</a>.</b>';
 
     defaultTokenCredit = new Credit(defaultTokenMessage, true);
-    defaultTokenCredit._isDefaultToken = true;
   }
 
   return defaultTokenCredit;

--- a/packages/engine/Source/Scene/CreditDisplay.js
+++ b/packages/engine/Source/Scene/CreditDisplay.js
@@ -437,7 +437,7 @@ CreditDisplay.prototype.addCreditToNextFrame = function (credit) {
   Check.defined("credit", credit);
   //>>includeEnd('debug');
 
-  if (credit._isIon) {
+  if (credit.isIon()) {
     // If this is the an ion logo credit from the ion server
     // Just use the default credit (which is identical) to avoid blinking
     if (!defined(this._defaultCredit)) {
@@ -546,7 +546,7 @@ CreditDisplay.prototype.beginFrame = function () {
       : lightboxCredits;
 
     if (
-      staticCredit._isIon &&
+      staticCredit.isIon() &&
       Credit.equals(CreditDisplay.cesiumCredit, this._cesiumCredit)
     ) {
       // If this is an ion logo credit from the ion server,

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -408,6 +408,7 @@ function Model(options) {
     credit = new Credit(credit);
   }
 
+  this._credits = [];
   this._credit = credit;
 
   // Credits to be added from the Resource (if it is an IonResource)
@@ -2258,24 +2259,29 @@ function updateShowCreditsOnScreen(model) {
     return;
   }
   model._showCreditsOnScreenDirty = false;
+  model._credits.length = 0;
 
   const showOnScreen = model._showCreditsOnScreen;
   if (defined(model._credit)) {
-    model._credit.showOnScreen = showOnScreen || model._credit._isDefaultToken;
+    const credit = Credit.clone(model._credit);
+    credit.showOnScreen = credit.showOnScreen || showOnScreen;
+    model._credits.push(credit);
   }
 
   const resourceCredits = model._resourceCredits;
   const resourceCreditsLength = resourceCredits.length;
   for (let i = 0; i < resourceCreditsLength; i++) {
-    resourceCredits[i].showOnScreen =
-      showOnScreen || resourceCredits[i]._isDefaultToken;
+    const credit = Credit.clone(resourceCredits[i]);
+    credit.showOnScreen = credit.showOnScreen || showOnScreen;
+    model._credits.push(credit);
   }
 
   const gltfCredits = model._gltfCredits;
   const gltfCreditsLength = gltfCredits.length;
   for (let i = 0; i < gltfCreditsLength; i++) {
-    gltfCredits[i].showOnScreen =
-      showOnScreen || gltfCredits[i]._isDefaultToken;
+    const credit = Credit.clone(gltfCredits[i]);
+    credit.showOnScreen = credit.showOnScreen || showOnScreen;
+    model._credits.push(credit);
   }
 }
 
@@ -2385,22 +2391,10 @@ function passesDistanceDisplayCondition(model, frameState) {
 
 function addCreditsToCreditDisplay(model, frameState) {
   const creditDisplay = frameState.creditDisplay;
-  // Add all credits to the credit display.
-  const credit = model._credit;
-  if (defined(credit)) {
-    creditDisplay.addCreditToNextFrame(credit);
-  }
-
-  const resourceCredits = model._resourceCredits;
-  const resourceCreditsLength = resourceCredits.length;
-  for (let c = 0; c < resourceCreditsLength; c++) {
-    creditDisplay.addCreditToNextFrame(resourceCredits[c]);
-  }
-
-  const gltfCredits = model._gltfCredits;
-  const gltfCreditsLength = gltfCredits.length;
-  for (let c = 0; c < gltfCreditsLength; c++) {
-    creditDisplay.addCreditToNextFrame(gltfCredits[c]);
+  const credits = model._credits;
+  const creditsLength = credits.length;
+  for (let c = 0; c < creditsLength; c++) {
+    creditDisplay.addCreditToNextFrame(credits[c]);
   }
 }
 
@@ -2795,7 +2789,7 @@ Model.fromGltfAsync = async function (options) {
   if (defined(resourceCredits)) {
     const length = resourceCredits.length;
     for (let i = 0; i < length; i++) {
-      model._resourceCredits.push(resourceCredits[i]);
+      model._resourceCredits.push(Credit.clone(resourceCredits[i]));
     }
   }
 


### PR DESCRIPTION
This fixes an issue where tilesets from ion which specify additional credits that should be shown on screen were not displaying correctly, instead going to the lightbox.

This was due to `Cesium3DTileset` and `Model` mutating crediting properties and therefore overriding what the values should be. As a solution to this, we make sure to clone incoming Credits before we change them at all.