### PR TITLE
[FIX] Added undefined as union type fo contrainedAxis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 #### @cesium/engine
 
+##### Fixes :type:
+
+- Added a uninon type undefined for camera.constrainedAxis to fix the issue [#11475](https://github.com/CesiumGS/cesium/issues/11475)
+- By adding a union type undefined to camera.constrainedAxis, it will allow typescript user to assign undefined value to it.
+
 ##### Breaking Changes :mega:
 
 - By default, the screen space camera controller will no longer go inside or under instances of `Cesium3DTileset`. [#11581](https://github.com/CesiumGS/cesium/pull/11581)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,6 @@
 
 #### @cesium/engine
 
-##### Fixes :type:
-
-- Added a uninon type undefined for camera.constrainedAxis to fix the issue [#11475](https://github.com/CesiumGS/cesium/issues/11475)
-- By adding a union type undefined to camera.constrainedAxis, it will allow typescript user to assign undefined value to it.
-
 ##### Breaking Changes :mega:
 
 - By default, the screen space camera controller will no longer go inside or under instances of `Cesium3DTileset`. [#11581](https://github.com/CesiumGS/cesium/pull/11581)
@@ -33,6 +28,7 @@
 - Fixed `Entity` documentation for `orientation` property. [#11762](https://github.com/CesiumGS/cesium/pull/11762)
 - Fixed an issue where `DataSource` objects incorrectly shared a single `PolylineCollection` in the `PolylineGeometryUpdater`. Updated `PolylineGeometryUpdater` to create a distinct `PolylineCollection` instance per `DataSource`. This resolves the crashes reported under [#7758](https://github.com/CesiumGS/cesium/issues/7758) and [#9154](https://github.com/CesiumGS/cesium/issues/9154).
 - Fixed a bug where transforms that had been defined with the `KHR_texture_transform` extension had not been applied to Feature ID Textures in `EXT_mesh_features`. [#11731](https://github.com/CesiumGS/cesium/issues/11731)
+- Fixed type definition for `Camera.constrainedAxis`. [#11475](https://github.com/CesiumGS/cesium/issues/11475)
 
 #### @cesium/widgets
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -376,3 +376,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Subhajit Saha](https://github.com/subhajits)
 - [Jared Webber](https://github.com/jaredwebber)
 - [Anne Gropler](https://github.com/anne-gropler)
+- [Harsh Lakhara](https://github.com/harshlakhara)

--- a/packages/engine/Source/Scene/Camera.js
+++ b/packages/engine/Source/Scene/Camera.js
@@ -197,7 +197,7 @@ function Camera(scene) {
   this.defaultZoomAmount = 100000.0;
   /**
    * If set, the camera will not be able to rotate past this axis in either direction.
-   * @type {Cartesian3}
+   * @type {Cartesian3 | undefined}
    * @default undefined
    */
   this.constrainedAxis = undefined;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->
Added undefined as union type for contrainedAxis so in typescript it won't show errow while assinging undefined to it.

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->
#11475

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
