### PR TITLE
Fix race condition in OctahedralProjectedCubeMapSpec.js

### DIFF
--- a/packages/engine/Specs/Scene/OctahedralProjectedCubeMapSpec.js
+++ b/packages/engine/Specs/Scene/OctahedralProjectedCubeMapSpec.js
@@ -208,7 +208,7 @@ describe(
         });
     });
 
-    it("raises error event when environment map fails to load.", function () {
+    it("raises error event when environment map fails to load.", async function () {
       if (!OctahedralProjectedCubeMap.isSupported(context)) {
         return;
       }
@@ -217,17 +217,22 @@ describe(
       const frameState = createFrameState(context);
       let error;
 
-      const removeListener = projection.errorEvent.addEventListener((e) => {
-        error = e;
-        expect(error).toBeDefined();
-        expect(projection.ready).toEqual(false);
-        removeListener();
+      const promise = new Promise((resolve, reject) => {
+        const removeListener = projection.errorEvent.addEventListener((e) => {
+          error = e;
+          expect(error).toBeDefined();
+          expect(projection.ready).toEqual(false);
+          removeListener();
+          resolve();
+        });
       });
 
-      return pollToPromise(function () {
+      await pollToPromise(function () {
         projection.update(frameState);
         return defined(error);
       });
+
+      return promise;
     });
   },
   "WebGL"


### PR DESCRIPTION
`raises error event when environment map fails to load.` assumes that the errorEvent listener will always be fired before `projection.update` returns true, but inspecting the code shows that is clearly not the case. It's possible for an error to be thrown, the update to return true, another tick to run and then the error event is raised. This lead to a Jasmine `afterAll` failure pointing to line 222 of this file on my machine when running the tests.

Wrapping the event in a promise and waiting for both `projection.update` to return true and the event to be handled is the way to ensure no race conditions in the spec itself.