### PR TITLE
Fix typo in `createGeometry`

### DIFF
--- a/packages/engine/Source/Workers/createGeometry.js
+++ b/packages/engine/Source/Workers/createGeometry.js
@@ -8,7 +8,7 @@ import createTaskProcessorWorker from "./createTaskProcessorWorker.js";
 const moduleCache = {};
 
 async function getModule(moduleName, modulePath) {
-  let module = defaultValue(moduleCache[modulePath] ?? moduleCache[moduleName]);
+  let module = defaultValue(moduleCache[modulePath], moduleCache[moduleName]);
 
   if (defined(module)) {
     return module;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

I noticed a typo I accidentally introduced in https://github.com/CesiumGS/cesium/pull/11859. I do not believe it should have any negative affect on the code as is but essentially means we're needlessly doing a call to `defaultValue`

Discussed with @ggetz offline and we don't feel this needs a re-release of 1.115 which went out earlier today

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Make sure geometry based entities render fine in `main` and this branch

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
