### PR TITLE
Update to Node 20 & 18

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: install node 18
+      - name: install node 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: npm install
         run: npm install
       - name: lint *.js
@@ -105,10 +105,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: install node 16
+      - name: install node 18
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: npm install
         run: npm install
       - name: release build

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "@cesium/widgets": "^4.2.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-s3": "^3.342.0",
-    "@aws-sdk/lib-storage": "^3.342.0",
+    "@aws-sdk/client-s3": "^3.438.0",
+    "@aws-sdk/lib-storage": "^3.438.0",
     "@playwright/test": "^1.34.3",
     "chokidar": "^3.5.3",
     "cloc": "^2.8.0",
@@ -105,7 +105,7 @@
     "prismjs": "^1.28.0",
     "request": "^2.79.0",
     "rimraf": "^5.0.0",
-    "sinon": "^16.0.0",
+    "sinon": "^17.0.0",
     "stream-to-promise": "^3.0.0",
     "tsd-jsdoc": "^2.5.0",
     "typescript": "^5.0.2",


### PR DESCRIPTION
Updates CI to use Node 20 and Node 18 instead of Node 18 and Node 16 respectively.

Also update a few dev dependencies in preparation for the release. They support CI deployment and screenshot testing with playwright.