### PR TITLE
Add iterator to all collections

### DIFF
--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -403,17 +403,16 @@ if (defined(pos)) {
   consumeDefined(pos);
 }
 
-
 // Verify that a collection (like LabelCollection) is iterable
 // and can be used in a for-of loop
 const labels = new LabelCollection();
 labels.add({
-  position : new Cartesian3(1.0, 2.0, 3.0),
-  text : 'A label'
+  position: new Cartesian3(1.0, 2.0, 3.0),
+  text: "A label",
 });
 labels.add({
-  position : new Cartesian3(4.0, 5.0, 6.0),
-  text : 'Another label'
+  position: new Cartesian3(4.0, 5.0, 6.0),
+  text: "Another label",
 });
 
 for (const label of labels) {

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -50,6 +50,7 @@ import {
   ImageryProvider,
   IonImageryProvider,
   KmlDataSource,
+  LabelCollection,
   MapboxImageryProvider,
   MapboxStyleImageryProvider,
   MaterialProperty,
@@ -400,4 +401,21 @@ function consumeDefined(pos: Cartesian3) {
 pos = undefined;
 if (defined(pos)) {
   consumeDefined(pos);
+}
+
+
+// Verify that a collection (like LabelCollection) is iterable
+// and can be used in a for-of loop
+const labels = new LabelCollection();
+labels.add({
+  position : new Cartesian3(1.0, 2.0, 3.0),
+  text : 'A label'
+});
+labels.add({
+  position : new Cartesian3(4.0, 5.0, 6.0),
+  text : 'Another label'
+});
+
+for (const label of labels) {
+  console.log(label.text);
 }

--- a/Specs/TypeScript/tsconfig.json
+++ b/Specs/TypeScript/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "compilerOptions": {
+    "lib": [
+      "ES2015",
+      "DOM"
+    ],
+    "downlevelIteration": true,
     "noEmit": true,
     "types": [],
     "strict": true,

--- a/Tools/jsdoc/tsconfig.json
+++ b/Tools/jsdoc/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+      "lib": [
+        "ES2015",
+        "DOM"
+      ],
       "noEmit": true,
       "types": []
   },

--- a/packages/engine/Source/Core/TimeIntervalCollection.js
+++ b/packages/engine/Source/Core/TimeIntervalCollection.js
@@ -16,6 +16,7 @@ function compareIntervalStartTimes(left, right) {
 /**
  * A non-overlapping collection of {@link TimeInterval} instances sorted by start time.
  * @alias TimeIntervalCollection
+ * @implements {Iterable<TimeInterval>}
  * @constructor
  *
  * @param {TimeInterval[]} [intervals] An array of intervals to add to the collection.

--- a/packages/engine/Source/Core/TimeIntervalCollection.js
+++ b/packages/engine/Source/Core/TimeIntervalCollection.js
@@ -1133,4 +1133,14 @@ TimeIntervalCollection.fromIso8601DurationArray = function (options, result) {
     result
   );
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<TimeInterval>} The iterator
+ */
+TimeIntervalCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._intervals;
+};
+
 export default TimeIntervalCollection;

--- a/packages/engine/Source/DataSources/CompositeEntityCollection.js
+++ b/packages/engine/Source/DataSources/CompositeEntityCollection.js
@@ -589,4 +589,16 @@ CompositeEntityCollection.prototype._onDefinitionChanged = function (
 
   compositeEntity[propertyName] = compositeProperty;
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Entity>} The iterator
+ */
+CompositeEntityCollection.prototype[Symbol.iterator] = function* () {
+  for (const collection of this._collections) {
+    yield* collection;
+  }
+};
+
 export default CompositeEntityCollection;

--- a/packages/engine/Source/DataSources/CompositeEntityCollection.js
+++ b/packages/engine/Source/DataSources/CompositeEntityCollection.js
@@ -123,6 +123,7 @@ function recomposite(that) {
  * EntityCollection is used.
  *
  * @alias CompositeEntityCollection
+ * @implements {Iterable<Entity>}
  * @constructor
  *
  * @param {EntityCollection[]} [collections] The initial list of EntityCollection instances to merge.

--- a/packages/engine/Source/DataSources/DataSourceCollection.js
+++ b/packages/engine/Source/DataSources/DataSourceCollection.js
@@ -8,6 +8,7 @@ import CesiumMath from "../Core/Math.js";
 /**
  * A collection of {@link DataSource} instances.
  * @alias DataSourceCollection
+ * @implements {Iterable<DataSource>}
  * @constructor
  */
 function DataSourceCollection() {

--- a/packages/engine/Source/DataSources/DataSourceCollection.js
+++ b/packages/engine/Source/DataSources/DataSourceCollection.js
@@ -333,4 +333,14 @@ DataSourceCollection.prototype.destroy = function () {
   this.removeAll(true);
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<DataSource>} The iterator
+ */
+DataSourceCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._dataSources;
+};
+
 export default DataSourceCollection;

--- a/packages/engine/Source/DataSources/EntityCollection.js
+++ b/packages/engine/Source/DataSources/EntityCollection.js
@@ -49,6 +49,7 @@ function fireChangedEvent(collection) {
 /**
  * An observable collection of {@link Entity} instances where each entity has a unique id.
  * @alias EntityCollection
+ * @implements {Iterable<Entity>}
  * @constructor
  *
  * @param {DataSource|CompositeEntityCollection} [owner] The data source (or composite entity collection) which created this collection.

--- a/packages/engine/Source/DataSources/EntityCollection.js
+++ b/packages/engine/Source/DataSources/EntityCollection.js
@@ -437,4 +437,14 @@ EntityCollection.prototype._onEntityDefinitionChanged = function (entity) {
   }
   fireChangedEvent(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Entity>} The iterator
+ */
+EntityCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._entities;
+};
+
 export default EntityCollection;

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -2414,4 +2414,14 @@ BillboardCollection.prototype.destroy = function () {
 
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Billboard>} The iterator
+ */
+BillboardCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._billboards;
+};
+
 export default BillboardCollection;

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -103,6 +103,7 @@ const attributeLocationsInstanced = {
  * for images with the same identifier.
  *
  * @alias BillboardCollection
+ * @implements {Iterable<Billboard>}
  * @constructor
  *
  * @param {object} [options] Object with the following properties:

--- a/packages/engine/Source/Scene/ClippingPlaneCollection.js
+++ b/packages/engine/Source/Scene/ClippingPlaneCollection.js
@@ -768,4 +768,14 @@ ClippingPlaneCollection.prototype.destroy = function () {
     this._clippingPlanesTexture && this._clippingPlanesTexture.destroy();
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<ClippingPlane>} The iterator
+ */
+ClippingPlaneCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._planes;
+};
+
 export default ClippingPlaneCollection;

--- a/packages/engine/Source/Scene/ClippingPlaneCollection.js
+++ b/packages/engine/Source/Scene/ClippingPlaneCollection.js
@@ -31,6 +31,7 @@ import ClippingPlane from "./ClippingPlane.js";
  * </p>
  *
  * @alias ClippingPlaneCollection
+ * @implements {Iterable<ClippingPlane>}
  * @constructor
  *
  * @param {object} [options] Object with the following properties:

--- a/packages/engine/Source/Scene/CloudCollection.js
+++ b/packages/engine/Source/Scene/CloudCollection.js
@@ -1047,4 +1047,13 @@ CloudCollection.prototype.destroy = function () {
   return destroyObject(this);
 };
 
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Cloud>} The iterator
+ */
+CloudCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._clouds;
+};
+
 export default CloudCollection;

--- a/packages/engine/Source/Scene/CloudCollection.js
+++ b/packages/engine/Source/Scene/CloudCollection.js
@@ -74,6 +74,7 @@ const COLOR_INDEX = CumulusCloud.COLOR_INDEX;
  * Clouds are added and removed from the collection using {@link CloudCollection#add}
  * and {@link CloudCollection#remove}.
  * @alias CloudCollection
+ * @implements {Iterable<CumulusCloud>}
  * @constructor
  *
  * @param {object} [options] Object with the following properties:
@@ -1050,7 +1051,7 @@ CloudCollection.prototype.destroy = function () {
 /**
  * Returns an iterator over the elements of this collection.
  *
- * @returns {Iterator<Cloud>} The iterator
+ * @returns {Iterator<CumulusCloud>} The iterator
  */
 CloudCollection.prototype[Symbol.iterator] = function* () {
   yield* this._clouds;

--- a/packages/engine/Source/Scene/ImageryLayerCollection.js
+++ b/packages/engine/Source/Scene/ImageryLayerCollection.js
@@ -644,4 +644,14 @@ ImageryLayerCollection.prototype._update = function () {
     }
   }
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<ImageryLayer>} The iterator
+ */
+ImageryLayerCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._layers;
+};
+
 export default ImageryLayerCollection;

--- a/packages/engine/Source/Scene/ImageryLayerCollection.js
+++ b/packages/engine/Source/Scene/ImageryLayerCollection.js
@@ -11,6 +11,7 @@ import ImageryLayer from "./ImageryLayer.js";
  * An ordered collection of imagery layers.
  *
  * @alias ImageryLayerCollection
+ * @implements {Iterable<ImageryLayer>}
  * @constructor
  *
  * @demo {@link https://sandcastle.cesium.com/index.html?src=Imagery%20Adjustment.html|Cesium Sandcastle Imagery Adjustment Demo}

--- a/packages/engine/Source/Scene/LabelCollection.js
+++ b/packages/engine/Source/Scene/LabelCollection.js
@@ -995,4 +995,14 @@ LabelCollection.prototype.destroy = function () {
 
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Label>} The iterator
+ */
+LabelCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._labels;
+};
+
 export default LabelCollection;

--- a/packages/engine/Source/Scene/LabelCollection.js
+++ b/packages/engine/Source/Scene/LabelCollection.js
@@ -557,6 +557,7 @@ function destroyLabel(labelCollection, label) {
  * and {@link LabelCollection#remove}.
  *
  * @alias LabelCollection
+ * @implements {Iterable<Label>}
  * @constructor
  *
  * @param {object} [options] Object with the following properties:

--- a/packages/engine/Source/Scene/Model/ModelAnimationCollection.js
+++ b/packages/engine/Source/Scene/Model/ModelAnimationCollection.js
@@ -16,6 +16,7 @@ import ModelAnimationState from ".././ModelAnimationState.js";
  * A collection of active model animations.
  *
  * @alias ModelAnimationCollection
+ * @implements {Iterable<ModelAnimation>}
  * @internalConstructor
  * @class
  *

--- a/packages/engine/Source/Scene/Model/ModelAnimationCollection.js
+++ b/packages/engine/Source/Scene/Model/ModelAnimationCollection.js
@@ -550,4 +550,13 @@ ModelAnimationCollection.prototype.update = function (frameState) {
   return animationOccurred;
 };
 
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<ModelAnimation>} The iterator
+ */
+ModelAnimationCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._runtimeAnimations;
+};
+
 export default ModelAnimationCollection;

--- a/packages/engine/Source/Scene/OrderedGroundPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/OrderedGroundPrimitiveCollection.js
@@ -216,4 +216,16 @@ OrderedGroundPrimitiveCollection.prototype.destroy = function () {
   this.removeAll();
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<GroundPrimitive>} The iterator
+ */
+OrderedGroundPrimitiveCollection.prototype[Symbol.iterator] = function* () {
+  for (const collection of this._collectionsArray) {
+    yield* collection;
+  }
+};
+
 export default OrderedGroundPrimitiveCollection;

--- a/packages/engine/Source/Scene/OrderedGroundPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/OrderedGroundPrimitiveCollection.js
@@ -7,6 +7,7 @@ import PrimitiveCollection from "./PrimitiveCollection.js";
 /**
  * A primitive collection for helping maintain the order or ground primitives based on a z-index
  *
+ * @implements {Iterable<GroundPrimitive>}
  * @private
  */
 function OrderedGroundPrimitiveCollection() {

--- a/packages/engine/Source/Scene/PointPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/PointPrimitiveCollection.js
@@ -56,6 +56,7 @@ const attributeLocations = {
  * and {@link PointPrimitiveCollection#remove}.
  *
  * @alias PointPrimitiveCollection
+ * @implements {Iterable<PointPrimitive>}
  * @constructor
  *
  * @param {object} [options] Object with the following properties:

--- a/packages/engine/Source/Scene/PointPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/PointPrimitiveCollection.js
@@ -1214,4 +1214,14 @@ PointPrimitiveCollection.prototype.destroy = function () {
 
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<PointPrimitive>} The iterator
+ */
+PointPrimitiveCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._pointPrimitives;
+};
+
 export default PointPrimitiveCollection;

--- a/packages/engine/Source/Scene/PolylineCollection.js
+++ b/packages/engine/Source/Scene/PolylineCollection.js
@@ -1954,4 +1954,14 @@ PolylineBucket.prototype.writeUpdate = function (
     );
   }
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Polyline>} The iterator
+ */
+PolylineCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._polylines;
+};
+
 export default PolylineCollection;

--- a/packages/engine/Source/Scene/PolylineCollection.js
+++ b/packages/engine/Source/Scene/PolylineCollection.js
@@ -75,6 +75,7 @@ const attributeLocations = {
  * and {@link PolylineCollection#remove}.
  *
  * @alias PolylineCollection
+ * @implements {Iterable<Polyline>}
  * @constructor
  *
  * @param {object} [options] Object with the following properties:

--- a/packages/engine/Source/Scene/PostProcessStageCollection.js
+++ b/packages/engine/Source/Scene/PostProcessStageCollection.js
@@ -30,6 +30,7 @@ const stackScratch = [];
  * </p>
  *
  * @alias PostProcessStageCollection
+ * @implements {Iterable<PostProcessStage>}
  * @constructor
  */
 function PostProcessStageCollection() {

--- a/packages/engine/Source/Scene/PostProcessStageCollection.js
+++ b/packages/engine/Source/Scene/PostProcessStageCollection.js
@@ -885,4 +885,14 @@ PostProcessStageCollection.prototype.destroy = function () {
   this._textureCache = this._textureCache && this._textureCache.destroy();
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<PostProcessStage|PostProcessStageComposite>} The iterator
+ */
+PostProcessStageCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._stages;
+};
+
 export default PostProcessStageCollection;

--- a/packages/engine/Source/Scene/PrimitiveCollection.js
+++ b/packages/engine/Source/Scene/PrimitiveCollection.js
@@ -503,4 +503,14 @@ PrimitiveCollection.prototype.destroy = function () {
   this.removeAll();
   return destroyObject(this);
 };
+
+/**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Primitive>} The iterator
+ */
+PrimitiveCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._primitives;
+};
+
 export default PrimitiveCollection;

--- a/packages/engine/Source/Scene/PrimitiveCollection.js
+++ b/packages/engine/Source/Scene/PrimitiveCollection.js
@@ -11,6 +11,7 @@ import Event from "../Core/Event.js";
  * be added to collections forming a hierarchy.
  *
  * @alias PrimitiveCollection
+ * @implements {Iterable<Primitive>}
  * @constructor
  *
  * @param {object} [options] Object with the following properties:

--- a/packages/engine/Source/Scene/TweenCollection.js
+++ b/packages/engine/Source/Scene/TweenCollection.js
@@ -572,6 +572,15 @@ TweenCollection.prototype.update = function (time) {
 };
 
 /**
+ * Returns an iterator over the elements of this collection.
+ *
+ * @returns {Iterator<Tween>} The iterator
+ */
+TweenCollection.prototype[Symbol.iterator] = function* () {
+  yield* this._tweens;
+};
+
+/**
  * A function that will execute when a tween completes.
  * @callback TweenCollection.TweenCompleteCallback
  */

--- a/packages/engine/Source/Scene/TweenCollection.js
+++ b/packages/engine/Source/Scene/TweenCollection.js
@@ -171,6 +171,7 @@ Tween.prototype.cancelTween = function () {
  * A collection of tweens for animating properties.  Commonly accessed using {@link Scene#tweens}.
  *
  * @alias TweenCollection
+ * @implements {Iterable<Tween>}
  * @constructor
  *
  * @private


### PR DESCRIPTION
A draft for how https://github.com/CesiumGS/cesium/issues/11592 could be addressed: It just adds the `[Symbol.iterator]` function to all `...Collection.js` types, with the same pattern in each case, e.g. 
```
/**
 * Returns an iterator over the elements of this collection.
 *
 * @returns {Iterator<ImageryLayer>} The iterator
 */
ImageryLayerCollection.prototype[Symbol.iterator] = function* () {
  yield* this._layers;
};
```
(with `OrderedGroundPrimitiveCollection` and `CompositeEntityCollection` being the only exceptions here, because they are "nested" colletions)

---

For example, the simplified iteration would look like this:
```javascript
const labels = new Cesium.LabelCollection();
labels.add({
  position : new Cesium.Cartesian3(1.0, 2.0, 3.0),
  text : 'A label'
});
labels.add({
  position : new Cesium.Cartesian3(4.0, 5.0, 6.0),
  text : 'Another label'
});

// Old:
for (let i=0; i<labels.length; i++) {
  const label = labels.get(i);
  console.log(label.text);
}

// New
for (const label of labels) {
  console.log(label.text);
}
```

---


- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
