### PR TITLE
Refactoring for `pickModel.js`

### DIFF
--- a/packages/engine/Source/Scene/Model/pickModel.js
+++ b/packages/engine/Source/Scene/Model/pickModel.js
@@ -394,6 +394,12 @@ function computeInstancesTransforms(
       transforms.push(transform);
     }
   }
+  // TODO Mimic the behavior of the old implementation.
+  // The case that there are no transforms here should probably
+  // never occur, but it does for `EXT_mesh_gpu_instancing`
+  if (transforms.length === 0) {
+    transforms.push(computedModelMatrix);
+  }
   return transforms;
 }
 


### PR DESCRIPTION

There are some issues that are related to model picking, most of them boiling down to the `pickModel.js` functions. These became more apparent with the changed behavior of the screen space camera controller that was introduced in Cesium 1.114. This change caused the `pickModel.js` functions to be called _many_ times, and the behavior was crucially dependent on the correctness of the results. Some of these issues are 

- https://github.com/CesiumGS/cesium/issues/11811
- https://github.com/CesiumGS/cesium/issues/11812
- https://github.com/CesiumGS/cesium/issues/11814
- https://github.com/CesiumGS/cesium/issues/11816

This PR attempts to refactor the `pickModel.js` functions to either resolve/alleviate these issues, isolate their causes, and/or make fixing them a bit easier. 

**NOTE:** The current state is an _intermediate_ state, containing some debug output and compile-time flags. There are a few places marked with `TODO` where the correctness of the refactored state has to be verified, or where specific reasons for some of the issues have been identified but not fixed yet.

(BTW: The build failure is only due to TSDoc issues - this can trivially be resolved. The unit tests are still passing, apparently)

### Changes until now

The change started with breaking the original `pickModel` function into smaller pieces. These should not include any changes in the behavior or approach. The was only intended to have functions that may be easier to test and modify.

The main actual _changes_  for now try to address the performance issues. The old behavior for this part can be restored via the `DEBUG_USE_ORIGINAL` compile-time flag.

**Old approach**

The original approach for finding intersections is now carved out into a function `computeClosestOriginal`. This approach was as follows:

- For each instance transform `t`
  - For each triangle (v0,v1,v2)
    - Transform the triangle vertices with `t`  (done on-the fly in `getVertexPosition`)
    - Test the transformed triangle for intersection with the `ray`

This causes _all_ vertices to be transformed _many_ times (once for each instancing transform).

**New approach**

The new approach is in the `computeClosestWithTransformedRays` function. It works as follows

- For each instance transform `t`
  - compute a `transformedRay` that was computed as `t^-1 * ray`
- For each triangle (v0,v1,v2)
  - Test the triangle for intersections with each `transformedRay`

Now, the vertices do not have to be transformed any more.

---

A comparision of a very crude "benchmak" (details below), with ballpark estimates for picking times:

- `TOTAL took 16198.300000000745ms for 81 hits` with current `main`
- `TOTAL took 16834.5ms for 81 hits` with the refactored state, **without** the new approach
- `TOTAL took 10083.099999999627ms for 81 hits` **with** the new approach


---

### Current state

The original `pickModel` function is wrapped into one that prints timing- and debug information. (Before merging, the lines that contain `debugInfo` may simply be removed, but _maybe_ something like that could be useful later, maybe via some compile-time flag?). The debug information just collects info about how many nodes/primitives/indices have been considered during the picking. This may be an output like
```
{
  "numNodes": 10,
  "nodeInfos": [
    {
      "numTransforms": 1,
      "numPrimitives": 1,
      "numCheckedPrimitives": 1,
      "primitiveInfos": [
        {
          "numIndices": 372006
        }
      ]
    },
    ...
  ],
  "totalNumIndices": 3720060
}
took 125.5ms
``` 
The idea is that this could give valuable hints about **why** a certain pick operation took as long as it took.

Here is an archive that contains a Sandcastle for picking tests, and a few test models:

[Cesium 114 picking issues PR 2024-02-14.zip](https://github.com/CesiumGS/cesium/files/14284008/Cesium.114.picking.issues.PR.2024-02-14.zip)

The archive also contains a `README.md` explaining some details about the test models. 

The sandcastle can load one of these models, and allows "debug picking". It also contains some sort of crude "benchmark". For example, when loading the `plane-xz-p-n-250x250-times-10.glb` test model and then **RIGHT** clicking once, it will send many picking rays through the model and print the accumulated timing information. 

### Further steps

The main change until now was to avoid transforming the vertices, and instead, transforming the picking ray. The function `getVertexPositionRaw` is obtaining the vertices in their _un_-transformed form. **But** this function is still doing dequantization and other things. Considering that each vertex is contained in (on average) six triangles, this will still do a lot of work _multiple times_. It may be worthwhile to consider doing this only _once_, and storing the "fully decoded" vertices, before going through the indices/triangles and doing the intersection tests. 

I have not yet created test models that contain quantization. One reason for that is that I'd do this with glTF-Transform, and this always uses interleaved buffers, which don't work at all right now - see below. As soon as this issue is resolved, further test models with quantization can be created, to perform the appropriate benchmark runs and comparisons.


## Testing plan

As mentioned above, the current state is a **DRAFT**. Aspects that require review and further tests are marked with `TODO` in the current code. This includes...

- Models with _interleaved accessors_ do not work. The reasons are pointed out in https://github.com/CesiumGS/cesium/issues/11816#issuecomment-1939803607 , and the archive contains two test models for that: One "unit square" with standard accessor layout, and once with _interleaved_ accessor layout
- The new approach for the intersection tests will transform the _ray_, and not the _vertices_. One place in the code is marked with a `TODO` to point out that the "vertical exaggeration" may have to be taken into account here (I haven't yet thought about the details _how_ this could be done)
- Models that use `EXT_mesh_gpu_instancing` cannot be picked. The point for addressing this is in the part that is now carved out into a function called `computeInstancesTransforms`. 


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [X] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
