### PR TITLE
Minimum required attribution for Google 3D Tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 - Fixed `czm_normal`, `czm_normal3D`, `czm_inverseNormal`, and `czm_inverseNormal3D` for cases where the model matrix has non-uniform scale. [#11553](https://github.com/CesiumGS/cesium/pull/11553)
 - Fixed issue with clustered labels when `dataSource.show` was toggled. [#11560](https://github.com/CesiumGS/cesium/pull/11560)
 - Fixed inconsistant clustering when `dataSource.show` was toggled. [#11560](https://github.com/CesiumGS/cesium/pull/11560)
-- By default, `createGooglePhotorealistic3DTileset` no longer shows credits on screen, as this is compliant with the minimum required attribution. To restore this behavior, pass the option `showCreditsOnScreen: true`.
+- By default, `createGooglePhotorealistic3DTileset` no longer shows credits on screen, as this is compliant with the minimum required attribution. To restore this behavior, pass the option `showCreditsOnScreen: true`. [#11589](https://github.com/CesiumGS/cesium/pull/11589)
 
 ### 1.110.1 - 2023-10-25
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Fixed `czm_normal`, `czm_normal3D`, `czm_inverseNormal`, and `czm_inverseNormal3D` for cases where the model matrix has non-uniform scale. [#11553](https://github.com/CesiumGS/cesium/pull/11553)
 - Fixed issue with clustered labels when `dataSource.show` was toggled. [#11560](https://github.com/CesiumGS/cesium/pull/11560)
 - Fixed inconsistant clustering when `dataSource.show` was toggled. [#11560](https://github.com/CesiumGS/cesium/pull/11560)
+- By default, `createGooglePhotorealistic3DTileset` no longer shows credits on screen, as this is compliant with the minimum required attribution. To restore this behavior, pass the option `showCreditsOnScreen: true`.
 
 ### 1.110.1 - 2023-10-25
 

--- a/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
+++ b/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
@@ -41,7 +41,6 @@ import Resource from "../Core/Resource.js";
  */
 async function createGooglePhotorealistic3DTileset(key, options) {
   options = defaultValue(options, {});
-  options.showCreditsOnScreen = true;
   options.cacheBytes = defaultValue(options.cacheBytes, 1536 * 1024 * 1024);
   options.maximumCacheOverflowBytes = defaultValue(
     options.maximumCacheOverflowBytes,


### PR DESCRIPTION
By default, `createGooglePhotorealistic3DTileset` no longer shows credits on screen, as this is compliant with the minimum required attribution. Traditionally CesiumJS uses the minimum necessary to be compliant as to avoid any confusion about what is required.

To restore this behavior, pass the option `showCreditsOnScreen: true`.