### PR TITLE
Cesium3DTileset.disableCollision is removed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 #### @cesium/engine
 
-##### Fixes :wrench:
+##### Breaking Changes :mega:
 
 - `Cesium3DTileset.disableCollision` has been removed. Use `Cesium3DTileset.enableCollision` instead.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.116 - 2024-04-01
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- `Cesium3DTileset.disableCollision` has been removed. Use `Cesium3DTileset.enableCollision` instead.
+
 ### 1.115 - 2024-03-01
 
 #### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -191,6 +191,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Terradepth, Inc.](https://www.terradepth.com/)
   - [Marc Johnson](https://github.com/marcejohnson)
   - [Jacob Frazer](https://github.com/coderjake91)
+- [T2 Software](https://www.t2.com.tr/)
+  - [İbrahim Furkan Aygar](https://github.com/furkanaygar)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -113,7 +113,6 @@ import Ray from "../Core/Ray.js";
  * @property {boolean} [showCreditsOnScreen=false] Whether to display the credits of this tileset on screen.
  * @property {SplitDirection} [splitDirection=SplitDirection.NONE] The {@link SplitDirection} split to apply to this tileset.
  * @property {boolean} [enableCollision=false] When <code>true</code>, enables collisions for camera or CPU picking. While this is <code>true</code> the camera will be prevented from going below the tileset surface if {@link ScreenSpaceCameraController#enableCollisionDetection} is true.
- * @property {boolean} [disableCollision=true] Whether to turn off collisions for camera collisions or picking. While this is <code>true</code> the camera will be allowed to go in or below the tileset surface if {@link ScreenSpaceCameraController#enableCollisionDetection} is true. Deprecated.
  * @property {boolean} [projectTo2D=false] Whether to accurately project the tileset to 2D. If this is true, the tileset will be projected accurately to 2D, but it will use more memory to do so. If this is false, the tileset will use less memory and will still render in 2D / CV mode, but its projected positions may be inaccurate. This cannot be set after the tileset has been created.
  * @property {boolean} [enablePick=false] Whether to allow collision and CPU picking with <code>pick</code> when using WebGL 1. If using WebGL 2 or above, this option will be ignored. If using WebGL 1 and this is true, the <code>pick</code> operation will work correctly, but it will use more memory to do so. If running with WebGL 1 and this is false, the model will use less memory, but <code>pick</code> will always return <code>undefined</code>. This cannot be set after the tileset has loaded.
  * @property {string} [debugHeatmapTilePropertyName] The tile variable to colorize as a heatmap. All rendered tiles will be colorized relative to each other's specified variable value.
@@ -871,16 +870,6 @@ function Cesium3DTileset(options) {
    * @default false
    */
   this.enableCollision = defaultValue(options.enableCollision, false);
-
-  if (defined(options.disableCollision)) {
-    deprecationWarning(
-      "Cesium3DTileset options.disableCollision",
-      "Cesium3DTileset options.disableCollision has been deprecated in CesiumJS 1.115.  It will be removed in CesiumJS 1.116. Use options.enableCollision instead."
-    );
-
-    this.enableCollision = !options.disableCollision;
-  }
-
   this._projectTo2D = defaultValue(options.projectTo2D, false);
   this._enablePick = defaultValue(options.enablePick, false);
 
@@ -1080,34 +1069,6 @@ Object.defineProperties(Cesium3DTileset.prototype, {
   isCesium3DTileset: {
     get: function () {
       return true;
-    },
-  },
-
-  /**
-   * Whether to turn off collisions for camera collisions or picking. While this is <code>true</code> the camera will be allowed to go in or below the tileset surface if {@link ScreenSpaceCameraController#enableCollisionDetection} is true.
-   * @memberof Cesium3DTileset.prototype
-   *
-   * @type {boolean}
-   * @default true
-   *
-   * @deprecated
-   */
-  disableCollision: {
-    get: function () {
-      deprecationWarning(
-        "Cesium3DTileset.disableCollision",
-        "Cesium3DTileset.disableCollision has been deprecated in CesiumJS 1.115.  It will be removed in CesiumJS 1.116. Use Cesium3DTileset.enableCollision instead."
-      );
-
-      return !this.enableCollision;
-    },
-    set: function (value) {
-      deprecationWarning(
-        "Cesium3DTileset.disableCollision",
-        "Cesium3DTileset.disableCollision has been deprecated in CesiumJS 1.115.  It will be removed in CesiumJS 1.116. Use Cesium3DTileset.enableCollision instead."
-      );
-
-      this.enableCollision = !value;
     },
   },
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
In this PR, the already deprecated Cesium3DTileset.disableCollision is removed.

## Issue number and link

#11867

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
