### PR TITLE
Fix global require usage

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -2,15 +2,11 @@
 "use strict";
 
 const path = require("path");
+const minified = path.join(__dirname, "Build/Cesium/index.cjs");
+const unminified = path.join(__dirname, "Build/CesiumUnminified/index.cjs");
 
 // If in 'production' mode, use the combined/minified/optimized version of Cesium
-if (process.env.NODE_ENV === "production") {
-  // eslint-disable-next-line global-require
-  module.exports = require(path.join(__dirname, "Build/Cesium/index.cjs"));
-  return;
-}
-
-module.exports = require(path.join(
-  __dirname,
-  "Build/CesiumUnminified/index.cjs"
-));
+module.exports =
+  process.env.NODE_ENV === "production"
+    ? require(minified)
+    : require(unminified);


### PR DESCRIPTION
This was failing since our update to the eslint rules. Resolve with a ternary operator as suggest in [the `n/global-require` docs](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/global-require.md)

It was only be picked up during CI since the local commit hook is only ran on changed files.