### PR TITLE
Fix scaling of czm_normal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.111 - 2023-11-01
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Fixed `czm_normal`, `czm_normal3D`, `czm_inverseNormal`, and `czm_inverseNormal3D` for cases where the model matrix has non-uniform scale. [#11553](https://github.com/CesiumGS/cesium/pull/11553)
+
 ### 1.110 - 2023-10-02
 
 #### @cesium/engine

--- a/packages/engine/Source/Renderer/UniformState.js
+++ b/packages/engine/Source/Renderer/UniformState.js
@@ -1513,7 +1513,6 @@ function cleanNormal(uniformState) {
 
     const m = uniformState._normal;
     Matrix4.getMatrix3(uniformState.inverseModelView, m);
-    Matrix3.getRotation(m, m);
     Matrix3.transpose(m, m);
   }
 }

--- a/packages/engine/Source/Renderer/UniformState.js
+++ b/packages/engine/Source/Renderer/UniformState.js
@@ -1530,28 +1530,20 @@ function cleanNormal3D(uniformState) {
 function cleanInverseNormal(uniformState) {
   if (uniformState._inverseNormalDirty) {
     uniformState._inverseNormalDirty = false;
-    Matrix4.getMatrix3(
-      uniformState.inverseModelView,
-      uniformState._inverseNormal
-    );
-    Matrix3.getRotation(
-      uniformState._inverseNormal,
-      uniformState._inverseNormal
-    );
+
+    const m = uniformState._inverseNormal;
+    Matrix4.getMatrix3(uniformState.modelView, m);
+    Matrix3.transpose(m, m);
   }
 }
 
 function cleanInverseNormal3D(uniformState) {
   if (uniformState._inverseNormal3DDirty) {
     uniformState._inverseNormal3DDirty = false;
-    Matrix4.getMatrix3(
-      uniformState.inverseModelView3D,
-      uniformState._inverseNormal3D
-    );
-    Matrix3.getRotation(
-      uniformState._inverseNormal3D,
-      uniformState._inverseNormal3D
-    );
+
+    const m = uniformState._inverseNormal3D;
+    Matrix4.getMatrix3(uniformState.modelView, m);
+    Matrix3.transpose(m, m);
   }
 }
 

--- a/packages/engine/Source/Renderer/UniformState.js
+++ b/packages/engine/Source/Renderer/UniformState.js
@@ -1523,7 +1523,6 @@ function cleanNormal3D(uniformState) {
 
     const m = uniformState._normal3D;
     Matrix4.getMatrix3(uniformState.inverseModelView3D, m);
-    Matrix3.getRotation(m, m);
     Matrix3.transpose(m, m);
   }
 }

--- a/packages/engine/Source/Renderer/UniformState.js
+++ b/packages/engine/Source/Renderer/UniformState.js
@@ -1542,7 +1542,7 @@ function cleanInverseNormal3D(uniformState) {
     uniformState._inverseNormal3DDirty = false;
 
     const m = uniformState._inverseNormal3D;
-    Matrix4.getMatrix3(uniformState.modelView, m);
+    Matrix4.getMatrix3(uniformState.modelView3D, m);
     Matrix3.transpose(m, m);
   }
 }


### PR DESCRIPTION
Normals should be transformed by the inverse transpose of the model-view matrix. See [lighthouse3d.com](https://www.lighthouse3d.com/tutorials/glsl-12-tutorial/the-normal-matrix/) and Jason McKesson's [Learning Modern 3D Graphics Programming](https://paroj.github.io/gltut/Illumination/Tut09%20Normal%20Transformation.html).

The automatic uniform `czm_normal`, as computed in `UniformState`, is currently derived from the transpose of the _rotation component_ of the inverse model-view matrix. This approach is only valid when the model-view matrix has uniform scale.

I think `UniformState` was actually correct before #8182. In that PR, we renamed `Matrix4.getRotation` as`Matrix4.getMatrix3` to [better describe what it was actually doing](https://github.com/CesiumGS/cesium/issues/7398#issuecomment-445862147). But then in `UniformState`, we mistakenly [replaced `Matrix4.getRotation` with a `Matrix4.getMatrix3` _followed by_ `Matrix3.getRotation`](https://github.com/CesiumGS/cesium/pull/8182/files#diff-7c7edcf13d6add47de5007ba19ffd488b4ae5320268c6369a75aaee51045b833R1317-R1318).

This PR removes the spurious `Matrix3.getRotation` call.

One caution: ever since #8182, `czm_normal` has been unitary. This PR will leave a scale component in the matrix, so normals will need to be re-normalized after the transform.