### PR TITLE
Sandcaslte: keyboard events use `code` instead of `keyCode`

### DIFF
--- a/Apps/Sandcastle/gallery/Camera Tutorial.html
+++ b/Apps/Sandcastle/gallery/Camera Tutorial.html
@@ -103,19 +103,19 @@
           flags.looking = false;
         }, Cesium.ScreenSpaceEventType.LEFT_UP);
 
-        function getFlagForKeyCode(keyCode) {
-          switch (keyCode) {
-            case "W".charCodeAt(0):
+        function getFlagForKeyCode(code) {
+          switch (code) {
+            case "KeyW":
               return "moveForward";
-            case "S".charCodeAt(0):
+            case "KeyS":
               return "moveBackward";
-            case "Q".charCodeAt(0):
+            case "KeyQ":
               return "moveUp";
-            case "E".charCodeAt(0):
+            case "KeyE":
               return "moveDown";
-            case "D".charCodeAt(0):
+            case "KeyD":
               return "moveRight";
-            case "A".charCodeAt(0):
+            case "KeyA":
               return "moveLeft";
             default:
               return undefined;
@@ -125,7 +125,7 @@
         document.addEventListener(
           "keydown",
           function (e) {
-            const flagName = getFlagForKeyCode(e.keyCode);
+            const flagName = getFlagForKeyCode(e.code);
             if (typeof flagName !== "undefined") {
               flags[flagName] = true;
             }
@@ -136,7 +136,7 @@
         document.addEventListener(
           "keyup",
           function (e) {
-            const flagName = getFlagForKeyCode(e.keyCode);
+            const flagName = getFlagForKeyCode(e.code);
             if (typeof flagName !== "undefined") {
               flags[flagName] = false;
             }

--- a/Apps/Sandcastle/gallery/HeadingPitchRoll.html
+++ b/Apps/Sandcastle/gallery/HeadingPitchRoll.html
@@ -170,8 +170,8 @@
           });
 
           document.addEventListener("keydown", function (e) {
-            switch (e.keyCode) {
-              case 40:
+            switch (e.code) {
+              case "ArrowDown":
                 if (e.shiftKey) {
                   // speed down
                   speed = Math.max(--speed, 1);
@@ -183,7 +183,7 @@
                   }
                 }
                 break;
-              case 38:
+              case "ArrowUp":
                 if (e.shiftKey) {
                   // speed up
                   speed = Math.min(++speed, 100);
@@ -195,7 +195,7 @@
                   }
                 }
                 break;
-              case 39:
+              case "ArrowRight":
                 if (e.shiftKey) {
                   // roll right
                   hpRoll.roll += deltaRadians;
@@ -210,7 +210,7 @@
                   }
                 }
                 break;
-              case 37:
+              case "ArrowLeft":
                 if (e.shiftKey) {
                   // roll left until
                   hpRoll.roll -= deltaRadians;

--- a/Apps/Sandcastle/gallery/Imagery Cutout.html
+++ b/Apps/Sandcastle/gallery/Imagery Cutout.html
@@ -111,15 +111,15 @@
           moveSouth: false,
         };
 
-        function getFlagForKeyCode(keyCode) {
-          switch (keyCode) {
-            case "W".charCodeAt(0):
+        function getFlagForKeyCode(code) {
+          switch (code) {
+            case "KeyW":
               return "moveNorth";
-            case "S".charCodeAt(0):
+            case "KeyS":
               return "moveSouth";
-            case "D".charCodeAt(0):
+            case "KeyD":
               return "moveEast";
-            case "A".charCodeAt(0):
+            case "KeyA":
               return "moveWest";
             default:
               return undefined;
@@ -129,7 +129,7 @@
         document.addEventListener(
           "keydown",
           function (e) {
-            const flagName = getFlagForKeyCode(e.keyCode);
+            const flagName = getFlagForKeyCode(e.code);
             if (typeof flagName !== "undefined") {
               flags[flagName] = true;
             }
@@ -140,7 +140,7 @@
         document.addEventListener(
           "keyup",
           function (e) {
-            const flagName = getFlagForKeyCode(e.keyCode);
+            const flagName = getFlagForKeyCode(e.code);
             if (typeof flagName !== "undefined") {
               flags[flagName] = false;
             }

--- a/Apps/Sandcastle/gallery/LocalToFixedFrame.html
+++ b/Apps/Sandcastle/gallery/LocalToFixedFrame.html
@@ -196,22 +196,22 @@
         });
 
         document.addEventListener("keydown", function (e) {
-          switch (e.keyCode) {
-            case 40:
+          switch (e.code) {
+            case "ArrowDown":
               // pitch down
               hpRoll.pitch -= deltaRadians;
               if (hpRoll.pitch < -Cesium.Math.TWO_PI) {
                 hpRoll.pitch += Cesium.Math.TWO_PI;
               }
               break;
-            case 38:
+            case "ArrowUp":
               // pitch up
               hpRoll.pitch += deltaRadians;
               if (hpRoll.pitch > Cesium.Math.TWO_PI) {
                 hpRoll.pitch -= Cesium.Math.TWO_PI;
               }
               break;
-            case 39:
+            case "ArrowRight":
               if (e.shiftKey) {
                 // roll right
                 hpRoll.roll += deltaRadians;
@@ -226,7 +226,7 @@
                 }
               }
               break;
-            case 37:
+            case "ArrowLeft":
               if (e.shiftKey) {
                 // roll left until
                 hpRoll.roll -= deltaRadians;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

When exploring our camera sandcastles I noticed they're still using [`KeyboardEvent.keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) which has been deprecated for quite a while. This PR just updates all uses of `keyCode` in the sandcastles to use the [`KeyboardEvent.code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) property which is much more reliable.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Testing plan

- Open the following sandcastles and make sure they still behave as expected and listed in the demo tooltip
    - Camera Tutorial
    - HeadingPitchRoll
    - Imagery Cutout
    - LocalToFixedFrame

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
