### PR TITLE
Improve handling of lost contexts in `SceneSpec`

### DIFF
--- a/Specs/getWebGLStub.js
+++ b/Specs/getWebGLStub.js
@@ -92,7 +92,7 @@ function getWebGLStub(canvas, options) {
   stub.getVertexAttribOffset = getStubWarning;
   stub.hint = noop;
   stub.isBuffer = getStubWarning;
-  stub.isContextLost = noop;
+  stub.isContextLost = getStubWarning;
   stub.isEnabled = getStubWarning;
   stub.isFramebuffer = getStubWarning;
   stub.isProgram = getStubWarning;

--- a/Specs/getWebGLStub.js
+++ b/Specs/getWebGLStub.js
@@ -92,7 +92,7 @@ function getWebGLStub(canvas, options) {
   stub.getVertexAttribOffset = getStubWarning;
   stub.hint = noop;
   stub.isBuffer = getStubWarning;
-  stub.isContextLost = getStubWarning;
+  stub.isContextLost = noop;
   stub.isEnabled = getStubWarning;
   stub.isFramebuffer = getStubWarning;
   stub.isProgram = getStubWarning;

--- a/packages/engine/Source/Core/Ellipsoid.js
+++ b/packages/engine/Source/Core/Ellipsoid.js
@@ -363,6 +363,12 @@ Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function (
  * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided, or undefined if a normal cannot be found.
  */
 Ellipsoid.prototype.geodeticSurfaceNormal = function (cartesian, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("cartesian", cartesian);
+  if (isNaN(cartesian.x) || isNaN(cartesian.y) || isNaN(cartesian.z)) {
+    throw new DeveloperError("cartesian has a NaN component");
+  }
+  //>>includeEnd('debug');
   if (
     Cartesian3.equalsEpsilon(cartesian, Cartesian3.ZERO, CesiumMath.EPSILON14)
   ) {

--- a/packages/engine/Source/Core/Transforms.js
+++ b/packages/engine/Source/Core/Transforms.js
@@ -127,6 +127,9 @@ Transforms.localFrameToFixedFrameGenerator = function (firstAxis, secondAxis) {
       if (!defined(origin)) {
         throw new DeveloperError("origin is required.");
       }
+      if (isNaN(origin.x) || isNaN(origin.y) || isNaN(origin.z)) {
+        throw new DeveloperError("origin has a NaN component");
+      }
       //>>includeEnd('debug');
       if (!defined(result)) {
         result = new Matrix4();

--- a/packages/engine/Source/Scene/Camera.js
+++ b/packages/engine/Source/Scene/Camera.js
@@ -1233,6 +1233,11 @@ const scratchSetViewMatrix3 = new Matrix3();
 const scratchSetViewCartographic = new Cartographic();
 
 function setView3D(camera, position, hpr) {
+  //>>includeStart('debug', pragmas.debug);
+  if (isNaN(position.x) || isNaN(position.y) || isNaN(position.z)) {
+    throw new DeveloperError("position has a NaN component");
+  }
+  //>>includeEnd('debug');
   const currentTransform = Matrix4.clone(
     camera.transform,
     scratchSetViewTransform1
@@ -1473,6 +1478,11 @@ Camera.prototype.setView = function (options) {
       destination,
       scratchSetViewCartesian
     );
+    //>>includeStart('debug', pragmas.debug);
+    if (isNaN(destination.x) || isNaN(destination.y) || isNaN(destination.z)) {
+      throw new DeveloperError("destination has a NaN component");
+    }
+    //>>includeEnd('debug');
     convert = false;
   }
 

--- a/packages/engine/Source/Scene/Camera.js
+++ b/packages/engine/Source/Scene/Camera.js
@@ -1479,8 +1479,9 @@ Camera.prototype.setView = function (options) {
       scratchSetViewCartesian
     );
     //>>includeStart('debug', pragmas.debug);
-    if (isNaN(destination.x) || isNaN(destination.y) || isNaN(destination.z)) {
-      throw new DeveloperError("destination has a NaN component");
+    // destination.z may be null in 2D, but .x and .y should be numeric
+    if (isNaN(destination.x) || isNaN(destination.y)) {
+      throw new DeveloperError(`destination has a NaN component`);
     }
     //>>includeEnd('debug');
     convert = false;

--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -467,14 +467,12 @@ describe(
         }
       }
 
-      const s = createScene();
-
-      if (defined(s._oit)) {
-        s._oit._translucentMRTSupport = false;
-        s._oit._translucentMultipassSupport = false;
+      if (defined(scene._oit)) {
+        scene._oit._translucentMRTSupport = false;
+        scene._oit._translucentMultipassSupport = false;
       }
 
-      s.postProcessStages.fxaa.enabled = false;
+      scene.postProcessStages.fxaa.enabled = false;
 
       const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
@@ -486,34 +484,27 @@ describe(
         1.0
       );
 
-      const primitives = s.primitives;
+      const primitives = scene.primitives;
       primitives.add(rectanglePrimitive);
 
-      s.camera.setView({ destination: rectangle });
+      scene.camera.setView({ destination: rectangle });
 
-      expect(s).toRenderAndCall(function (rgba) {
+      expect(scene).toRenderAndCall(function (rgba) {
         expect(rgba[0]).not.toEqual(0);
         expect(rgba[1]).toEqual(0);
         expect(rgba[2]).toEqual(0);
       });
-
-      s.destroyForSpecs();
     });
 
     it("setting a globe", function () {
-      const scene = createScene();
       const ellipsoid = Ellipsoid.UNIT_SPHERE;
       const globe = new Globe(ellipsoid);
       scene.globe = globe;
 
       expect(scene.globe).toBe(globe);
-
-      scene.destroyForSpecs();
     });
 
     it("sets verticalExaggeration and verticalExaggerationRelativeHeight", function () {
-      const scene = createScene();
-
       expect(scene.verticalExaggeration).toEqual(1.0);
       expect(scene.verticalExaggerationRelativeHeight).toEqual(0.0);
 
@@ -525,7 +516,6 @@ describe(
     });
 
     it("destroys primitive on set globe", function () {
-      const scene = createScene();
       const globe = new Globe(Ellipsoid.UNIT_SPHERE);
 
       scene.globe = globe;
@@ -533,8 +523,6 @@ describe(
 
       scene.globe = undefined;
       expect(globe.isDestroyed()).toEqual(true);
-
-      scene.destroyForSpecs();
     });
 
     describe("render tests", function () {
@@ -674,69 +662,61 @@ describe(
     });
 
     it("renders with multipass OIT if MRT is available", function () {
-      if (!scene.context.drawBuffers) {
+      if (!scene.context.drawBuffers || !defined(scene._oit)) {
         return;
       }
-      const s = createScene();
-      if (defined(s._oit)) {
-        s._oit._translucentMRTSupport = false;
-        s._oit._translucentMultipassSupport = true;
+      scene._oit._translucentMRTSupport = false;
+      scene._oit._translucentMultipassSupport = true;
 
-        const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
+      const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        const rectanglePrimitive = createRectangle(rectangle, 1000.0);
-        rectanglePrimitive.appearance.material.uniforms.color = new Color(
-          1.0,
-          0.0,
-          0.0,
-          0.5
-        );
+      const rectanglePrimitive = createRectangle(rectangle, 1000.0);
+      rectanglePrimitive.appearance.material.uniforms.color = new Color(
+        1.0,
+        0.0,
+        0.0,
+        0.5
+      );
 
-        const primitives = s.primitives;
-        primitives.add(rectanglePrimitive);
+      const primitives = scene.primitives;
+      primitives.add(rectanglePrimitive);
 
-        s.camera.setView({ destination: rectangle });
+      scene.camera.setView({ destination: rectangle });
 
-        expect(s).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).not.toEqual(0);
-          expect(rgba[1]).toEqual(0);
-          expect(rgba[2]).toEqual(0);
-        });
-      }
-      s.destroyForSpecs();
+      expect(scene).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).not.toEqual(0);
+        expect(rgba[1]).toEqual(0);
+        expect(rgba[2]).toEqual(0);
+      });
     });
 
     it("renders with alpha blending if floating point textures are available", function () {
-      if (!scene.context.floatingPointTexture) {
+      if (!scene.context.floatingPointTexture || !defined(scene._oit)) {
         return;
       }
-      const s = createScene();
-      if (defined(s._oit)) {
-        s._oit._translucentMRTSupport = false;
-        s._oit._translucentMultipassSupport = false;
+      scene._oit._translucentMRTSupport = false;
+      scene._oit._translucentMultipassSupport = false;
 
-        const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
+      const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        const rectanglePrimitive = createRectangle(rectangle, 1000.0);
-        rectanglePrimitive.appearance.material.uniforms.color = new Color(
-          1.0,
-          0.0,
-          0.0,
-          0.5
-        );
+      const rectanglePrimitive = createRectangle(rectangle, 1000.0);
+      rectanglePrimitive.appearance.material.uniforms.color = new Color(
+        1.0,
+        0.0,
+        0.0,
+        0.5
+      );
 
-        const primitives = s.primitives;
-        primitives.add(rectanglePrimitive);
+      const primitives = scene.primitives;
+      primitives.add(rectanglePrimitive);
 
-        s.camera.setView({ destination: rectangle });
+      scene.camera.setView({ destination: rectangle });
 
-        expect(s).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).not.toEqual(0);
-          expect(rgba[1]).toEqual(0);
-          expect(rgba[2]).toEqual(0);
-        });
-      }
-      s.destroyForSpecs();
+      expect(scene).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).not.toEqual(0);
+        expect(rgba[1]).toEqual(0);
+        expect(rgba[2]).toEqual(0);
+      });
     });
 
     it("renders map twice when in 2D", function () {
@@ -813,8 +793,7 @@ describe(
         return;
       }
 
-      const s = createScene();
-      s.highDynamicRange = true;
+      scene.highDynamicRange = true;
 
       const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
@@ -826,47 +805,43 @@ describe(
         1.0
       );
 
-      const primitives = s.primitives;
+      const primitives = scene.primitives;
       primitives.add(rectanglePrimitive);
 
-      s.camera.setView({ destination: rectangle });
+      scene.camera.setView({ destination: rectangle });
 
-      expect(s).toRenderAndCall(function (rgba) {
+      expect(scene).toRenderAndCall(function (rgba) {
         expect(rgba[0]).toBeGreaterThan(0);
         expect(rgba[0]).toBeLessThanOrEqual(255);
         expect(rgba[1]).toEqual(0);
         expect(rgba[2]).toEqual(0);
       });
-
-      s.destroyForSpecs();
     });
 
     it("copies the globe depth", function () {
-      const scene = createScene();
-      if (scene.context.depthTexture) {
-        const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
-
-        const rectanglePrimitive = createRectangle(rectangle, 1000.0);
-        rectanglePrimitive.appearance.material.uniforms.color = new Color(
-          1.0,
-          0.0,
-          0.0,
-          0.5
-        );
-
-        const primitives = scene.primitives;
-        primitives.add(rectanglePrimitive);
-
-        scene.camera.setView({ destination: rectangle });
-
-        const uniformState = scene.context.uniformState;
-
-        expect(scene).toRenderAndCall(function (rgba) {
-          expect(uniformState.globeDepthTexture).toBeDefined();
-        });
+      if (!scene.context.depthTexture) {
+        return;
       }
+      const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-      scene.destroyForSpecs();
+      const rectanglePrimitive = createRectangle(rectangle, 1000.0);
+      rectanglePrimitive.appearance.material.uniforms.color = new Color(
+        1.0,
+        0.0,
+        0.0,
+        0.5
+      );
+
+      const primitives = scene.primitives;
+      primitives.add(rectanglePrimitive);
+
+      scene.camera.setView({ destination: rectangle });
+
+      const uniformState = scene.context.uniformState;
+
+      expect(scene).toRenderAndCall(function (rgba) {
+        expect(uniformState.globeDepthTexture).toBeDefined();
+      });
     });
 
     it("pickPosition", function () {
@@ -1155,311 +1130,267 @@ describe(
     });
 
     it("a render error is rethrown if rethrowRenderErrors is true", function () {
-      const s = createScene();
-      s.rethrowRenderErrors = true;
+      scene.rethrowRenderErrors = true;
 
       const spyListener = jasmine.createSpy("listener");
-      s.renderError.addEventListener(spyListener);
+      scene.renderError.addEventListener(spyListener);
 
       const error = new RuntimeError("error");
-      s.primitives.update = function () {
+      scene.primitives.update = function () {
         throw error;
       };
 
       expect(function () {
-        s.render();
+        scene.render();
       }).toThrowError(RuntimeError);
 
-      expect(spyListener).toHaveBeenCalledWith(s, error);
-
-      s.destroyForSpecs();
+      expect(spyListener).toHaveBeenCalledWith(scene, error);
     });
 
     it("always raises preUpdate event prior to updating", function () {
-      const s = createScene();
-
       const spyListener = jasmine.createSpy("listener");
-      s.preUpdate.addEventListener(spyListener);
+      scene.preUpdate.addEventListener(spyListener);
 
-      s.render();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
-      s.requestRenderMode = true;
-      s.maximumRenderTimeChange = undefined;
+      scene.requestRenderMode = true;
+      scene.maximumRenderTimeChange = undefined;
 
-      s.render();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(2);
-
-      s.destroyForSpecs();
     });
 
     it("always raises postUpdate event after updating", function () {
-      const s = createScene();
-
       const spyListener = jasmine.createSpy("listener");
-      s.postUpdate.addEventListener(spyListener);
+      scene.postUpdate.addEventListener(spyListener);
 
-      s.render();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
-      s.requestRenderMode = true;
-      s.maximumRenderTimeChange = undefined;
+      scene.requestRenderMode = true;
+      scene.maximumRenderTimeChange = undefined;
 
-      s.render();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(2);
-
-      s.destroyForSpecs();
     });
 
     it("raises the preRender event prior to rendering only if the scene renders", function () {
-      const s = createScene();
-
       const spyListener = jasmine.createSpy("listener");
-      s.preRender.addEventListener(spyListener);
+      scene.preRender.addEventListener(spyListener);
 
-      s.render();
-
-      expect(spyListener.calls.count()).toBe(1);
-
-      s.requestRenderMode = true;
-      s.maximumRenderTimeChange = undefined;
-
-      s.render();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
-      s.destroyForSpecs();
+      scene.requestRenderMode = true;
+      scene.maximumRenderTimeChange = undefined;
+
+      scene.render();
+
+      expect(spyListener.calls.count()).toBe(1);
     });
 
     it("raises the postRender event after rendering if the scene rendered", function () {
-      const s = createScene();
-
       const spyListener = jasmine.createSpy("listener");
-      s.postRender.addEventListener(spyListener);
+      scene.postRender.addEventListener(spyListener);
 
-      s.render();
-
-      expect(spyListener.calls.count()).toBe(1);
-
-      s.requestRenderMode = true;
-      s.maximumRenderTimeChange = undefined;
-
-      s.render();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
-      s.destroyForSpecs();
+      scene.requestRenderMode = true;
+      scene.maximumRenderTimeChange = undefined;
+
+      scene.render();
+
+      expect(spyListener.calls.count()).toBe(1);
     });
 
     it("raises the cameraMoveStart event after moving the camera", function () {
-      const s = createScene();
-      s.render();
+      scene.render();
 
       const spyListener = jasmine.createSpy("listener");
-      s.camera.moveStart.addEventListener(spyListener);
-      s._cameraStartFired = false; // reset this value after camera changes for initial render trigger the event
+      scene.camera.moveStart.addEventListener(spyListener);
+      scene._cameraStartFired = false; // reset this value after camera changes for initial render trigger the event
 
-      s.camera.moveLeft();
-      s.render();
+      scene.camera.moveLeft();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
-
-      s.destroyForSpecs();
     });
 
     it("raises the cameraMoveEvent event when the camera stops moving", function () {
-      const s = createScene();
-      s.render();
+      scene.render();
 
       const spyListener = jasmine.createSpy("listener");
-      s.camera.moveEnd.addEventListener(spyListener);
+      scene.camera.moveEnd.addEventListener(spyListener);
 
       // We use negative time here to ensure the event runs on the next frame.
-      s.cameraEventWaitTime = -1.0;
-      s.camera.moveLeft();
+      scene.cameraEventWaitTime = -1.0;
+      scene.camera.moveLeft();
       // The first render will trigger the moveStart event.
-      s.render();
+      scene.render();
       // The second will trigger the moveEnd.
-      s.render();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
-
-      s.destroyForSpecs();
     });
 
     it("raises the camera changed event on direction changed", function () {
-      const s = createScene();
-
       const spyListener = jasmine.createSpy("listener");
-      s.camera.changed.addEventListener(spyListener);
+      scene.camera.changed.addEventListener(spyListener);
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
-      s.camera.lookLeft(
-        s.camera.frustum.fov * (s.camera.percentageChanged + 0.1)
+      scene.camera.lookLeft(
+        scene.camera.frustum.fov * (scene.camera.percentageChanged + 0.1)
       );
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
       const args = spyListener.calls.allArgs();
       expect(args.length).toEqual(1);
       expect(args[0].length).toEqual(1);
-      expect(args[0][0]).toBeGreaterThan(s.camera.percentageChanged);
-
-      s.destroyForSpecs();
+      expect(args[0][0]).toBeGreaterThan(scene.camera.percentageChanged);
     });
 
     it("raises the camera changed event on heading changed", function () {
-      const s = createScene();
-
       const spyListener = jasmine.createSpy("listener");
-      s.camera.changed.addEventListener(spyListener);
+      scene.camera.changed.addEventListener(spyListener);
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
-      s.camera.twistLeft(CesiumMath.PI * (s.camera.percentageChanged + 0.1));
+      scene.camera.twistLeft(
+        CesiumMath.PI * (scene.camera.percentageChanged + 0.1)
+      );
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
       const args = spyListener.calls.allArgs();
       expect(args.length).toEqual(1);
       expect(args[0].length).toEqual(1);
-      expect(args[0][0]).toBeGreaterThan(s.camera.percentageChanged);
-
-      s.destroyForSpecs();
+      expect(args[0][0]).toBeGreaterThan(scene.camera.percentageChanged);
     });
 
     it("raises the camera changed event on position changed", function () {
-      const s = createScene();
-
       const spyListener = jasmine.createSpy("listener");
-      s.camera.changed.addEventListener(spyListener);
+      scene.camera.changed.addEventListener(spyListener);
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
-      s.camera.moveUp(
-        s.camera.positionCartographic.height *
-          (s.camera.percentageChanged + 0.1)
+      scene.camera.moveUp(
+        scene.camera.positionCartographic.height *
+          (scene.camera.percentageChanged + 0.1)
       );
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
       const args = spyListener.calls.allArgs();
       expect(args.length).toEqual(1);
       expect(args[0].length).toEqual(1);
-      expect(args[0][0]).toBeGreaterThan(s.camera.percentageChanged);
-
-      s.destroyForSpecs();
+      expect(args[0][0]).toBeGreaterThan(scene.camera.percentageChanged);
     });
 
     it("raises the camera changed event in 2D", function () {
-      const s = createScene();
-      s.morphTo2D(0);
+      scene.morphTo2D(0);
 
       const spyListener = jasmine.createSpy("listener");
-      s.camera.changed.addEventListener(spyListener);
+      scene.camera.changed.addEventListener(spyListener);
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
-      s.camera.moveLeft(
-        s.camera.positionCartographic.height *
-          (s.camera.percentageChanged + 0.1)
+      scene.camera.moveLeft(
+        scene.camera.positionCartographic.height *
+          (scene.camera.percentageChanged + 0.1)
       );
 
-      s.initializeFrame();
-      s.render();
+      scene.initializeFrame();
+      scene.render();
 
       expect(spyListener.calls.count()).toBe(1);
 
       const args = spyListener.calls.allArgs();
       expect(args.length).toEqual(1);
       expect(args[0].length).toEqual(1);
-      expect(args[0][0]).toBeGreaterThan(s.camera.percentageChanged);
-
-      s.destroyForSpecs();
+      expect(args[0][0]).toBeGreaterThan(scene.camera.percentageChanged);
     });
 
     it("get maximumAliasedLineWidth", function () {
-      const s = createScene();
-      expect(s.maximumAliasedLineWidth).toBeGreaterThanOrEqual(1);
-      s.destroyForSpecs();
+      expect(scene.maximumAliasedLineWidth).toBeGreaterThanOrEqual(1);
     });
 
     it("get maximumCubeMapSize", function () {
-      const s = createScene();
-      expect(s.maximumCubeMapSize).toBeGreaterThanOrEqual(16);
-      s.destroyForSpecs();
+      expect(scene.maximumCubeMapSize).toBeGreaterThanOrEqual(16);
     });
 
     it("does not throw with debugShowCommands", function () {
-      const s = createScene();
-      if (s.context.drawBuffers) {
-        s.debugShowCommands = true;
-
-        const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
-
-        const rectanglePrimitive = createRectangle(rectangle, 1000.0);
-        rectanglePrimitive.appearance.material.uniforms.color = new Color(
-          1.0,
-          0.0,
-          0.0,
-          0.5
-        );
-
-        const primitives = s.primitives;
-        primitives.add(rectanglePrimitive);
-
-        s.camera.setView({ destination: rectangle });
-
-        expect(function () {
-          s.renderForSpecs();
-        }).not.toThrowError(RuntimeError);
+      if (!scene.context.drawBuffers) {
+        return;
       }
-      s.destroyForSpecs();
+      scene.debugShowCommands = true;
+
+      const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
+
+      const rectanglePrimitive = createRectangle(rectangle, 1000.0);
+      rectanglePrimitive.appearance.material.uniforms.color = new Color(
+        1.0,
+        0.0,
+        0.0,
+        0.5
+      );
+
+      const primitives = scene.primitives;
+      primitives.add(rectanglePrimitive);
+
+      scene.camera.setView({ destination: rectangle });
+
+      expect(function () {
+        scene.renderForSpecs();
+      }).not.toThrowError(RuntimeError);
     });
 
     it("does not throw with debugShowFrustums", function () {
-      const s = createScene();
-      if (s.context.drawBuffers) {
-        s.debugShowFrustums = true;
-
-        const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
-
-        const rectanglePrimitive = createRectangle(rectangle, 1000.0);
-        rectanglePrimitive.appearance.material.uniforms.color = new Color(
-          1.0,
-          0.0,
-          0.0,
-          0.5
-        );
-
-        const primitives = s.primitives;
-        primitives.add(rectanglePrimitive);
-
-        s.camera.setView({ destination: rectangle });
-
-        expect(function () {
-          s.renderForSpecs();
-        }).not.toThrowError(RuntimeError);
+      if (!scene.context.drawBuffers) {
+        return;
       }
-      s.destroyForSpecs();
+      scene.debugShowFrustums = true;
+
+      const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
+
+      const rectanglePrimitive = createRectangle(rectangle, 1000.0);
+      rectanglePrimitive.appearance.material.uniforms.color = new Color(
+        1.0,
+        0.0,
+        0.0,
+        0.5
+      );
+
+      const primitives = scene.primitives;
+      primitives.add(rectanglePrimitive);
+
+      scene.camera.setView({ destination: rectangle });
+
+      expect(function () {
+        scene.renderForSpecs();
+      }).not.toThrowError(RuntimeError);
     });
 
     it("throws when minimumDisableDepthTestDistance is set less than 0.0", function () {
@@ -1494,31 +1425,24 @@ describe(
     });
 
     it("Gets imageryLayers", function () {
-      const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
       expect(scene.imageryLayers).toBe(globe.imageryLayers);
 
       scene.globe = undefined;
       expect(scene.imageryLayers).toBeUndefined();
-
-      scene.destroyForSpecs();
     });
 
     it("Gets terrainProvider", function () {
-      const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
       expect(scene.terrainProvider).toBe(globe.terrainProvider);
 
       scene.globe = undefined;
       expect(scene.terrainProvider).toBeUndefined();
-
-      scene.destroyForSpecs();
     });
 
     it("Sets terrainProvider", async function () {
       returnQuantizedMeshTileJson();
 
-      const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
       scene.terrainProvider = await CesiumTerrainProvider.fromUrl(
         "//terrain/tiles"
@@ -1532,7 +1456,7 @@ describe(
       expect(function () {
         scene.terrainProvider = newProvider;
       }).not.toThrow();
-      scene.destroyForSpecs();
+
       Resource._Implementations.loadWithXhr =
         Resource._DefaultImplementations.loadWithXhr;
     });
@@ -1540,7 +1464,6 @@ describe(
     it("setTerrain updates terrain provider", async function () {
       returnQuantizedMeshTileJson();
 
-      const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
       const promise = CesiumTerrainProvider.fromUrl("//terrain/tiles");
       scene.setTerrain(new Terrain(promise));
@@ -1558,15 +1481,14 @@ describe(
 
       expect(terrainWasChanged).toBeTrue();
 
-      scene.destroyForSpecs();
       Resource._Implementations.loadWithXhr =
         Resource._DefaultImplementations.loadWithXhr;
     });
 
     it("setTerrain handles destroy", async function () {
+      const scene = createScene();
       returnQuantizedMeshTileJson();
 
-      const scene = createScene();
       scene.globe = new Globe(Ellipsoid.UNIT_SPHERE);
 
       const promise = CesiumTerrainProvider.fromUrl("//newTerrain/tiles");
@@ -1581,18 +1503,14 @@ describe(
     });
 
     it("Gets terrainProviderChanged", function () {
-      const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
       expect(scene.terrainProviderChanged).toBe(globe.terrainProviderChanged);
 
       scene.globe = undefined;
       expect(scene.terrainProviderChanged).toBeUndefined();
-
-      scene.destroyForSpecs();
     });
 
     it("Sets material", function () {
-      const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
       const material = Material.fromType("ElevationContour");
       globe.material = material;
@@ -1600,15 +1518,11 @@ describe(
 
       globe.material = undefined;
       expect(globe.material).toBeUndefined();
-
-      scene.destroyForSpecs();
     });
 
     const scratchTime = new JulianDate();
 
     it("doesn't render scene if requestRenderMode is enabled", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1617,13 +1531,9 @@ describe(
       scene.maximumRenderTimeChange = undefined;
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("requestRender causes a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1637,13 +1547,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("moving the camera causes a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1656,13 +1562,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("changing the camera frustum does not cause continuous rendering in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       let lastFrameNumber = scene.frameState.frameNumber;
@@ -1681,13 +1583,9 @@ describe(
       lastFrameNumber = scene.frameState.frameNumber;
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("successful completed requests causes a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1704,13 +1602,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("data returning from a web worker causes a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1727,13 +1621,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("Executing an after render function causes a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1755,13 +1645,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("Globe tile loading triggers a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       let lastFrameNumber = scene.frameState.frameNumber;
@@ -1782,13 +1668,9 @@ describe(
       expect(scene._renderRequested).toBe(true);
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("Globe imagery updates triggers a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1808,13 +1690,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("Globe changing terrain providers triggers a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1834,12 +1712,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("scene morphing causes a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
       scene.renderForSpecs();
 
       let lastFrameNumber = scene.frameState.frameNumber;
@@ -1892,13 +1767,9 @@ describe(
 
       scene.renderForSpecs();
       expect(scene.frameState.frameNumber).toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("time change exceeding maximumRenderTimeChange causes a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1925,13 +1796,9 @@ describe(
         JulianDate.addSeconds(lastRenderTime, 150.0, new JulianDate())
       );
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("undefined maximumRenderTimeChange will not cause a new frame to be rendered in requestRenderMode", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1955,13 +1822,9 @@ describe(
       scene.renderForSpecs(farFuture);
 
       expect(scene.frameState.frameNumber).toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     it("forceRender renders a scene regardless of whether a render was requested", function () {
-      const scene = createScene();
-
       scene.renderForSpecs();
 
       const lastFrameNumber = scene.frameState.frameNumber;
@@ -1972,8 +1835,6 @@ describe(
 
       scene.forceRender();
       expect(scene.frameState.frameNumber).not.toEqual(lastFrameNumber);
-
-      scene.destroyForSpecs();
     });
 
     function getFrustumCommandsLength(scene, pass) {
@@ -1992,7 +1853,6 @@ describe(
     }
 
     it("occludes primitive", function () {
-      const scene = createScene();
       scene.globe = new Globe(Ellipsoid.WGS84);
 
       const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
@@ -2033,12 +1893,9 @@ describe(
       scene.globe.show = false;
       scene.renderForSpecs();
       expect(getFrustumCommandsLength(scene)).toBe(1);
-
-      scene.destroyForSpecs();
     });
 
     it("does not occlude if DrawCommand.occlude is false", function () {
-      const scene = createScene();
       scene.globe = new Globe(Ellipsoid.WGS84);
 
       const rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
@@ -2062,12 +1919,9 @@ describe(
       });
       scene.renderForSpecs();
       expect(getFrustumCommandsLength(scene)).toBe(1);
-
-      scene.destroyForSpecs();
     });
 
     it("sets light", function () {
-      const scene = createScene();
       const uniformState = scene.context.uniformState;
       const lightDirectionWC = uniformState._lightDirectionWC;
       const sunDirectionWC = uniformState._sunDirectionWC;
@@ -2107,8 +1961,6 @@ describe(
       expect(lightDirectionWC).toEqual(sunDirectionWC);
       expect(lightColor).toEqual(new Cartesian3(1.0, 1.0, 1.0));
       expect(lightColorHdr).toEqual(new Cartesian3(2.0, 2.0, 2.0));
-
-      scene.destroyForSpecs();
     });
 
     function updateGlobeUntilDone(scene) {
@@ -2119,7 +1971,6 @@ describe(
     }
 
     it("detects when camera is underground", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2148,37 +1999,29 @@ describe(
         })
         .then(function () {
           expect(scene.cameraUnderground).toBe(true);
-          scene.destroyForSpecs();
         });
     });
 
     it("detects that camera is above ground if globe is undefined", function () {
-      const scene = createScene();
       scene.renderForSpecs();
       expect(scene.cameraUnderground).toBe(false);
-      scene.destroyForSpecs();
     });
 
     it("detects that camera is above ground if scene mode is 2D", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
       scene.morphTo2D(0.0);
       expect(scene.cameraUnderground).toBe(false);
-      scene.destroyForSpecs();
     });
 
     it("detects that camera is above ground if scene mode is morphing", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
       scene.morphTo2D(1.0);
       expect(scene.cameraUnderground).toBe(false);
-      scene.destroyForSpecs();
     });
 
     it("detects that camera is underground in Columbus View", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2200,12 +2043,10 @@ describe(
       return updateGlobeUntilDone(scene).then(function () {
         scene.renderForSpecs();
         expect(scene.cameraUnderground).toBe(true);
-        scene.destroyForSpecs();
       });
     });
 
     it("does not occlude primitives when camera is underground", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2251,12 +2092,10 @@ describe(
         .then(function () {
           scene.renderForSpecs();
           expect(getFrustumCommandsLength(scene, Pass.OPAQUE)).toBe(1);
-          scene.destroyForSpecs();
         });
     });
 
     it("does not occlude primitives when the globe is translucent", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2288,12 +2127,9 @@ describe(
 
       scene.renderForSpecs();
       expect(getFrustumCommandsLength(scene, Pass.OPAQUE)).toBe(1);
-
-      scene.destroyForSpecs();
     });
 
     it("does not render environment when camera is underground and translucency is disabled", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
       scene.sun = new Sun();
@@ -2324,12 +2160,10 @@ describe(
         globe.translucency.enabled = false;
         scene.renderForSpecs(time);
         expect(scene.environmentState.isSunVisible).toBe(false);
-        scene.destroyForSpecs(time);
       });
     });
 
     it("renders globe with translucency", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2357,13 +2191,11 @@ describe(
 
         expect(scene).toRenderAndCall(function (rgba) {
           expect(rgba).not.toEqual(opaqueColor);
-          scene.destroyForSpecs();
         });
       });
     });
 
     it("renders ground primitive on translucent globe", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
       globe.baseColor = Color.BLACK;
@@ -2408,13 +2240,11 @@ describe(
       return updateGlobeUntilDone(scene).then(function () {
         expect(scene).toRenderAndCall(function (rgba) {
           expect(rgba[0]).toBeGreaterThan(0);
-          scene.destroyForSpecs();
         });
       });
     });
 
     it("picks ground primitive on translucent globe", function () {
-      const scene = createScene();
       const globe = new Globe();
       scene.globe = globe;
       globe.baseColor = Color.BLACK;
@@ -2458,12 +2288,10 @@ describe(
 
       return updateGlobeUntilDone(scene).then(function () {
         expect(scene).toPickPrimitive(primitive);
-        scene.destroyForSpecs();
       });
     });
 
     it("updates frameState.atmosphere", function () {
-      const scene = createScene();
       const frameState = scene.frameState;
 
       // Before the first render, the atmosphere has not yet been set

--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -11,7 +11,6 @@ import {
   GeometryInstance,
   HeadingPitchRoll,
   JulianDate,
-  PerspectiveFrustum,
   PixelFormat,
   Rectangle,
   RectangleGeometry,
@@ -60,12 +59,21 @@ describe(
   "Scene/Scene",
   function () {
     let scene;
-    let simpleShaderProgram;
-    let simpleRenderState;
 
     beforeAll(function () {
+      return GroundPrimitive.initializeTerrainHeights();
+    });
+
+    beforeEach(function () {
       scene = createScene();
-      simpleShaderProgram = ShaderProgram.fromCache({
+    });
+
+    afterEach(function () {
+      scene.destroyForSpecs();
+    });
+
+    function getSimpleShaderProgram() {
+      return ShaderProgram.fromCache({
         context: scene.context,
         vertexShaderSource: new ShaderSource({
           sources: ["void main() { gl_Position = vec4(1.0); }"],
@@ -74,49 +82,7 @@ describe(
           sources: ["void main() { out_FragColor = vec4(1.0); }"],
         }),
       });
-      simpleRenderState = new RenderState();
-
-      const camera = scene.camera;
-      camera.frustum = new PerspectiveFrustum();
-      camera.frustum.aspectRatio =
-        scene.drawingBufferWidth / scene.drawingBufferHeight;
-      camera.frustum.fov = CesiumMath.toRadians(60.0);
-
-      return GroundPrimitive.initializeTerrainHeights();
-    });
-
-    afterEach(function () {
-      scene.backgroundColor = new Color(0.0, 0.0, 0.0, 0.0);
-      scene.debugCommandFilter = undefined;
-      scene.postProcessStages.fxaa.enabled = false;
-      scene.primitives.removeAll();
-      scene.morphTo3D(0.0);
-
-      const camera = scene.camera;
-      camera.frustum = new PerspectiveFrustum();
-      camera.frustum.aspectRatio =
-        scene.drawingBufferWidth / scene.drawingBufferHeight;
-      camera.frustum.fov = CesiumMath.toRadians(60.0);
-    });
-
-    beforeEach(function () {
-      if (scene.context._gl.isContextLost()) {
-        scene = createScene();
-        simpleShaderProgram = ShaderProgram.fromCache({
-          context: scene.context,
-          vertexShaderSource: new ShaderSource({
-            sources: ["void main() { gl_Position = vec4(1.0); }"],
-          }),
-          fragmentShaderSource: new ShaderSource({
-            sources: ["void main() { out_FragColor = vec4(1.0); }"],
-          }),
-        });
-      }
-    });
-
-    afterAll(function () {
-      scene.destroyForSpecs();
-    });
+    }
 
     function returnTileJson(path) {
       Resource._Implementations.loadWithXhr = function (
@@ -260,8 +226,8 @@ describe(
 
     it("debugCommandFilter filters commands", function () {
       const c = new DrawCommand({
-        shaderProgram: simpleShaderProgram,
-        renderState: simpleRenderState,
+        shaderProgram: getSimpleShaderProgram(),
+        renderState: new RenderState(),
         pass: Pass.OPAQUE,
       });
       c.execute = function () {};
@@ -282,8 +248,8 @@ describe(
       scene.logarithmicDepthBuffer = false;
 
       const c = new DrawCommand({
-        shaderProgram: simpleShaderProgram,
-        renderState: simpleRenderState,
+        shaderProgram: getSimpleShaderProgram(),
+        renderState: new RenderState(),
         pass: Pass.OPAQUE,
       });
       c.execute = function () {};
@@ -310,8 +276,8 @@ describe(
       );
 
       const c = new DrawCommand({
-        shaderProgram: simpleShaderProgram,
-        renderState: simpleRenderState,
+        shaderProgram: getSimpleShaderProgram(),
+        renderState: new RenderState(),
         pass: Pass.OPAQUE,
         debugShowBoundingVolume: true,
         boundingVolume: new BoundingSphere(center, radius),
@@ -333,8 +299,8 @@ describe(
       scene.logarithmicDepthBuffer = false;
 
       const c = new DrawCommand({
-        shaderProgram: simpleShaderProgram,
-        renderState: simpleRenderState,
+        shaderProgram: getSimpleShaderProgram(),
+        renderState: new RenderState(),
         pass: Pass.OPAQUE,
       });
       c.execute = function () {};
@@ -2253,8 +2219,8 @@ describe(
       const radius = 10.0;
 
       const command = new DrawCommand({
-        shaderProgram: simpleShaderProgram,
-        renderState: simpleRenderState,
+        shaderProgram: getSimpleShaderProgram(),
+        renderState: new RenderState(),
         pass: Pass.OPAQUE,
         boundingVolume: new BoundingSphere(center, radius),
       });
@@ -2304,8 +2270,8 @@ describe(
       const radius = 10.0;
 
       const command = new DrawCommand({
-        shaderProgram: simpleShaderProgram,
-        renderState: simpleRenderState,
+        shaderProgram: getSimpleShaderProgram(),
+        renderState: new RenderState(),
         pass: Pass.OPAQUE,
         boundingVolume: new BoundingSphere(center, radius),
       });

--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -1970,36 +1970,31 @@ describe(
       });
     }
 
-    it("detects when camera is underground", function () {
+    it("detects when camera is underground", async function () {
       const globe = new Globe();
       scene.globe = globe;
 
       scene.camera.setView({
         destination: new Rectangle(0.0001, 0.0001, 0.003, 0.003),
       });
+      await updateGlobeUntilDone(scene);
+      expect(scene.cameraUnderground).toBe(false);
 
-      return updateGlobeUntilDone(scene)
-        .then(function () {
-          expect(scene.cameraUnderground).toBe(false);
-
-          // Look underground
-          scene.camera.setView({
-            destination: new Cartesian3(
-              -746658.0557573901,
-              -5644191.0002196245,
-              2863585.099969967
-            ),
-            orientation: new HeadingPitchRoll(
-              0.3019699121236403,
-              0.07316306869231592,
-              0.0007089903642230055
-            ),
-          });
-          return updateGlobeUntilDone(scene);
-        })
-        .then(function () {
-          expect(scene.cameraUnderground).toBe(true);
-        });
+      // Look underground
+      scene.camera.setView({
+        destination: new Cartesian3(
+          -746658.0557573901,
+          -5644191.0002196245,
+          2863585.099969967
+        ),
+        orientation: new HeadingPitchRoll(
+          0.3019699121236403,
+          0.07316306869231592,
+          0.0007089903642230055
+        ),
+      });
+      await updateGlobeUntilDone(scene);
+      expect(scene.cameraUnderground).toBe(true);
     });
 
     it("detects that camera is above ground if globe is undefined", function () {
@@ -2021,7 +2016,7 @@ describe(
       expect(scene.cameraUnderground).toBe(false);
     });
 
-    it("detects that camera is underground in Columbus View", function () {
+    it("detects that camera is underground in Columbus View", async function () {
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2040,13 +2035,12 @@ describe(
       });
       scene.morphToColumbusView(0.0);
 
-      return updateGlobeUntilDone(scene).then(function () {
-        scene.renderForSpecs();
-        expect(scene.cameraUnderground).toBe(true);
-      });
+      await updateGlobeUntilDone(scene);
+      scene.renderForSpecs();
+      expect(scene.cameraUnderground).toBe(true);
     });
 
-    it("does not occlude primitives when camera is underground", function () {
+    it("does not occlude primitives when camera is underground", async function () {
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2070,29 +2064,25 @@ describe(
 
       spyOn(DrawCommand.prototype, "execute"); // Don't execute any commands, just watch what gets added to the frustum commands list
 
-      return updateGlobeUntilDone(scene)
-        .then(function () {
-          expect(getFrustumCommandsLength(scene, Pass.OPAQUE)).toBe(0);
+      await updateGlobeUntilDone(scene);
+      expect(getFrustumCommandsLength(scene, Pass.OPAQUE)).toBe(0);
 
-          // Look underground at the primitive
-          scene.camera.setView({
-            destination: new Cartesian3(
-              -4643042.379120885,
-              4314056.579506199,
-              -451828.8968118975
-            ),
-            orientation: new HeadingPitchRoll(
-              6.283185307179586,
-              -0.7855491933100796,
-              6.283185307179586
-            ),
-          });
-          return updateGlobeUntilDone(scene);
-        })
-        .then(function () {
-          scene.renderForSpecs();
-          expect(getFrustumCommandsLength(scene, Pass.OPAQUE)).toBe(1);
-        });
+      // Look underground at the primitive
+      scene.camera.setView({
+        destination: new Cartesian3(
+          -4643042.379120885,
+          4314056.579506199,
+          -451828.8968118975
+        ),
+        orientation: new HeadingPitchRoll(
+          6.283185307179586,
+          -0.7855491933100796,
+          6.283185307179586
+        ),
+      });
+      await updateGlobeUntilDone(scene);
+      scene.renderForSpecs();
+      expect(getFrustumCommandsLength(scene, Pass.OPAQUE)).toBe(1);
     });
 
     it("does not occlude primitives when the globe is translucent", function () {
@@ -2129,7 +2119,7 @@ describe(
       expect(getFrustumCommandsLength(scene, Pass.OPAQUE)).toBe(1);
     });
 
-    it("does not render environment when camera is underground and translucency is disabled", function () {
+    it("does not render environment when camera is underground and translucency is disabled", async function () {
       const globe = new Globe();
       scene.globe = globe;
       scene.sun = new Sun();
@@ -2148,22 +2138,21 @@ describe(
         ),
       });
 
-      return updateGlobeUntilDone(scene).then(function () {
-        const time = JulianDate.fromIso8601(
-          "2020-04-25T03:07:26.04924034334544558Z"
-        );
-        globe.translucency.enabled = true;
-        globe.translucency.frontFaceAlpha = 0.5;
-        scene.renderForSpecs(time);
+      await updateGlobeUntilDone(scene);
+      const time = JulianDate.fromIso8601(
+        "2020-04-25T03:07:26.04924034334544558Z"
+      );
+      globe.translucency.enabled = true;
+      globe.translucency.frontFaceAlpha = 0.5;
+      scene.renderForSpecs(time);
 
-        expect(scene.environmentState.isSunVisible).toBe(true);
-        globe.translucency.enabled = false;
-        scene.renderForSpecs(time);
-        expect(scene.environmentState.isSunVisible).toBe(false);
-      });
+      expect(scene.environmentState.isSunVisible).toBe(true);
+      globe.translucency.enabled = false;
+      scene.renderForSpecs(time);
+      expect(scene.environmentState.isSunVisible).toBe(false);
     });
 
-    it("renders globe with translucency", function () {
+    it("renders globe with translucency", async function () {
       const globe = new Globe();
       scene.globe = globe;
 
@@ -2180,22 +2169,21 @@ describe(
         ),
       });
 
-      return updateGlobeUntilDone(scene).then(function () {
-        let opaqueColor;
-        expect(scene).toRenderAndCall(function (rgba) {
-          opaqueColor = rgba;
-        });
+      await updateGlobeUntilDone(scene);
+      let opaqueColor;
+      expect(scene).toRenderAndCall(function (rgba) {
+        opaqueColor = rgba;
+      });
 
-        globe.translucency.enabled = true;
-        globe.translucency.frontFaceAlpha = 0.5;
+      globe.translucency.enabled = true;
+      globe.translucency.frontFaceAlpha = 0.5;
 
-        expect(scene).toRenderAndCall(function (rgba) {
-          expect(rgba).not.toEqual(opaqueColor);
-        });
+      expect(scene).toRenderAndCall(function (rgba) {
+        expect(rgba).not.toEqual(opaqueColor);
       });
     });
 
-    it("renders ground primitive on translucent globe", function () {
+    it("renders ground primitive on translucent globe", async function () {
       const globe = new Globe();
       scene.globe = globe;
       globe.baseColor = Color.BLACK;
@@ -2237,14 +2225,13 @@ describe(
         })
       );
 
-      return updateGlobeUntilDone(scene).then(function () {
-        expect(scene).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toBeGreaterThan(0);
-        });
+      await updateGlobeUntilDone(scene);
+      expect(scene).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toBeGreaterThan(0);
       });
     });
 
-    it("picks ground primitive on translucent globe", function () {
+    it("picks ground primitive on translucent globe", async function () {
       const globe = new Globe();
       scene.globe = globe;
       globe.baseColor = Color.BLACK;
@@ -2286,9 +2273,8 @@ describe(
         })
       );
 
-      return updateGlobeUntilDone(scene).then(function () {
-        expect(scene).toPickPrimitive(primitive);
-      });
+      await updateGlobeUntilDone(scene);
+      expect(scene).toPickPrimitive(primitive);
     });
 
     it("updates frameState.atmosphere", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

`SceneSpec` declares a global `scene` in `beforeAll`. However, many of the tests are constructing and destroying their own `scene`. After too many of these test-specific scenes (and associated WebGL contexts) are created, the context associated with the global scene is lost.

This PR adds a check in `beforeEach` to see if the top-level `scene` is pointing to a lost context. If so, it recreates the `scene`.

The errors in #11666 were caused by `NaN` values in the camera frustum, which were not caught until a call to `Cartesian.normalize` far down the stack. This PR adds a few checks to catch the `NaN` values sooner, for easier debugging.

## Issue number and link

Fixes #11666

## Testing plan

1. Run `SceneSpec` locally.
2. Generate the release zip `npm run make-zip`
3. Run tests against the release `npm run test -- --failTaskOnError --release`

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
