### PR TITLE
Increase default `RequestsScheduler.maximumRequestsPerServer`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.113 - 2024-01-02
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Changes the default `RequestScheduler.maximumRequestsPerServer` from 6 to 18. This should improve performance on HTTP/2 servers and above [#11627](https://github.com/CesiumGS/cesium/issues/11627)
+
 ### 1.112 - 2023-12-01
 
 #### @cesium/engine
@@ -8,7 +16,6 @@
 
 - Fixed terrain lockups in `requestTileGeometry` by ensuring promise handling aligns with CesiumJS's expectations. [#11630](https://github.com/CesiumGS/cesium/pull/11630)
 - Corrected JSDoc and Typescript definitions that marked optional arguments as required in `Cesium3dTileset.fromIonAssetId` [#11623](https://github.com/CesiumGS/cesium/issues/11623), and `IonImageryProvider.fromAssetId` [#11624](https://github.com/CesiumGS/cesium/issues/11624)
-- Changes the default `RequestScheduler.maximumRequestsPerServer` from 6 to 18. This should improve performance on HTTP/2 servers and above [#11627](https://github.com/CesiumGS/cesium/issues/11627)
 
 ### 1.111 - 2023-11-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fixed terrain lockups in `requestTileGeometry` by ensuring promise handling aligns with CesiumJS's expectations. [#11630](https://github.com/CesiumGS/cesium/pull/11630)
 - Corrected JSDoc and Typescript definitions that marked optional arguments as required in `Cesium3dTileset.fromIonAssetId` [#11623](https://github.com/CesiumGS/cesium/issues/11623), and `IonImageryProvider.fromAssetId` [#11624](https://github.com/CesiumGS/cesium/issues/11624)
+- Changes the default `RequestScheduler.maximumRequestsPerServer` from 6 to 18. This should improve performance on HTTP/2 servers and above [#11627](https://github.com/CesiumGS/cesium/issues/11627)
 
 ### 1.111 - 2023-11-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -161,6 +161,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Jeshurun Hembd](https://github.com/jjhembd)
   - [Mia Tang](https://github.com/miatang13)
   - [Mark Dane](https://github.com/angrycat9000)
+  - [jjspace](https://github.com/jjspace)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/packages/engine/Source/Core/RequestScheduler.js
+++ b/packages/engine/Source/Core/RequestScheduler.js
@@ -60,9 +60,9 @@ RequestScheduler.maximumRequests = 50;
  * The maximum number of simultaneous active requests per server. Un-throttled requests or servers specifically
  * listed in {@link requestsByServer} do not observe this limit.
  * @type {number}
- * @default 6
+ * @default 18
  */
-RequestScheduler.maximumRequestsPerServer = 6;
+RequestScheduler.maximumRequestsPerServer = 18;
 
 /**
  * A per server key list of overrides to use for throttling instead of <code>maximumRequestsPerServer</code>.
@@ -78,13 +78,7 @@ RequestScheduler.maximumRequestsPerServer = 6;
  *   "assets.cesium.com:443": 18,
  * };
  */
-RequestScheduler.requestsByServer = {
-  "api.cesium.com:443": 18,
-  "assets.ion.cesium.com:443": 18,
-  "ibasemaps-api.arcgis.com:443": 18,
-  "tile.googleapis.com:443": 18,
-  "tile.openstreetmap.org:443": 18,
-};
+RequestScheduler.requestsByServer = {};
 
 /**
  * Specifies if the request scheduler should throttle incoming requests, or let the browser queue requests under its control.

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -314,7 +314,11 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
       const promises = [];
       return pollToPromise(function () {
         let b = true;
-        for (let i = 0; i < 10; ++i) {
+        for (
+          let i = 0;
+          i < RequestScheduler.maximumRequestsPerServer + 2;
+          ++i
+        ) {
           b = b && terrainProvider.getTileDataAvailable(i, i, i);
         }
         return b && terrainProvider.getTileDataAvailable(1, 2, 3);


### PR DESCRIPTION
Increase the default requests per server and remove the default known "per server" overrides. This is to help improve performance with HTTP/2 and above servers.

Fixes #https://github.com/CesiumGS/cesium/issues/11627