### PR TITLE
docs: Improve the types of Billboard&BillboardCollection.add and Label&LabelCollection.add

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -379,3 +379,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Anne Gropler](https://github.com/anne-gropler)
 - [Harsh Lakhara](https://github.com/harshlakhara)
 - [Pavlo Skakun](https://github.com/p-skakun)
+- [s3xysteak](https://github.com/s3xysteak)

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -23,6 +23,33 @@ import SceneTransforms from "./SceneTransforms.js";
 import VerticalOrigin from "./VerticalOrigin.js";
 
 /**
+ * @typedef {object} Billboard.ConstructorOptions
+ *
+ * Initialization options for the first param of Billboard constructor
+ *
+ * @property {Property | boolean} [show=true] A boolean Property specifying the visibility of the billboard.
+ * @property {Property | string | HTMLCanvasElement} [image] A Property specifying the Image, URI, or Canvas to use for the billboard.
+ * @property {Property | number} [scale=1.0] A numeric Property specifying the scale to apply to the image size.
+ * @property {Property | Cartesian2} [pixelOffset=Cartesian2.ZERO] A {@link Cartesian2} Property specifying the pixel offset.
+ * @property {Property | Cartesian3} [eyeOffset=Cartesian3.ZERO] A {@link Cartesian3} Property specifying the eye offset.
+ * @property {Property | HorizontalOrigin} [horizontalOrigin=HorizontalOrigin.CENTER] A Property specifying the {@link HorizontalOrigin}.
+ * @property {Property | VerticalOrigin} [verticalOrigin=VerticalOrigin.CENTER] A Property specifying the {@link VerticalOrigin}.
+ * @property {Property | HeightReference} [heightReference=HeightReference.NONE] A Property specifying what the height is relative to.
+ * @property {Property | Color} [color=Color.WHITE] A Property specifying the tint {@link Color} of the image.
+ * @property {Property | number} [rotation=0] A numeric Property specifying the rotation about the alignedAxis.
+ * @property {Property | Cartesian3} [alignedAxis=Cartesian3.ZERO] A {@link Cartesian3} Property specifying the unit vector axis of rotation.
+ * @property {Property | boolean} [sizeInMeters] A boolean Property specifying whether this billboard's size should be measured in meters.
+ * @property {Property | number} [width] A numeric Property specifying the width of the billboard in pixels, overriding the native size.
+ * @property {Property | number} [height] A numeric Property specifying the height of the billboard in pixels, overriding the native size.
+ * @property {Property | NearFarScalar} [scaleByDistance] A {@link NearFarScalar} Property used to scale the point based on distance from the camera.
+ * @property {Property | NearFarScalar} [translucencyByDistance] A {@link NearFarScalar} Property used to set translucency based on distance from the camera.
+ * @property {Property | NearFarScalar} [pixelOffsetScaleByDistance] A {@link NearFarScalar} Property used to set pixelOffset based on distance from the camera.
+ * @property {Property | BoundingRectangle} [imageSubRegion] A Property specifying a {@link BoundingRectangle} that defines a sub-region of the image to use for the billboard, rather than the entire image, measured in pixels from the bottom-left.
+ * @property {Property | DistanceDisplayCondition} [distanceDisplayCondition] A Property specifying at what distance from the camera that this billboard will be displayed.
+ * @property {Property | number} [disableDepthTestDistance] A Property specifying the distance from the camera at which to disable the depth test to.
+ */
+
+/**
  * <div class="notice">
  * A billboard is created and its initial
  * properties are set by calling {@link BillboardCollection#add}. Do not call the constructor directly.
@@ -55,6 +82,9 @@ import VerticalOrigin from "./VerticalOrigin.js";
  *
  * @internalConstructor
  * @class
+ *
+ * @param {Billboard.ConstructorOptions} options Object describing initialization options
+ * @param {BillboardCollection} billboardCollection Instance of BillboardCollection
  *
  * @demo {@link https://sandcastle.cesium.com/index.html?src=Billboards.html|Cesium Sandcastle Billboard Demo}
  */

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -426,7 +426,7 @@ function destroyBillboards(billboards) {
  * Creates and adds a billboard with the specified initial properties to the collection.
  * The added billboard is returned so it can be modified or removed from the collection later.
  *
- * @param {object}[options] A template describing the billboard's properties as shown in Example 1.
+ * @param {Billboard.ConstructorOptions}[options] A template describing the billboard's properties as shown in Example 1.
  * @returns {Billboard} The billboard that was added to the collection.
  *
  * @performance Calling <code>add</code> is expected constant time.  However, the collection's vertex buffer

--- a/packages/engine/Source/Scene/Label.js
+++ b/packages/engine/Source/Scene/Label.js
@@ -86,6 +86,34 @@ function parseFont(label) {
 }
 
 /**
+ * @typedef {object} Label.ConstructorOptions
+ *
+ * Initialization options for the Label constructor
+ *
+ * @property {Property | boolean} [show=true] A boolean Property specifying the visibility of the label.
+ * @property {Property | string} [text] A Property specifying the text. Explicit newlines '\n' are supported.
+ * @property {Property | string} [font='30px sans-serif'] A Property specifying the CSS font.
+ * @property {Property | LabelStyle} [style=LabelStyle.FILL] A Property specifying the {@link LabelStyle}.
+ * @property {Property | number} [scale=1.0] A numeric Property specifying the scale to apply to the text.
+ * @property {Property | boolean} [showBackground=false] A boolean Property specifying the visibility of the background behind the label.
+ * @property {Property | Color} [backgroundColor=new Color(0.165, 0.165, 0.165, 0.8)] A Property specifying the background {@link Color}.
+ * @property {Property | Cartesian2} [backgroundPadding=new Cartesian2(7, 5)] A {@link Cartesian2} Property specifying the horizontal and vertical background padding in pixels.
+ * @property {Property | Cartesian2} [pixelOffset=Cartesian2.ZERO] A {@link Cartesian2} Property specifying the pixel offset.
+ * @property {Property | Cartesian3} [eyeOffset=Cartesian3.ZERO] A {@link Cartesian3} Property specifying the eye offset.
+ * @property {Property | HorizontalOrigin} [horizontalOrigin=HorizontalOrigin.CENTER] A Property specifying the {@link HorizontalOrigin}.
+ * @property {Property | VerticalOrigin} [verticalOrigin=VerticalOrigin.CENTER] A Property specifying the {@link VerticalOrigin}.
+ * @property {Property | HeightReference} [heightReference=HeightReference.NONE] A Property specifying what the height is relative to.
+ * @property {Property | Color} [fillColor=Color.WHITE] A Property specifying the fill {@link Color}.
+ * @property {Property | Color} [outlineColor=Color.BLACK] A Property specifying the outline {@link Color}.
+ * @property {Property | number} [outlineWidth=1.0] A numeric Property specifying the outline width.
+ * @property {Property | NearFarScalar} [translucencyByDistance] A {@link NearFarScalar} Property used to set translucency based on distance from the camera.
+ * @property {Property | NearFarScalar} [pixelOffsetScaleByDistance] A {@link NearFarScalar} Property used to set pixelOffset based on distance from the camera.
+ * @property {Property | NearFarScalar} [scaleByDistance] A {@link NearFarScalar} Property used to set scale based on distance from the camera.
+ * @property {Property | DistanceDisplayCondition} [distanceDisplayCondition] A Property specifying at what distance from the camera that this label will be displayed.
+ * @property {Property | number} [disableDepthTestDistance] A Property specifying the distance from the camera at which to disable the depth test to.
+ */
+
+/**
  * <div class="notice">
  * Create labels by calling {@link LabelCollection#add}. Do not call the constructor directly.
  * </div>
@@ -93,6 +121,9 @@ function parseFont(label) {
  * @alias Label
  * @internalConstructor
  * @class
+ *
+ * @param {Label.ConstructorOptions} options Object describing initialization options
+ * @param {LabelCollection} labelCollection Instance of LabelCollection
  *
  * @exception {DeveloperError} translucencyByDistance.far must be greater than translucencyByDistance.near
  * @exception {DeveloperError} pixelOffsetScaleByDistance.far must be greater than pixelOffsetScaleByDistance.near

--- a/packages/engine/Source/Scene/LabelCollection.js
+++ b/packages/engine/Source/Scene/LabelCollection.js
@@ -755,6 +755,8 @@ Object.defineProperties(LabelCollection.prototype, {
  *   font : '24px Helvetica',
  * });
  *
+ * @param {Label.ConstructorOptions} options
+ *
  * @see LabelCollection#remove
  * @see LabelCollection#removeAll
  */


### PR DESCRIPTION
# Description

It improves the types of `Billboard`&`BillboardCollection.add` and `Label`&`LabelCollection.add`.

Fix a doc bug that they both do not contain `disableDepthTestDistance` in option, which should be contained.
Add types about the constructOptions of Label and Billboard. They are copy from `BillboardGraphics` / `LabelGraphics`. 

Future improvement:
I think it may be need a little discussion that The [BillboardGraphics](https://github.com/CesiumGS/cesium/blob/1.114/packages/engine/Source/DataSources/BillboardGraphics.js#L50) and [LabelGraphics](https://github.com/CesiumGS/cesium/blob/1.114/packages/engine/Source/DataSources/LabelGraphics.js#L8) already have similar type declarations. Should I
use the type declarations here directly in Billboard and Label,
or declare them in Billboard and Label and then reference them elsewhere,
or simply copy the type declarations and use them in both Label and LabelCollection?

I believe both approaches would not have any impact on the usage of the code (including TypeScript users). However, a less optimal solution might cause confusion during future maintenance.

## Issue number and link

see #11813.

## Testing plan

The PR is only about docs. Run `build-docs` and `build-ts`, and check the effect.
Before: BillboardCollection.add and LabelCollection.add have no intellisense.
After:  They should have correct intellisense. 

Run `npm run build-docs` to confirm the document should be correct to show the information.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
