### PR TITLE
Add missing 'featureCount' property in the spec data

### DIFF
--- a/Specs/Data/Models/glTF-2.0/FeatureIdTextureWithTextureTransform/glTF/FeatureIdTextureWithTextureTransform.gltf
+++ b/Specs/Data/Models/glTF-2.0/FeatureIdTextureWithTextureTransform/glTF/FeatureIdTextureWithTextureTransform.gltf
@@ -122,6 +122,7 @@
             "EXT_mesh_features": {
               "featureIds": [
                 {
+                  "featureCount": 64,
                   "texture": {
                     "channels": [
                       0


### PR DESCRIPTION
The `/Specs/Data/Models/glTF-2.0/FeatureIdTextureWithTextureTransform/glTF/FeatureIdTextureWithTextureTransform.gltf` contains a feature ID texture, but the `featureId` definition was missing the required `featureCount` property. 

(Noticed in https://github.com/CesiumGS/cesium-unreal/pull/1360 )

Specifically, the file caused a validator error

{
  "date": "2024-02-27T16:02:00.583Z",
  "numErrors": 1,
  "numWarnings": 0,
  "numInfos": 1,
  [
    ....
    {
      "type": "PROPERTY_MISSING",
      "path": "FeatureIdTextureWithTextureTransform.gltf/featureIds/0/featureCount",
      "message": "The 'featureCount' property is required",
      "severity": "ERROR"
    }
  ]
}
```

