### PR TITLE
Remove obsolete workarounds in SceneSpec

### DIFF
--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -163,10 +163,10 @@ describe(
     it("constructor sets options", function () {
       const webglOptions = {
         alpha: true,
-        depth: true, //TODO Change to false when https://bugzilla.mozilla.org/show_bug.cgi?id=745912 is fixed.
+        depth: false,
         stencil: true,
         antialias: false,
-        premultipliedAlpha: true, // Workaround IE 11.0.8, which does not honor false.
+        premultipliedAlpha: false,
         preserveDrawingBuffer: true,
       };
       const mapProjection = new WebMercatorProjection();


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

One `Scene` spec had special settings to work around old browser problems:
- A [bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=745912) which has been fixed
- A limitation of IE 11, which we no longer support

This 2-line PR changes those settings and cleans up the comments.

## Testing plan

Verify `SceneSpec` runs successfully.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
