### PR TITLE
Update power plant tileset

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles BIM.html
+++ b/Apps/Sandcastle/gallery/3D Tiles BIM.html
@@ -187,7 +187,7 @@
         }
 
         try {
-          const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(1240402, {
+          const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(2464651, {
             disableCollision: true,
           });
           scene.primitives.add(tileset);

--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -291,7 +291,7 @@
         }
 
         // Power Plant design model provided by Bentley Systems
-        const bimUrl = Cesium.IonResource.fromAssetId(1240402, {
+        const bimUrl = Cesium.IonResource.fromAssetId(2464651, {
           disableCollision: true,
         });
         const pointCloudUrl = Cesium.IonResource.fromAssetId(16421);

--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -192,7 +192,7 @@
 
         try {
           // Power Plant design model provided by Bentley Systems
-          const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(1240402, {
+          const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(2464651, {
             disableCollision: true,
           });
           viewer.scene.primitives.add(tileset);

--- a/Apps/Sandcastle/gallery/MSAA.html
+++ b/Apps/Sandcastle/gallery/MSAA.html
@@ -139,7 +139,7 @@
                   roll: 6.283184816241989,
                 },
               });
-              createTileset(1240402, {
+              createTileset(2464651, {
                 disableCollision: true,
               });
             },

--- a/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
@@ -59,7 +59,7 @@
         let powerPlant;
         let powerPlantShow = true;
         try {
-          powerPlant = await Cesium.Cesium3DTileset.fromIonAssetId(1240402, {
+          powerPlant = await Cesium.Cesium3DTileset.fromIonAssetId(2464651, {
             disableCollision: true,
           });
           powerPlant.show = powerPlantShow;

--- a/Apps/Sandcastle/gallery/development/3D Tiles Picking.html
+++ b/Apps/Sandcastle/gallery/development/3D Tiles Picking.html
@@ -76,7 +76,7 @@
             onselect: async () => {
               scene.primitives.remove(tileset);
               try {
-                tileset = await Cesium.Cesium3DTileset.fromIonAssetId(1240402, {
+                tileset = await Cesium.Cesium3DTileset.fromIonAssetId(2464651, {
                   disableCollision: true,
                 });
                 scene.primitives.add(tileset);


### PR DESCRIPTION
# Description

When the power plant model was updated in https://github.com/CesiumGS/cesium/pull/10615 one of the batch table properties got lost. I reprocessed the data and uploaded it to ion.

## Testing plan

When you click any feature in the tileset you should now see a `Type` property.

![image](https://github.com/CesiumGS/cesium/assets/915398/0522e728-d853-4de6-9b58-9945fcc427d7)


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
