### PR TITLE
Turn on `dynamicScreenSpaceError` by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 #### @cesium/engine
 
+##### Additions :tada:
+
+- The `Cesium3DTileset.dynamicScreenSpaceError` optimization is now enabled by default, as this improves performance for street-level horizon views. TODO: PR link
+
 ##### Fixes :wrench:
 
 - Changes the default `RequestScheduler.maximumRequestsPerServer` from 6 to 18. This should improve performance on HTTP/2 servers and above [#11627](https://github.com/CesiumGS/cesium/issues/11627)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Changes the default `RequestScheduler.maximumRequestsPerServer` from 6 to 18. This should improve performance on HTTP/2 servers and above [#11627](https://github.com/CesiumGS/cesium/issues/11627)
 - Corrected JSDoc and Typescript definitions that marked optional arguments as required in `ImageryProvider` constructor [#11625](https://github.com/CesiumGS/cesium/issues/11625)
 - The `Quaternion.computeAxis` function created an axis that was `(0,0,0)` for the unit quaternion, and an axis that was `(NaN,NaN,NaN)` for the quaternion `(0,0,0,-1)` (which describes a rotation about 360 degrees). Now, it returns the x-axis `(1,0,0)` in both of these cases.
+- Fixed a bug where the 3D Tiles Inspector's `dynamicScreenSpaceErrorDensity` slider did not update the tileset [#6143](https://github.com/CesiumGS/cesium/issues/6143)
 
 ### 1.112 - 2023-12-01
 

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -75,10 +75,10 @@ import Cesium3DTilesetSkipTraversal from "./Cesium3DTilesetSkipTraversal.js";
  * @property {boolean} [preloadWhenHidden=false] Preload tiles when <code>tileset.show</code> is <code>false</code>. Loads tiles as if the tileset is visible but does not render them.
  * @property {boolean} [preloadFlightDestinations=true] Optimization option. Preload tiles at the camera's flight destination while the camera is in flight.
  * @property {boolean} [preferLeaves=false] Optimization option. Prefer loading of leaves first.
- * @property {boolean} [dynamicScreenSpaceError=false] Optimization option. Reduce the screen space error for tiles that are further away from the camera.
- * @property {number} [dynamicScreenSpaceErrorDensity=0.00278] Density used to adjust the dynamic screen space error, similar to fog density.
- * @property {number} [dynamicScreenSpaceErrorFactor=4.0] A factor used to increase the computed dynamic screen space error.
- * @property {number} [dynamicScreenSpaceErrorHeightFalloff=0.25] A ratio of the tileset's height at which the density starts to falloff.
+ * @property {boolean} [dynamicScreenSpaceError=true] Optimization option. Reduce the screen space error for tiles that are further away from the camera so that lower resolution tiles are used.
+ * @property {number} [dynamicScreenSpaceErrorDensity=0.00278] Similar to fog density, this value determines how far away from the camera that screen space error falls off. Larger values will cause tiles closer to the camera to be affected by dynamicScreenSpaceError.
+ * @property {number} [dynamicScreenSpaceErrorFactor=4.0] The maximum screen space error adjustment in px to apply to a tile for tiles far away on the horizon. Increase this value to make the SSE adjustment stronger, which in turn will select lower LOD tiles near the horizon.
+ * @property {number} [dynamicScreenSpaceErrorHeightFalloff=0.25] A ratio of the tileset's height above which the density decreases for dynamic screen space error. This way, dynamicScreenSpaceError has the strongest effect when the camera is close to street level.
  * @property {number} [progressiveResolutionHeightFraction=0.3] Optimization option. If between (0.0, 0.5], tiles at or above the screen space error for the reduced screen resolution of <code>progressiveResolutionHeightFraction*screenHeight</code> will be prioritized first. This can help get a quick layer of tiles down while full resolution tiles continue to load.
  * @property {boolean} [foveatedScreenSpaceError=true] Optimization option. Prioritize loading tiles in the center of the screen by temporarily raising the screen space error for tiles around the edge of the screen. Screen space error returns to normal once all the tiles in the center of the screen as determined by the {@link Cesium3DTileset#foveatedConeSize} are loaded.
  * @property {number} [foveatedConeSize=0.1] Optimization option. Used when {@link Cesium3DTileset#foveatedScreenSpaceError} is true to control the cone size that determines which tiles are deferred. Tiles that are inside this cone are loaded immediately. Tiles outside the cone are potentially deferred based on how far outside the cone they are and their screen space error. This is controlled by {@link Cesium3DTileset#foveatedInterpolationCallback} and {@link Cesium3DTileset#foveatedMinimumScreenSpaceErrorRelaxation}. Setting this to 0.0 means the cone will be the line formed by the camera position and its view direction. Setting this to 1.0 means the cone encompasses the entire field of view of the camera, disabling the effect.
@@ -361,18 +361,18 @@ function Cesium3DTileset(options) {
   this._pass = undefined; // Cesium3DTilePass
 
   /**
-   * Optimization option. Whether the tileset should refine based on a dynamic screen space error. Tiles that are further
-   * away will be rendered with lower detail than closer tiles. This improves performance by rendering fewer
-   * tiles and making less requests, but may result in a slight drop in visual quality for tiles in the distance.
-   * The algorithm is biased towards "street views" where the camera is close to the ground plane of the tileset and looking
-   * at the horizon. In addition results are more accurate for tightly fitting bounding volumes like box and region.
+   * Optimization option. Whether the tileset should adjust the screen space error for tiles on the horizon. Tiles that
+   * are far away will be adjusted to render at lower detail than tiles closer at the camera. This improves performance
+   * by loading and rendering fewer tiles, but may result in a slight drop in visual quality in the distance. This
+   * optimization is strongest when the camera is close to the ground plane of the tileset and looking at the horizon.
+   * Furthermore, the results are more accurate for tightly fitting bounding volumes like box and region.
    *
    * @type {boolean}
    * @default false
    */
   this.dynamicScreenSpaceError = defaultValue(
     options.dynamicScreenSpaceError,
-    false
+    true
   );
 
   /**
@@ -416,18 +416,22 @@ function Cesium3DTileset(options) {
   this.foveatedTimeDelay = defaultValue(options.foveatedTimeDelay, 0.2);
 
   /**
-   * A scalar that determines the density used to adjust the dynamic screen space error, similar to {@link Fog}. Increasing this
-   * value has the effect of increasing the maximum screen space error for all tiles, but in a non-linear fashion.
-   * The error starts at 0.0 and increases exponentially until a midpoint is reached, and then approaches 1.0 asymptotically.
-   * This has the effect of keeping high detail in the closer tiles and lower detail in the further tiles, with all tiles
-   * beyond a certain distance all roughly having an error of 1.0.
+   * A parameter that controls how far away from the camera screen space error (SSE) falls off when
+   * <code>dynamicScreenSpaceError</code> is enabled. This is similar to the <code>density</code> parameter of
+   * {@link Fog}. This value must be non-negative.
    * <p>
-   * The dynamic error is in the range [0.0, 1.0) and is multiplied by <code>dynamicScreenSpaceErrorFactor</code> to produce the
-   * final dynamic error. This dynamic error is then subtracted from the tile's actual screen space error.
+   * <code>dynamicScreenSpaceError</code> causes the tile SSE to fall off with distance from the camera like a bell
+   * curve. At the camera, no adjustment is made (peak of bell curve). For tiles further away, the SSE is reduced
+   * up to a limit for tiles on the horizon. The maximum reduction is determined by the
+   * <code>dynamicScreenSpaceErrorFactor</code>. Reducing the SSE allows the rendering algorithm to select
+   * lower-resolution tiles.
    * </p>
    * <p>
-   * Increasing <code>dynamicScreenSpaceErrorDensity</code> has the effect of moving the error midpoint closer to the camera.
-   * It is analogous to moving fog closer to the camera.
+   * Increasing the density makes the bell curve narrower. This means that the SSE adjustment will start happening
+   * closer to the camera. This is analgous to moving fog closer to the camera.
+   * </p>
+   * <p>
+   * When the density is 0, no tiles will have their SSE adjusted.
    * </p>
    *
    * @type {number}
@@ -436,8 +440,19 @@ function Cesium3DTileset(options) {
   this.dynamicScreenSpaceErrorDensity = 0.00278;
 
   /**
-   * A factor used to increase the screen space error of tiles for dynamic screen space error. As this value increases less tiles
-   * are requested for rendering and tiles in the distance will have lower detail. If set to zero, the feature will be disabled.
+   * The maximum screen space error (SSE) reduction when {@link Cesium3DTileset#dynamicScreenSpaceError} is used. The
+   * value must be non-negative.
+   * <p>
+   * Increasing the SSE factor increases the maximum amount to reduce a tile's SSE. This maximum reduction happens
+   * for tiles near the horizon. For tiles closer to the camera, the SSE adjustment can be small as 0 (at the camera).
+   * In between, the SSE falls off like a bell curve. See {@link Cesium3DTileset#dynamicScreenSpaceErrorDensity}
+   * </p>
+   * <p>
+   * When the SSE factor is set to 0, the adjustment will be 0 for all tiles.
+   * </p>
+   * A factor used to increase the screen space error of tiles for dynamic screen space error. As this value increases
+   * less tiles are requested for rendering and tiles in the distance will have lower detail. If set to zero, the
+   * feature will be disabled.
    *
    * @type {number}
    * @default 4.0
@@ -445,9 +460,9 @@ function Cesium3DTileset(options) {
   this.dynamicScreenSpaceErrorFactor = 4.0;
 
   /**
-   * A ratio of the tileset's height at which the density starts to falloff. If the camera is below this height the
-   * full computed density is applied, otherwise the density falls off. This has the effect of higher density at
-   * street level views.
+   * A ratio of the tileset's height above which the effects of {@link Cesium3DTileset#dynamicScreenSpaceError} begin
+   * to fall off. This determines what is considered "street level" for the tileset. The dynamic screen space error
+   * optimization is intended for when the camera is at street level and pointed at the horizon.
    * <p>
    * Valid values are between 0.0 and 1.0.
    * </p>
@@ -457,7 +472,8 @@ function Cesium3DTileset(options) {
    */
   this.dynamicScreenSpaceErrorHeightFalloff = 0.25;
 
-  this._dynamicScreenSpaceErrorComputedDensity = 0.0; // Updated based on the camera position and direction
+  // Updated based on the camera position and direction
+  this._dynamicScreenSpaceErrorComputedDensity = 0.0;
 
   /**
    * Determines whether the tileset casts or receives shadows from light sources.

--- a/packages/engine/Specs/Scene/PickingSpec.js
+++ b/packages/engine/Specs/Scene/PickingSpec.js
@@ -134,11 +134,10 @@ describe(
     function createTileset(url) {
       const options = {
         maximumScreenSpaceError: 0,
-        // Since unit tests render to a tiny canvas, tileset rendering is
-        // extremely sensitive to changes in screen space error. Turn the
-        // dynamic screen space error down significantly so we don't cull tiles
-        // needed for the unit tests.
-        dynamicScreenSpaceErrorFactor: 0.0001,
+        // The camera is zoomed pretty far out for these tests, so
+        // turn off dynamicScreenSpaceError so tiles don't get culled
+        // unintentionally.
+        dynamicScreenSpaceError: false,
       };
       return Cesium3DTilesTester.loadTileset(scene, url, options).then(
         function (tileset) {

--- a/packages/engine/Specs/Scene/PickingSpec.js
+++ b/packages/engine/Specs/Scene/PickingSpec.js
@@ -134,6 +134,11 @@ describe(
     function createTileset(url) {
       const options = {
         maximumScreenSpaceError: 0,
+        // Since unit tests render to a tiny canvas, tileset rendering is
+        // extremely sensitive to changes in screen space error. Turn the
+        // dynamic screen space error down significantly so we don't cull tiles
+        // needed for the unit tests.
+        dynamicScreenSpaceErrorFactor: 0.0001,
       };
       return Cesium3DTilesTester.loadTileset(scene, url, options).then(
         function (tileset) {

--- a/packages/widgets/Source/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/packages/widgets/Source/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -740,7 +740,11 @@ function Cesium3DTilesInspectorViewModel(scene, performanceContainer) {
       return Math.pow(dynamicScreenSpaceErrorDensity(), 1 / 6);
     },
     set: function (value) {
-      dynamicScreenSpaceErrorDensity(Math.pow(value, 6));
+      const scaledValue = Math.pow(value, 6);
+      dynamicScreenSpaceErrorDensity(scaledValue);
+      if (defined(that._tileset)) {
+        that._tileset.dynamicScreenSpaceErrorDensity = scaledValue;
+      }
     },
   });
 


### PR DESCRIPTION


<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

This PR:
- Sets `tileset.dynamicScreenSpaceError` to `true`, enabling this optimization for lowering the resolution of tiles far away in horizon views
- Adds missing code in the `Cesium3DTilesetConstructor` to assign initial values based on constructor options
- Fixes the 3D Tiles Inspector SSE Density slider (which wasn't updating the tileset), as this is helpful for testing.
- Improves the documentation for `dynamicScreenSpaceError*` parameters

Example of it in action: [local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dVTbThsxEP2VUdSHRQre3ewt2wZUBKhFAjVqUZ/ygOMdEguvHdlOQor4985egHB7WWXOzJwzN0cY7TxsJG7RwhFo3MIpOrmu2d8WC2YD0dqnRnsuNdrZYAgPMw3gZY2KkK9wy5XDYYNxLWvupdH7oBOo8cpUOJXiDu2+a84dXvId2veuMITrJcJCmTlCZdCBNp4KxAq8gQaTbqUot3oKd1ILBE9J06XxxiJX0nkpIDmDa6mIgQLUuqIYtJaaafJa/hfdx4NvM8KJ7VzzuUKwqCu0Ui9aYne3m+luWqxtixFy4mvjVku0ZC3Nlsbo7Rpbnj4U7z3RBP1kO7AzkrO2sgvtViio5it5L/VzDSdV9VkvM+3trluEaHfoGxQ9qfMtl/5pjYJSPf4wZqHwNVUvjT5o9ABetbWyspZebtAxXlVBT94EPoLgXiwhoBkae/BSglHIlFkEN+eNA5ThVTO2z3bRU7Im/ctDS/Z40wr0zU+N1L6duuA1Wg68s7peVgrv36yiC2NE2txu0BZWIanq/iT3rvuUW0+/uE6CJgzgcJSXSVEWLMviKI/Sohj2jnRUFnGSsSwuojItRlnvSMZZWkQRK+ibxmmSpw1+0HqNlUjv5Z3sT2yHMpU0wd9GqV48ZXmWRaRbjrI4LstnjcOIjcZ5Mi5T+sbJeJzkvSdmSZbHBVU6yooiiYsED4unAuiKYTAcTJzfKTzuEgC+y3plrIe1VQFjocea3g9NIZyv6fF5JpzrLgFgEu6nTiq5AVkdffBfAEJx58hzu1bqj/yHs8HxJKT4d6n9PfzaoKVX24Qt4+PLDmSMTUIyP870xqg5t2+Y/wM) -- open up the `Update` section and adjust the SSE Density/Factor sliders:

![image](https://github.com/CesiumGS/cesium/assets/8422414/47111294-fbd4-4866-8b46-0e5919e7ffef)

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

Fixes #6143 
Fixes #11715 
Fixes #11677

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

### Choosing better defaults

Tomorrow I plan to focus on selecting better default values for these parameters.

I'm going to start with the performance testing page from https://github.com/CesiumGS/cesium/issues/4196#issuecomment-1843560992

(here modified to use the copy of CesiumJS from `npm build release` and the local Cesium Dev server) - [performance-local.html.txt](https://github.com/CesiumGS/cesium/files/13746276/performance-local.html.txt).

This involves:

1. Make more versions the perf testing page as needed to get a variety of datasets and camera views. I want to also include One World Terrain and Melbourne.
2. I want to do a visual inspection using the 3D Tiles Inspector. How large can I increase the SSE factor/density without the quality loss being obvious? (Note: for Google P3DT, Google Earth serves as a visual benchmark) 
3. Once I narrow down the range of values, performance test a few more cases to verify that the changes give a performance boost everywhere.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
- [ ] Experiment with different SSE Factor and SSE Density settings to get the best performance without a noticeable reduction in quality (See Testing Plan above)