### PR TITLE
fix PolygonGeometry uvs by projectTo2d input should is array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 - Fixes issue with `BingMapsImageryProvider` where given culture option is ineffective [#11695](https://github.com/CesiumGS/cesium/issues/11695)
 - Fixed a bug where dynamic geometries caused the Scene to continuously render when running in requestRenderMode [#6631](https://github.com/CesiumGS/cesium/issues/6631)
+- Fixes issue with PolygonGeometry uvs are improperly computed [#11767](https://github.com/CesiumGS/cesium/issues/11767)
 
 ##### Additions :tada:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -385,3 +385,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Pavlo Skakun](https://github.com/p-skakun)
 - [Taylor Huffman](https://github.com/huffmantayler)
 - [蒋宇梁](https://github.com/s3xysteak)
+- [dslming](https://github.com/dslming)

--- a/packages/engine/Source/Core/PolygonGeometry.js
+++ b/packages/engine/Source/Core/PolygonGeometry.js
@@ -171,7 +171,7 @@ function computeAttributes(options) {
             scratchPosition
           );
           p = ellipsoid.scaleToGeodeticSurface(p, p);
-          const st = projectTo2d(p, appendTextureCoordinatesCartesian2);
+          const st = projectTo2d([p], appendTextureCoordinatesCartesian2)[0];
           Cartesian2.subtract(st, origin, st);
 
           const stx = CesiumMath.clamp(st.x / boundingRectangle.width, 0, 1);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->
Fix PolygonGeometry uvs by projectTo2d input should is array

<!-- Consider: Why is this change required? What problem does it solve? -->
projectTo2d  actually called is : EllipsoidTangentPlane.prototype.projectPointsOntoPlane .

but both input and output are arrays.

<!-- Include screenshots if appropriate -->

## Issue number and link
[#11767](https://github.com/CesiumGS/cesium/issues/11767)
[#11870](https://github.com/CesiumGS/cesium/issues/11870)

<!-- If it fixes an open issue, link to the issue here -->
[#11767](https://github.com/CesiumGS/cesium/issues/11767)
[#11870](https://github.com/CesiumGS/cesium/issues/11870)


<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
The water surface can be rendered normally or the UV calculation is correct.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
