### PR TITLE
Fixes BingMapsImageryProvider ineffective culture option problem.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.116 - 2024-04-01
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Fixes issue with `BingMapsImageryProvider` where given culture option is ineffective [#11695](https://github.com/CesiumGS/cesium/issues/11695)
+
 ### 1.115 - 2024-03-01
 
 #### @cesium/engine

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@
 ##### Breaking Changes :mega:
 
 - `Cesium3DTileset.disableCollision` has been removed. Use `Cesium3DTileset.enableCollision` instead.
-- 
+-
+
 ##### Fixes :wrench:
 
 - Fixes issue with `BingMapsImageryProvider` where given culture option is ineffective [#11695](https://github.com/CesiumGS/cesium/issues/11695)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -191,6 +191,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Terradepth, Inc.](https://www.terradepth.com/)
   - [Marc Johnson](https://github.com/marcejohnson)
   - [Jacob Frazer](https://github.com/coderjake91)
+- [T2 Software](http://t2.com.tr/)
+  - [Hüseyin ATEŞ](https://github.com/ateshuseyin)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/packages/engine/Source/Scene/BingMapsImageryProvider.js
+++ b/packages/engine/Source/Scene/BingMapsImageryProvider.js
@@ -500,6 +500,10 @@ BingMapsImageryProvider.fromUrl = async function (url, options) {
     queryParameters.mapLayer = options.mapLayer;
   }
 
+  if (defined(options.culture)) {
+    queryParameters.culture = options.culture;
+  }
+
   const metadataResource = resource.getDerivedResource({
     url: `REST/v1/Imagery/Metadata/${mapStyle}`,
     queryParameters: queryParameters,

--- a/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -82,7 +82,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     expect(BingMapsImageryProvider).toConformToInterface(ImageryProvider);
   });
 
-  function installFakeMetadataRequest(url, mapStyle, mapLayer) {
+  function installFakeMetadataRequest(url, mapStyle, mapLayer, culture) {
     const baseUri = new Uri(appendForwardSlash(url));
     const expectedUri = new Uri(
       `REST/v1/Imagery/Metadata/${mapStyle}`
@@ -101,6 +101,10 @@ describe("Scene/BingMapsImageryProvider", function () {
 
       if (defined(mapLayer)) {
         expect(query.mapLayer).toEqual(mapLayer);
+      }
+
+      if (defined(culture)) {
+        expect(query.culture).toEqual(culture);
       }
 
       uri.query("");
@@ -434,11 +438,10 @@ describe("Scene/BingMapsImageryProvider", function () {
   it("sets correct culture in tile requests", async function () {
     const url = "http://fake.fake.invalid";
     const mapStyle = BingMapsStyle.AERIAL_WITH_LABELS;
-
-    installFakeMetadataRequest(url, mapStyle);
-    installFakeImageRequest();
-
     const culture = "ja-jp";
+
+    installFakeMetadataRequest(url, mapStyle, undefined, culture);
+    installFakeImageRequest();
 
     const provider = await BingMapsImageryProvider.fromUrl(url, {
       key: "",


### PR DESCRIPTION
# Description
This PR fixes #11695 

According to Cesium documentation (To construct a BingMapsImageryProvider, call [BingMapsImageryProvider.fromUrl](https://cesium.com/learn/cesiumjs/ref-doc/BingMapsImageryProvider.html#.fromUrl). Do not call the constructor directly.) I modified the code as below;
```javascript
const viewer = new Cesium.Viewer("cesiumContainer");

const bing = await Cesium.BingMapsImageryProvider.fromUrl(
  "https://dev.virtualearth.net", {
    culture: "es-ES",
    key: "use-your-own-key",
    mapStyle: Cesium.BingMapsStyle.AERIAL_WITH_LABELS_ON_DEMAND,
});

viewer.scene.imageryLayers.removeAll();
viewer.scene.imageryLayers.addImageryProvider(bing);
```
When I evaluated the problem I saw that the problem was about metadata request and it did not tested well.  I just added culture parameter into metadata request which fixes the problem.

![image](https://github.com/CesiumGS/cesium/assets/10994250/0323d5c2-fa15-49ff-b3ef-04bd0e36403d)

## Issue number and link

Fixes #11695 11695

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
