### PR TITLE
Run dev workflow for external contributor PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: deploy
+on: 
+  push:
+    branches-ignore: 
+      - 'cesium.com'
+      - production
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: read
+    env:
+      BUILD_VERSION: ${{ github.ref_name }}.${{ github.run_number }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-east-1
+      BRANCH: ${{ github.ref_name }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPO: ${{ github.repository }}
+      GITHUB_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: install node 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: npm install
+        run: npm install
+      - name: set the version in package.json
+        run: npm run deploy-set-version -- --buildVersion $BUILD_VERSION
+      - name: create release zip
+        run: npm run make-zip
+      - name: package cesium module
+        run: npm pack &> /dev/null
+      - name: package workspace modules
+        run: npm pack --workspaces &> /dev/null
+      - name: build apps
+        run: npm run build-apps
+      - uses: ./.github/actions/verify-package
+      - name: deploy to s3
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
+        run: |
+          aws s3 sync . s3://cesium-public-builds/cesium/$BRANCH/ \
+          --cache-control "no-cache" \
+          --exclude ".git/*" \
+          --exclude ".concierge/*" \
+          --exclude ".github/*" \
+          --exclude ".husky/*" \
+          --exclude ".vscode/*" \
+          --exclude "Build/Coverage/*" \
+          --exclude "Build/CesiumDev/*" \
+          --exclude "Build/Specs/e2e" \
+          --exclude "Documentation/*" \
+          --exclude "node_modules/*" \
+          --exclude "scripts/*" \
+          --exclude "Tools/*" \
+          --delete 
+      - name: set status
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
+        run: npm run deploy-status -- --status success --message Deployed

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,6 +4,7 @@ on:
     branches-ignore: 
       - 'cesium.com'
       - production
+  pull_request:
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,12 +1,11 @@
 name: dev
 on: 
   push:
-    branches-ignore: 
-      - 'cesium.com'
-      - production
+    branches: 
+      - main
   pull_request:
 concurrency:
-  group: ${{ github.ref }}
+  group: dev-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   lint:
@@ -34,10 +33,10 @@ jobs:
       BRANCH: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
-      - name: install node 18
+      - name: install node 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: npm install
         run: npm install
       - name: build
@@ -51,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: install node 18
+      - name: install node 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: npm install
         run: npm install
       - name: release build
@@ -63,61 +62,7 @@ jobs:
         run: npm run test -- --browsers ChromeHeadless --failTaskOnError --webgl-stub --release --suppressPassed
       - name: cloc
         run: npm run cloc
-  deploy:
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      contents: read
-    env:
-      BUILD_VERSION: ${{ github.ref_name }}.${{ github.run_number }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: us-east-1
-      BRANCH: ${{ github.ref_name }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_REPO: ${{ github.repository }}
-      GITHUB_SHA: ${{ github.sha }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: install node 18
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      - name: npm install
-        run: npm install
-      - name: set the version in package.json
-        run: npm run deploy-set-version -- --buildVersion $BUILD_VERSION
-      - name: create release zip
-        run: npm run make-zip
-      - name: package cesium module
-        run: npm pack &> /dev/null
-      - name: package workspace modules
-        run: npm pack --workspaces &> /dev/null
-      - name: build apps
-        run: npm run build-apps
-      - uses: ./.github/actions/verify-package
-      - name: deploy to s3
-        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
-        run: |
-          aws s3 sync . s3://cesium-public-builds/cesium/$BRANCH/ \
-          --cache-control "no-cache" \
-          --exclude ".git/*" \
-          --exclude ".concierge/*" \
-          --exclude ".github/*" \
-          --exclude ".husky/*" \
-          --exclude ".vscode/*" \
-          --exclude "Build/Coverage/*" \
-          --exclude "Build/CesiumDev/*" \
-          --exclude "Build/Specs/e2e" \
-          --exclude "Documentation/*" \
-          --exclude "node_modules/*" \
-          --exclude "scripts/*" \
-          --exclude "Tools/*" \
-          --delete 
-      - name: set status
-        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
-        run: npm run deploy-status -- --status success --message Deployed
-  node-16:
+  node-18:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -57,7 +57,7 @@ jobs:
       - name: npm install
         run: npm install
       - name: release build
-        run: npm run build-release
+        run: npm run make-zip
       - name: release tests (chrome)
         run: npm run test -- --browsers ChromeHeadless --failTaskOnError --webgl-stub --release --suppressPassed
       - name: cloc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: main
 on: 
   workflow_run:
-    workflows: [dev]
+    workflows: [dev, prod]
     types: [completed]
     branches: 
       - main


### PR DESCRIPTION
# Description

I noticed that https://github.com/CesiumGS/cesium/pull/11678 and other external PRs do not have any GitHub Action workflows run. Nor do I see the approval workflow as described in [Approving workflow runs from public forks](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks).

While its not very clear from the GitHub actions documentation, it appears that the external contributor workflows are expected to be triggered from PRs rather than pushes.

This PR also cleans up some missed references when transitioning from Node 16 and 18 to Node 18 and 20 to reflect LTS status.

## Issue number and link

N/A

## Testing plan

This should:
1) Trigger the dev workflow for this PR once opened
2) Once merged into main, newly opened external PRs and their updates should trigger the dev workflow.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~ N/A
- [ ] ~I have added or updated unit tests to ensure consistant code coverage~ N/A
- [ ] ~I have update the inline documentation, and included code examples where relevant~ N/A
- [x] I have performed a self-review of my code
