### PR TITLE
Fix: set check-cla workflow to trigger on forked repo PRs too

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,6 +1,6 @@
 name: CLA Checking
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: CLA Checking
+name: check-cla
 on:
   pull_request_target:
     types: [opened]


### PR DESCRIPTION
# Description

This a bug fix for the CLA checking workflow. Original [PR here](https://github.com/CesiumGS/cesium/pull/11783). The workflow wasn't working for pull requests from forked repositories - the trigger wasn't right and the GitHub API was failing.

With the new changes ([docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)) the workflow runs successfully. See the bot comment on this [test PR](https://github.com/CesiumGS/cesium/pull/11861). 

## Issue number and link

This is part of https://github.com/CesiumGS/engineering/issues/235.

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

To test this, you can:
1. fork this repo,
2. submit a pull request, ensuring the target repo is this and the target branch is `cla-checking-mod`,
3. verify that the github-actions a) writes a comment on your PR b) that does not have an error.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
