### PR TITLE
Keep voxel data in memory for picking

### DIFF
--- a/packages/engine/Source/Scene/PickFramebuffer.js
+++ b/packages/engine/Source/Scene/PickFramebuffer.js
@@ -29,8 +29,7 @@ function PickFramebuffer(context) {
 }
 PickFramebuffer.prototype.begin = function (screenSpaceRectangle, viewport) {
   const context = this._context;
-  const width = viewport.width;
-  const height = viewport.height;
+  const { width, height } = viewport;
 
   BoundingRectangle.clone(
     screenSpaceRectangle,

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -2264,12 +2264,10 @@ const scratchOrthographicFrustum = new OrthographicFrustum();
 const scratchOrthographicOffCenterFrustum = new OrthographicOffCenterFrustum();
 
 function executeCommands(scene, passState) {
-  const camera = scene.camera;
-  const context = scene.context;
-  const frameState = scene.frameState;
-  const us = context.uniformState;
+  const { camera, context, frameState } = scene;
+  const { uniformState } = context;
 
-  us.updateCamera(camera);
+  uniformState.updateCamera(camera);
 
   // Create a working frustum from the original camera frustum.
   let frustum;
@@ -2287,8 +2285,8 @@ function executeCommands(scene, passState) {
   // early-z, but we would have to draw it in each frustum
   frustum.near = camera.frustum.near;
   frustum.far = camera.frustum.far;
-  us.updateFrustum(frustum);
-  us.updatePass(Pass.ENVIRONMENT);
+  uniformState.updateFrustum(frustum);
+  uniformState.updatePass(Pass.ENVIRONMENT);
 
   const passes = frameState.passes;
   const picking = passes.pick;
@@ -2393,8 +2391,8 @@ function executeCommands(scene, passState) {
       camera.position.z = height2D - frustumCommands.near + 1.0;
       frustum.far = Math.max(1.0, frustumCommands.far - frustumCommands.near);
       frustum.near = 1.0;
-      us.update(frameState);
-      us.updateFrustum(frustum);
+      uniformState.update(frameState);
+      uniformState.updateFrustum(frustum);
     } else {
       // Avoid tearing artifacts between adjacent frustums in the opaque passes
       frustum.near =
@@ -2402,7 +2400,7 @@ function executeCommands(scene, passState) {
           ? frustumCommands.near * scene.opaqueFrustumNearOffset
           : frustumCommands.near;
       frustum.far = frustumCommands.far;
-      us.updateFrustum(frustum);
+      uniformState.updateFrustum(frustum);
     }
 
     clearDepth.execute(context, passState);
@@ -2411,7 +2409,7 @@ function executeCommands(scene, passState) {
       clearStencil.execute(context, passState);
     }
 
-    us.updatePass(Pass.GLOBE);
+    uniformState.updatePass(Pass.GLOBE);
     let commands = frustumCommands.commands[Pass.GLOBE];
     let length = frustumCommands.indices[Pass.GLOBE];
 
@@ -2436,7 +2434,7 @@ function executeCommands(scene, passState) {
 
     // Draw terrain classification
     if (!environmentState.renderTranslucentDepthForPick) {
-      us.updatePass(Pass.TERRAIN_CLASSIFICATION);
+      uniformState.updatePass(Pass.TERRAIN_CLASSIFICATION);
       commands = frustumCommands.commands[Pass.TERRAIN_CLASSIFICATION];
       length = frustumCommands.indices[Pass.TERRAIN_CLASSIFICATION];
 
@@ -2470,7 +2468,7 @@ function executeCommands(scene, passState) {
       // Common/fastest path. Draw 3D Tiles and classification normally.
 
       // Draw 3D Tiles
-      us.updatePass(Pass.CESIUM_3D_TILE);
+      uniformState.updatePass(Pass.CESIUM_3D_TILE);
       commands = frustumCommands.commands[Pass.CESIUM_3D_TILE];
       length = frustumCommands.indices[Pass.CESIUM_3D_TILE];
       for (j = 0; j < length; ++j) {
@@ -2492,7 +2490,7 @@ function executeCommands(scene, passState) {
 
         // Draw classifications. Modifies 3D Tiles color.
         if (!environmentState.renderTranslucentDepthForPick) {
-          us.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION);
+          uniformState.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION);
           commands =
             frustumCommands.commands[Pass.CESIUM_3D_TILE_CLASSIFICATION];
           length = frustumCommands.indices[Pass.CESIUM_3D_TILE_CLASSIFICATION];
@@ -2540,7 +2538,7 @@ function executeCommands(scene, passState) {
       passState.framebuffer = scene._invertClassification._fbo.framebuffer;
 
       // Draw normally
-      us.updatePass(Pass.CESIUM_3D_TILE);
+      uniformState.updatePass(Pass.CESIUM_3D_TILE);
       commands = frustumCommands.commands[Pass.CESIUM_3D_TILE];
       length = frustumCommands.indices[Pass.CESIUM_3D_TILE];
       for (j = 0; j < length; ++j) {
@@ -2558,7 +2556,7 @@ function executeCommands(scene, passState) {
       }
 
       // Set stencil
-      us.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION_IGNORE_SHOW);
+      uniformState.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION_IGNORE_SHOW);
       commands =
         frustumCommands.commands[
           Pass.CESIUM_3D_TILE_CLASSIFICATION_IGNORE_SHOW
@@ -2584,7 +2582,7 @@ function executeCommands(scene, passState) {
       }
 
       // Draw style over classification.
-      us.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION);
+      uniformState.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION);
       commands = frustumCommands.commands[Pass.CESIUM_3D_TILE_CLASSIFICATION];
       length = frustumCommands.indices[Pass.CESIUM_3D_TILE_CLASSIFICATION];
       for (j = 0; j < length; ++j) {
@@ -2596,13 +2594,13 @@ function executeCommands(scene, passState) {
       clearStencil.execute(context, passState);
     }
 
-    us.updatePass(Pass.VOXELS);
+    uniformState.updatePass(Pass.VOXELS);
     commands = frustumCommands.commands[Pass.VOXELS];
     length = frustumCommands.indices[Pass.VOXELS];
     commands.length = length;
     executeVoxelCommands(scene, executeCommand, passState, commands);
 
-    us.updatePass(Pass.OPAQUE);
+    uniformState.updatePass(Pass.OPAQUE);
     commands = frustumCommands.commands[Pass.OPAQUE];
     length = frustumCommands.indices[Pass.OPAQUE];
     for (j = 0; j < length; ++j) {
@@ -2612,7 +2610,7 @@ function executeCommands(scene, passState) {
     if (index !== 0 && scene.mode !== SceneMode.SCENE2D) {
       // Do not overlap frustums in the translucent pass to avoid blending artifacts
       frustum.near = frustumCommands.near;
-      us.updateFrustum(frustum);
+      uniformState.updateFrustum(frustum);
     }
 
     let invertClassification;
@@ -2626,7 +2624,7 @@ function executeCommands(scene, passState) {
       invertClassification = scene._invertClassification;
     }
 
-    us.updatePass(Pass.TRANSLUCENT);
+    uniformState.updatePass(Pass.TRANSLUCENT);
     commands = frustumCommands.commands[Pass.TRANSLUCENT];
     commands.length = frustumCommands.indices[Pass.TRANSLUCENT];
     executeTranslucentCommands(
@@ -2685,9 +2683,9 @@ function executeCommands(scene, passState) {
         ? frustumCommands.near * scene.opaqueFrustumNearOffset
         : frustumCommands.near;
     frustum.far = frustumCommands.far;
-    us.updateFrustum(frustum);
+    uniformState.updateFrustum(frustum);
 
-    us.updatePass(Pass.GLOBE);
+    uniformState.updatePass(Pass.GLOBE);
     commands = frustumCommands.commands[Pass.GLOBE];
     length = frustumCommands.indices[Pass.GLOBE];
 
@@ -2715,21 +2713,21 @@ function executeCommands(scene, passState) {
       depthPlane.execute(context, passState);
     }
 
-    us.updatePass(Pass.CESIUM_3D_TILE);
+    uniformState.updatePass(Pass.CESIUM_3D_TILE);
     commands = frustumCommands.commands[Pass.CESIUM_3D_TILE];
     length = frustumCommands.indices[Pass.CESIUM_3D_TILE];
     for (j = 0; j < length; ++j) {
       executeIdCommand(commands[j], scene, context, passState);
     }
 
-    us.updatePass(Pass.OPAQUE);
+    uniformState.updatePass(Pass.OPAQUE);
     commands = frustumCommands.commands[Pass.OPAQUE];
     length = frustumCommands.indices[Pass.OPAQUE];
     for (j = 0; j < length; ++j) {
       executeIdCommand(commands[j], scene, context, passState);
     }
 
-    us.updatePass(Pass.TRANSLUCENT);
+    uniformState.updatePass(Pass.TRANSLUCENT);
     commands = frustumCommands.commands[Pass.TRANSLUCENT];
     length = frustumCommands.indices[Pass.TRANSLUCENT];
     for (j = 0; j < length; ++j) {

--- a/packages/engine/Source/Scene/SpatialNode.js
+++ b/packages/engine/Source/Scene/SpatialNode.js
@@ -353,7 +353,6 @@ SpatialNode.prototype.addKeyframeNodeToMegatextures = function (
   for (let i = 0; i < megatextures.length; i++) {
     const megatexture = megatextures[i];
     keyframeNode.megatextureIndex = megatexture.add(keyframeNode.metadatas[i]);
-    keyframeNode.metadatas[i] = undefined; // data is in megatexture so no need to hold onto it
   }
 
   keyframeNode.state = KeyframeNode.LoadState.LOADED;

--- a/packages/engine/Source/Scene/SpatialNode.js
+++ b/packages/engine/Source/Scene/SpatialNode.js
@@ -23,7 +23,6 @@ import OrientedBoundingBox from "../Core/OrientedBoundingBox.js";
  */
 function SpatialNode(level, x, y, z, parent, shape, voxelDimensions) {
   /**
-   * @ignore
    * @type {SpatialNode[]}
    */
   this.children = undefined;
@@ -35,29 +34,24 @@ function SpatialNode(level, x, y, z, parent, shape, voxelDimensions) {
   this.z = z;
 
   /**
-   * @ignore
    * @type {Cartesian3}
    */
   this.dimensions = Cartesian3.clone(voxelDimensions);
   /**
-   * @ignore
    * @type {KeyframeNode[]}
    */
   this.keyframeNodes = [];
   /**
-   * @ignore
    * @type {KeyframeNode[]}
    */
   this.renderableKeyframeNodes = [];
 
   this.renderableKeyframeNodeLerp = 0.0;
   /**
-   * @ignore
    * @type {KeyframeNode}
    */
   this.renderableKeyframeNodePrevious = undefined;
   /**
-   * @ignore
    * @type {KeyframeNode}
    */
   this.renderableKeyframeNodeNext = undefined;

--- a/packages/engine/Source/Scene/SpatialNode.js
+++ b/packages/engine/Source/Scene/SpatialNode.js
@@ -36,6 +36,11 @@ function SpatialNode(level, x, y, z, parent, shape, voxelDimensions) {
 
   /**
    * @ignore
+   * @type {Cartesian3}
+   */
+  this.dimensions = Cartesian3.clone(voxelDimensions);
+  /**
+   * @ignore
    * @type {KeyframeNode[]}
    */
   this.keyframeNodes = [];
@@ -62,19 +67,15 @@ function SpatialNode(level, x, y, z, parent, shape, voxelDimensions) {
   this.screenSpaceError = 0.0;
   this.visitedFrameNumber = -1;
 
-  this.computeBoundingVolumes(shape, voxelDimensions);
+  this.computeBoundingVolumes(shape);
 }
 
 const scratchObbHalfScale = new Cartesian3();
 
 /**
  * @param {VoxelShape} shape
- * @param {Cartesian3} voxelDimensions
  */
-SpatialNode.prototype.computeBoundingVolumes = function (
-  shape,
-  voxelDimensions
-) {
+SpatialNode.prototype.computeBoundingVolumes = function (shape) {
   this.orientedBoundingBox = shape.computeOrientedBoundingBoxForTile(
     this.level,
     this.x,
@@ -89,15 +90,14 @@ SpatialNode.prototype.computeBoundingVolumes = function (
   );
   const maximumScale = 2.0 * Cartesian3.maximumComponent(halfScale);
   this.approximateVoxelSize =
-    maximumScale / Cartesian3.minimumComponent(voxelDimensions);
+    maximumScale / Cartesian3.minimumComponent(this.dimensions);
 };
 
 /**
  * @param {VoxelShape} shape The shape of the parent VoxelPrimitive
- * @param {Cartesian3} voxelDimensions
  * @private
  */
-SpatialNode.prototype.constructChildNodes = function (shape, voxelDimensions) {
+SpatialNode.prototype.constructChildNodes = function (shape) {
   const { level, x, y, z } = this;
   const xMin = x * 2;
   const yMin = y * 2;
@@ -119,7 +119,7 @@ SpatialNode.prototype.constructChildNodes = function (shape, voxelDimensions) {
   ];
 
   this.children = childCoords.map(([level, x, y, z]) => {
-    return new SpatialNode(level, x, y, z, this, shape, voxelDimensions);
+    return new SpatialNode(level, x, y, z, this, shape, this.dimensions);
   });
 };
 

--- a/packages/engine/Source/Scene/VoxelEllipsoidShape.js
+++ b/packages/engine/Source/Scene/VoxelEllipsoidShape.js
@@ -944,9 +944,9 @@ VoxelEllipsoidShape.DefaultMinBounds = Object.freeze(
  */
 VoxelEllipsoidShape.DefaultMaxBounds = Object.freeze(
   new Cartesian3(
-    +CesiumMath.PI,
-    +CesiumMath.PI_OVER_TWO,
-    +10.0 * Ellipsoid.WGS84.maximumRadius
+    CesiumMath.PI,
+    CesiumMath.PI_OVER_TWO,
+    10.0 * Ellipsoid.WGS84.maximumRadius
   )
 );
 

--- a/packages/engine/Source/Scene/VoxelEllipsoidShape.js
+++ b/packages/engine/Source/Scene/VoxelEllipsoidShape.js
@@ -928,7 +928,11 @@ function getEllipsoidChunkObb(
  * @readonly
  */
 VoxelEllipsoidShape.DefaultMinBounds = Object.freeze(
-  new Cartesian3(-CesiumMath.PI, -CesiumMath.PI_OVER_TWO, -Number.MAX_VALUE)
+  new Cartesian3(
+    -CesiumMath.PI,
+    -CesiumMath.PI_OVER_TWO,
+    -Ellipsoid.WGS84.minimumRadius
+  )
 );
 
 /**
@@ -939,7 +943,11 @@ VoxelEllipsoidShape.DefaultMinBounds = Object.freeze(
  * @readonly
  */
 VoxelEllipsoidShape.DefaultMaxBounds = Object.freeze(
-  new Cartesian3(+CesiumMath.PI, +CesiumMath.PI_OVER_TWO, +Number.MAX_VALUE)
+  new Cartesian3(
+    +CesiumMath.PI,
+    +CesiumMath.PI_OVER_TWO,
+    +10.0 * Ellipsoid.WGS84.maximumRadius
+  )
 );
 
 export default VoxelEllipsoidShape;

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -219,25 +219,12 @@ function VoxelTraversal(
 /**
  * Finds a keyframe node in the traversal
  *
- * @param {object} coordinates An object with the following properties:
- * @param {number} coordinates.level
- * @param {number} coordinates.x
- * @param {number} coordinates.y
- * @param {number} coordinates.z
- * @param {number} [coordinates.keyframe=0]
+ * @param {number} megatextureIndex
  * @returns {KeyframeNode}
  */
-VoxelTraversal.prototype.findKeyframeNode = function (coordinates) {
-  const { level, x, y, z, keyframe = 0 } = coordinates;
+VoxelTraversal.prototype.findKeyframeNode = function (megatextureIndex) {
   return this._keyframeNodesInMegatexture.find(function (keyframeNode) {
-    const { spatialNode } = keyframeNode;
-    return (
-      spatialNode.level === level &&
-      spatialNode.x === x &&
-      spatialNode.y === y &&
-      spatialNode.z === z &&
-      keyframeNode.keyframe === keyframe
-    );
+    return (keyframeNode.megatextureIndex = megatextureIndex);
   });
 };
 

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -502,7 +502,6 @@ function loadAndUnload(that, frameState) {
   const priorityQueue = that._priorityQueue;
   const keyframeCount = that._keyframeCount;
 
-  // Some values are constant because of incomplete support for time-dynamic data
   const previousKeyframe = CesiumMath.clamp(
     Math.floor(that._keyframeLocation),
     0,

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -218,6 +218,31 @@ function VoxelTraversal(
   this.leafNodeTexelSizeUv = new Cartesian2();
 }
 
+/**
+ * Finds a keyframe node in the traversal
+ *
+ * @param {object} coordinates An object with the following properties:
+ * @param {number} coordinates.level
+ * @param {number} coordinates.x
+ * @param {number} coordinates.y
+ * @param {number} coordinates.z
+ * @param {number} [coordinates.keyframe=0]
+ * @returns {KeyframeNode}
+ */
+VoxelTraversal.prototype.findKeyframeNode = function (coordinates) {
+  const { level, x, y, z, keyframe = 0 } = coordinates;
+  return this._keyframeNodesInMegatexture.find(function (keyframeNode) {
+    const { spatialNode } = keyframeNode;
+    return (
+      spatialNode.level === level &&
+      spatialNode.x === x &&
+      spatialNode.y === y &&
+      spatialNode.z === z &&
+      keyframeNode.keyframe === keyframe
+    );
+  });
+};
+
 function binaryTreeWeightingRecursive(arr, start, end, depth) {
   if (start > end) {
     return;
@@ -382,10 +407,7 @@ VoxelTraversal.prototype.destroy = function () {
  * @private
  */
 function recomputeBoundingVolumesRecursive(that, node) {
-  const primitive = that._primitive;
-  const shape = primitive._shape;
-  const dimensions = primitive._provider.dimensions;
-  node.computeBoundingVolumes(shape, dimensions);
+  node.computeBoundingVolumes(that._primitive._shape);
   if (defined(node.children)) {
     for (let i = 0; i < 8; i++) {
       const child = node.children[i];
@@ -410,12 +432,11 @@ function requestData(that, keyframeNode) {
     return;
   }
 
-  const primitive = that._primitive;
-  const provider = primitive._provider;
+  const provider = that._primitive._provider;
 
   function postRequestSuccess(result) {
     that._simultaneousRequestCount--;
-    const length = primitive._provider.types.length;
+    const length = provider.types.length;
 
     if (!defined(result)) {
       keyframeNode.state = KeyframeNode.LoadState.UNAVAILABLE;
@@ -492,41 +513,22 @@ function loadAndUnload(that, frameState) {
   const frameNumber = that._frameNumber;
   const primitive = that._primitive;
   const shape = primitive._shape;
-  const { dimensions } = primitive;
   const targetScreenSpaceError = primitive.screenSpaceError;
   const priorityQueue = that._priorityQueue;
-  const keyframeLocation = that._keyframeLocation;
   const keyframeCount = that._keyframeCount;
-  const rootNode = that.rootNode;
+
+  // Some values are constant because of incomplete support for time-dynamic data
+  const previousKeyframe = CesiumMath.clamp(
+    Math.floor(that._keyframeLocation),
+    0,
+    keyframeCount - 2
+  );
+  const nextKeyframe = previousKeyframe + 1;
 
   const { camera, context, pixelRatio } = frameState;
   const { positionWC, frustum } = camera;
   const screenHeight = context.drawingBufferHeight / pixelRatio;
   const screenSpaceErrorMultiplier = screenHeight / frustum.sseDenominator;
-
-  function keyframePriority(previousKeyframe, keyframe, nextKeyframe) {
-    const keyframeDifference = Math.min(
-      Math.abs(keyframe - previousKeyframe),
-      Math.abs(keyframe - nextKeyframe)
-    );
-    const maxKeyframeDifference = Math.max(
-      previousKeyframe,
-      keyframeCount - nextKeyframe - 1,
-      1
-    );
-    const keyframeFactor = Math.pow(
-      1.0 - keyframeDifference / maxKeyframeDifference,
-      4.0
-    );
-    const binaryTreeFactor = Math.exp(
-      -that._binaryTreeKeyframeWeighting[keyframe]
-    );
-    return CesiumMath.lerp(
-      binaryTreeFactor,
-      keyframeFactor,
-      0.15 + 0.85 * keyframeFactor
-    );
-  }
 
   /**
    * @ignore
@@ -545,13 +547,6 @@ function loadAndUnload(that, frameState) {
     }
     spatialNode.visitedFrameNumber = frameNumber;
 
-    const previousKeyframe = CesiumMath.clamp(
-      Math.floor(keyframeLocation),
-      0,
-      keyframeCount - 2
-    );
-    const nextKeyframe = previousKeyframe + 1;
-
     // Create keyframe nodes at the playhead.
     // If they already exist, nothing will be created.
     if (keyframeCount === 1) {
@@ -561,16 +556,21 @@ function loadAndUnload(that, frameState) {
         spatialNode.createKeyframeNode(k);
       }
     }
-    const ssePriority = mapInfiniteRangeToZeroOne(spatialNode.screenSpaceError);
+    const { screenSpaceError, keyframeNodes } = spatialNode;
+    const ssePriority = mapInfiniteRangeToZeroOne(screenSpaceError);
 
     let hasLoadedKeyframe = false;
-    const keyframeNodes = spatialNode.keyframeNodes;
     for (let i = 0; i < keyframeNodes.length; i++) {
       const keyframeNode = keyframeNodes[i];
 
       keyframeNode.priority =
         10.0 * ssePriority +
-        keyframePriority(previousKeyframe, keyframeNode.keyframe, nextKeyframe);
+        keyframePriority(
+          previousKeyframe,
+          keyframeNode.keyframe,
+          nextKeyframe,
+          that
+        );
 
       if (
         keyframeNode.state !== KeyframeNode.LoadState.UNAVAILABLE &&
@@ -584,16 +584,14 @@ function loadAndUnload(that, frameState) {
       }
     }
 
-    const meetsScreenSpaceError =
-      spatialNode.screenSpaceError < targetScreenSpaceError;
-    if (meetsScreenSpaceError || !hasLoadedKeyframe) {
+    if (screenSpaceError < targetScreenSpaceError || !hasLoadedKeyframe) {
       // Free up memory
       spatialNode.children = undefined;
       return;
     }
 
     if (!defined(spatialNode.children)) {
-      spatialNode.constructChildNodes(shape, dimensions);
+      spatialNode.constructChildNodes(shape);
     }
     for (let childIndex = 0; childIndex < 8; childIndex++) {
       const child = spatialNode.children[childIndex];
@@ -601,9 +599,11 @@ function loadAndUnload(that, frameState) {
     }
   }
 
+  // Add all the nodes to the queue, to sort them by priority.
   priorityQueue.reset();
-  addToQueueRecursive(rootNode, CullingVolume.MASK_INDETERMINATE);
+  addToQueueRecursive(that.rootNode, CullingVolume.MASK_INDETERMINATE);
 
+  // Move the nodes from the queue to array of high priority nodes.
   const highPriorityKeyframeNodes = that._highPriorityKeyframeNodes;
   let highPriorityKeyframeNodeCount = 0;
   let highPriorityKeyframeNode;
@@ -616,6 +616,8 @@ function loadAndUnload(that, frameState) {
     highPriorityKeyframeNodeCount++;
   }
 
+  // Sort the list of keyframe nodes in the megatexture by priority, so
+  // we can remove the lowest priority nodes if we need space.
   const keyframeNodesInMegatexture = that._keyframeNodesInMegatexture;
   // TODO: some of the megatexture state should be stored once, not duplicate for each megatexture
   const megatexture = that.megatextures[0];
@@ -628,6 +630,8 @@ function loadAndUnload(that, frameState) {
     return b.highPriorityFrameNumber - a.highPriorityFrameNumber;
   });
 
+  // Add the high priority nodes to the megatexture,
+  // removing existing lower-priority nodes if necessary.
   let destroyedCount = 0;
   let addedCount = 0;
 
@@ -673,6 +677,40 @@ function loadAndUnload(that, frameState) {
       keyframeNodesInMegatexture[addNodeIndex] = highPriorityKeyframeNode;
     }
   }
+}
+
+/**
+ * Compute a priority for a keyframe node.
+ *
+ * @private
+ * @param {number} previousKeyframe
+ * @param {number} keyframe
+ * @param {number} nextKeyframe
+ * @param {VoxelTraversal} traversal
+ * @returns {number} The computed priority
+ */
+function keyframePriority(previousKeyframe, keyframe, nextKeyframe, traversal) {
+  const keyframeDifference = Math.min(
+    Math.abs(keyframe - previousKeyframe),
+    Math.abs(keyframe - nextKeyframe)
+  );
+  const maxKeyframeDifference = Math.max(
+    previousKeyframe,
+    traversal._keyframeCount - nextKeyframe - 1,
+    1
+  );
+  const keyframeFactor = Math.pow(
+    1.0 - keyframeDifference / maxKeyframeDifference,
+    4.0
+  );
+  const binaryTreeFactor = Math.exp(
+    -traversal._binaryTreeKeyframeWeighting[keyframe]
+  );
+  return CesiumMath.lerp(
+    binaryTreeFactor,
+    keyframeFactor,
+    0.15 + 0.85 * keyframeFactor
+  );
 }
 
 /**

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -49,16 +49,14 @@ function VoxelTraversal(
    */
   this._primitive = primitive;
 
-  const length = types.length;
-
   /**
    * @type {Megatexture[]}
    * @readonly
    */
-  this.megatextures = new Array(length);
+  this.megatextures = new Array(types.length);
 
   // TODO make sure to split the maximumTextureMemoryByteLength across all the megatextures
-  for (let i = 0; i < length; i++) {
+  for (let i = 0; i < types.length; i++) {
     const type = types[i];
     const componentCount = MetadataType.getComponentCount(type);
     const componentType = componentTypes[i];

--- a/packages/engine/Specs/Scene/VoxelTraversalSpec.js
+++ b/packages/engine/Specs/Scene/VoxelTraversalSpec.js
@@ -1,14 +1,15 @@
 import {
+  Cartesian3,
+  Cesium3DTilesVoxelProvider,
+  CullingVolume,
+  KeyframeNode,
+  Math as CesiumMath,
   Matrix4,
+  MetadataType,
+  OrientedBoundingBox,
   VoxelEllipsoidShape,
   VoxelTraversal,
   VoxelPrimitive,
-  Cartesian3,
-  OrientedBoundingBox,
-  Math as CesiumMath,
-  MetadataType,
-  CullingVolume,
-  Cesium3DTilesVoxelProvider,
 } from "../../index.js";
 import createScene from "../../../../Specs/createScene.js";
 import pollToPromise from "../../../../Specs/pollToPromise.js";
@@ -163,6 +164,29 @@ describe(
 
       const megatexture = traversal.megatextures[0];
       expect(megatexture.occupiedCount).toBe(1);
+    });
+
+    it("finds keyframe node with expected metadata values", async function () {
+      const keyFrameLocation = 0;
+      const recomputeBoundingVolumes = true;
+      const pauseUpdate = false;
+      await pollToPromise(function () {
+        traversal.update(
+          scene.frameState,
+          keyFrameLocation,
+          recomputeBoundingVolumes,
+          pauseUpdate
+        );
+        scene.renderForSpecs();
+        return traversal.megatextures[0].occupiedCount > 0;
+      });
+
+      const megatextureIndex = 1;
+      const keyframeNode = traversal.findKeyframeNode(megatextureIndex);
+      expect(keyframeNode).toBeDefined();
+      expect(keyframeNode.state).toBe(KeyframeNode.LoadState.LOADED);
+      const expectedMetadata = new Float32Array([0, 0, 0, 0, 1, 1, 1, 1]);
+      expect(keyframeNode.metadatas[0]).toEqual(expectedMetadata);
     });
 
     xit("unloads tiles in megatexture", function () {

--- a/packages/engine/Specs/Scene/VoxelTraversalSpec.js
+++ b/packages/engine/Specs/Scene/VoxelTraversalSpec.js
@@ -151,17 +151,14 @@ describe(
       const recomputeBoundingVolumes = true;
       const pauseUpdate = false;
       await pollToPromise(function () {
-        scene.renderForSpecs();
         traversal.update(
           scene.frameState,
           keyFrameLocation,
           recomputeBoundingVolumes,
           pauseUpdate
         );
-        return traversal.megatextures[0].occupiedCount > 0;
-      }).then(function () {
         scene.renderForSpecs();
-        return traversal;
+        return traversal.megatextures[0].occupiedCount > 0;
       });
 
       const megatexture = traversal.megatextures[0];

--- a/packages/engine/Specs/Scene/VoxelTraversalSpec.js
+++ b/packages/engine/Specs/Scene/VoxelTraversalSpec.js
@@ -39,11 +39,11 @@ describe(
       );
 
       camera = scene.camera;
-      camera.position = Cartesian3.fromElements(-10, -10, -10);
+      camera.position = Cartesian3.fromElements(-6378000, -6378000, -6378000);
       camera.direction = Cartesian3.fromElements(1, 1, 1);
       camera.frustum.fov = CesiumMath.PI_OVER_TWO;
       primitive = new VoxelPrimitive({
-        voxelProvider: provider,
+        provider: provider,
       });
       scene.primitives.add(primitive);
       scene.renderForSpecs();
@@ -146,7 +146,7 @@ describe(
       expect(traversal.isDestroyed()).toBe(true);
     });
 
-    xit("loads tiles into megatexture", async function () {
+    it("loads tiles into megatexture", async function () {
       const keyFrameLocation = 0;
       const recomputeBoundingVolumes = true;
       const pauseUpdate = false;
@@ -165,20 +165,7 @@ describe(
       });
 
       const megatexture = traversal.megatextures[0];
-      let tilesInMegatextureCount = megatexture.occupiedCount;
-      const tileInQueueWhenLookingAtRoot = tilesInMegatextureCount === 1;
-      expect(tileInQueueWhenLookingAtRoot).toBe(true);
-
-      turnCameraAround(scene);
-      traversal.update(
-        scene.frameState,
-        keyFrameLocation,
-        recomputeBoundingVolumes,
-        pauseUpdate
-      );
-      tilesInMegatextureCount = traversal.megatextures[0].occupiedCount;
-      const tileNotInQueueWhenLookingAway = tilesInMegatextureCount === 0;
-      expect(tileNotInQueueWhenLookingAway).toBe(true);
+      expect(megatexture.occupiedCount).toBe(1);
     });
 
     xit("unloads tiles in megatexture", function () {

--- a/packages/engine/Specs/Scene/VoxelTraversalSpec.js
+++ b/packages/engine/Specs/Scene/VoxelTraversalSpec.js
@@ -11,6 +11,7 @@ import {
   Cesium3DTilesVoxelProvider,
 } from "../../index.js";
 import createScene from "../../../../Specs/createScene.js";
+import pollToPromise from "../../../../Specs/pollToPromise.js";
 
 const towardPrimitive = Cartesian3.fromElements(1.0, 1.0, 1.0);
 
@@ -145,16 +146,23 @@ describe(
       expect(traversal.isDestroyed()).toBe(true);
     });
 
-    xit("loads tiles into megatexture", function () {
+    xit("loads tiles into megatexture", async function () {
       const keyFrameLocation = 0;
       const recomputeBoundingVolumes = true;
       const pauseUpdate = false;
-      traversal.update(
-        scene.frameState,
-        keyFrameLocation,
-        recomputeBoundingVolumes,
-        pauseUpdate
-      );
+      await pollToPromise(function () {
+        scene.renderForSpecs();
+        traversal.update(
+          scene.frameState,
+          keyFrameLocation,
+          recomputeBoundingVolumes,
+          pauseUpdate
+        );
+        return traversal.megatextures[0].occupiedCount > 0;
+      }).then(function () {
+        scene.renderForSpecs();
+        return traversal;
+      });
 
       const megatexture = traversal.megatextures[0];
       let tilesInMegatextureCount = megatexture.occupiedCount;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR is an incremental step towards Voxel Picking. Key changes include:
- Voxel metadata is retained in CPU memory, even after it is loaded to a texture
- `VoxelTraversal` has a new helper function to look up a voxel tile in memory

Some additional changes along the way:
- Updated voxel traversal and picking-related code for clarity
- Fixed some broken specs in `VoxelTraversalSpec`

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

See updated `VoxelTraversalSpec`. More complete testing will be performed in the target staging branch.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
