### PR TITLE
Add support for Bing Maps mapLayer template parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.111 - 2023-10-02
+
+- `BingMapsImageryProvider.fromUrl` now takes an optional `mapLayer` parameter which is a string that maps directly to the [mapLayer template parameters](https://learn.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata#template-parameters) specified in the Bing Maps documentation.
+
 ### 1.110 - 2023-10-02
 
 #### @cesium/engine

--- a/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -82,7 +82,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     expect(BingMapsImageryProvider).toConformToInterface(ImageryProvider);
   });
 
-  function installFakeMetadataRequest(url, mapStyle, proxy) {
+  function installFakeMetadataRequest(url, mapStyle, mapLayer) {
     const baseUri = new Uri(appendForwardSlash(url));
     const expectedUri = new Uri(
       `REST/v1/Imagery/Metadata/${mapStyle}`
@@ -92,15 +92,16 @@ describe("Scene/BingMapsImageryProvider", function () {
       url,
       functionName
     ) {
-      let uri = new Uri(url);
-      if (proxy) {
-        uri = new Uri(decodeURIComponent(uri.query()));
-      }
+      const uri = new Uri(url);
 
       const query = queryToObject(uri.query());
       expect(query.jsonp).toBeDefined();
       expect(query.incl).toEqual("ImageryProviders");
       expect(query.key).toBeDefined();
+
+      if (defined(mapLayer)) {
+        expect(query.mapLayer).toEqual(mapLayer);
+      }
 
       uri.query("");
       expect(uri.toString()).toStartWith(expectedUri.toString());
@@ -301,11 +302,12 @@ describe("Scene/BingMapsImageryProvider", function () {
     expect(provider.url).toEqual(url);
   });
 
-  it("fromUrl takes mapLayer as option and sets hasAlphaChannel accordingly.", async function () {
+  it("fromUrl takes mapLayer as option and sets hasAlphaChannel accordingly", async function () {
     const url = "http://fake.fake.invalid/";
     const mapStyle = BingMapsStyle.AERIAL_WITH_LABELS_ON_DEMAND;
+    const mapLayer = "Foreground";
 
-    installFakeMetadataRequest(url, mapStyle);
+    installFakeMetadataRequest(url, mapStyle, mapLayer);
     installFakeImageRequest();
 
     const resource = new Resource({
@@ -315,7 +317,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     const provider = await BingMapsImageryProvider.fromUrl(resource, {
       key: "",
       mapStyle: mapStyle,
-      mapLayer: "Foreground",
+      mapLayer: mapLayer,
     });
 
     expect(provider.mapLayer).toEqual("Foreground");

--- a/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -301,6 +301,27 @@ describe("Scene/BingMapsImageryProvider", function () {
     expect(provider.url).toEqual(url);
   });
 
+  it("fromUrl takes mapLayer as option and sets hasAlphaChannel accordingly.", async function () {
+    const url = "http://fake.fake.invalid/";
+    const mapStyle = BingMapsStyle.AERIAL_WITH_LABELS_ON_DEMAND;
+
+    installFakeMetadataRequest(url, mapStyle);
+    installFakeImageRequest();
+
+    const resource = new Resource({
+      url: url,
+    });
+
+    const provider = await BingMapsImageryProvider.fromUrl(resource, {
+      key: "",
+      mapStyle: mapStyle,
+      mapLayer: "Foreground",
+    });
+
+    expect(provider.mapLayer).toEqual("Foreground");
+    expect(provider.hasAlphaChannel).toBe(true);
+  });
+
   it("fromUrl throws if request fails", async function () {
     const url = "http://fake.fake.invalid";
 


### PR DESCRIPTION
Bing Maps [mapLayer template parameters](https://learn.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata#template-parameters) allow users to customize imagery to enable certain features, such as traffic flow. This change updates `BingMapsImageryProvider.fromUrl` to take an optional `mapLayer` string parameter which is then maps directly to the equivalent Bing query parameter.

Also had to change Bing to identify itself as having transparency when this option is used.