### PR TITLE
Swap node internal packages out for `fetch` in `Resource`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 - By default, the screen space camera controller will no longer go inside or under instances of `Cesium3DTileset`. [#11581](https://github.com/CesiumGS/cesium/pull/11581)
   - This behavior can be disabled by setting `Cesium3DTileset.disableCollision` to true.
   - This feature is enabled by default only for WebGL 2 and above, but can be enabled for WebGL 1 by setting the `enablePick` option to true when creating the `Cesium3DTileset`.
+- Remove the need for node internal packages `http`, `https`, `url` and `zlib` in the `Resource` class. This means they do not need to be marked external by build tools anymore. [#11773](https://github.com/CesiumGS/cesium/pull/11773)
+  - This slightly changed the contents of the `RequestErrorEvent` error that is thrown in node environments when a request fails. The `response` property is now a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object instead of an [`http.IncomingMessage`](https://nodejs.org/docs/latest-v20.x/api/http.html#class-httpincomingmessage)
 
 ##### Additions :tada:
 

--- a/Specs/test.cjs
+++ b/Specs/test.cjs
@@ -1,8 +1,6 @@
 /*eslint-env node*/
 "use strict";
 
-// NodeJS smoke screen test
-
 const assert = require("node:assert");
 const {
   Cartographic,
@@ -10,16 +8,23 @@ const {
   sampleTerrain,
 } = require("cesium");
 
+// NodeJS smoke screen test
+
 async function test() {
+  console.log("start");
   const provider = await createWorldTerrainAsync();
+  console.log("loaded terrain");
   const results = await sampleTerrain(provider, 11, [
     Cartographic.fromDegrees(86.925145, 27.988257),
     Cartographic.fromDegrees(87.0, 28.0),
   ]);
+  console.log("sampled terrain");
   assert(results[0].height > 5000);
   assert(results[0].height < 10000);
   assert(results[1].height > 5000);
   assert(results[1].height < 10000);
+
+  console.log("all assertions passed");
 }
 
-test();
+test().finally(() => console.log("done"));

--- a/Specs/test.cjs
+++ b/Specs/test.cjs
@@ -11,20 +11,15 @@ const {
 // NodeJS smoke screen test
 
 async function test() {
-  console.log("start");
   const provider = await createWorldTerrainAsync();
-  console.log("loaded terrain");
   const results = await sampleTerrain(provider, 11, [
     Cartographic.fromDegrees(86.925145, 27.988257),
     Cartographic.fromDegrees(87.0, 28.0),
   ]);
-  console.log("sampled terrain");
   assert(results[0].height > 5000);
   assert(results[0].height < 10000);
   assert(results[1].height > 5000);
   assert(results[1].height < 10000);
-
-  console.log("all assertions passed");
 }
 
-test().finally(() => console.log("done"));
+test();

--- a/Specs/test.mjs
+++ b/Specs/test.mjs
@@ -4,21 +4,16 @@ import assert from "node:assert";
 // NodeJS smoke screen test
 
 async function test() {
-  console.log("start");
   const provider = await createWorldTerrainAsync();
-  console.log("loaded terrain");
   const results = await sampleTerrain(provider, 11, [
     Cartographic.fromDegrees(86.925145, 27.988257),
     Cartographic.fromDegrees(87.0, 28.0),
   ]);
-  console.log("sampled terrain");
   assert(results[0].height > 5000);
   assert(results[0].height < 10000);
   assert(results[1].height > 5000);
   assert(results[1].height < 10000);
-
-  console.log("all assertions passed");
 }
 
-test().finally(() => console.log('done'));
+test()
 

--- a/Specs/test.mjs
+++ b/Specs/test.mjs
@@ -4,15 +4,21 @@ import assert from "node:assert";
 // NodeJS smoke screen test
 
 async function test() {
+  console.log("start");
   const provider = await createWorldTerrainAsync();
+  console.log("loaded terrain");
   const results = await sampleTerrain(provider, 11, [
     Cartographic.fromDegrees(86.925145, 27.988257),
     Cartographic.fromDegrees(87.0, 28.0),
   ]);
+  console.log("sampled terrain");
   assert(results[0].height > 5000);
   assert(results[0].height < 10000);
   assert(results[1].height > 5000);
   assert(results[1].height < 10000);
+
+  console.log("all assertions passed");
 }
 
-test();
+test().finally(() => console.log('done'));
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -798,7 +798,6 @@ export async function runCoverage(options) {
     sourcemap: true,
     format: "esm",
     target: "es2020",
-    external: ["https", "http", "url", "zlib"],
     outfile: karmaBundle,
     logLevel: "error", // print errors immediately, and collect warnings so we can filter out known ones
   });
@@ -812,7 +811,6 @@ export async function runCoverage(options) {
     sourcemap: true,
     format: "esm",
     target: "es2020",
-    external: ["https", "http", "url", "zlib"],
     outfile: specListBundle,
     plugins: [instrumentPlugin],
     logLevel: "error", // print errors immediately, and collect warnings so we can filter out known ones
@@ -1697,7 +1695,6 @@ async function buildCesiumViewer() {
   config.format = "iife";
   // Configure Cesium base path to use built
   config.define = { CESIUM_BASE_URL: `"."` };
-  config.external = ["https", "http", "url", "zlib"];
   config.outdir = cesiumViewerOutputDirectory;
   config.outbase = "Apps/CesiumViewer";
   config.logLevel = "error"; // print errors immediately, and collect warnings so we can filter out known ones

--- a/packages/engine/Source/Core/Resource.js
+++ b/packages/engine/Source/Core/Resource.js
@@ -2045,17 +2045,6 @@ Resource.createImageBitmapFromBlob = function (blob, options) {
   });
 };
 
-function decodeResponse(loadWithHttpResponse, responseType) {
-  switch (responseType) {
-    case "text":
-      return loadWithHttpResponse.toString("utf8");
-    case "json":
-      return JSON.parse(loadWithHttpResponse.toString("utf8"));
-    default:
-      return new Uint8Array(loadWithHttpResponse).buffer;
-  }
-}
-
 function loadWithHttpRequest(
   url,
   responseType,
@@ -2066,64 +2055,37 @@ function loadWithHttpRequest(
   overrideMimeType
 ) {
   // Note: only the 'json' and 'text' responseTypes transforms the loaded buffer
-  let URL;
-  let zlib;
-  Promise.all([import("url"), import("zlib")])
-    .then(([urlImport, zlibImport]) => {
-      URL = urlImport.parse(url);
-      zlib = zlibImport;
+  fetch(url, {
+    method,
+    headers,
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        const responseHeaders = {};
+        response.headers.forEach((value, key) => {
+          responseHeaders[key] = value;
+        });
+        deferred.reject(
+          // TODO: there is not directly equivalent to http.IncomingMessage, is the full obj ok as the second arg here?
+          new RequestErrorEvent(response.status, response, responseHeaders)
+        );
+        return;
+      }
 
-      return URL.protocol === "https:" ? import("https") : import("http");
+      switch (responseType) {
+        case "text":
+          deferred.resolve(response.text());
+          break;
+        case "json":
+          deferred.resolve(response.json());
+          break;
+        default:
+          deferred.resolve(new Uint8Array(await response.arrayBuffer()).buffer);
+          break;
+      }
     })
-    .then((http) => {
-      const options = {
-        protocol: URL.protocol,
-        hostname: URL.hostname,
-        port: URL.port,
-        path: URL.path,
-        query: URL.query,
-        method: method,
-        headers: headers,
-      };
-      http
-        .request(options)
-        .on("response", function (res) {
-          if (res.statusCode < 200 || res.statusCode >= 300) {
-            deferred.reject(
-              new RequestErrorEvent(res.statusCode, res, res.headers)
-            );
-            return;
-          }
-
-          const chunkArray = [];
-          res.on("data", function (chunk) {
-            chunkArray.push(chunk);
-          });
-
-          res.on("end", function () {
-            // eslint-disable-next-line no-undef
-            const result = Buffer.concat(chunkArray);
-            if (res.headers["content-encoding"] === "gzip") {
-              zlib.gunzip(result, function (error, resultUnzipped) {
-                if (error) {
-                  deferred.reject(
-                    new RuntimeError("Error decompressing response.")
-                  );
-                } else {
-                  deferred.resolve(
-                    decodeResponse(resultUnzipped, responseType)
-                  );
-                }
-              });
-            } else {
-              deferred.resolve(decodeResponse(result, responseType));
-            }
-          });
-        })
-        .on("error", function (e) {
-          deferred.reject(new RequestErrorEvent());
-        })
-        .end();
+    .catch(() => {
+      deferred.reject(new RequestErrorEvent());
     });
 }
 
@@ -2226,7 +2188,7 @@ Resource._Implementations.loadWithXhr = function (
     //or do not support the xhr.response property.
     if (xhr.status === 204) {
       // accept no content
-      deferred.resolve();
+      deferred.resolve(undefined);
     } else if (
       defined(response) &&
       (!defined(responseType) || browserResponseType === responseType)
@@ -2241,7 +2203,7 @@ Resource._Implementations.loadWithXhr = function (
     } else if (
       (browserResponseType === "" || browserResponseType === "document") &&
       defined(xhr.responseXML) &&
-      xhr.responseXML.hasChildNodes()
+      xhr.responseXML?.hasChildNodes()
     ) {
       deferred.resolve(xhr.responseXML);
     } else if (

--- a/packages/engine/Source/Core/Resource.js
+++ b/packages/engine/Source/Core/Resource.js
@@ -2066,7 +2066,6 @@ function loadWithHttpRequest(
           responseHeaders[key] = value;
         });
         deferred.reject(
-          // TODO: there is not directly equivalent to http.IncomingMessage, is the full obj ok as the second arg here?
           new RequestErrorEvent(response.status, response, responseHeaders)
         );
         return;
@@ -2203,7 +2202,7 @@ Resource._Implementations.loadWithXhr = function (
     } else if (
       (browserResponseType === "" || browserResponseType === "document") &&
       defined(xhr.responseXML) &&
-      xhr.responseXML?.hasChildNodes()
+      xhr.responseXML.hasChildNodes()
     ) {
       deferred.resolve(xhr.responseXML);
     } else if (

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -162,7 +162,6 @@ export async function bundleCesiumJs(options) {
   buildConfig.entryPoints = ["Source/Cesium.js"];
   buildConfig.minify = options.minify;
   buildConfig.sourcemap = options.sourcemap;
-  buildConfig.external = ["https", "http", "url", "zlib"];
   buildConfig.plugins = options.removePragmas ? [stripPragmaPlugin] : undefined;
   buildConfig.write = options.write;
   buildConfig.banner = {
@@ -361,7 +360,7 @@ export async function bundleWorkers(options) {
   const workers = await globby(["packages/engine/Source/Workers/**"]);
   const workerConfig = defaultESBuildOptions();
   workerConfig.bundle = true;
-  workerConfig.external = ["http", "https", "url", "zlib", "fs", "path"];
+  workerConfig.external = ["fs", "path"];
 
   if (options.iife) {
     let contents = ``;
@@ -816,7 +815,6 @@ export async function bundleCombinedSpecs(options) {
     sourcemap: true,
     outdir: path.join("Build", "Specs"),
     plugins: [externalResolvePlugin],
-    external: [`http`, `https`, `url`, `zlib`],
     write: options.write,
   });
 }
@@ -843,7 +841,7 @@ export async function bundleTestWorkers(options) {
     format: "esm",
     sourcemap: true,
     outdir: path.join("Build", "Specs", "TestWorkers"),
-    external: ["http", "https", "url", "zlib", "fs", "path"],
+    external: ["fs", "path"],
     write: options.write,
   });
 }
@@ -960,7 +958,6 @@ async function bundleSpecs(options) {
     format: "esm",
     outdir: options.outdir,
     sourcemap: true,
-    external: ["https", "http", "zlib", "url"],
     target: "es2020",
     write: write,
   };


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Working on updating [`cesium-webpack-example`](https://github.com/CesiumGS/cesium-webpack-example) and creating [`cesium-vite-example`](https://github.com/CesiumGS/cesium-vite-example) I realized there are 2 main sticking points to using Cesium in various JS build environments.

1. Copying the required static files for workers (https://github.com/CesiumGS/cesium/issues/10619)
2. Marking select node modules as external, `http`, `https`, `url` and `zlib`, which are only used in `Resource.js` when on node

This PR aims to remove that second point by swapping out the "node only" logic for `fetch()` which has been enabled by default since Node v18. 

As far as I can tell I was able to mimic the existing behavior except for one issue with an error that's thrown. There's currently no Specs set up for running in a Node environment so running the smoke screen tests `Specs/test.cjs` and `Specs/test.mjs` was the only way to verify and that works correctly.

I'd really appreciate more eyes on this as I know `Resource` is a fairly core class to cesium and I don't want to negatively impact anything.

## Issue number and link

No issue

## Testing plan

- run `node Specs/test.cjs`
- run `node Specs/test.mjs`

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
