### PR TITLE
Add doc about orientation default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fix globe materials when lighting is false. Slope/Aspect material no longer rely on turning on lighting or shadows. [#11563](https://github.com/CesiumGS/cesium/issues/11563)
 - Fixed a bug where `GregorianDate` constructor would not validate the input parameters for valid date. [#10075](https://github.com/CesiumGS/cesium/pull/10075)
 - Fixed improper scaling of ellipsoid inner radii in 3D mode. [#11656](https://github.com/CesiumGS/cesium/issues/11656) and [#10245](https://github.com/CesiumGS/cesium/issues/10245)
+- Fixed `Entity` documentation for `orientation` property. [#11762](https://github.com/CesiumGS/cesium/pull/11762)
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/DataSources/Entity.js
+++ b/packages/engine/Source/DataSources/Entity.js
@@ -71,7 +71,7 @@ function createPropertyTypeDescriptor(name, Type) {
  * @property {boolean} [show] A boolean value indicating if the entity and its children are displayed.
  * @property {Property | string} [description] A string Property specifying an HTML description for this entity.
  * @property {PositionProperty | Cartesian3} [position] A Property specifying the entity position.
- * @property {Property} [orientation] A Property specifying the entity orientation.
+ * @property {Property} [orientation=Transforms.eastNorthUpToFixedFrame(position)] A Property specifying the entity orientation in respect to Earth-fixed-Earth-centered (ECEF). If undefined, east-north-up at entity position is used.
  * @property {Property} [viewFrom] A suggested initial offset for viewing this object.
  * @property {Entity} [parent] A parent entity to associate with this entity.
  * @property {BillboardGraphics | BillboardGraphics.ConstructorOptions} [billboard] A billboard to associate with this entity.
@@ -413,7 +413,8 @@ Object.defineProperties(Entity.prototype, {
    */
   tileset: createPropertyTypeDescriptor("tileset", Cesium3DTilesetGraphics),
   /**
-   * Gets or sets the orientation.
+   * Gets or sets the orientation in respect to Earth-fixed-Earth-centered (ECEF).
+   * Defaults to east-north-up at entity position.
    * @memberof Entity.prototype
    * @type {Property|undefined}
    */


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This adds info in the docs about the default values used for Entity `orientation`.

In my local app, I was debugging my orientation calculations and found out that it makes a difference whether I set a rotation by 0° or nothing at all. This was confusing. Then I found out that if no orientation is given, the entity is always rotated towards Earth's center by checking the code and by finding [this post in the community forum](https://community.cesium.com/t/entity-rotation-origin/2037/6). 

Usually, documentation for methods and classes include default values, but those are missing for `orientation`.

I hope that this way, the info about the reference frame is found faster by people working on their entities' orientation.

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

I built the Documentation locally and checked the changes.

# Author checklist

- ~~[ ] I have submitted a Contributor License Agreement~~ already previously done
- ~~[ ] I have added my name to `CONTRIBUTORS.md`~~ already previously done
- [x] I have updated `CHANGES.md` with a short summary of my change -- **yes, in the same style as it was done for #10205**
- ~~[ ] I have added or updated unit tests to ensure consistent code coverage~~ no code changed
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
