### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
   ],
   "dependencies": {
     "@cesium/engine": "^6.1.0",
-    "@cesium/widgets": "^4.3.0",
-    "meshoptimizer": "^0.20.0"
+    "@cesium/widgets": "^4.3.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.1.3",
     "gulp-tap": "^2.0.0",
-    "gulp-zip": "^5.1.0",
+    "gulp-zip": "^6.0.0",
     "husky": "^8.0.2",
     "istanbul-lib-instrument": "^6.0.0",
     "jasmine-core": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -51,21 +51,22 @@
   ],
   "dependencies": {
     "@cesium/engine": "^6.1.0",
-    "@cesium/widgets": "^4.3.0"
+    "@cesium/widgets": "^4.3.0",
+    "meshoptimizer": "^0.20.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.34.3",
+    "@playwright/test": "^1.40.1",
     "chokidar": "^3.5.3",
     "cloc": "^2.8.0",
     "compression": "^1.7.4",
-    "esbuild": "^0.19.2",
-    "eslint": "^8.41.0",
+    "esbuild": "^0.19.8",
+    "eslint": "^8.54.0",
     "eslint-config-cesium": "^10.0.1",
     "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-node": "^11.1.0",
     "express": "^4.17.1",
-    "globby": "^13.1.3",
+    "globby": "^14.0.0",
     "glsl-strip-comments": "^1.0.0",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.3.0",
@@ -102,7 +103,7 @@
     "sinon": "^17.0.0",
     "stream-to-promise": "^3.0.0",
     "tsd-jsdoc": "^2.5.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.3.2",
     "yargs": "^17.0.1"
   },
   "scripts": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -45,7 +45,7 @@
     "ktx-parse": "^0.6.0",
     "lerc": "^2.0.0",
     "mersenne-twister": "^1.1.0",
-    "meshoptimizer": "^0.19.0",
+    "meshoptimizer": "^0.20.0",
     "pako": "^2.0.4",
     "protobufjs": "^7.1.0",
     "rbush": "^3.0.1",


### PR DESCRIPTION
Most of these are minor version changes.
One bigger change was `gulp-zip`, which is now ESM only. I verified that the `make-zip` script still runs through succesfully.