### PR TITLE
GitHub issue links in WebStorm Git log

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/CesiumGS/cesium/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>


### PR DESCRIPTION
## Overview

GitHub issue links in WebStorm Git log

---

### Definition of Done

Clickable links in WebStorm Git log 

Before - `#2236` 
After -  #2236 

<img width="602" alt="Screenshot 2020-04-05 at 16 26 37" src="https://user-images.githubusercontent.com/9942723/78499594-3cdb7a00-775a-11ea-9c03-0c42f6558b90.png">

