### PR TITLE
Remove Cesium3DTileset.maximumMemoryUsage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 #### @cesium/engine
 
+##### Breaking Changes :mega:
+
+- `Cesium3DTileset.maximumMemoryUsage` has been removed. Use `Cesium3DTileset.cacheBytes` and `Cesium3DTileset.maximumCacheOverflowBytes` instead.
+
 ##### Additions :tada:
 
 - Worker files are now embedded in `Build/Cesium/Cesium.js` and `Build/CesiumUnminified/Cesium.js`. [#11519](https://github.com/CesiumGS/cesium/pull/11519)

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -67,7 +67,6 @@ import Cesium3DTilesetSkipTraversal from "./Cesium3DTilesetSkipTraversal.js";
  * @property {Axis} [modelForwardAxis=Axis.X] Which axis is considered forward when loading models for tile contents.
  * @property {ShadowMode} [shadows=ShadowMode.ENABLED] Determines whether the tileset casts or receives shadows from light sources.
  * @property {number} [maximumScreenSpaceError=16] The maximum screen space error used to drive level of detail refinement.
- * @property {number} [maximumMemoryUsage=512] The maximum amount of memory in MB that can be used by the tileset. Deprecated.
  * @property {number} [cacheBytes=536870912] The size (in bytes) to which the tile cache will be trimmed, if the cache contains tiles not needed for the current view.
  * @property {number} [maximumCacheOverflowBytes=536870912] The maximum additional memory (in bytes) to allow for cache headroom, if more than {@link Cesium3DTileset#cacheBytes} are needed for the current view.
  * @property {boolean} [cullWithChildrenBounds=true] Optimization option. Whether to cull tiles using the union of their children bounding volumes.
@@ -224,15 +223,7 @@ function Cesium3DTileset(options) {
   );
   this._memoryAdjustedScreenSpaceError = this._maximumScreenSpaceError;
 
-  let defaultCacheBytes = 512 * 1024 * 1024;
-  if (defined(options.maximumMemoryUsage)) {
-    deprecationWarning(
-      "Cesium3DTileset.maximumMemoryUsage",
-      "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.107.  It will be removed in CesiumJS 1.110. Use Cesium3DTileset.cacheBytes instead."
-    );
-    defaultCacheBytes = options.maximumMemoryUsage * 1024 * 1024;
-  }
-  this._cacheBytes = defaultValue(options.cacheBytes, defaultCacheBytes);
+  this._cacheBytes = defaultValue(options.cacheBytes, 512 * 1024 * 1024);
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number.greaterThanOrEquals("cacheBytes", this._cacheBytes, 0);
   //>>includeEnd('debug');
@@ -1373,57 +1364,6 @@ Object.defineProperties(Cesium3DTileset.prototype, {
 
       this._maximumScreenSpaceError = value;
       this._memoryAdjustedScreenSpaceError = value;
-    },
-  },
-
-  /**
-   * The maximum amount of GPU memory (in MB) that may be used to cache tiles. This value is estimated from
-   * geometry, textures, and batch table textures of loaded tiles. For point clouds, this value also
-   * includes per-point metadata.
-   * <p>
-   * Tiles not in view are unloaded to enforce this.
-   * </p>
-   * <p>
-   * If decreasing this value results in unloading tiles, the tiles are unloaded the next frame.
-   * </p>
-   * <p>
-   * If tiles sized more than <code>maximumMemoryUsage</code> are needed
-   * to meet the desired screen space error, determined by {@link Cesium3DTileset#maximumScreenSpaceError},
-   * for the current view, then the memory usage of the tiles loaded will exceed
-   * <code>maximumMemoryUsage</code>.  For example, if the maximum is 256 MB, but
-   * 300 MB of tiles are needed to meet the screen space error, then 300 MB of tiles may be loaded.  When
-   * these tiles go out of view, they will be unloaded.
-   * </p>
-   *
-   * @memberof Cesium3DTileset.prototype
-   *
-   * @type {number}
-   * @default 512
-   *
-   * @exception {DeveloperError} <code>maximumMemoryUsage</code> must be greater than or equal to zero.
-   * @see Cesium3DTileset#totalMemoryUsageInBytes
-   *
-   * @deprecated
-   */
-  maximumMemoryUsage: {
-    get: function () {
-      deprecationWarning(
-        "Cesium3DTileset.maximumMemoryUsage",
-        "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.107.  It will be removed in CesiumJS 1.110. Use Cesium3DTileset.cacheBytes instead."
-      );
-      return this._maximumMemoryUsage;
-    },
-    set: function (value) {
-      deprecationWarning(
-        "Cesium3DTileset.maximumMemoryUsage",
-        "Cesium3DTileset.maximumMemoryUsage was deprecated in CesiumJS 1.107.  It will be removed in CesiumJS 1.110. Use Cesium3DTileset.cacheBytes instead."
-      );
-      //>>includeStart('debug', pragmas.debug);
-      Check.typeOf.number.greaterThanOrEquals("value", value, 0);
-      //>>includeEnd('debug');
-
-      this._maximumMemoryUsage = value;
-      this._cacheBytes = value * 1024 * 1024;
     },
   },
 

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3295,77 +3295,6 @@ describe(
     ///////////////////////////////////////////////////////////////////////////
     // Cache replacement tests
 
-    it("Unload all cached tiles not required to meet SSE using maximumMemoryUsage", function () {
-      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
-        tileset
-      ) {
-        tileset.maximumMemoryUsage = 0;
-
-        // Render parent and four children (using additive refinement)
-        viewAllTiles();
-        scene.renderForSpecs();
-
-        const statistics = tileset._statistics;
-        expect(statistics.numberOfCommands).toEqual(5);
-        expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
-        expect(tileset.totalMemoryUsageInBytes).toEqual(37200); // Specific to this tileset
-
-        // Zoom out so only root tile is needed to meet SSE.  This unloads
-        // the four children since the maximum memory usage is zero.
-        viewRootOnly();
-        scene.renderForSpecs();
-
-        expect(statistics.numberOfCommands).toEqual(1);
-        expect(statistics.numberOfTilesWithContentReady).toEqual(1);
-        expect(tileset.totalMemoryUsageInBytes).toEqual(7440); // Specific to this tileset
-
-        // Zoom back in so all four children are re-requested.
-        viewAllTiles();
-
-        return Cesium3DTilesTester.waitForTilesLoaded(scene, tileset).then(
-          function () {
-            expect(statistics.numberOfCommands).toEqual(5);
-            expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
-            expect(tileset.totalMemoryUsageInBytes).toEqual(37200); // Specific to this tileset
-          }
-        );
-      });
-    });
-
-    it("Unload some cached tiles not required to meet SSE using maximumMemoryUsage", function () {
-      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
-        tileset
-      ) {
-        tileset.maximumMemoryUsage = 0.025; // Just enough memory to allow 3 tiles to remain
-        // Render parent and four children (using additive refinement)
-        viewAllTiles();
-        scene.renderForSpecs();
-
-        const statistics = tileset._statistics;
-        expect(statistics.numberOfCommands).toEqual(5);
-        expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
-
-        // Zoom out so only root tile is needed to meet SSE.  This unloads
-        // two of the four children so three tiles are still loaded (the
-        // root and two children) since the maximum memory usage is sufficient.
-        viewRootOnly();
-        scene.renderForSpecs();
-
-        expect(statistics.numberOfCommands).toEqual(1);
-        expect(statistics.numberOfTilesWithContentReady).toEqual(3);
-
-        // Zoom back in so the two children are re-requested.
-        viewAllTiles();
-
-        return Cesium3DTilesTester.waitForTilesLoaded(scene, tileset).then(
-          function () {
-            expect(statistics.numberOfCommands).toEqual(5);
-            expect(statistics.numberOfTilesWithContentReady).toEqual(5); // Five loaded tiles
-          }
-        );
-      });
-    });
-
     it("Unload all cached tiles not required to meet SSE using cacheBytes", function () {
       return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
         tileset
@@ -3669,13 +3598,6 @@ describe(
         expect(spyUpdate.calls.argsFor(2)[0]).toBe(tileset.root.children[2]);
         expect(spyUpdate.calls.argsFor(3)[0]).toBe(tileset.root.children[3]);
       });
-    });
-
-    it("maximumMemoryUsage throws when negative", async function () {
-      const tileset = await Cesium3DTileset.fromUrl(tilesetUrl, options);
-      expect(function () {
-        tileset.maximumMemoryUsage = -1;
-      }).toThrowDeveloperError();
     });
 
     it("cacheBytes throws when negative", async function () {


### PR DESCRIPTION
Resolves #11344. 
`Cesium3DTileset.maximumMemoryUsage` has been replaced by `Cesium3DTileset.cacheBytes` and `Cesium3DTileset.maximumCacheOverflowBytes`.