### PR TITLE
Fixing refinement of mixed empty and non-empty tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fixed a bug affecting voxel shader compilation in WebGL1 contexts. [#11798](https://github.com/CesiumGS/cesium/pull/11798)
 - Fixed a bug where legacy B3DM files that contained glTF 1.0 data that used a `CONSTANT` technique in the `KHR_material_common` extension and only defined ambient- or emissive textures (but no diffuse textures) showed up without any texture [#11825](https://github.com/CesiumGS/cesium/pull/11825)
+- Fixed a bug causing the wrong tile to be selected for some implicit tilesets.
 
 ### 1.114 - 2024-02-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,6 @@
 - Fixed a bug with where a mix of empty and non-empty tiles were not refining. [#9356](https://github.com/CesiumGS/cesium/issues/9356)
 - Fixed a bug affecting voxel shader compilation in WebGL1 contexts. [#11798](https://github.com/CesiumGS/cesium/pull/11798)
 - Fixed a bug where legacy B3DM files that contained glTF 1.0 data that used a `CONSTANT` technique in the `KHR_material_common` extension and only defined ambient- or emissive textures (but no diffuse textures) showed up without any texture [#11825](https://github.com/CesiumGS/cesium/pull/11825)
-- Fixed a bug causing the wrong tile to be selected for some implicit tilesets.
 
 ### 1.114 - 2024-02-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -163,6 +163,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Mark Dane](https://github.com/angrycat9000)
   - [jjspace](https://github.com/jjspace)
   - [Siddhesh Ranade](https://github.com/siddheshranade)
+  - [Adam Morris](https://github.com/weegeekps)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -139,6 +139,7 @@ function updateAndPushChildren(tile, stack, frameState) {
         childRefines = false;
       } else if (!child.hasRenderableContent) {
         childRefines = executeEmptyTraversal(child, frameState);
+        // childRefines = true;
       } else {
         childRefines = child.contentAvailable;
       }
@@ -295,7 +296,9 @@ function executeEmptyTraversal(root, frameState) {
     }
   }
 
-  return allDescendantsLoaded;
+  return (
+    root.hasEmptyContent || root.hasImplicitContent || allDescendantsLoaded
+  );
 }
 
 export default Cesium3DTilesetBaseTraversal;

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -295,9 +295,7 @@ function executeEmptyTraversal(root, frameState) {
     }
   }
 
-  return (
-    root.hasEmptyContent || root.hasImplicitContent || allDescendantsLoaded
-  );
+  return root.hasEmptyContent || allDescendantsLoaded;
 }
 
 export default Cesium3DTilesetBaseTraversal;

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -139,7 +139,6 @@ function updateAndPushChildren(tile, stack, frameState) {
         childRefines = false;
       } else if (!child.hasRenderableContent) {
         childRefines = executeEmptyTraversal(child, frameState);
-        // childRefines = true;
       } else {
         childRefines = child.contentAvailable;
       }

--- a/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js
@@ -271,12 +271,10 @@ function executeEmptyTraversal(root, frameState) {
 
     // Only traverse if the tile is empty - traversal stops at descendants with content
     const traverse = !tile.hasRenderableContent && canTraverse(tile);
-    const emptyLeaf = !tile.hasRenderableContent && tile.children.length === 0;
 
     // Traversal stops but the tile does not have content yet
     // There will be holes if the parent tries to refine to its children, so don't refine
-    // One exception: a parent may refine even if one of its descendants is an empty leaf
-    if (!traverse && !tile.contentAvailable && !emptyLeaf) {
+    if (!traverse && !tile.contentAvailable) {
       allDescendantsLoaded = false;
     }
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

Adds a short circuit in `executeEmptyTraversal` for when descendants may not be loaded, but the tile may have empty or implicit content. This resolves some selection issues with implicit tilesets.

<!-- Consider: Why is this change required? What problem does it solve? -->

We believe this is the root cause for several instances where the wrong tiles are being selected with implicit tilesets. With the release of the Reality Tiler, we're seeing this more and more often, with bugs similar to: https://github.com/CesiumGS/tilers/issues/1297

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

Fixes #9356. 

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

I tested a variety of scenarios and tilesets, including but not excluding:

- The private tileset that triggered this issue.
- Google Photorealistic Tiles
- San Francisco Aerometrex
- Cesium World Terrain
- Cesium World Bathemetry

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
