### PR TITLE
Fix render error  when dataSource.cluster.enabled  after toggle dataSource.show

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,8 @@
 - Restore previous behavior for cut out terrain loading. [#11482](https://github.com/CesiumGS/cesium/issues/11482)
 - The return type of `SingleTileImageryProvider.fromUrl` has been fixed to be `Promise.<SingleTileImageryProvider>` (was `void`). [#11432](https://github.com/CesiumGS/cesium/pull/11432)
 - Fixed request render mode when models are loading without `incrementallyLoadTextures`. [#11486](https://github.com/CesiumGS/cesium/pull/11486)
+- Fixed toggle dataSource.show,the cluster Label not hide. [#11560](https://github.com/CesiumGS/cesium/pull/11560)
+- Fixed toggle dataSource.show,the cluster hava differently distribution. [#11560](https://github.com/CesiumGS/cesium/pull/11560)
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/DataSources/EntityCluster.js
+++ b/packages/engine/Source/DataSources/EntityCluster.js
@@ -648,7 +648,7 @@ function createGetEntity(
 
     const unusedIndices = this[unusedIndicesProperty];
     if (unusedIndices.length > 0) {
-      index = unusedIndices.pop();
+      index = unusedIndices.shift();
       entityItem = collection.get(index);
     } else {
       entityItem = collection.add();

--- a/packages/engine/Source/Scene/LabelCollection.js
+++ b/packages/engine/Source/Scene/LabelCollection.js
@@ -143,7 +143,7 @@ function rebindAllGlyphs(labelCollection, label) {
   glyphs.length = textLength;
 
   const showBackground =
-    label._showBackground && text.split("\n").join("").length > 0;
+    label.show && label._showBackground && text.split("\n").join("").length > 0;
   let backgroundBillboard = label._backgroundBillboard;
   const backgroundBillboardCollection =
     labelCollection._backgroundBillboardCollection;
@@ -181,6 +181,7 @@ function rebindAllGlyphs(labelCollection, label) {
       label._distanceDisplayCondition;
     backgroundBillboard.disableDepthTestDistance =
       label._disableDepthTestDistance;
+    backgroundBillboard.clusterShow = label.clusterShow;
   }
 
   const glyphTextureCache = labelCollection._glyphTextureCache;


### PR DESCRIPTION
Example URL: [click this link then  toggle datasouce.show twice ](https://sandcastle.cesium.com/#c=pVjrTuM4FH4Vq7s/UlHcC0VCLaAdoLPT3S5FtMtqtEEzbuK23knsKHYKDOq773HiXBumwFRQEp/v3OxzM47gUqENow80RGeI0wd0SSWLfHwXr1l2w4nfLwVXhHEa2o3m0OY2d2JOESgGD8D6bHOEHOLTkAyMQCwdyilOFlsJnW+I3KHrRaBvh6lYlygyE1Ho0JtQ+ExSUGB4cpLExHUtmxuDf6fiDyn4VUbHniCajpDdwLg9I37gUU1uS6YfpXqCL7yi4j/gsxs2b8IP2LCjHas15dYy4o72Flk5oJn4bWz7LoQ/F0XyMFYPvyhxjHLFFKN6w3IUTlfxhngRlTnTUoTI8qhCDBg6Q/hzmonAHuUrtYbFgwNjRvIpaHoCthT/L7sfVkEcjiaFPGH9VoCYVY8sqJcecP5R9FENUkwQioCGsRa7ASsetRv3sLPqTjtkNVtl3iXzvEvhgXODNNziV/x5NJlM/6mgXSbJAk6OBmo9h1O7YlIR7lBgvo78Bez7zXQ2no/vRl/G1x/H1+P554oEuRYPF8T5tgpFxF3gU2FEK5hFRq+17HZ0VWLYZhu1jQM73s6APVLvlvCV3tTu8TCn+IwzH7LIi6Si4Yx914ijAoBy7aMLq9q2OMNQMUSchJPxFc6h5mn4MrZkUf7yA45aS3cXjYU6NkPqiw2dwKlANoeGkG4Iv4iY51aLy022bjWHJfhxJzY0JSebjJeQh3MIOChHx50Du9GqDRvUP2kaBiV0ov99O6nK7++T3/85+Uf75B/9nPzePvm9n5Pf3Se/+w75uQYJIQapzFZMQQxIExUfwpA8WSeJKXU1r8KWlb6DA5aVvgoGyl2NJ0Vfvv76zNAB6m2/Vty5G08no3nBnZoN2yZeZT3BgcwQ/ky3FCsziS2RZSS7dAnd07XKydIsFO4yxajZJYBTUKMSaQayRdSDFvn8IkN9ppvH0QaKuG6l8UOmPy92ed8zHNQdmZ7SQmapWW4PZjXpHViXX7BiScDKYR1sAf1gIUjoplBTA3+EZLoAlvUwdw/PRvcoh3jTEKKEo7NyB0gHnxIIX0zn8+lfJojTjz7Ync0wUYnOz9Bxp1ntlzUe+MSUZah6JcvNge7T0n+jlv67tBy9UcvRu7T03qil9y4t3Tdq6dZqea2EMmy3Qr1o6SHq3ZcV5y/ZY1ogtmlottu6dsJcRKACHBrh6IGBQJhf40KrR14wIsHXzCz7hgij8hWzRuf10Ip44w94A2NeqBIHkvIa20/jblIst0ly6uUZ4a5DJMyfuqDNxQr2+yJSSnDoXCp+LVqkq41uZvE4WKxza+p8o24WKxUWXXgSRGJwYkDe5NZghVcdeWZOSCmfBcShcaH9lIBMna25EGlCcsZGHpZUjXkQqQ+xmYX7iC73PsjMDE6PVts4MfN7SYUmZWw4EJJpSWlI1fStgqxi00oUMVfG55hBiqVYC4sbPGYyafQAb5bysK7lA6i2zRuhrm7whZRz4qH9bGdoH9ZkzjZLHPhqvXRA86eA4sno4/zL5WR8+afem/ikG63GaRyH56m83+A6KSBSo9Cz4KKpKNwuiaKyvYhgRxR2pMy7+S9KCG9BwqI/+d1jgMLVglj9Hkwf5reDT5oFLwIIbEihAeoHj4XlhQhhyDkMicsiWSZud1QzHUVFA9LGeEg8tuIDmPddiLhdrYdKBAPUK2lOSQsBeeaXqUb1abu4Yacu28ABntX8awFqKZESKMvI8/Q1w26cn7YBv8Oq7/agdQqWe+RJw9bd80myiDE+bcNrPafZBGAxVqY25uD/AQ)

In this example,we can descript there are two problem:

**`with  dataSource.clustering.enabled = true`**:
1. By toggle `dataSource.show` attribute, if entity in the dataSource have  Label component, then the  Label's foreground and background  hiding is inconsistencies. 
   > should display as :
   > ![image](https://github.com/CesiumGS/cesium/assets/32406400/97bea58f-8818-4702-8fb9-6fd01bc5d391)
   > but get :
   > ![image](https://github.com/CesiumGS/cesium/assets/32406400/8e92505f-8b73-44e7-9de2-348df8b4ea71)

2. Continuous toggle dataSource.show attribute, We can observe that the cluster distribution is different and is switch between 
two types distribution


this pr fix these problem.
