### PR TITLE
Document additional limitations of 3D Tiles classification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,6 @@
 ##### Additions :tada:
 
 - Vertical exaggeration can now be applied to a `Cesium3DTileset`. Exaggeration of `Terrain` and `Cesium3DTileset` can be controlled simultaneously via the new `Scene` properties `Scene.verticalExaggeration` and `Scene.verticalExaggerationRelativeHeight`. [#11655](https://github.com/CesiumGS/cesium/pull/11655)
-- Added documentation for `Cesium3DTileset.classificationType` and `Model.classificationType` to clarify additional requirements. The classification tileset must be watertight, and the receiving tileset/terrain must be opaque. [#11739](https://github.com/CesiumGS/cesium/pull/11739)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 ##### Additions :tada:
 
 - Vertical exaggeration can now be applied to a `Cesium3DTileset`. Exaggeration of `Terrain` and `Cesium3DTileset` can be controlled simultaneously via the new `Scene` properties `Scene.verticalExaggeration` and `Scene.verticalExaggerationRelativeHeight`. [#11655](https://github.com/CesiumGS/cesium/pull/11655)
-- Added documentation for `Cesium3DTileset.classificationType` and `Model.classificationType` to clarify additional requirements. The classification tileset must be watertight, and the receiving tileset/terrain must be opaque.
+- Added documentation for `Cesium3DTileset.classificationType` and `Model.classificationType` to clarify additional requirements. The classification tileset must be watertight, and the receiving tileset/terrain must be opaque. [#11739](https://github.com/CesiumGS/cesium/pull/11739)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 ##### Additions :tada:
 
 - Vertical exaggeration can now be applied to a `Cesium3DTileset`. Exaggeration of `Terrain` and `Cesium3DTileset` can be controlled simultaneously via the new `Scene` properties `Scene.verticalExaggeration` and `Scene.verticalExaggerationRelativeHeight`. [#11655](https://github.com/CesiumGS/cesium/pull/11655)
+- Added documentation for `Cesium3DTileset.classificationType` and `Model.classificationType` to clarify additional requirements. The classification tileset must be watertight, and the receiving tileset/terrain must be opaque.
 
 ##### Fixes :wrench:
 

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -1635,7 +1635,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    *     <li>The glTF cannot contain morph targets, skins, or animations.</li>
    *     <li>The glTF cannot contain the <code>EXT_mesh_gpu_instancing</code> extension.</li>
    *     <li>Only meshes with TRIANGLES can be used to classify other assets.</li>
-   *     <li>Meshes must be watertight</li>
+   *     <li>Meshes must be watertight.</li>
    *     <li>The <code>POSITION</code> semantic is required.</li>
    *     <li>If <code>_BATCHID</code>s and an index buffer are both present, all indices with the same batch id must occupy contiguous sections of the index buffer.</li>
    *     <li>If <code>_BATCHID</code>s are present with no index buffer, all positions with the same batch id must occupy contiguous sections of the position buffer.</li>

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -1635,6 +1635,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    *     <li>The glTF cannot contain morph targets, skins, or animations.</li>
    *     <li>The glTF cannot contain the <code>EXT_mesh_gpu_instancing</code> extension.</li>
    *     <li>Only meshes with TRIANGLES can be used to classify other assets.</li>
+   *     <li>Meshes must be watertight</li>
    *     <li>The <code>POSITION</code> semantic is required.</li>
    *     <li>If <code>_BATCHID</code>s and an index buffer are both present, all indices with the same batch id must occupy contiguous sections of the index buffer.</li>
    *     <li>If <code>_BATCHID</code>s are present with no index buffer, all positions with the same batch id must occupy contiguous sections of the position buffer.</li>
@@ -1643,6 +1644,9 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * <p>
    * Additionally, classification is not supported for points or instanced 3D
    * models.
+   * </p>
+   * <p>
+   * The 3D Tiles or terrain receiving the classification must be opaque.
    * </p>
    *
    * @memberof Cesium3DTileset.prototype

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -1635,7 +1635,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    *     <li>The glTF cannot contain morph targets, skins, or animations.</li>
    *     <li>The glTF cannot contain the <code>EXT_mesh_gpu_instancing</code> extension.</li>
    *     <li>Only meshes with TRIANGLES can be used to classify other assets.</li>
-   *     <li>Meshes must be watertight.</li>
+   *     <li>The meshes must be watertight.</li>
    *     <li>The <code>POSITION</code> semantic is required.</li>
    *     <li>If <code>_BATCHID</code>s and an index buffer are both present, all indices with the same batch id must occupy contiguous sections of the index buffer.</li>
    *     <li>If <code>_BATCHID</code>s are present with no index buffer, all positions with the same batch id must occupy contiguous sections of the position buffer.</li>

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -1550,7 +1550,7 @@ Object.defineProperties(Model.prototype, {
    *     <li>The glTF cannot contain morph targets, skins, or animations.</li>
    *     <li>The glTF cannot contain the <code>EXT_mesh_gpu_instancing</code> extension.</li>
    *     <li>Only meshes with TRIANGLES can be used to classify other assets.</li>
-   *     <li>Meshes must be watertight </li>
+   *     <li>The meshes must be watertight.</li>
    *     <li>The POSITION attribute is required.</li>
    *     <li>If feature IDs and an index buffer are both present, all indices with the same feature id must occupy contiguous sections of the index buffer.</li>
    *     <li>If feature IDs are present without an index buffer, all positions with the same feature id must occupy contiguous sections of the position buffer.</li>

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -112,7 +112,7 @@ import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
  * @internalConstructor
  *
  * @privateParam {ResourceLoader} options.loader The loader used to load resources for this model.
- * @privateParam {ModelType} options.type Type of this model, to distinguish individual glTF files from 3D Tiles internally. 
+ * @privateParam {ModelType} options.type Type of this model, to distinguish individual glTF files from 3D Tiles internally.
  * @privateParam {object} options Object with the following properties:
  * @privateParam {Resource} options.resource The Resource to the 3D model.
  * @privateParam {boolean} [options.show=true] Whether or not to render the model.
@@ -154,7 +154,7 @@ import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
  * @privateParam {string|number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @privateParam {object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  * @privateParam {ClassificationType} [options.classificationType] Determines whether terrain, 3D Tiles or both will be classified by this model. This cannot be set after the model has loaded.
- 
+
  *
  * @see Model.fromGltfAsync
  *
@@ -192,7 +192,7 @@ function Model(options) {
    * When this is the identity matrix, the model is drawn in world coordinates, i.e., Earth's Cartesian WGS84 coordinates.
    * Local reference frames can be used by providing a different transformation matrix, like that returned
    * by {@link Transforms.eastNorthUpToFixedFrame}.
-   * 
+   *
    * @type {Matrix4}
 
    * @default {@link Matrix4.IDENTITY}
@@ -1550,10 +1550,14 @@ Object.defineProperties(Model.prototype, {
    *     <li>The glTF cannot contain morph targets, skins, or animations.</li>
    *     <li>The glTF cannot contain the <code>EXT_mesh_gpu_instancing</code> extension.</li>
    *     <li>Only meshes with TRIANGLES can be used to classify other assets.</li>
-   *     <li>The position attribute is required.</li>
+   *     <li>Meshes must be watertight </li>
+   *     <li>The POSITION attribute is required.</li>
    *     <li>If feature IDs and an index buffer are both present, all indices with the same feature id must occupy contiguous sections of the index buffer.</li>
    *     <li>If feature IDs are present without an index buffer, all positions with the same feature id must occupy contiguous sections of the position buffer.</li>
    * </ul>
+   * </p>
+   * <p>
+   * The 3D Tiles or terrain receiving the classification must be opaque.
    * </p>
    *
    * @memberof Model.prototype


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

After investigating #11341 and #11223, the result was that these are limitations of shadow-volume based classification that were not well-documented. The two examples had two different issues:

1. OSM buildings is not watertight (most buildings do not have a bottom). The stencil test used for shadow volumes assumes that the mesh is closed (so there are the same number of front and back faces to render, so this causes the coloring to be flipped for some fragments:

![image](https://github.com/CesiumGS/cesium/assets/8422414/c020ae3a-6fdf-414d-b9d8-326278e554ef)

2. For the other issue, the problem happens because the tileset being classified has translucent primitives. Since translucent primitives do not update the depth buffer, the stencil test will give incorrect results. This leads to artifacts for some camera views:

See [This Sandcastle](https://sandcastle.cesium.com/#c=fVZtc+I2EP4rGj6RKZVtDDhwSaYZkuaYSXrpQK4fmk5OyDKoJ1uMJMORm/z3roxtZIc0w8Ra7euz2l2JykwbtOVsxxS6RBnboSnTPE/x12Kv+9yhBT2VmSE8Y+q500M/nzNU/vGUrJjaPyq55TFTE9fEtaJ3XD+QzZypLVOzpmjXsYJQrsTEpRF67qyN2eiJ52lQ5xAGJoquuJaZgEAwlalnPczmnmLa1FLeX1KJ+KX05tXuIfCjg7ezmng7+1QtBTPIcME0fC/LrGBNGXjbKJ5yw7c2ijjuHi2RHeGmQnz4hDeLgxGcKJk+KdH9CBnlKc2XDK+EjGVWQFomFo7MFWUeSdiInQ9GgT8i4yENh/EgGNOB79PROPGj0VFyG3phXITulQDwv5CoBuazamkBV+tKmubayHS+JnG7EKYOxz0zz0NPGUScsgyytuYa2WNBRqKE/0BEGZ4QajSK82LTKJJpkVMrvQGuRjIBNYaWORcxz1bYNX2UpvsHGbPJqWgWLSH85fH6z6dbB7Lgq7UB25Yrahv37i5++uN+tnB0EkVWFlPpg/0wE/TNPUAAPpVCqkPu0HKPYq4NyegBJ0CiJGWKuDpbyePa8gM0Uvf3kphlm9ygRBffHuKZBJK+pi+pje6BGKY4ESgtF2eu1Z/NukK1FI55kuSa2SpmNOz62O+h4l+A/WO9f6SGV6D4axkTJsYovswNlP5GamgCmd1O8SvyrDE2aFh7c4lvzR6riKNI2WGvUqYL2S1L0RW1DVn51BDT30fdwA/x+XkQBefDaBj2R2PnCEMfD0bD0O9Hg7Afjf2g19KLojAcBePxMPDf6fUHYTQAvh+d99/pjYNBGETDUTgM23rBAJhRfxhG4/GR+U+dHhdHVczQB7AiWVhMihu2Uozpa6XIvluLt/MBBanymMWPUuxXMms2a7l5x2TKjNq7/bo5sD5zKE1F1/vJCb2a6bh3cK6Z7ZwJCobOZhXP55qJfoFs+f7p07cQNLSW3H2VIk9Za9gIojVPOCXW+WM1dF0cqxLbLDs0nW4AuWtxm7dMpTv5IF+YKga9UKevlWs3FzD5676YtDuR2vlwnFmWagd2XWkXR1+IdNt96SamEAigi4ufbeOmdDM2BDmWu0Zm5rDxYRBdwMmaJt4aFI8ncG8BVvPRPQoJ0fuMrpWEEQYpSYjQzOUKIXePnH6HyTtB1l/Pnfi0cfKL/caZ+e9YeHo7nz09vIQ3L4vZ/e2pu/z/bm+3/tza3PEM9nH9HDosPnV6nQtt9oJdVYK/8XQjlbGvli7GnmHpRkDdaG+Z0+/2NtW6iuTCc1UvYr6FXF6eeFahIgPASXIh5vyVPXeuLjyQf6cqJLEX5hd41Aiyt2Lr4Or+sIkxvvCAPK1ppBRLolqW/wM) for an example

| translucent building (has artifacts) | opaque building (no artifacts) |
|---|---|
| ![image](https://github.com/CesiumGS/cesium/assets/8422414/9e584c10-26ba-4eb2-802c-0cc58327ca97) | ![image](https://github.com/CesiumGS/cesium/assets/8422414/c81a9a4a-4910-4ad0-87c7-ed168d583c45) |

This PR simply documents these additional limitations of 3D Tiles classification.

## Issue number and link

Fixes #11341 (by documenting the limitations)

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- ~~I have added or updated unit tests to ensure consistent code coverage~~ Documentation-only change.
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code