### PR TITLE
Documentation fixes 2024-01-20

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@
 - Fixed `Entity` documentation for `orientation` property. [#11762](https://github.com/CesiumGS/cesium/pull/11762)
 - Fixed an issue where `DataSource` objects incorrectly shared a single `PolylineCollection` in the `PolylineGeometryUpdater`. Updated `PolylineGeometryUpdater` to create a distinct `PolylineCollection` instance per `DataSource`. This resolves the crashes reported under [#7758](https://github.com/CesiumGS/cesium/issues/7758) and [#9154](https://github.com/CesiumGS/cesium/issues/9154).
 - Fixed a bug where transforms that had been defined with the `KHR_texture_transform` extension had not been applied to Feature ID Textures in `EXT_mesh_features`. [#11731](https://github.com/CesiumGS/cesium/issues/11731)
+- The `EntityCollection#add` method was documented to throw a `DeveloperError` for duplicate IDs, but did throw a `RuntimeError` in this case. This is now changed to throw a `DeveloperError`. [#11776](https://github.com/CesiumGS/cesium/pull/11776)
+- Parts of the documentation have been updated to resolve potential issues with the generated TypedScript definitions. [#11776](https://github.com/CesiumGS/cesium/pull/11776)
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/DataSources/Entity.js
+++ b/packages/engine/Source/DataSources/Entity.js
@@ -71,8 +71,8 @@ function createPropertyTypeDescriptor(name, Type) {
  * @property {boolean} [show] A boolean value indicating if the entity and its children are displayed.
  * @property {Property | string} [description] A string Property specifying an HTML description for this entity.
  * @property {PositionProperty | Cartesian3} [position] A Property specifying the entity position.
- * @property {Property} [orientation=Transforms.eastNorthUpToFixedFrame(position)] A Property specifying the entity orientation in respect to Earth-fixed-Earth-centered (ECEF). If undefined, east-north-up at entity position is used.
- * @property {Property} [viewFrom] A suggested initial offset for viewing this object.
+ * @property {Property | Quaternion} [orientation=Transforms.eastNorthUpToFixedFrame(position)] A Property specifying the entity orientation in respect to Earth-fixed-Earth-centered (ECEF). If undefined, east-north-up at entity position is used.
+ * @property {Property | Cartesian3} [viewFrom] A suggested initial offset for viewing this object.
  * @property {Entity} [parent] A parent entity to associate with this entity.
  * @property {BillboardGraphics | BillboardGraphics.ConstructorOptions} [billboard] A billboard to associate with this entity.
  * @property {BoxGraphics | BoxGraphics.ConstructorOptions} [box] A box to associate with this entity.

--- a/packages/engine/Source/DataSources/EntityCollection.js
+++ b/packages/engine/Source/DataSources/EntityCollection.js
@@ -5,7 +5,6 @@ import DeveloperError from "../Core/DeveloperError.js";
 import Event from "../Core/Event.js";
 import Iso8601 from "../Core/Iso8601.js";
 import JulianDate from "../Core/JulianDate.js";
-import RuntimeError from "../Core/RuntimeError.js";
 import TimeInterval from "../Core/TimeInterval.js";
 import Entity from "./Entity.js";
 
@@ -281,7 +280,7 @@ EntityCollection.prototype.add = function (entity) {
   const id = entity.id;
   const entities = this._entities;
   if (entities.contains(id)) {
-    throw new RuntimeError(
+    throw new DeveloperError(
       `An entity with id ${id} already exists in this collection.`
     );
   }

--- a/packages/engine/Source/DataSources/GeometryUpdater.js
+++ b/packages/engine/Source/DataSources/GeometryUpdater.js
@@ -233,8 +233,7 @@ Object.defineProperties(GeometryUpdater.prototype, {
   },
   /**
    * Gets a value indicating if the geometry is time-varying.
-   * If true, all visualization is delegated to a DynamicGeometryUpdater
-   * returned by GeometryUpdater#createDynamicUpdater.
+   *
    * @memberof GeometryUpdater.prototype
    *
    * @type {boolean}

--- a/packages/engine/Source/DataSources/PolylineGeometryUpdater.js
+++ b/packages/engine/Source/DataSources/PolylineGeometryUpdater.js
@@ -249,8 +249,7 @@ Object.defineProperties(PolylineGeometryUpdater.prototype, {
   },
   /**
    * Gets a value indicating if the geometry is time-varying.
-   * If true, all visualization is delegated to the {@link DynamicGeometryUpdater}
-   * returned by GeometryUpdater#createDynamicUpdater.
+   *
    * @memberof PolylineGeometryUpdater.prototype
    *
    * @type {boolean}

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -1956,7 +1956,8 @@ Object.defineProperties(Cesium3DTileset.prototype, {
  * @param {Cesium3DTileset.ConstructorOptions} [options] An object describing initialization options
  * @returns {Promise<Cesium3DTileset>}
  *
- * @exception {DeveloperError} The tileset must be 3D Tiles version 0.0 or 1.0.
+ * @exception {RuntimeError} When the tileset asset version is not 0.0, 1.0, or 1.1,
+ * or when the tileset contains a required extension that is not supported.
  *
  * @see Cesium3DTileset#fromUrl
  *
@@ -1986,7 +1987,8 @@ Cesium3DTileset.fromIonAssetId = async function (assetId, options) {
  * @param {Cesium3DTileset.ConstructorOptions} [options] An object describing initialization options
  * @returns {Promise<Cesium3DTileset>}
  *
- * @exception {DeveloperError} The tileset must be 3D Tiles version 0.0 or 1.0.
+ * @exception {RuntimeError} When the tileset asset version is not 0.0, 1.0, or 1.1,
+ * or when the tileset contains a required extension that is not supported.
  *
  * @see Cesium3DTileset#fromIonAssetId
  *
@@ -2128,6 +2130,9 @@ Cesium3DTileset.prototype.makeStyleDirty = function () {
 
 /**
  * Loads the main tileset JSON file or a tileset JSON file referenced from a tile.
+ *
+ * @exception {RuntimeError} When the tileset asset version is not 0.0, 1.0, or 1.1,
+ * or when the tileset contains a required extension that is not supported.
  *
  * @private
  */

--- a/packages/engine/Specs/DataSources/EntityCollectionSpec.js
+++ b/packages/engine/Specs/DataSources/EntityCollectionSpec.js
@@ -5,7 +5,6 @@ import {
   TimeIntervalCollection,
   Entity,
   EntityCollection,
-  RuntimeError,
 } from "../../index.js";
 
 describe("DataSources/EntityCollection", function () {
@@ -474,7 +473,7 @@ describe("DataSources/EntityCollection", function () {
 
     expect(function () {
       entityCollection.add(entity2);
-    }).toThrowError(RuntimeError);
+    }).toThrowDeveloperError();
   });
 
   it("contains returns true if in collection", function () {

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -269,7 +269,7 @@ describe(
     it("loads json with static loadJson method", async function () {
       const tilesetJson = {
         asset: {
-          version: 2.0,
+          version: 1.1,
         },
       };
 


### PR DESCRIPTION
Addresses https://github.com/CesiumGS/cesium/issues/11749#issue-2072624863 (not the issue as a whole, but only the points mentioned in this comment)

The commits basically correspond to the points that are listed in the comment, each implementing the 'Suggested fix'.

For the last point (entity constructor options) I also documented `viewFrom` as `{Property | Cartesian3}`. (It could probably be a `PositionProperty`, but ... maybe that would be confusing..?)

Note: The `EntityCollection#add` function originally threw a `RuntimeError` for duplicate IDs, and now throws a `DeveloperError` (as of  https://github.com/CesiumGS/cesium/commit/80d09540657df549ec70bdd0803167f827ce8aeb ). This could be considered as a "breaking change", or.... as a bugfix: The documentation already said that it throws a `DeveloperError`, so this just aligns the implementation with the existing documentation...

Beyond that, I'm not sure whether anything here should be mentioned in the `CHANGES.md`...