### PR TITLE
Fix empty traversal for mixed empty and non-empty tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.112 - 2023-12-01
+
+##### Fixes :wrench:
+
+- Fixed a bug where 3D Tiles replacement refinement would sometimes not refine correctly for a tile with both empty and non-empty children.[#11611](https://github.com/CesiumGS/cesium/pull/11611)
+
 ### 1.111 - 2023-11-01
 
 #### @cesium/engine

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -283,13 +283,13 @@ function executeEmptyTraversal(root, frameState) {
     // tile.contentAvailable checks for expired content and only works for
     // renderable content, so for placeholder tiles (external or implicit
     // tilesets) check for contentReady instead
-    const isWaiting =
+    const isWaitingForContent =
       (isPlaceholder && !tile.contentReady) ||
       (hasRenderableContent && !tile.contentAvailable);
 
     // We want to refine as much as possible for the current SSE threshold, but
     // if content is still loading, we have to wait.
-    if (isWaiting) {
+    if (isWaitingForContent) {
       shouldRefine = false;
     }
 

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -274,6 +274,11 @@ function executeEmptyTraversal(root, frameState) {
     );
     const tile = stack.pop();
 
+    // Skip tiles that are expired.
+    if (tile.contentExpired) {
+      continue;
+    }
+
     // Distinguish placeholder tiles (that will load more tiles once the content
     // loads) from empty tiles
     const isPlaceholder = tile.hasTilesetContent || tile.hasImplicitContent;

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -274,11 +274,6 @@ function executeEmptyTraversal(root, frameState) {
     );
     const tile = stack.pop();
 
-    // Skip tiles that are expired.
-    if (tile.contentExpired) {
-      continue;
-    }
-
     // Distinguish placeholder tiles (that will load more tiles once the content
     // loads) from empty tiles
     const isPlaceholder = tile.hasTilesetContent || tile.hasImplicitContent;
@@ -318,7 +313,12 @@ function executeEmptyTraversal(root, frameState) {
     // This block makes use of the fact that empty tiles and placeholder tiles
     // that have not yet loaded will have 0 children
     const shouldTraverse = isAboveErrorThreshold || isPlaceholder;
-    if (shouldTraverse) {
+
+    // Expired placeholder tiles destroy their descendants, so stop the
+    // traversal early if this is detected.
+    const isExpiredPlaceholder = isPlaceholder && tile.isExpired;
+
+    if (shouldTraverse && !isExpiredPlaceholder) {
       const children = tile.children;
       const childrenLength = children.length;
 

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1303,8 +1303,8 @@ describe(
       });
     });
 
-    it("replacement refinement - selects upwards when traversal stops at empty tile", function () {
-      // No children have content, but all grandchildren have content
+    it("replacement refinement - empty tile traversal does not examine tiles that are too deep to be in view", function () {
+      // No children have content, but all grandchildren have content.
       //
       //          C
       //      E       E
@@ -1314,14 +1314,17 @@ describe(
         scene,
         tilesetReplacement1Url
       ).then(function (tileset) {
+        // Set up a camera view where the empty tiles are the first tiles
+        // to meet the SSE threshold. While perhaps counterintuitive, such
+        // tiles should be rendered empty even though they're technically holes.
         tileset.root.geometricError = 90;
         setZoom(80);
         scene.renderForSpecs();
 
         const statistics = tileset._statistics;
-        expect(statistics.selected).toEqual(1);
+        expect(statistics.selected).toEqual(0);
         expect(statistics.visited).toEqual(3);
-        expect(isSelected(tileset, tileset.root)).toBe(true);
+        expect(isSelected(tileset, tileset.root)).toBe(false);
         return Cesium3DTilesTester.waitForTilesLoaded(scene, tileset);
       });
     });


### PR DESCRIPTION
Fixes #9356

This PR fixes a bug in empty tile traversal code where sometimes a parent tile wouldn't refine if one of its children is a long chain of empty tiles followed by a tile with content. The old logic would assume the parent shouldn't refine because there was a renderable descendant, and refining would create a hole. However, some cases (like in #9356 and #11564) actually require the hole to render properly.

I went through and redid the logic of that function, and was able to simplify and document it so it's easier to follow.

The biggest difference is that now only tiles that would be rendered for the current camera view are examined, before it would traverse deeper in the tree if there are a lot of empty tiles. 

@jjhembd could you review?

CC @lilleyse 