### PR TITLE
Workaround for geometry displacement on iOS. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - The `EntityCollection#add` method was documented to throw a `DeveloperError` for duplicate IDs, but did throw a `RuntimeError` in this case. This is now changed to throw a `DeveloperError`. [#11776](https://github.com/CesiumGS/cesium/pull/11776)
 - Parts of the documentation have been updated to resolve potential issues with the generated TypedScript definitions. [#11776](https://github.com/CesiumGS/cesium/pull/11776)
 - Fixed type definition for `Camera.constrainedAxis`. [#11475](https://github.com/CesiumGS/cesium/issues/11475)
+- Fixed a geometry displacement on iOS devices that was caused by NaN value in `czm_translateRelativeToEye` function. [#7100](https://github.com/CesiumGS/cesium/issues/7100)
 
 #### @cesium/widgets
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -377,3 +377,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jared Webber](https://github.com/jaredwebber)
 - [Anne Gropler](https://github.com/anne-gropler)
 - [Harsh Lakhara](https://github.com/harshlakhara)
+- [Pavlo Skakun](https://github.com/p-skakun)

--- a/packages/engine/Source/Shaders/Builtin/Functions/translateRelativeToEye.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/translateRelativeToEye.glsl
@@ -34,6 +34,7 @@
 vec4 czm_translateRelativeToEye(vec3 high, vec3 low)
 {
     vec3 highDifference = high - czm_encodedCameraPositionMCHigh;
+    if (length(highDifference) == 0.0) highDifference = vec3(0);
     vec3 lowDifference = low - czm_encodedCameraPositionMCLow;
 
     return vec4(highDifference + lowDifference, 1.0);

--- a/packages/engine/Source/Shaders/Builtin/Functions/translateRelativeToEye.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/translateRelativeToEye.glsl
@@ -34,7 +34,11 @@
 vec4 czm_translateRelativeToEye(vec3 high, vec3 low)
 {
     vec3 highDifference = high - czm_encodedCameraPositionMCHigh;
-    if (length(highDifference) == 0.0) highDifference = vec3(0);
+    // This check handles the case when NaN values have gotten into `highDifference`.
+    // Such a thing could happen on devices running iOS.
+    if (length(highDifference) == 0.0) {  
+        highDifference = vec3(0);  
+    }
     vec3 lowDifference = low - czm_encodedCameraPositionMCLow;
 
     return vec4(highDifference + lowDifference, 1.0);


### PR DESCRIPTION
# Description

This change fixes geometry displacement on iOS, referred in related issue and forum post. 
The issue still takes place in version 1.113. I encountered it on iPhone XR and iPad when displaying PolylineVolume entities.

## Issue number and link

Distorted Box Entity in iOS #7100 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

I tested it on iPhone XR and iPad with the sample provided in #7100 integrated to built-in CesiumViewer app and in my production app. 

Screenshots for sample: 

Before fix:
<img src="https://github.com/CesiumGS/cesium/assets/32131961/4d773e6e-ff68-478a-b830-0029e4a57f6d" height="400px">

After fix: 
<img src="https://github.com/CesiumGS/cesium/assets/32131961/0f44f2bd-aa6a-4beb-a182-8002c7a70ad2" height="400px">

# Author checklist

- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
- [x] Send in a [Contributor License Agreement](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA)
- [x] Add yourself to the [contributors](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTORS.md) file