### PR TITLE
Destroy event handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fixed a bug affecting voxel shader compilation in WebGL1 contexts. [#11798](https://github.com/CesiumGS/cesium/pull/11798)
 - Fixed a bug where legacy B3DM files that contained glTF 1.0 data that used a `CONSTANT` technique in the `KHR_material_common` extension and only defined ambient- or emissive textures (but no diffuse textures) showed up without any texture [#11825](https://github.com/CesiumGS/cesium/pull/11825)
+- Fixed develop error from `screenSpaceEventHandler` being destroyed before `Viewer` [#10576](https://github.com/CesiumGS/cesium/issues/10576)
 
 ### 1.114 - 2024-02-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 - Fixed a bug affecting voxel shader compilation in WebGL1 contexts. [#11798](https://github.com/CesiumGS/cesium/pull/11798)
 - Fixed a bug where legacy B3DM files that contained glTF 1.0 data that used a `CONSTANT` technique in the `KHR_material_common` extension and only defined ambient- or emissive textures (but no diffuse textures) showed up without any texture [#11825](https://github.com/CesiumGS/cesium/pull/11825)
-- Fixed develop error from `screenSpaceEventHandler` being destroyed before `Viewer` [#10576](https://github.com/CesiumGS/cesium/issues/10576)
+- Fixed an error when the `screenSpaceEventHandler` was destroyed before `Viewer` [#10576](https://github.com/CesiumGS/cesium/issues/10576)
 
 ### 1.114 - 2024-02-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -379,3 +379,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Anne Gropler](https://github.com/anne-gropler)
 - [Harsh Lakhara](https://github.com/harshlakhara)
 - [Pavlo Skakun](https://github.com/p-skakun)
+- [Taylor Huffman](https://github.com/huffmantayler)

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -1718,15 +1718,17 @@ Viewer.prototype.isDestroyed = function () {
  */
 Viewer.prototype.destroy = function () {
   let i;
-  if(defined(this.screenSpaceEventHandler)){
+  if (
+    defined(this.screenSpaceEventHandler) &&
+    !this.screenSpaceEventHandler.isDestroyed()
+  ) {
     this.screenSpaceEventHandler.removeInputAction(
-    ScreenSpaceEventType.LEFT_CLICK
+      ScreenSpaceEventType.LEFT_CLICK
     );
     this.screenSpaceEventHandler.removeInputAction(
       ScreenSpaceEventType.LEFT_DOUBLE_CLICK
     );
   }
-
 
   // Unsubscribe from data sources
   const dataSources = this.dataSources;

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -1718,13 +1718,15 @@ Viewer.prototype.isDestroyed = function () {
  */
 Viewer.prototype.destroy = function () {
   let i;
-
-  this.screenSpaceEventHandler.removeInputAction(
+  if(defined(this.screenSpaceEventHandler)){
+    this.screenSpaceEventHandler.removeInputAction(
     ScreenSpaceEventType.LEFT_CLICK
-  );
-  this.screenSpaceEventHandler.removeInputAction(
-    ScreenSpaceEventType.LEFT_DOUBLE_CLICK
-  );
+    );
+    this.screenSpaceEventHandler.removeInputAction(
+      ScreenSpaceEventType.LEFT_DOUBLE_CLICK
+    );
+  }
+
 
   // Unsubscribe from data sources
   const dataSources = this.dataSources;


### PR DESCRIPTION
Updated Viewers destroy method to check if screenSpaceEventHandler is defined before removing.

Fixes https://github.com/CesiumGS/cesium/issues/10576
