### PR TITLE
Remove custom measure text

### DIFF
--- a/packages/engine/Source/Scene/LabelCollection.js
+++ b/packages/engine/Source/Scene/LabelCollection.js
@@ -23,6 +23,20 @@ import GraphemeSplitter from "grapheme-splitter";
 // not have a billboard, depending on whether the texture info has an index into
 // the the label collection's texture atlas.  Invisible characters have no texture, and
 // no billboard.  However, it always has a valid dimensions object.
+//
+// A valid 'dimensions' object is an object that has the properties that are
+// derived from a https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics
+// object (in pixels)
+// - width: The width of the glyph, as given by TextMetrics.width
+// - ascent: The the distance from the 'textBaseline' attribute to
+//   the top of the bounding rectangle of the glyph, as given by
+//   TextMetrics.actualBoundingBoxAscent
+// - descent: The the distance from the 'textBaseline' attribute to
+//   the bottom of the bounding rectangle of the glyph, as given by
+//   TextMetrics.actualBoundingBoxDescent
+// - minx: The distance of the alignment point given by the 'textAlign'
+//   property to the left side of the bounding rectangle of the glyph,
+//   as given by TextMetrics.actualBoundingBoxLeft
 function Glyph() {
   this.textureInfo = undefined;
   this.dimensions = undefined;
@@ -33,6 +47,7 @@ function Glyph() {
 // shared and reference counted across all labels.  It may or may not have an
 // index into the label collection's texture atlas, depending on whether the character
 // has both width and height, but it always has a valid dimensions object.
+// (See notes above about what that means)
 function GlyphTextureInfo(labelCollection, index, dimensions) {
   this.labelCollection = labelCollection;
   this.index = index;


### PR DESCRIPTION
# Description

The `writeTextToCanvas` function writes text into a canvas, basically to create "an image of the text". This is used for labels and Billboards. The _size_ of this canvas is computed with a custom function that was supposed to serve a smilar purpose as [`measureText`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText). This custom function has some issues. The reason for using the custom implementation was probably that certain properties of the `TextMetrics` that are required by `measureText` had not been supported on all browsers. As mentioned in [a related comment](https://github.com/CesiumGS/cesium/issues/10649#issuecomment-1222595171), the [`TextMetrics` browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics#browser_compatibility) summary suggests that all required properties are now widely available. So the custom implementation can be replaced by the built-in `measureText` function.

## Issue number and link

Fixed issues:

- https://github.com/CesiumGS/cesium/issues/10649 
- https://github.com/CesiumGS/cesium/issues/9767
- https://github.com/CesiumGS/cesium/issues/11705

Related issues: 

- https://github.com/CesiumGS/cesium/issues/378 appears to be obsolete
- https://github.com/CesiumGS/cesium/issues/2521 may need clarification about the expected behavior
- https://github.com/CesiumGS/cesium/issues/9945 may also need clarification (What should Cesium display for a "backspace"?)

Caused issues: 

- It will certainly cause _some_ issues. We'll see...


## Testing plan

Until now, I only tested it **visually**. The following is a sandcastle that is based on https://github.com/CesiumGS/cesium/issues/10649 , with some additional cases: 

https://sandcastle.cesium.com/index.html#c=zZbbattAEIZfZdBNZLDWpx5dx7R1Cr1oKaSmvRGYlTRWlqx3ze7Krhv8DoWQi0IP1+0L6XU6smK3pCkB2S4eyUYzO/9ovrWEZ8YNzATO0cAxKJzDAK3IJuzdKuaHXrzyB1o5LhSa0Ks9CVWpYKNy8b1IUnTkGUyE26Qy6xYSWSLsVPIFlQ89pRWGHhXYlEDlhBNoGU8S/yJUAFNtKaJVd93KgBtHV1x12NjoyQmmBtH6zTo0a/VCEQkpI81N0oVVBQAx4SluCsyNcDjED26oB1zNuPXLLKCO4IY5PQ0C+LeFXn0tvoCIx+ep0ZlKBlpq87vjwmOnL05gWSbXrkU25pL6aq/cJX0vazvbjKDJmmSdynviBcFRQEaIaw3cjXhNtrwLMdbKOkB6DHYI+2ALWBiNRgGUx9F+mHdI+rg6KWEG688+OHdH2WpvQ0l24Hj3t3k39/dq7pDwUXXC59o5PYEieuiY7VZ1zFORnrnA6UDi2HXhNbeO/nv9/FN+mV/l32tdeIlSash/5l/yb/nn/BJ867KE2qa1/AdFr/KvB79D97Z4EFDqObgzYYFODnbKYwSt5OLgqR9Wp4ZDh+tUn7a8Z5Ge4f//ScdyMdQ+FjGv7vVW82h/fbOnYjLVxkFmpM9Yw+GExlTagUaUxec0zsbWFsIitdf4U9pLxAxEcnzLbAyx5NbSyjiT8q34SMNuv9eg/L+kUvNEqPTNDA0Nx0XaWav/qgwyxnoNcm9XOq1lxM2Nyr8A

The comparison of the current state and the state after this PR is shown here:

![Cesium MeasureText Test](https://github.com/CesiumGS/cesium/assets/5597569/f3557b7f-46df-4f66-b686-320a751044b0)

It shows that the missing underlines and the missing (?) leading spaces are now included.

The following is a comparison of the current state and the new state for the example from https://github.com/CesiumGS/cesium/issues/11705 :  

![Cesium MeasureText Comparison 11705](https://github.com/CesiumGS/cesium/assets/5597569/e8db74f5-e15a-4d53-b033-81e647d01493)

It shows that the background is no longer longer than the rendered text. 

The following is a comparison of the output of [the "Labels" Sandcastle](https://sandcastle.cesium.com/index.html?src=Labels.html) for the old and the new state:

![Cesium MeasureText Comparison](https://github.com/CesiumGS/cesium/assets/5597569/8194970a-d019-4700-9228-281f4da5c0b3)

It shows that there are _small_ differences in the positioning, but ... it's nearly impossible to say what is "right" or "wrong" here. The only thing that bugs me a bit is that in some cases, it looks like the text is not properly aligned to the baseline:

![Cesium MeasureText Alignment](https://github.com/CesiumGS/cesium/assets/5597569/938448f7-7dbf-40a1-92c8-5f88cce9ba91)

After looking at the approach of the `LabelCollection` and its "Glyph-based" rendering, I wonder whether this can be avoided in all cases. (Subjectively, in other cases, the text appears _less_ jagged with the new state, so...)

Beyond that, I'm reasonably sure that some of the automated tests **will** fail with the new state, e.g. some [not-really-but-somehow pixel-exact check in `writeTextToCanvasSpec`](https://github.com/CesiumGS/cesium/blob/31293c147e9e14a32ba3d6e04662198e5874fed4/packages/engine/Specs/Core/writeTextToCanvasSpec.js#L27) or so. But this will have to be investigated. Some tests can probably be fixed pragmatically by adjusting them to "the new truth"...


# Author checklist

- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [X] I have update the inline documentation, and included code examples where relevant
- [X] I have performed a self-review of my code


