### PR TITLE
Use proper type for scratch variables

### DIFF
--- a/packages/engine/Source/Scene/Model/ModelAnimationChannel.js
+++ b/packages/engine/Source/Scene/Model/ModelAnimationChannel.js
@@ -215,8 +215,8 @@ function createSplines(times, points, interpolation, path, count) {
   return splines;
 }
 
-let scratchCartesian3;
-let scratchQuaternion;
+const scratchCartesian3 = new Cartesian3();
+const scratchQuaternion = new Quaternion();
 
 function initialize(runtimeChannel) {
   const channel = runtimeChannel._channel;
@@ -237,19 +237,6 @@ function initialize(runtimeChannel) {
 
   runtimeChannel._splines = splines;
   runtimeChannel._path = path;
-
-  switch (path) {
-    case AnimatedPropertyType.TRANSLATION:
-    case AnimatedPropertyType.SCALE:
-      scratchCartesian3 = new Cartesian3();
-      break;
-    case AnimatedPropertyType.ROTATION:
-      scratchQuaternion = new Quaternion();
-      break;
-    case AnimatedPropertyType.WEIGHTS:
-      // This is unused when setting a node's morph weights.
-      break;
-  }
 }
 
 /**

--- a/packages/engine/Source/Scene/Model/ModelAnimationChannel.js
+++ b/packages/engine/Source/Scene/Model/ModelAnimationChannel.js
@@ -215,7 +215,8 @@ function createSplines(times, points, interpolation, path, count) {
   return splines;
 }
 
-let scratchVariable;
+let scratchCartesian3;
+let scratchQuaternion;
 
 function initialize(runtimeChannel) {
   const channel = runtimeChannel._channel;
@@ -240,10 +241,10 @@ function initialize(runtimeChannel) {
   switch (path) {
     case AnimatedPropertyType.TRANSLATION:
     case AnimatedPropertyType.SCALE:
-      scratchVariable = new Cartesian3();
+      scratchCartesian3 = new Cartesian3();
       break;
     case AnimatedPropertyType.ROTATION:
-      scratchVariable = new Quaternion();
+      scratchQuaternion = new Quaternion();
       break;
     case AnimatedPropertyType.WEIGHTS:
       // This is unused when setting a node's morph weights.
@@ -286,7 +287,20 @@ ModelAnimationChannel.prototype.animate = function (time) {
       : spline.wrapTime(time);
 
     // This sets the translate, rotate, and scale properties.
-    runtimeNode[path] = spline.evaluate(localAnimationTime, scratchVariable);
+    if (
+      path === AnimatedPropertyType.TRANSLATION ||
+      path === AnimatedPropertyType.SCALE
+    ) {
+      runtimeNode[path] = spline.evaluate(
+        localAnimationTime,
+        scratchCartesian3
+      );
+    } else if (path === AnimatedPropertyType.ROTATION) {
+      runtimeNode[path] = spline.evaluate(
+        localAnimationTime,
+        scratchQuaternion
+      );
+    }
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/11685 

It is not really "required", and does not solve "problem" (except for that itchy feeling in the head of people who usually use _typed_ languages): The `scratchVariable` that was used either as a `Cartesian3` or as a `Quaternion` has now been split into a `scratchCartesian3` and `scratchQuaternion` that are used depending on the animated `path` (i.e. the cartesian for `"translation"` and `"scale"`, and the quaternion for the `"rotation"`).

Should this be mentioned in `CHANGES.md`? It seems like something that is "too internal" to be mentioned...

I considered to add a unit test - basically consisting of
```
    // Create rotation and translation (leaving the scratch variable to be a Cartesian3)
    const runtimeChannelRotation = new ModelAnimationChannel({.,.});
    const runtimeChannelTranslation = new ModelAnimationChannel({...});
...
    // Animate rotation (using the Cartesian3 scratch variable...)
    runtimeChannelRotation.animate(time);
```
But none of that is "visible" at the outside: The `runtimeNode["rotation"]` is still a `Quaternion`, because the [setter in `ModelRuntimeNode`](https://github.com/CesiumGS/cesium/blob/b57f9fb52e3a6444086922ef0fb4394c0cc2eb51/packages/engine/Source/Scene/Model/ModelRuntimeNode.js#L370) clones the input `value` - which **is** a `Cartesian3`, but it **does** have that `.w` component, so ... it happens to work 😬 If anyone has an idea for how to "test" this, I'd add the tests accordingly...


