### PR TITLE
Fix performance bug with many tilesets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,9 @@
 
 ##### Fixes :wrench:
 
-- Fixes issue with `BingMapsImageryProvider` where given culture option is ineffective [#11695](https://github.com/CesiumGS/cesium/issues/11695)
+- Fixed issue with `BingMapsImageryProvider` where given culture option is ineffective [#11695](https://github.com/CesiumGS/cesium/issues/11695)
 - Fixed a bug where dynamic geometries caused the Scene to continuously render when running in requestRenderMode [#6631](https://github.com/CesiumGS/cesium/issues/6631)
+- Fixed a bug with performance in scenes with multiple tilesets [#11878](https://github.com/CesiumGS/cesium/pull/11878)
 - Fixed voxel rendering bugs for non-spherical ellipsoid shapes [#11848](https://github.com/CesiumGS/cesium/pull/11848)
 
 ##### Additions :tada:

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -2638,7 +2638,7 @@ const scratchUpdateHeightCartographic = new Cartographic();
 const scratchUpdateHeightCartographic2 = new Cartographic();
 const scratchUpdateHeightCartesian = new Cartesian3();
 function processUpdateHeight(tileset, tile, frameState) {
-  if (!tileset.enableCollision) {
+  if (!tileset.enableCollision || !tileset.show) {
     return;
   }
 

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -2638,6 +2638,10 @@ const scratchUpdateHeightCartographic = new Cartographic();
 const scratchUpdateHeightCartographic2 = new Cartographic();
 const scratchUpdateHeightCartesian = new Cartesian3();
 function processUpdateHeight(tileset, tile, frameState) {
+  if (!tileset.enableCollision) {
+    return;
+  }
+
   const heightCallbackData = tileset._addHeightCallbacks;
   const boundingSphere = tile.boundingSphere;
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Pointed out [on the forum](https://community.cesium.com/t/bug-updateheights-performance-issue/30389). This was an oversight on my part in https://github.com/CesiumGS/cesium/pull/11837.

## Issue number and link

N/A

## Testing plan

1. Verify before and after performance of [OP's Sandcastle](https://sandcastle.cesium.com/#c=rVJRa9swEP4rh9mDsyayk6WhtG7Y1g7WMlhYwh6GH6rIl0RU1gVJTnBL/vtky97KVtjLwOZ8uvu+++6zkgQWdEQDC8W1gwKt3GooqUAFe0MHWWAB6xo+onYKa1jW1mFpcy1IWwcHiQ34GjQe4caDq5J9b8/iPBJtfkPacanR5NHgqsdZgRo9LOBZm/pirrsDoUg8MlEZ4+euZNn0dvT3lZJc33KHbGOovLN0MUvHca4B8miSTiaj9GKUjldpetk+P/Io14OW3JkanpvGIMJJhRadp+ZHLl0/IIR3t6tQDlNIf7A+uSviyXQ2nZ2PG0YIe7C9kaV08oCW8aKIO94wE/odn4jKFbU6oR89DNkL8z4jL6TeLqQTu29cb7EDAKTsfNh/j1I2+ZV0XGxNlW6wy/0ODTLjiSoLb2HK0tA6aELQ3bwbMhArv7/0DqRXPmQw9vHsTA6CTf/RqH9bBXDK9QkE95tDjMaQGfz+W6SQKdrGD5+aAihqbeqVXcKb5xZxemioThANo8y6WuG8d+m9LPdkHFRGxYwl/hLvlb9DNllX4tGLF9b2SrPkJTQr5AFkcf3KfQahuLW+sqmUWsonzKN5lvj+v6Cd3q8HNIrXTdtuPP8SDhljWeLT15GOSK25+YP5Jw)
2. Verify collision still works for google tilesets

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [ ] ~I have update the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
