### PR TITLE
Added PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for the Pull Request!
+
+Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.
+
+To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).
+
+--->
+
+# Description
+
+<!--- Describe your changes in detail -->
+
+<!--- Consider: Why is this change required? What problem does it solve? -->
+
+<!--- Include screenshots if appropriate --->
+
+## Issue number and link
+
+<!--- If it fixes an open issue, link to the issue here -->
+
+<!--- Consider: If suggesting a new feature or change, discuss it in an issue first. -->
+
+## Testing plan
+
+<!--- Describe in detail how you tested your changes -->
+
+# Author checklist
+
+- [ ] I have submitted a Contributor License Agreement
+- [ ] I have added my name to `CONTRIBUTORS.md`
+- [ ] I have updated `CHANGES.md` with a short summary of my change
+- [ ] I have added or updated unit tests to ensure consistant code coverage
+- [ ] I have update the inline documentation, and included code examples where relevant
+- [ ] I have performed a self-review of my code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,21 +9,21 @@ To ensure your Pull Request is reviewed and accepted quickly, please refer to ou
 
 # Description
 
-<!--- Describe your changes in detail -->
+<!-- Describe your changes in detail -->
 
-<!--- Consider: Why is this change required? What problem does it solve? -->
+<!-- Consider: Why is this change required? What problem does it solve? -->
 
-<!--- Include screenshots if appropriate --->
+<!-- Include screenshots if appropriate -->
 
 ## Issue number and link
 
-<!--- If it fixes an open issue, link to the issue here -->
+<!-- If it fixes an open issue, link to the issue here -->
 
-<!--- Consider: If suggesting a new feature or change, discuss it in an issue first. -->
+<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->
 
 ## Testing plan
 
-<!--- Describe in detail how you tested your changes -->
+<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
 
 # Author checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/
 
 To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).
 
---->
+-->
 
 # Description
 


### PR DESCRIPTION
# Description

We've gotten rid of the Cesium Concierge, who will no longer post [handy comments like this](https://github.com/CesiumGS/cesium/pull/11581#issuecomment-1775863898).

While CLA checking is still in the works as part of a separate effort, this PR template aims to replace the functionality of that comment.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/6167

## Testing plan

I've used the template for this PR. 
It will show up for PRs once merged into `main`.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~ N/A
- [ ] ~I have added or updated unit tests to ensure consistant code coverage~ N/A
- [ ] ~I have update the inline documentation, and included code examples where relevant~ N/A
- [x] I have performed a self-review of my code

