### PR TITLE
Update S3 CI location and public URLs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,8 +27,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: us-east-1
       BRANCH: ${{ github.ref_name }}
     steps:
@@ -45,7 +45,7 @@ jobs:
         run: npm run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
       - name: upload coverage artifacts
         if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
-        run: aws s3 sync ./Build/Coverage s3://cesium-dev/cesium/$BRANCH/Build/Coverage --delete --color on
+        run: aws s3 sync ./Build/Coverage s3://cesium-public-builds/cesium/$BRANCH/Build/Coverage --delete --color on
   release-tests:
     runs-on: ubuntu-latest
     steps:
@@ -69,8 +69,8 @@ jobs:
       contents: read
     env:
       BUILD_VERSION: ${{ github.ref_name }}.${{ github.run_number }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: us-east-1
       BRANCH: ${{ github.ref_name }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
       - uses: ./.github/actions/verify-package
       - name: deploy to s3
         if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
-        run: npm run deploy-s3 -- -b "cesium-dev" -d cesium/$BRANCH -c 'no-cache' --confirm 
+        run: npm run deploy-s3 -- -b "cesium-public-builds" -d cesium/$BRANCH -c 'no-cache' --confirm 
       - name: set status
         if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
         run: npm run deploy-status -- --status success --message Deployed

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -27,8 +27,8 @@ jobs:
     env:
       PROD: true
       BUILD_VERSION: ${{ github.ref_name }}.${{ github.run_number }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: us-east-1
       BRANCH: ${{ github.ref_name }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Documentation/Contributors/BuildGuide/README.md
+++ b/Documentation/Contributors/BuildGuide/README.md
@@ -170,23 +170,22 @@ Additional set up is required for deployment if you do not have commit access to
 
 ### Configure a Different S3 Bucket
 
-It is possible to configure your development branch of CesiumJS to deploy build artifacts to a different [AWS S3 Bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html). If you are using the cesium-dev bucket and have valid credentials, skip to [Configure S3 Credentials](#configure-s3-credentials)
+It is possible to configure your development branch of CesiumJS to deploy build artifacts to a different [AWS S3 Bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html). If you are using the cesium-public-builds bucket and have valid credentials, skip to [Configure S3 Credentials](#configure-s3-credentials)
 
-- In `.gtihub/workflows/dev.yml`, in the following lines, replace "cesium-dev" with the name of your S3 bucket.
+- In `.gtihub/workflows/dev.yml`, in the following lines, replace "cesium-public-builds" with the name of your S3 bucket.
 
 ```yml
-aws s3 sync ./Build/Coverage s3://cesium-dev/cesium/$BRANCH/Build/Coverage --delete --color on
+aws s3 sync ./Build/Coverage s3://cesium-public-builds/cesium/$BRANCH/Build/Coverage --delete --color on
 ```
 
 ```yml
-npm run deploy-s3 -- -b "cesium-dev" -d cesium/$BRANCH -c 'no-cache' --confirm
+npm run deploy-s3 -- -b "cesium-public-builds" -d cesium/$BRANCH -c 'no-cache' --confirm
 ```
 
 - In `gulpfile.js`, edit the following line:
 
 ```javascript
-const devDeployUrl =
-  "http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/";
+const devDeployUrl = "https://ci-builds.cesium.com/cesium/";
 ```
 
 - Edit the URL to match the URL of the S3 bucket specified in the previous step.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1224,7 +1224,7 @@ export async function deployStatus() {
   const status = argv.status;
   const message = argv.message;
 
-  const deployUrl = `${devDeployUrl + process.env.BRANCH}/`;
+  const deployUrl = `${devDeployUrl + process.env.BRANCH}/index.html`;
   const zipUrl = `${deployUrl}Cesium-${version}.zip`;
   const npmUrl = `${deployUrl}cesium-${version}.tgz`;
   const coverageUrl = `${

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,8 +61,7 @@ if (/\.0$/.test(version)) {
 }
 const karmaConfigFile = resolve("./Specs/karma.conf.cjs");
 
-const devDeployUrl =
-  "http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/";
+const devDeployUrl = "https://ci-builds.cesium.com/cesium/";
 const isProduction = process.env.PROD;
 
 //Gulp doesn't seem to have a way to get the currently running tasks for setting


### PR DESCRIPTION
* Break into deploy credentials DEV_ and PROD_ versions as these are no longer managed in the same account.
* Deploy dev to `s3://cesium-public-builds/cesium/$BRANCH/`
* Host as `https://ci-builds.cesium.com/cesium/$BRANCH/`
* No changes to production at this time.
* This also means CI is now hosted under https, which is allows some features that require https to be used. Should also slightly improve performance when working with deployed branches do to the backend now being through CloudFront instead of old-school s3 public bucket.