### PR TITLE
Handle errors in ApproximateTerrainHeight.initialize

### DIFF
--- a/packages/engine/Source/Core/ApproximateTerrainHeights.js
+++ b/packages/engine/Source/Core/ApproximateTerrainHeights.js
@@ -45,9 +45,15 @@ ApproximateTerrainHeights.initialize = function () {
   }
   initPromise = Resource.fetchJson(
     buildModuleUrl("Assets/approximateTerrainHeights.json")
-  ).then(function (json) {
-    ApproximateTerrainHeights._terrainHeights = json;
-  });
+  )
+    .then(function (json) {
+      ApproximateTerrainHeights._terrainHeights = json;
+    })
+    .catch(function (error) {
+      throw new DeveloperError(
+        `Failed to initialize approximate terrain heights. Error = ${error}`
+      );
+    });
   ApproximateTerrainHeights._initPromise = initPromise;
 
   return initPromise;

--- a/packages/engine/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/GeometryVisualizerSpec.js
@@ -43,8 +43,6 @@ describe(
       scene.destroyForSpecs();
 
       // Leave ground primitive uninitialized
-      GroundPrimitive._initialized = false;
-      GroundPrimitive._initPromise = undefined;
       ApproximateTerrainHeights._initPromise = undefined;
       ApproximateTerrainHeights._terrainHeights = undefined;
     });

--- a/packages/engine/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/packages/engine/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -48,9 +48,6 @@ describe(
     afterAll(function () {
       scene.destroyForSpecs();
 
-      GroundPolylinePrimitive._initPromise = undefined;
-      GroundPolylinePrimitive._initialized = false;
-
       ApproximateTerrainHeights._initPromise = undefined;
       ApproximateTerrainHeights._terrainHeights = undefined;
     });

--- a/packages/engine/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
+++ b/packages/engine/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
@@ -33,8 +33,6 @@ describe("DataSources/StaticGroundGeometryColorBatch", function () {
     scene.destroyForSpecs();
 
     // Leave ground primitive uninitialized
-    GroundPrimitive._initialized = false;
-    GroundPrimitive._initPromise = undefined;
     ApproximateTerrainHeights._initPromise = undefined;
     ApproximateTerrainHeights._terrainHeights = undefined;
   });

--- a/packages/engine/Specs/DataSources/StaticGroundGeometryPerMaterialBatchSpec.js
+++ b/packages/engine/Specs/DataSources/StaticGroundGeometryPerMaterialBatchSpec.js
@@ -37,8 +37,6 @@ describe("DataSources/StaticGroundGeometryPerMaterialBatch", function () {
     scene.destroyForSpecs();
 
     // Leave ground primitive uninitialized
-    GroundPrimitive._initialized = false;
-    GroundPrimitive._initPromise = undefined;
     ApproximateTerrainHeights._initPromise = undefined;
     ApproximateTerrainHeights._terrainHeights = undefined;
   });

--- a/packages/engine/Specs/DataSources/StaticGroundPolylinePerMaterialBatchSpec.js
+++ b/packages/engine/Specs/DataSources/StaticGroundPolylinePerMaterialBatchSpec.js
@@ -39,9 +39,6 @@ describe("DataSources/StaticGroundPolylinePerMaterialBatch", function () {
   afterAll(function () {
     scene.destroyForSpecs();
 
-    GroundPolylinePrimitive._initPromise = undefined;
-    GroundPolylinePrimitive._initialized = false;
-
     ApproximateTerrainHeights._initPromise = undefined;
     ApproximateTerrainHeights._terrainHeights = undefined;
   });


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR catches errors from `ApproximateTerrainHeight.initialize` and throws them as `DeveloperError`s. This is to avoid erratic behavior when the promise is rejected.

When running tests locally on the webgl stub (`npm test -- --webgl-stub`), many runs would end early with an unclear error message:
```bash
  An error was thrown in afterAll
  Unhandled promise rejection: undefined thrown
```

Handling the error resolves the `afterAll` error in some cases.

Along the way, I cleaned up some references to obsolete `.initialized` flags.

## Issue number and link

Possibly related to #11231.

## Testing plan

Run tests locally with the webgl stub (`npm test -- --webgl-stub`). On my machine, I can consistently trigger the `afterAll` error in the [#d1ed5ba commit from the `voxel-pick-api` branch](https://github.com/CesiumGS/cesium/commit/d1ed5bad39c6379cd1d82e8311d719a54b2600bd). The changes in this PR consistently prevent the error.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- ~[ ] I have update the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
