### PR TITLE
Update JSDoc for optional options

### DIFF
--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -1902,7 +1902,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
  * used for streaming massive heterogeneous 3D geospatial datasets, from a Cesium ion asset ID.
  *
  * @param {number} assetId The Cesium ion asset id.
- * @param {Cesium3DTileset.ConstructorOptions} options An object describing initialization options
+ * @param {Cesium3DTileset.ConstructorOptions} [options] An object describing initialization options
  * @returns {Promise<Cesium3DTileset>}
  *
  * @exception {DeveloperError} The tileset must be 3D Tiles version 0.0 or 1.0.

--- a/packages/engine/Source/Scene/IonImageryProvider.js
+++ b/packages/engine/Source/Scene/IonImageryProvider.js
@@ -251,7 +251,7 @@ Object.defineProperties(IonImageryProvider.prototype, {
  * Creates a provider for tiled imagery using the Cesium ion REST API.
  *
  * @param {Number} assetId  An ion imagery asset ID.
- * @param {IonImageryProvider.ConstructorOptions} options Object describing initialization options.
+ * @param {IonImageryProvider.ConstructorOptions} [options] Object describing initialization options.
  * @returns {Promise<IonImageryProvider>} A promise which resolves to the created IonImageryProvider.
  *
  * @example


### PR DESCRIPTION
Updates `IonImageryProvider.fromAssetId` and `Cesium3DTileset.fromIonAssetId` to have optional options.  In both cases options arguments were not marked as optional in JSDoc causing them to be required in Typescript.

Fixes #11623 and fixes #11624

## Test Plan

Run `npm build-ts`

Open the generated typescript definition file, and verify that both methods now include `optinons?:` instead of `options:` to mark them as optional


```ts
 static fromAssetId(assetId: number, options?: IonImageryProvider.ConstructorOptions): Promise<IonImageryProvider>;

 static fromIonAssetId(assetId: number, options?: Cesium3DTileset.ConstructorOptions): Promise<Cesium3DTileset>;
```
