### PR TITLE
3D Tiles pick improvement: Check intersections with tile bounding volumes

### DIFF
--- a/packages/engine/Source/Core/OrientedBoundingBox.js
+++ b/packages/engine/Source/Core/OrientedBoundingBox.js
@@ -14,6 +14,7 @@ import CesiumMath from "./Math.js";
 import Matrix3 from "./Matrix3.js";
 import Matrix4 from "./Matrix4.js";
 import Plane from "./Plane.js";
+import Ray from "./Ray.js";
 import Rectangle from "./Rectangle.js";
 
 /**
@@ -670,13 +671,8 @@ OrientedBoundingBox.clone = function (box, result) {
  */
 OrientedBoundingBox.intersectPlane = function (box, plane) {
   //>>includeStart('debug', pragmas.debug);
-  if (!defined(box)) {
-    throw new DeveloperError("box is required.");
-  }
-
-  if (!defined(plane)) {
-    throw new DeveloperError("plane is required.");
-  }
+  Check.defined("box", box);
+  Check.defined("plane", plane);
   //>>includeEnd('debug');
 
   const center = box.center;
@@ -712,6 +708,168 @@ OrientedBoundingBox.intersectPlane = function (box, plane) {
     return Intersect.INSIDE;
   }
   return Intersect.INTERSECTING;
+};
+
+const scratchInverse = new Matrix4();
+const scratchNormal = new Cartesian3();
+const scratchRay = new Ray();
+
+/**
+ * Computes the nearest intersection along the ray with the oriented bounding box.
+ *
+ * @param {OrientedBoundingBox} box The oriented bounding box to test.
+ * @param {Ray} ray The ray to test against.
+ * @param {Cartesian3} [result] The nearest intersection along the provided ray with the oriented bounding box.
+ * @returns {Cartesian3|undefined} The nearest intersection along the provided ray with the oriented bounding box, or <code>undefined</code> if there is no intersection.
+ */
+OrientedBoundingBox.intersectRay = function (box, ray, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("box", box);
+  Check.defined("ray", ray);
+  //>>includeEnd('debug');
+
+  const transformedRay = scratchRay;
+  transformedRay.origin = Cartesian3.subtract(
+    ray.origin,
+    box.center,
+    transformedRay.origin
+  );
+  transformedRay.direction = Cartesian3.clone(ray.direction);
+
+  const transform = Matrix4.multiplyByMatrix3(
+    Matrix4.IDENTITY,
+    box.halfAxes,
+    scratchInverse
+  );
+  const inverseHalfAxis = Matrix4.inverse(transform, scratchInverse);
+  Ray.transform(transformedRay, inverseHalfAxis, transformedRay);
+
+  const origin = transformedRay.origin;
+  const direction = transformedRay.direction;
+
+  let tNear = -Infinity,
+    tFar = Infinity;
+
+  // Implementation based on https://education.siggraph.org/static/HyperGraph/raytrace/rtinter3.htm#:~:text=We%20can%20use%20a%20box,bounding%20volume%20or%20a%20box.
+  let normal = Cartesian3.UNIT_X;
+  let denominator = Cartesian3.dot(normal, direction);
+  if (Math.abs(denominator) < CesiumMath.EPSILON15) {
+    // parallel
+
+    if (origin.x > 1.0 || origin.x < -1.0) {
+      return;
+    }
+  } else {
+    const negativeNormal = Cartesian3.negate(normal, scratchNormal);
+    const negativeDenominator = Cartesian3.dot(negativeNormal, direction);
+    let tx1 = (-1.0 - Cartesian3.dot(normal, origin)) / denominator;
+    let tx2 =
+      (-1.0 - Cartesian3.dot(negativeNormal, origin)) / negativeDenominator;
+
+    if (tx1 > tx2) {
+      const swap = tx1;
+      tx1 = tx2;
+      tx2 = swap;
+    }
+
+    if (tx1 > tNear) {
+      tNear = tx1;
+    }
+
+    if (tx2 < tFar) {
+      tFar = tx2;
+    }
+
+    if (tNear > tFar) {
+      return;
+    }
+
+    if (tFar < 0.0) {
+      return;
+    }
+  }
+
+  normal = Cartesian3.UNIT_Y;
+  denominator = Cartesian3.dot(normal, direction);
+  if (Math.abs(denominator) < CesiumMath.EPSILON15) {
+    // parallel
+
+    if (origin.y > 1.0 || origin.y < -1.0) {
+      return;
+    }
+  } else {
+    const negativeNormal = Cartesian3.negate(normal, scratchNormal);
+    const negativeDenominator = Cartesian3.dot(negativeNormal, direction);
+    let ty1 = (-1.0 - Cartesian3.dot(normal, origin)) / denominator;
+    let ty2 =
+      (-1.0 - Cartesian3.dot(negativeNormal, origin)) / negativeDenominator;
+
+    if (ty1 > ty2) {
+      const swap = ty1;
+      ty1 = ty2;
+      ty2 = swap;
+    }
+
+    if (ty1 > tNear) {
+      tNear = ty1;
+    }
+
+    if (ty2 < tFar) {
+      tFar = ty2;
+    }
+
+    if (tNear > tFar) {
+      return;
+    }
+
+    if (tFar < 0.0) {
+      return;
+    }
+  }
+
+  normal = Cartesian3.UNIT_Z;
+  denominator = Cartesian3.dot(normal, direction);
+  if (Math.abs(denominator) < CesiumMath.EPSILON15) {
+    // parallel
+
+    if (origin.z > 1.0 || origin.z < -1.0) {
+      return;
+    }
+  } else {
+    const negativeNormal = Cartesian3.negate(normal, scratchNormal);
+    const negativeDenominator = Cartesian3.dot(negativeNormal, direction);
+    let tz1 = (-1.0 - Cartesian3.dot(normal, origin)) / denominator;
+    let tz2 =
+      (-1.0 - Cartesian3.dot(negativeNormal, origin)) / negativeDenominator;
+
+    if (tz1 > tz2) {
+      const swap = tz1;
+      tz1 = tz2;
+      tz2 = swap;
+    }
+
+    if (tz1 > tNear) {
+      tNear = tz1;
+    }
+
+    if (tz2 < tFar) {
+      tFar = tz2;
+    }
+
+    if (tNear > tFar) {
+      return;
+    }
+
+    if (tFar < 0.0) {
+      return;
+    }
+  }
+
+  if (tNear <= 0.0) {
+    return Ray.getPoint(ray, tFar, result);
+  }
+
+  return Ray.getPoint(ray, tNear, result);
 };
 
 const scratchCartesianU = new Cartesian3();
@@ -1159,6 +1317,17 @@ OrientedBoundingBox.isOccluded = function (box, occluder) {
  */
 OrientedBoundingBox.prototype.intersectPlane = function (plane) {
   return OrientedBoundingBox.intersectPlane(this, plane);
+};
+
+/**
+ * Computes the nearest intersection along the ray with the oriented bounding box.
+ *
+ * @param {Ray} ray The ray to test against.
+ * @param {Cartesian3} [result] The nearest intersection along the provided ray with the oriented bounding box.
+ * @returns {Cartesian3|undefined} The nearest intersection along the provided ray with the oriented bounding box, or <code>undefined</code> if there is no intersection.
+ */
+OrientedBoundingBox.prototype.intersectRay = function (ray, result) {
+  return OrientedBoundingBox.intersectRay(this, ray, result);
 };
 
 /**

--- a/packages/engine/Source/Core/Ray.js
+++ b/packages/engine/Source/Core/Ray.js
@@ -2,6 +2,7 @@ import Cartesian3 from "./Cartesian3.js";
 import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
+import Matrix4 from "./Matrix4.js";
 
 /**
  * Represents a ray that extends infinitely from the provided origin in the provided direction.
@@ -77,4 +78,33 @@ Ray.getPoint = function (ray, t, result) {
   result = Cartesian3.multiplyByScalar(ray.direction, t, result);
   return Cartesian3.add(ray.origin, result, result);
 };
+
+/**
+ * Transforms the ray by the given transformation matrix. The resulting ray's direction is not garunteed to be normalized.
+ *
+ * @param {Ray} ray The ray.
+ * @param {Matrix4} transform The transformation matrix.
+ * @param {Ray} [result] The transformed ray.
+ * @returns {Ray} The transformed ray.
+ */
+Ray.transform = function (ray, transform, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("ray", ray);
+  Check.typeOf.object("transform", transform);
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new Ray();
+  }
+
+  result.origin = Matrix4.multiplyByPoint(transform, ray.origin, result.origin);
+  result.direction = Matrix4.multiplyByPoint(
+    transform,
+    ray.direction,
+    result.direction
+  );
+
+  return result;
+};
+
 export default Ray;

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -1,5 +1,4 @@
 import ApproximateTerrainHeights from "../Core/ApproximateTerrainHeights.js";
-import BoundingSphere from "../Core/BoundingSphere.js";
 import Cartesian2 from "../Core/Cartesian2.js";
 import Cartesian3 from "../Core/Cartesian3.js";
 import Cartographic from "../Core/Cartographic.js";
@@ -14,8 +13,6 @@ import destroyObject from "../Core/destroyObject.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import Event from "../Core/Event.js";
 import ImageBasedLighting from "./ImageBasedLighting.js";
-import Interval from "../Core/Interval.js";
-import IntersectionTests from "../Core/IntersectionTests.js";
 import IonResource from "../Core/IonResource.js";
 import JulianDate from "../Core/JulianDate.js";
 import ManagedArray from "../Core/ManagedArray.js";
@@ -3594,7 +3591,7 @@ Cesium3DTileset.prototype.updateHeight = function (
   return removeCallback;
 };
 
-const scratchSphereIntersection = new Interval();
+const scratchVolumeIntersection = new Cartesian3();
 const scratchPickIntersection = new Cartesian3();
 
 /**
@@ -3618,12 +3615,15 @@ Cesium3DTileset.prototype.pick = function (ray, frameState, result) {
 
   for (let i = 0; i < selectedLength; ++i) {
     const tile = selectedTiles[i];
-    const boundsIntersection = IntersectionTests.raySphere(
+    if (!defined(tile.content)) {
+      continue;
+    }
+
+    const boundsIntersection = tile.contentBoundingVolume.intersectRay(
       ray,
-      tile.contentBoundingVolume.boundingSphere,
-      scratchSphereIntersection
+      scratchVolumeIntersection
     );
-    if (!defined(boundsIntersection) || !defined(tile.content)) {
+    if (!defined(boundsIntersection)) {
       continue;
     }
 
@@ -3632,12 +3632,10 @@ Cesium3DTileset.prototype.pick = function (ray, frameState, result) {
 
   const length = candidates.length;
   candidates.sort((a, b) => {
-    const aDist = BoundingSphere.distanceSquaredTo(
-      a.contentBoundingVolume.boundingSphere,
+    const aDist = a.contentBoundingVolume.boundingVolume.distanceSquaredTo(
       ray.origin
     );
-    const bDist = BoundingSphere.distanceSquaredTo(
-      b.contentBoundingVolume.boundingSphere,
+    const bDist = b.contentBoundingVolume.boundingVolume.distanceSquaredTo(
       ray.origin
     );
 

--- a/packages/engine/Source/Scene/TileBoundingRegion.js
+++ b/packages/engine/Source/Scene/TileBoundingRegion.js
@@ -451,6 +451,17 @@ TileBoundingRegion.prototype.intersectPlane = function (plane) {
 };
 
 /**
+ * Computes the nearest intersection along the ray with the bounding volume.
+ *
+ * @param {Ray} ray The ray to test against.
+ * @param {Cartesian3} [result] The nearest intersection along the provided ray with the bounding volume.
+ * @returns {Cartesian3|undefined} The nearest intersection along the provided ray with the bounding volume, or <code>undefined</code> if there is no intersection.
+ */
+TileBoundingRegion.prototype.intersectRay = function (ray, result) {
+  return this._orientedBoundingBox.intersectRay(ray, result);
+};
+
+/**
  * Creates a debug primitive that shows the outline of the tile bounding region.
  *
  * @param {Color} color The desired color of the primitive's mesh

--- a/packages/engine/Source/Scene/TileBoundingS2Cell.js
+++ b/packages/engine/Source/Scene/TileBoundingS2Cell.js
@@ -616,6 +616,8 @@ TileBoundingS2Cell.prototype.intersectPlane = function (plane) {
   return Intersect.INTERSECTING;
 };
 
+// TODO
+
 /**
  * Creates a debug primitive that shows the outline of the tile bounding
  * volume.

--- a/packages/engine/Source/Scene/TileBoundingSphere.js
+++ b/packages/engine/Source/Scene/TileBoundingSphere.js
@@ -4,10 +4,13 @@ import Check from "../Core/Check.js";
 import ColorGeometryInstanceAttribute from "../Core/ColorGeometryInstanceAttribute.js";
 import GeometryInstance from "../Core/GeometryInstance.js";
 import CesiumMath from "../Core/Math.js";
+import IntersectionTests from "../Core/IntersectionTests.js";
 import Matrix4 from "../Core/Matrix4.js";
 import SphereOutlineGeometry from "../Core/SphereOutlineGeometry.js";
 import PerInstanceColorAppearance from "./PerInstanceColorAppearance.js";
 import Primitive from "./Primitive.js";
+import { defined } from "@cesium/engine";
+import Ray from "../Core/Ray.js";
 
 /**
  * A tile bounding volume specified as a sphere.
@@ -116,6 +119,35 @@ TileBoundingSphere.prototype.intersectPlane = function (plane) {
   Check.defined("plane", plane);
   //>>includeEnd('debug');
   return BoundingSphere.intersectPlane(this._boundingSphere, plane);
+};
+
+/**
+ * Computes the nearest intersection along the ray with the bounding volume.
+ *
+ * @param {Ray} ray The ray to test against.
+ * @param {Cartesian3} [result] The nearest intersection along the provided ray with the bounding volume.
+ * @returns {Cartesian3|undefined} The nearest intersection along the provided ray with the bounding volume, or <code>undefined</code> if there is no intersection.
+ */
+TileBoundingSphere.prototype.intersectRay = function (ray, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("ray", ray);
+  //>>includeEnd('debug');
+
+  const interval = IntersectionTests.raySphere(
+    ray,
+    this._boundingSphere,
+    result
+  );
+
+  if (!defined(interval)) {
+    return;
+  }
+
+  if (interval.start > 0.0) {
+    return Ray.getPoint(ray, interval.start, result);
+  }
+
+  return Ray.getPoint(ray, interval.stop, result);
 };
 
 /**

--- a/packages/engine/Source/Scene/TileBoundingVolume.js
+++ b/packages/engine/Source/Scene/TileBoundingVolume.js
@@ -56,6 +56,17 @@ TileBoundingVolume.prototype.intersectPlane = function (plane) {
 };
 
 /**
+ * Computes the nearest intersection along the ray with the bounding volume.
+ *
+ * @param {Ray} ray The ray to test against.
+ * @param {Cartesian3} [result] The nearest intersection along the provided ray with the bounding volume.
+ * @returns {Cartesian3|undefined} The nearest intersection along the provided ray with the bounding volume, or <code>undefined</code> if there is no intersection.
+ */
+TileBoundingVolume.prototype.intersectRay = function (ray, result) {
+  DeveloperError.throwInstantiationError();
+};
+
+/**
  * Creates a debug primitive that shows the outline of the tile bounding
  * volume.
  *

--- a/packages/engine/Source/Scene/TileOrientedBoundingBox.js
+++ b/packages/engine/Source/Scene/TileOrientedBoundingBox.js
@@ -161,6 +161,17 @@ TileOrientedBoundingBox.prototype.intersectPlane = function (plane) {
 };
 
 /**
+ * Computes the nearest intersection along the ray with the bounding volume.
+ *
+ * @param {Ray} ray The ray to test against.
+ * @param {Cartesian3} [result] The nearest intersection along the provided ray with the bounding volume.
+ * @returns {Cartesian3|undefined} The nearest intersection along the provided ray with the bounding volume, or <code>undefined</code> if there is no intersection.
+ */
+TileOrientedBoundingBox.prototype.intersectRay = function (ray, result) {
+  return this._orientedBoundingBox.intersectRay(ray, result);
+};
+
+/**
  * Update the bounding box after the tile is transformed.
  *
  * @param {Cartesian3} center The center of the box.

--- a/packages/engine/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/packages/engine/Specs/Core/OrientedBoundingBoxSpec.js
@@ -4,16 +4,16 @@ import {
   Cartesian4,
   Ellipsoid,
   Intersect,
+  Math as CesiumMath,
   Matrix3,
   Matrix4,
   Occluder,
   OrientedBoundingBox,
   Plane,
   Quaternion,
+  Ray,
   Rectangle,
 } from "../../index.js";
-
-import { Math as CesiumMath } from "../../index.js";
 
 import createPackableSpecs from "../../../../Specs/createPackableSpecs.js";
 
@@ -1503,6 +1503,217 @@ describe("Core/OrientedBoundingBox", function () {
     expect(function () {
       OrientedBoundingBox.intersectPlane(box, undefined);
     }).toThrowDeveloperError();
+  });
+
+  it("intersectRay fails without box parameter", function () {
+    const ray = new Ray();
+    expect(function () {
+      OrientedBoundingBox.intersectRay(undefined, ray);
+    }).toThrowDeveloperError();
+  });
+
+  it("intersectRay fails without ray parameter", function () {
+    const box = new OrientedBoundingBox(Cartesian3.IDENTITY, Matrix3.ZERO);
+    expect(function () {
+      OrientedBoundingBox.intersectRay(box, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("intersectRay works with untransformed box from inside", function () {
+    const box = new OrientedBoundingBox(
+      Cartesian3.ZERO,
+      Matrix3.multiplyByScalar(Matrix3.IDENTITY, 0.5, new Matrix3())
+    );
+
+    const ray = new Ray();
+    ray.direction = new Cartesian3(0.0, 0.0, 1.0);
+
+    let expectedValue = new Cartesian3(0, 0, 0.5);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqual(expectedValue);
+
+    ray.direction = new Cartesian3(0.0, 1.0, 0.0);
+
+    expectedValue = new Cartesian3(0.0, 0.5, 0.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqual(expectedValue);
+
+    ray.direction = new Cartesian3(1.0, 0.0, 0.0);
+
+    expectedValue = new Cartesian3(0.5, 0.0, 0.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqual(expectedValue);
+
+    ray.direction = new Cartesian3(1.0, 2.0, 3.0);
+    Cartesian3.normalize(ray.direction, ray.direction);
+
+    expectedValue = new Cartesian3(1 / 6, 1 / 3, 0.5);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+  });
+
+  it("intersectRay works with untransformed box from outside", function () {
+    const box = new OrientedBoundingBox(
+      Cartesian3.ZERO,
+      Matrix3.multiplyByScalar(Matrix3.IDENTITY, 0.5, new Matrix3())
+    );
+
+    const ray = new Ray();
+    ray.origin = new Cartesian3(0, 0, 2);
+    ray.direction = new Cartesian3(0, 0, -1);
+
+    let expectedValue = new Cartesian3(0, 0, 0.5);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqual(expectedValue);
+
+    ray.origin = new Cartesian3(0, 2, 0);
+    ray.direction = new Cartesian3(0, -1, 0);
+
+    expectedValue = new Cartesian3(0, 0.5, 0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqual(expectedValue);
+
+    ray.origin = new Cartesian3(2.0, 0.0, 0.0);
+    ray.direction = new Cartesian3(-1.0, 0.0, 0.0);
+
+    expectedValue = new Cartesian3(0.5, 0.0, 0.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqual(expectedValue);
+
+    ray.origin = new Cartesian3(2.0, 4.0, 6.0);
+    ray.direction = new Cartesian3(-1.0, -2.0, -3.0);
+    Cartesian3.normalize(ray.direction, ray.direction);
+
+    expectedValue = new Cartesian3(1 / 6, 1 / 3, 0.5);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+  });
+
+  it("intersectRay returns undefined when there is no intersection", function () {
+    const box = new OrientedBoundingBox(
+      Cartesian3.ZERO,
+      Matrix3.multiplyByScalar(Matrix3.IDENTITY, 0.5, new Matrix3())
+    );
+
+    const ray = new Ray();
+    ray.origin = new Cartesian3(-1.0, -2.0, -3.0);
+    ray.direction = new Cartesian3(-1.0, -2.0, -3.0);
+    Cartesian3.normalize(ray.direction, ray.direction);
+
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toBeUndefined();
+  });
+
+  it("intersectRay works with off-center box from the inside", function () {
+    let origin = new Cartesian3(1.0, 0.0, 0.0);
+    const box = new OrientedBoundingBox(origin, Matrix3.IDENTITY);
+
+    const ray = new Ray();
+    ray.origin = origin;
+    ray.direction = new Cartesian3(0.0, 0.0, 1.0);
+
+    let expectedValue = new Cartesian3(1.0, 0.0, 1.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+
+    origin = new Cartesian3(0.7, -1.8, 12.0);
+    box.center = origin;
+
+    ray.origin = origin;
+    expectedValue = new Cartesian3(0.7, -1.8, 13.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+  });
+
+  it("intersectRay works with off-center box from the outside", function () {
+    let origin = new Cartesian3(1.0, 0.0, 0.0);
+    const box = new OrientedBoundingBox(origin, Matrix3.IDENTITY);
+
+    const ray = new Ray();
+    ray.origin = new Cartesian3(1.0, 0.0, -5.0);
+    ray.direction = new Cartesian3(0.0, 0.0, 1.0);
+
+    let expectedValue = new Cartesian3(1.0, 0.0, -1.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+
+    origin = new Cartesian3(0.7, -1.8, 12.0);
+    box.center = origin;
+
+    ray.origin = new Cartesian3(0.7, -1.8, 6);
+    expectedValue = new Cartesian3(0.7, -1.8, 11.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+  });
+
+  it("intersectRay works with off-center scaled box", function () {
+    const origin = new Cartesian3(3.0, 0.0, 7.0);
+    const box = new OrientedBoundingBox(
+      origin,
+      Matrix3.fromScale(new Cartesian3(2.0, 1.0, 1.0))
+    );
+
+    const ray = new Ray();
+    ray.origin = origin;
+    ray.direction = new Cartesian3(2.0, 0.0, 1.0);
+    ray.direction = Cartesian3.normalize(ray.direction, ray.direction);
+
+    let expectedValue = new Cartesian3(5, 0.0, 8.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+
+    ray.origin = new Cartesian3(-3.0, 0.0, 5.0);
+
+    expectedValue = new Cartesian3(1.0, 0.0, 7.0);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+  });
+
+  it("intersectRay works with this arbitrary box", function () {
+    const m = Matrix3.fromScale(new Cartesian3(1.5, 80.4, 2.6), new Matrix3());
+    const n = Matrix3.fromQuaternion(
+      Quaternion.fromAxisAngle(new Cartesian3(0.5, 1.5, -1.2), 1.2),
+      new Matrix3()
+    );
+    Matrix3.multiply(m, n, n);
+
+    const origin = new Cartesian3(-5.1, 0.0, 0.1);
+    const box = new OrientedBoundingBox(origin, n);
+
+    const ray = new Ray();
+    ray.origin = origin;
+    ray.direction = new Cartesian3(0.0, 1.0, 0.0);
+
+    const expectedValue = new Cartesian3(-5.1, 110.66856614565339, 0.1);
+    expect(OrientedBoundingBox.intersectRay(box, ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON10
+    );
+  });
+
+  it("intersectRay uses result parameter", function () {
+    const box = new OrientedBoundingBox(
+      Cartesian3.ZERO,
+      Matrix3.multiplyByScalar(Matrix3.IDENTITY, 0.5, new Matrix3())
+    );
+
+    const ray = new Ray();
+    ray.direction = new Cartesian3(0.0, 0.0, 1.0);
+
+    const result = new Cartesian3();
+    const expectedValue = new Cartesian3(0.0, 0.0, 0.5);
+    const returned = OrientedBoundingBox.intersectRay(box, ray, result);
+    expect(returned).toBe(result);
+    expect(result).toEqual(expectedValue);
   });
 
   it("distanceSquaredTo", function () {

--- a/packages/engine/Specs/Core/RaySpec.js
+++ b/packages/engine/Specs/Core/RaySpec.js
@@ -1,4 +1,4 @@
-import { Cartesian3, Ray } from "../../index.js";
+import { Cartesian3, Matrix4, Ray } from "../../index.js";
 
 describe("Core/Ray", function () {
   it("default constructor create zero valued Ray", function () {
@@ -114,5 +114,60 @@ describe("Core/Ray", function () {
     expect(function () {
       Ray.getPoint(ray, undefined);
     }).toThrowDeveloperError();
+  });
+
+  it("transform throws without ray", function () {
+    const transform = Matrix4.IDENTITY;
+    expect(function () {
+      Ray.transform(undefined, transform);
+    }).toThrowDeveloperError();
+  });
+
+  it("transform throws without transform", function () {
+    const ray = new Ray();
+    expect(function () {
+      Ray.transform(ray, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("transform works with zero values for ray", function () {
+    const ray = new Ray();
+    const transform = Matrix4.IDENTITY;
+    const result = Ray.transform(ray, transform);
+    expect(result.origin).toEqual(Cartesian3.ZERO);
+    expect(result.direction).toEqual(Cartesian3.ZERO);
+  });
+
+  it("transform works with zero values for transform", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(-3, -2, -1);
+    ray.direction = new Cartesian3(1, 2, 3);
+    const transform = Matrix4.ZERO;
+    const result = Ray.transform(ray, transform);
+    expect(result.origin).toEqual(Cartesian3.ZERO);
+    expect(result.direction).toEqual(Cartesian3.ZERO);
+  });
+
+  it("transform works with non-zero values", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(-3, -2, -1);
+    ray.direction = new Cartesian3(1, 2, 3);
+    const transform = Matrix4.fromUniformScale(2.0);
+    const result = Ray.transform(ray, transform);
+    expect(result.origin).toEqual(new Cartesian3(-6, -4, -2));
+    expect(result.direction).toEqual(new Cartesian3(2, 4, 6));
+  });
+
+  it("transform works with result paramter", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(-3, -2, -1);
+    ray.direction = new Cartesian3(1, 2, 3);
+    const transform = Matrix4.fromUniformScale(2.0);
+
+    const result = new Ray();
+    const returned = Ray.transform(ray, transform, result);
+    expect(returned).toBe(result);
+    expect(result.origin).toEqual(new Cartesian3(-6, -4, -2));
+    expect(result.direction).toEqual(new Cartesian3(2, 4, 6));
   });
 });

--- a/packages/engine/Specs/Scene/TileBoundingRegionSpec.js
+++ b/packages/engine/Specs/Scene/TileBoundingRegionSpec.js
@@ -7,6 +7,7 @@ import {
   GeographicTilingScheme,
   Intersect,
   Plane,
+  Ray,
   Rectangle,
   SceneMode,
   TileBoundingRegion,
@@ -286,5 +287,42 @@ describe("Scene/TileBoundingRegion", function () {
     expect(tileBoundingRegion.intersectPlane(plane)).toEqual(
       Intersect.INTERSECTING
     );
+  });
+
+  it("intersectRay throws without ray", function () {
+    expect(function () {
+      tileBoundingRegion.intersectRay();
+    }).toThrowDeveloperError();
+  });
+
+  it("intersectRay returns undefined if there is no intersection", function () {
+    const ray = new Ray();
+    ray.origin = Cartesian3.fromRadians(0.0, 0.0, 2.0);
+    ray.direction = new Cartesian3(0.0, 0.0, -1.0);
+    expect(tileBoundingRegion.intersectRay(ray)).toBeUndefined();
+  });
+
+  it("intersectRay returns intersection", function () {
+    const ray = new Ray();
+    ray.origin = Cartesian3.fromRadians(0.0, 0.0, 0.0);
+    ray.direction = new Cartesian3(0.0, 0.0, -1.0);
+
+    const expectedValue = new Cartesian3(6378137, 0.0, 0.0);
+    expect(tileBoundingRegion.intersectRay(ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON8
+    );
+  });
+
+  it("intersectRay ruses result parameter", function () {
+    const ray = new Ray();
+    ray.origin = Cartesian3.fromRadians(0.0, 0.0, 0.0);
+    ray.direction = new Cartesian3(0.0, 0.0, -1.0);
+
+    const result = new Cartesian3();
+    const expectedValue = new Cartesian3(6378137, 0.0, 0.0);
+    const returned = tileBoundingRegion.intersectRay(ray, result);
+    expect(returned).toBe(result);
+    expect(result).toEqualEpsilon(expectedValue, CesiumMath.EPSILON8);
   });
 });

--- a/packages/engine/Specs/Scene/TileBoundingSphereSpec.js
+++ b/packages/engine/Specs/Scene/TileBoundingSphereSpec.js
@@ -2,11 +2,11 @@ import {
   Cartesian3,
   Color,
   Intersect,
+  Math as CesiumMath,
   Plane,
+  Ray,
   TileBoundingSphere,
 } from "../../index.js";
-
-import { Math as CesiumMath } from "../../index.js";
 
 import createFrameState from "../../../../Specs/createFrameState.js";
 
@@ -67,5 +67,46 @@ describe("Scene/TileBoundingSphere", function () {
     expect(tileBoundingSphere.intersectPlane(plane)).toEqual(
       Intersect.INTERSECTING
     );
+  });
+
+  it("intersectRay throws when ray is undefined", function () {
+    expect(function () {
+      return tileBoundingSphere.intersectRay();
+    }).toThrowDeveloperError();
+  });
+
+  it("intersectRay returns undefined if there is no intersection", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(0.0, 0.0, 2.0);
+    ray.direction = new Cartesian3(0.0, 1.0, 0.0);
+
+    expect(tileBoundingSphere.intersectRay(ray)).toBeUndefined();
+  });
+
+  it("intersectRay works with origin inside", function () {
+    const ray = new Ray();
+    ray.direction = new Cartesian3(0.0, 0.0, 1.0);
+
+    const expected = new Cartesian3(0.0, 0.0, 1.0);
+    expect(tileBoundingSphere.intersectRay(ray)).toEqual(expected);
+  });
+
+  it("intersectRay works with origin outside", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(0.0, 0.0, 2.0);
+    ray.direction = new Cartesian3(0.0, 0.0, -1.0);
+
+    const expected = new Cartesian3(0.0, 0.0, 1.0);
+    expect(tileBoundingSphere.intersectRay(ray)).toEqual(expected);
+  });
+
+  it("intersectRay works with result parameter", function () {
+    const ray = new Ray();
+    ray.direction = new Cartesian3(0.0, 0.0, 1.0);
+    const result = new Cartesian3();
+
+    const expected = new Cartesian3(0.0, 0.0, 1.0);
+    expect(tileBoundingSphere.intersectRay(ray, result)).toBe(result);
+    expect(result).toEqual(expected);
   });
 });

--- a/packages/engine/Specs/Scene/TileOrientedBoundingBoxSpec.js
+++ b/packages/engine/Specs/Scene/TileOrientedBoundingBoxSpec.js
@@ -4,6 +4,7 @@ import {
   Intersect,
   Matrix3,
   Plane,
+  Ray,
   TileOrientedBoundingBox,
 } from "../../index.js";
 
@@ -115,5 +116,42 @@ describe("Scene/TileOrientedBoundingBox", function () {
     expect(tileBoundingVolume.intersectPlane(plane)).toEqual(Intersect.OUTSIDE);
     plane = new Plane(Cartesian3.UNIT_Z, -0.5 - eps6);
     expect(tileBoundingVolume.intersectPlane(plane)).toEqual(Intersect.OUTSIDE);
+  });
+
+  it("intersectRay throws without ray", function () {
+    expect(function () {
+      tileBoundingVolume.intersectRay();
+    }).toThrowDeveloperError();
+  });
+
+  it("intersectRay returns undefined if there is no intersection", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(0.0, 0.0, 2.0);
+    ray.direction = new Cartesian3(-1.0, 0.0, 0.0);
+    expect(tileBoundingVolume.intersectRay(ray)).toBeUndefined();
+  });
+
+  it("intersectRay returns intersection", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(1.0, 0.0, 0.0);
+    ray.direction = new Cartesian3(-1.0, 0.0, 0.0);
+
+    const expectedValue = new Cartesian3(0.5, 0.0, 0.0);
+    expect(tileBoundingVolume.intersectRay(ray)).toEqualEpsilon(
+      expectedValue,
+      CesiumMath.EPSILON8
+    );
+  });
+
+  it("intersectRay ruses result parameter", function () {
+    const ray = new Ray();
+    ray.origin = new Cartesian3(1.0, 0.0, 0.0);
+    ray.direction = new Cartesian3(-1.0, 0.0, 0.0);
+
+    const result = new Cartesian3();
+    const expectedValue = new Cartesian3(0.5, 0.0, 0.0);
+    const returned = tileBoundingVolume.intersectRay(ray, result);
+    expect(returned).toBe(result);
+    expect(result).toEqualEpsilon(expectedValue, CesiumMath.EPSILON8);
   });
 });


### PR DESCRIPTION
# Description

This adjust the tileset pick code such that we are testing intersections with the tile content bounding volumes directly rather than the bounding spheres. 

The bounding sphere could be quite large, especially for tileset bounding region volumes, leading to need to check intersections more models directly, leading to poorer performance particularly in tilesets like OSM.

Along with @javagl's suggestions in https://github.com/CesiumGS/cesium/issues/11814 (which can go in separately), this should remedy the drop in performance seen for OSM.

## Issue number and link

At least partial addresses https://github.com/CesiumGS/cesium/issues/11811.

## Testing plan

- [ ] Test OSM performance in Sandcastle by adding:
```
viewer.scene.debugShowFramesPerSecond = true;
```
- [ ] Spot check other 3D tilesets (like Google P3DT) to wnsure performance was not negatively affected
- [ ] Test to make sure camera collisions still work with the surface of 3D Tiles

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
- [ ] I need to address the remaining TODO in S2 tileset bounding volumes
