### PR TITLE
Voxel pick api

### DIFF
--- a/packages/engine/Source/Renderer/demodernizeShader.js
+++ b/packages/engine/Source/Renderer/demodernizeShader.js
@@ -26,7 +26,10 @@ function demodernizeShader(input, isFragmentShader) {
 
   if (isFragmentShader) {
     // Replace the in with varying.
-    output = output.replaceAll(/(in)\s+(vec\d|mat\d|float)/g, `varying $2`);
+    output = output.replaceAll(
+      /\n\s*(in)\s+(vec\d|mat\d|float)/g,
+      `\nvarying $2`
+    );
 
     if (/out_FragData_(\d+)/.test(output)) {
       output = `#extension GL_EXT_draw_buffers : enable\n${output}`;

--- a/packages/engine/Source/Scene/Picking.js
+++ b/packages/engine/Source/Scene/Picking.js
@@ -325,7 +325,12 @@ Picking.prototype.pick = function (scene, windowPosition, width, height) {
  * @param {number} [height=3] Height of the pick rectangle.
  * @returns {object} Object containing the picked primitive.
  */
-Picking.prototype.pickVoxel = function (scene, windowPosition, width, height) {
+Picking.prototype.pickVoxelCoordinate = function (
+  scene,
+  windowPosition,
+  width,
+  height
+) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(windowPosition)) {
     throw new DeveloperError("windowPosition is undefined.");

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3970,26 +3970,6 @@ Scene.prototype.pick = function (windowPosition, width, height) {
 };
 
 /**
- * Returns an object with cordinates of the voxel sample rendered at
- * a particular window coordinate. Returns <code>undefined</code> if there is no
- * voxel at that position.
- *
- * @private
- *
- * @param {Cartesian2} windowPosition Window coordinates to perform picking on.
- * @param {number} [width=3] Width of the pick rectangle.
- * @param {number} [height=3] Height of the pick rectangle.
- * @returns {object} Object containing information about the voxel.
- */
-Scene.prototype._pickVoxelCoordinate = function (
-  windowPosition,
-  width,
-  height
-) {
-  return this._picking.pickVoxel(this, windowPosition, width, height);
-};
-
-/**
  * Returns a VoxelCell for the voxel sample rendered at a particular window coordinate,
  * or undefined if no voxel is rendered at that position.
  *
@@ -4016,7 +3996,7 @@ Scene.prototype.pickVoxel = function (windowPosition, width, height) {
   if (!(voxelPrimitive instanceof VoxelPrimitive)) {
     return;
   }
-  const voxelCoordinate = this._picking.pickVoxel(
+  const voxelCoordinate = this._picking.pickVoxelCoordinate(
     this,
     windowPosition,
     width,

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -70,6 +70,8 @@ import SunPostProcess from "./SunPostProcess.js";
 import TweenCollection from "./TweenCollection.js";
 import View from "./View.js";
 import DebugInspector from "./DebugInspector.js";
+import VoxelCell from "./VoxelCell.js";
+import VoxelPrimitive from "./VoxelPrimitive.js";
 
 const requestRenderAfterFrame = function (scene) {
   return function () {
@@ -3985,6 +3987,52 @@ Scene.prototype._pickVoxelCoordinate = function (
   height
 ) {
   return this._picking.pickVoxel(this, windowPosition, width, height);
+};
+
+/**
+ * Returns a VoxelCell for the voxel sample rendered at a particular window coordinate,
+ * or undefined if no voxel is rendered at that position.
+ *
+ * @example
+ * On left click, report the value of the "color" property at that voxel sample.
+ * handler.setInputAction(function(movement) {
+ *   const voxelCell = scene.pickVoxel(movement.position);
+ *   if (defined(voxelCell)) {
+ *     console.log(voxelCell.getProperty("color"));
+ *   }
+ * }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+ *
+ * @param {Cartesian2} windowPosition Window coordinates to perform picking on.
+ * @param {number} [width=3] Width of the pick rectangle.
+ * @param {number} [height=3] Height of the pick rectangle.
+ * @returns {VoxelCell} Information about the voxel cell rendered at the picked position.
+ */
+Scene.prototype.pickVoxel = function (windowPosition, width, height) {
+  const pickedObject = this.pick(windowPosition, width, height);
+  if (!defined(pickedObject)) {
+    return;
+  }
+  const voxelPrimitive = pickedObject.primitive;
+  if (!(voxelPrimitive instanceof VoxelPrimitive)) {
+    return;
+  }
+  const voxelCoordinate = this._picking.pickVoxel(
+    this,
+    windowPosition,
+    width,
+    height
+  );
+  // Look up the keyframeNode containing this picked cell
+  const tileIndex = 255 * voxelCoordinate[0] + voxelCoordinate[1];
+  const keyframeNode = voxelPrimitive._traversal.findKeyframeNode(tileIndex);
+  // Look up the metadata for the picked cell
+  const sampleIndex = 255 * voxelCoordinate[2] + voxelCoordinate[3];
+  return new VoxelCell(
+    voxelPrimitive,
+    tileIndex,
+    sampleIndex,
+    keyframeNode.metadatas
+  );
 };
 
 /**

--- a/packages/engine/Source/Scene/VoxelCell.js
+++ b/packages/engine/Source/Scene/VoxelCell.js
@@ -14,9 +14,9 @@ import MetadataType from "./MetadataType.js";
  * @constructor
  *
  * @example
- * // On mouse over, display all the properties for a voxel cell in the console log.
+ * // On left click, display all the properties for a voxel cell in the console log.
  * handler.setInputAction(function(movement) {
- *   const voxelCell = scene.pickVoxel(movement.endPosition);
+ *   const voxelCell = scene.pickVoxel(movement.position);
  *   if (voxelCell instanceof Cesium.VoxelCell) {
  *     const propertyIds = voxelCell.getPropertyIds();
  *     const length = propertyIds.length;
@@ -25,7 +25,7 @@ import MetadataType from "./MetadataType.js";
  *       console.log(`{propertyId}: ${voxelCell.getProperty(propertyId)}`);
  *     }
  *   }
- * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+ * }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
  */
 function VoxelCell(primitive, tileIndex, sampleIndex, metadatas) {
   this._primitive = primitive;

--- a/packages/engine/Source/Scene/VoxelCell.js
+++ b/packages/engine/Source/Scene/VoxelCell.js
@@ -1,0 +1,158 @@
+import defined from "../Core/defined.js";
+import MetadataType from "./MetadataType.js";
+
+/**
+ * A cell from a {@link VoxelPrimitive}.
+ * <p>
+ * Provides access to properties associated with one cell of a voxel primitive.
+ * </p>
+ * <p>
+ * Do not construct this directly.  Access it through picking using {@link Scene#pickVoxel}.
+ * </p>
+ *
+ * @alias VoxelCell
+ * @constructor
+ *
+ * @example
+ * // On mouse over, display all the properties for a voxel cell in the console log.
+ * handler.setInputAction(function(movement) {
+ *   const voxelCell = scene.pickVoxel(movement.endPosition);
+ *   if (voxelCell instanceof Cesium.VoxelCell) {
+ *     const propertyIds = voxelCell.getPropertyIds();
+ *     const length = propertyIds.length;
+ *     for (let i = 0; i < length; ++i) {
+ *       const propertyId = propertyIds[i];
+ *       console.log(`{propertyId}: ${voxelCell.getProperty(propertyId)}`);
+ *     }
+ *   }
+ * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+ */
+function VoxelCell(primitive, tileIndex, sampleIndex, metadatas) {
+  this._primitive = primitive;
+  this._tileIndex = tileIndex;
+  this._sampleIndex = sampleIndex;
+  this._metadatas = getMetadatasForSample(primitive, metadatas, sampleIndex);
+}
+
+function getMetadatasForSample(primitive, metadatas, sampleIndex) {
+  if (!defined(metadatas)) {
+    return undefined;
+  }
+  const { names, types } = primitive.provider;
+  const metadatasMap = {};
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    const componentCount = MetadataType.getComponentCount(types[i]);
+    const samples = metadatas[i].slice(
+      sampleIndex * componentCount,
+      (sampleIndex + 1) * componentCount
+    );
+    metadatasMap[name] = samples;
+  }
+  return metadatasMap;
+}
+
+Object.defineProperties(VoxelCell.prototype, {
+  /**
+   * Gets an object of the metadata values for this cell. The object's keys are the metadata names.
+   *
+   * @memberof VoxelCell.prototype
+   *
+   * @type {object}
+   *
+   * @readonly
+   * @private
+   */
+  metadatas: {
+    get: function () {
+      return this._metadatas;
+    },
+  },
+
+  /**
+   * All objects returned by {@link Scene#pick} have a <code>primitive</code> property. This returns
+   * the VoxelPrimitive containing the cell.
+   *
+   * @memberof VoxelCell.prototype
+   *
+   * @type {VoxelPrimitive}
+   *
+   * @readonly
+   */
+  primitive: {
+    get: function () {
+      return this._primitive;
+    },
+  },
+
+  /**
+   * Get the sample index of the cell.
+   *
+   * @memberof VoxelCell.prototype
+   *
+   * @type {number}
+   *
+   * @readonly
+   */
+  sampleIndex: {
+    get: function () {
+      return this._sampleIndex;
+    },
+  },
+
+  /**
+   * Get the index of the tile containing the cell.
+   * This is an arbitrary index based on the order of loading the tiles, for debugging purposes only
+   *
+   * @memberof VoxelCell.prototype
+   *
+   * @type {number}
+   *
+   * @readonly
+   * @private
+   */
+  tileIndex: {
+    get: function () {
+      return this._tileIndex;
+    },
+  },
+});
+
+/**
+ * Returns whether the feature contains this property.
+ *
+ * @param {string} name The case-sensitive name of the property.
+ * @returns {boolean} Whether the feature contains this property.
+ */
+VoxelCell.prototype.hasProperty = function (name) {
+  return defined(this._metadatas[name]);
+};
+
+/**
+ * Returns an array of metadata property names for the feature.
+ *
+ * @returns {string[]} The IDs of the feature's properties.
+ */
+VoxelCell.prototype.getNames = function () {
+  return Object.keys(this._metadatas);
+};
+
+/**
+ * Returns a copy of the value of the metadata in the cell with the given name.
+ *
+ * @param {string} name The case-sensitive name of the property.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
+ *
+ * @example
+ * // Display all the properties for a voxel cell in the console log.
+ * const names = voxelCell.getNames();
+ * for (let i = 0; i < names.length; ++i) {
+ *   const name = names[i];
+ *   console.log(`{name}: ${voxelCell.getProperty(name)}`);
+ * }
+ */
+VoxelCell.prototype.getProperty = function (name) {
+  return this._metadatas[name];
+};
+
+export default VoxelCell;

--- a/packages/engine/Specs/Scene/PickingSpec.js
+++ b/packages/engine/Specs/Scene/PickingSpec.js
@@ -236,10 +236,10 @@ describe(
       });
     });
 
-    describe("_pickVoxelCoordinate", function () {
+    describe("pickVoxelCoordinate", function () {
       it("does not pick undefined window positions", function () {
         expect(function () {
-          scene._pickVoxelCoordinate(undefined);
+          scene._picking.pickVoxelCoordinate(undefined);
         }).toThrowDeveloperError();
       });
 
@@ -250,10 +250,37 @@ describe(
         const primitive = new VoxelPrimitive({ provider });
         scene.primitives.add(primitive);
         scene.renderForSpecs();
-        const voxelCoordinate = scene._pickVoxelCoordinate(
+        const voxelCoordinate = scene._picking.pickVoxelCoordinate(
+          scene,
           new Cartesian2(0, 0)
         );
         expect(voxelCoordinate).toEqual(new Uint8Array(4));
+      });
+    });
+
+    describe("pickVoxel", function () {
+      it("does not pick undefined window positions", function () {
+        expect(function () {
+          scene.pickVoxel(undefined);
+        }).toThrowDeveloperError();
+      });
+
+      it("picks a voxel cell from a VoxelPrimitive", async function () {
+        const provider = await Cesium3DTilesVoxelProvider.fromUrl(
+          voxelTilesetUrl
+        );
+        const primitive = new VoxelPrimitive({ provider });
+        scene.primitives.add(primitive);
+        await pollToPromise(function () {
+          scene.renderForSpecs();
+          const traversal = primitive._traversal;
+          return traversal.isRenderable(traversal.rootNode);
+        });
+        const voxelCell = scene.pickVoxel(new Cartesian2(0, 0));
+        expect(voxelCell.tileIndex).toBe(0);
+        expect(voxelCell.sampleIndex).toBe(0);
+        expect(voxelCell.hasProperty("a")).toBe(true);
+        expect(voxelCell.getProperty("a")).toEqual(new Float32Array(1));
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR adds the public method `Scene.pickVoxel` to report information about a voxel cell under the cursor.

The return value from `Scene.pickVoxel` is an instance of the new `VoxelCell` class. This class includes getters to retrieve the values of the different properties contained in the voxel metadata.

## Testing plan

- Verify the additional specs in `PickingSpec` and `VoxelCellSpec` run successfully.
- Test mouseover picking in [this local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=3Vp9b9s2E/8qnLc/lNaV8zZgiJNgqZuuBuImqLOsbRy0tERbXClKD0k5dgp/9+dIinp1mvV5NjRdkEASeXc8/o53ujslSLhUaEHJLRHoCHFyiwZE0iz2r8yYN+kE5nmQcIUpJ2LS6aLPE47QFEtyhldEHDiWYYznRKzMoD8TSXwhkgUNiTiRKx54mgk52kvKyAinYyIWNCA5p6M3zL8LlrMUTNOMsnCUhBkjZrZzIiVRsndJlioTRPZeY7hidoqFiobDSWfLCjCXrW5N6wsafNK6zzCTxEzNSRIkYX1M0Zgw2HZ1DHMaY0UTXg6ut/oTPuGBQfMzkgHhpIsCHBOB0RqAtQgbInvrg8qEh16+Mzt4lSwJG3KZkkAlYkSXlGvBRpwfkmk2H0fJ7UsBcuUFEWMCC4YgXYmMGNmzjAdaM9iLGlH+PMl4KD0Z4ZRsWavRGbLP6OjoqLC1XnesRy9XKfFPz86GF+Pz4YucByG7sdhJRAXnAJCGO8z3/IAlnDQt1pC8Qa3cQn17LZbw72CRbX87HxcEDMvLaTO81lsu5mCYzMBUIcytW2Dg5d8NhpP4f4HRUKsBhps1YOxsm58WJI7oqyABTwtIqH1lTPmcEe2ORj3ngjWcVESlnwOFzLVfDFcPxQbzVggrgG3YekkYgs9xCVrKekQq4fV+6SL9W2Hi2ieA/hoCVsISCFM35aQCuM1kLmlEFA6xwsYMV6eD/QptkMQp2I6ry3uYBlUC/+XZ+cnl3u6NQ9geDhkIrIJooDVpbEIPeTZcPGgEPxWJSrT2viD/yYhUL0ABEFjY0RyxJNX3csJzc7kwpEDeGVkQ1jW3b+3lnb28N3EpZ+3bY6P9oWBCx3DmikO/4UQVp82uVzNbw5D9kkzvxhEYu1xv31SmBeZhEo8JgbhmV7bKPqnI91f1xyV6ane2efhtRbw1oLWKGRFZoN6YNTX6Gl6vFNE12nYrSm31aw4Ghoqp1NaRCVsQ77qQf6Mp1/17nG6UMUW/M5/b7yL9+7h8rhDxgekzO4DdKeDfd+74EOTf3MOayv8bHU6j/g/6mxa0yd3+p/Us/O74YRX5kGFaAa+zeKqTLhJ6dQXdXhf6ZLkjWMPlS2DeVSQEEea8lLHJdcCNC28wdJ7ew9Y9MU678kuWYLW3eyIEXnkVHZ/UlnNIz4DPY0Qhk4D14XJY1xbdPX1anNKCemWpV3XqFYxUqCv0S0u/rNMvYaRG7/bEiEiJeAtMS9RDXg3cZ/Ca6m9meAcMqwbD6ksM74HhrsFw5xhKll7PMkVAHmUEzr1T8AkkrT8Dg1tfP+8V8+/N825r8ahibH3mOFQH1UPntfXVTr/jbzeWaotmJo/+uTUe5CekmpeYuuuVZF7UReAcENVghW4tm6njYEVRiFFLFz3sz92D8WPD0LKlpPWz3a9HB7M0wpYGmA3XjCWQeTmJTzUo9c0UfnNtN1T3D81xY6KYBkrkAfkvcu6UnHNBCP8a3t2Sd8oy8jWse5q1AkXBu7Y363bJUMhslQyBIFiRC0FjqijE3jR/hUKdm0kF0TDC8JT7ri1ZU0csAbA4WZATxjwHeiVmFkJ1qtPkxGGYF1LV7kSNzSvihVPqoLjruqmqlge1p4IkhvKfwWERdHlQfcgJ1raPkOtf1xwOJYa3khrjOGWQzZdVeYvyT6qU6baY7oGhMFS2L7Co9QBMY2CkNfFbSNUH7AvAdBzgqK8uE5PpgSbjNCKCeA0lprXZrou4OlWyrQ0oNM22141XcGvVStlTBXVT7VOZtiabCTyHEKDsmG7jHKCPi4SGxcwIU+69zB+GPM0Umklz7ULcSeAxuIs/OFsRQTGDktjeGHMVR8ONQpY0m2VSI5hL8uP8Bevnzj2f9ltcxo3u58E2P/vYbAZVIfkjooo8ckgWJNjzIOpv3Y/ATt6CaG+24jK1kA3P++bdMg4ws22RdstEz58yojcl673CU8ZoKgEC/4/fxr/s66qGxln8Boc0k91/hNQ4+oTbzY0heAZYKkZ0MLpMEjbFYkR45l1X4FTGVJNOIRdezWX5gXT6OenkKgBahIGDH1TqjErWY9F0ESw/MQ+3bMo3wwOtLEdYGtmtWEaXZrgvhbciK2o7fnOFtY0l3Q14DVZMv77Eo4Nr8O5s+PrF6ZtHhdbzZPnogHp+/vbxYwRl3N8E0z3Nm+8NpS/EqW+O1fcWqb45YI8hVt1UUwEoRELW/KY4DnTxM05xQE4X8J5/ZYk8m/MHmC+w1EJynfUXunAAVRskqthkTmESZDpB0F2QPFd4vhpCfdBpEk86bUE2IX1YhmllavZ8E7oFZPKrE2NOr7Srrmm0gFpbME4glbpIJDU0R8gR+YSHbrjVNSKMlcUP6GHs69VEWcR1B/GHHM+8NegVIrYa7UPXNKx3LIe6WoSyXpcq9sF+o3RSDFcTUJ9CZSleXY7OgPSjaenZqvOnz4XMdReZ+qecqqyx/ljtOs6n+ApDOSurC2uTwJFPiVArr2gqV3tbwX1fVHzfL2Vu1Xag03OpVpC9TXHwaS505VN+A9CzKhlIaYbGkKvyualRYTP3HFvjcaPz38enH0bnV6eauNPtHJo1jvXKv9I4TYRCmWCgWE8RAAEglL1pBiopP5C5ij9qHd8QQ5wbrtTxmVHuwGDlbXdR/mvbFrlZf2w5iSvkqIQ1VwdgCf39+tmUJcGn3GVTyGJhlwdoJ4iKv70g2iBWo/QXJN7SUEUgj7gWQ0ToPFLVkfa+bnU5VHzqFHPKnzEyU0Ytp8phz6F6GNIFouHRhn9IQAHDUsLMLGOQxNyB8x8f9oC+xsYSrHd9viACtqFJop3jMzsIp+ewB49tLmWzfSDXGpXjpeHyqeZkPRgdm383COG8FYZya21mNSf/uKQpNMuv/wU).

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~ This will be done in the PR into main
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
