### PR TITLE
Remove placeholders in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -11,7 +11,6 @@ body:
     attributes:
       label: What happened?
       description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -12,7 +12,6 @@ body:
     id: new-feature
     attributes:
       label: Feature
-      placeholder: Explain the requested feature
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Github apparently has an annoying bug where it's displaying 2 placeholders on top of each other, see below. In order to avoid this and provide a cleaner experience I've removed them for now. Thanks for spotting that @jjhembd 

![2023-12-20_14-57_1](https://github.com/CesiumGS/cesium/assets/8007967/064f2521-d24f-4371-8332-6001854eba34)
![2023-12-20_14-57](https://github.com/CesiumGS/cesium/assets/8007967/8245659a-0c43-4de2-874b-904b283762c7)


## Testing plan

Not really possible to test without merging.

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
