### PR TITLE
Check for other title/name possibilities if title is empty on geojson…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -194,6 +194,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [T2 Software](http://t2.com.tr/)
   - [Hüseyin ATEŞ](https://github.com/ateshuseyin)
   - [İbrahim Furkan Aygar](https://github.com/furkanaygar)
+- [Applied Research Associates](https://www.ara.com)
+  - [mfarmer-ara](https://github.com/mfarmer-ara)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/packages/engine/Source/DataSources/GeoJsonDataSource.js
+++ b/packages/engine/Source/DataSources/GeoJsonDataSource.js
@@ -133,7 +133,7 @@ function createObject(geoJson, entityCollection, describe) {
 
     //Check for the simplestyle specified name first.
     const name = properties.title;
-    if (defined(name)) {
+    if (defined(name) && name !== "") {
       entity.name = name;
       nameProperty = "title";
     } else {

--- a/packages/engine/Specs/DataSources/GeoJsonDataSourceSpec.js
+++ b/packages/engine/Specs/DataSources/GeoJsonDataSourceSpec.js
@@ -272,6 +272,15 @@ describe("DataSources/GeoJsonDataSource", function () {
     },
   };
 
+  const featureWithEmptyTitle = {
+    type: "Feature",
+    geometry: point,
+    properties: {
+      title: "",
+      "fallback-title": "Has fallback Title",
+    },
+  };
+
   const featureWithId = {
     id: "myId",
     type: "Feature",
@@ -597,6 +606,17 @@ describe("DataSources/GeoJsonDataSource", function () {
         coordinatesToCartesian(featureWithNullName.geometry.coordinates)
       );
       expect(entity.billboard).toBeDefined();
+    });
+  });
+
+  it("Falls back to name-like property if title is empty", function () {
+    const dataSource = new GeoJsonDataSource();
+    return dataSource.load(featureWithEmptyTitle).then(function () {
+      const entityCollection = dataSource.entities;
+      const entity = entityCollection.values[0];
+      expect(entity.name).toBe(
+        featureWithEmptyTitle.properties["fallback-title"]
+      );
     });
   });
 


### PR DESCRIPTION
This adds an empty check to the initial name set for a GeoJsonDataSource. Adding this check allows it to fallback to checking other title/name possibilities a few lines below. 

[Example](https://sandcastle.cesium.com/#c=5Vddb5swFP0riL2kUuIYjLHp0mpT9iFN0zap0V7GHlxwO6sGI2NapVX/++yQNG0+m03JKu0+4etzr48vcI9upsraeNeC33DtnXglv/GGvBZNAb5PfJ3UzybroSoNEyXXqX/0Oi3T8pppT1VG2AQ28C4tPWsZK7hm3vE0I6gzXnLQersziA2tlyHOO4NIVlQj9VGrpsyPPaMbnpb3k1OzCd9Lrt4XlRmPhJF8fnrqX3BmGs3r1D/2frROZ3fzxxZnxhV3mNT/0EakfncRU2lVcW1Em20hxTSNO7/Ns5SgReS8zrSYlGkjLrNXNXrcK22ppsSYlOcsu/JG7SErwy6ElC38VZJAaxtwPVWxTJhxi4cAWzJPoPdLJbB1Lriltb4AD3X8puT40l1yzfWUzkXJzNKreWxr3Fu2nPVIAghCMaZhHCMUBd3NeIRBFMcRSpIowBAjtB7+s/tXrDCNMIUkTgiBmGynFYQ0ssQCFESIxPGeeFFAAkLCkNhSJRShZ/DCAbTlgiRAKKF7o5WEBCOM3TEJxttpkQjagkFCQ4STZG9vkWAYhmGEwjig9BmsXJFgEKMIw70Va39f/OqtFe4F1/18OX2cXXBFxx0qKXnWNkbb3Z809xfU199mpmFyYxPec483N6onuTFc9zKVTyO/DLcrAoSJtf9YEehu/wc+jCLEL1QR6I6KEB5CERIAd1QEehhFoLspAj2MIuzri/9XijCdEXJm2JlqtB1FAMvzznRE+cjVp1qV7x52gVQs78wEpDubT46OHjLdKlWMVOdP886njkfJ3Tzkd/1BbcaSn85u/EYUldLGa7TsANA3vKik63b98ya74gZkde0CHXTQfxw6yMW1J/KTFZOXm4zq2u5cNFKeiVtbv9NB3+KXQh1hUV5+veZasrGD/QpOP7dOAMCgb5erI41SVpP0Qubf)

Clicking each polygon in turn:

Current behavior (1.111)
- Green = Title is not empty, shows "Actual Title"
- Red = Title is empty and fallback possibility is not considered, shows ""

Changes here
- Green = "Actual Title"
- Red = "Fallback Title"

Closes #11633