### PR TITLE
Correct typing for ImageryProvider constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.113
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Corrected JSDoc and Typescript definitions that marked optional arguments as required in `ImageryProvider` constructor [#11625](https://github.com/CesiumGS/cesium/issues/11625)
+
 ### 1.112 - 2023-12-01
 
 #### @cesium/engine

--- a/packages/engine/Source/Scene/ImageryLayer.js
+++ b/packages/engine/Source/Scene/ImageryLayer.js
@@ -132,8 +132,8 @@ import TileImagery from "./TileImagery.js";
  * @alias ImageryLayer
  * @constructor
  *
- * @param {ImageryProvider} imageryProvider The imagery provider to use.
- * @param {ImageryLayer.ConstructorOptions} options An object describing initialization options
+ * @param {ImageryProvider} [imageryProvider] The imagery provider to use.
+ * @param {ImageryLayer.ConstructorOptions} [options] An object describing initialization options
  *
  * @see ImageryLayer.fromProviderAsync
  * @see ImageryLayer.fromWorldImagery


### PR DESCRIPTION
Mark the `ImageryProvider` constructor parameters as optional.  Fixes #11625 

## Test plan

1. Open up `packages/engine/index.d.ts` on main.  Find `ImageryProvider` and verify that both parameters are required for the constructor.
2. Open this branch and run `npm run build-ts`.  Find `ImageryProvider` and verify that both are now optional.