### PR TITLE
Package updates

### DIFF
--- a/Specs/e2e/sandcastle.spec.js
+++ b/Specs/e2e/sandcastle.spec.js
@@ -13,9 +13,6 @@ for (const example of gallery) {
 
     await page.evaluate(() => window.__clock.tickAsync(1000));
     await page.evaluate(() => window.__clock.tickAsync(1000));
-
-    await page.waitForLoadState("networkidle");
-
     await page.evaluate(() => window.__clock.tickAsync(1000));
     await page.evaluate(() => window.__clock.tickAsync(1000));
 

--- a/build.js
+++ b/build.js
@@ -793,8 +793,7 @@ export async function createIndexJs(workspace) {
   // Iterate over all provided source files for the workspace and export the assignment based on file name.
   const workspaceSources = workspaceSourceFiles[workspace];
   if (!workspaceSources) {
-    console.error(`Unable to find source files for workspace: ${workspace}`);
-    process.exit(-1);
+    throw new Error(`Unable to find source files for workspace: ${workspace}`);
   }
 
   const files = await globby(workspaceSources);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -253,6 +253,7 @@ export const buildWatch = gulp.series(build, async function () {
     }
 
     specs.dispose();
+    // eslint-disable-next-line n/no-process-exit
     process.exit(0);
   });
 });

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "karma-safari-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.4.0",
     "karma-spec-reporter": "^0.0.36",
-    "markdownlint-cli": "^0.35.0",
+    "markdownlint-cli": "^0.37.0",
     "merge-stream": "^2.0.0",
     "mime": "^3.0.0",
     "mkdirp": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "download": "^8.0.0",
     "esbuild": "^0.19.2",
     "eslint": "^8.41.0",
-    "eslint-config-cesium": "^9.0.1",
+    "eslint-config-cesium": "^10.0.1",
     "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "prismjs": "^1.28.0",
     "request": "^2.79.0",
     "rimraf": "^5.0.0",
-    "sinon": "^15.1.0",
+    "sinon": "^16.0.0",
     "stream-to-promise": "^3.0.0",
     "tsd-jsdoc": "^2.5.0",
     "typescript": "^5.0.2",

--- a/server.js
+++ b/server.js
@@ -456,21 +456,22 @@ function createRoute(app, name, route, context) {
         console.log("Try a port number higher than 1024.");
       }
     }
-    console.log(e);
-    process.exit(1);
+
+    throw e;
   });
 
   server.on("close", function () {
     console.log("Cesium development server stopped.");
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(0);
   });
 
   let isFirstSig = true;
   process.on("SIGINT", function () {
     if (isFirstSig) {
       console.log("\nCesium development server shutting down.");
-      server.close(function () {
-        process.exit(0);
-      });
+
+      server.close();
 
       if (!production) {
         contexts.esm.dispose();
@@ -482,8 +483,7 @@ function createRoute(app, name, route, context) {
 
       isFirstSig = false;
     } else {
-      console.log("Cesium development server force kill.");
-      process.exit(1);
+      throw new Error("Cesium development server force kill.");
     }
   });
 })();


### PR DESCRIPTION
Updates any outdated npm dependencies. In this case, they were all dev dependencies: `eslint-config-cesium` which updated liniting rules for node usage, `markdownlint-cli`, and `sinon` which is used for our timing control in e2e tests.