### PR TITLE
Apply vertical exaggeration to box-shaped voxels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@
 ##### Additions :tada:
 
 - Surface normals are now computed for clipping and shape bounds in VoxelEllipsoidShape and VoxelCylinderShape. [#11847](https://github.com/CesiumGS/cesium/pull/11847)
-- Implemented sharper rendering and lighting on voxels with CYLINDER and ELLIPSOID shape. [#11076](https://github.com/CesiumGS/cesium/pull/11076)
+- Implemented sharper rendering and lighting on voxels with CYLINDER and ELLIPSOID shape. [#11875](https://github.com/CesiumGS/cesium/pull/11875)
+- Implemented vertical exaggeration for voxels with BOX shape. [#11887](https://github.com/CesiumGS/cesium/pull/11887)
 
 ### 1.115 - 2024-03-01
 

--- a/packages/engine/Source/Core/VerticalExaggeration.js
+++ b/packages/engine/Source/Core/VerticalExaggeration.js
@@ -1,4 +1,5 @@
 import Cartesian3 from "./Cartesian3.js";
+import Cartographic from "./Cartographic.js";
 import DeveloperError from "./DeveloperError.js";
 import defined from "./defined.js";
 
@@ -26,7 +27,7 @@ VerticalExaggeration.getHeight = function (height, scale, relativeHeight) {
   return (height - relativeHeight) * scale + relativeHeight;
 };
 
-const scratchCartographic = new Cartesian3();
+const scratchCartographic = new Cartographic();
 
 /**
  * Scales a position by exaggeration.

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -866,7 +866,6 @@ Object.defineProperties(VoxelPrimitive.prototype, {
       return this._minClippingBounds;
     },
     set: function (minClippingBounds) {
-      console.log(`minClippingBounds = ${minClippingBounds}`);
       //>>includeStart('debug', pragmas.debug);
       Check.defined("minClippingBounds", minClippingBounds);
       //>>includeEnd('debug');
@@ -875,7 +874,6 @@ Object.defineProperties(VoxelPrimitive.prototype, {
         minClippingBounds,
         this._minClippingBounds
       );
-      console.log(`this._minClippingBounds = ${this._minClippingBounds}`);
     },
   },
 

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -469,10 +469,10 @@ function initialize(primitive, provider) {
     maxBounds = VoxelShapeType.getMaxBounds(shapeType),
   } = provider;
 
-  primitive._minBounds = minBounds;
-  primitive._maxBounds = maxBounds;
-  primitive._minClippingBounds = VoxelShapeType.getMinBounds(shapeType);
-  primitive._maxClippingBounds = VoxelShapeType.getMaxBounds(shapeType);
+  primitive.minBounds = minBounds;
+  primitive.maxBounds = maxBounds;
+  primitive.minClippingBounds = VoxelShapeType.getMinBounds(shapeType);
+  primitive.maxClippingBounds = VoxelShapeType.getMaxBounds(shapeType);
 
   // Initialize the exaggerated versions of bounds and model matrix
   primitive._exaggeratedMinBounds = Cartesian3.clone(
@@ -866,6 +866,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
       return this._minClippingBounds;
     },
     set: function (minClippingBounds) {
+      console.log(`minClippingBounds = ${minClippingBounds}`);
       //>>includeStart('debug', pragmas.debug);
       Check.defined("minClippingBounds", minClippingBounds);
       //>>includeEnd('debug');
@@ -874,6 +875,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
         minClippingBounds,
         this._minClippingBounds
       );
+      console.log(`this._minClippingBounds = ${this._minClippingBounds}`);
     },
   },
 

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -1231,10 +1231,15 @@ function computeBoxExaggerationTranslation(primitive, frameState) {
 
   // Find the cartographic height
   const ellipsoid = Ellipsoid.WGS84;
-  const centerHeight = ellipsoid.cartesianToCartographic(
+  const centerCartographic = ellipsoid.cartesianToCartographic(
     transformedCenter,
     scratchCartographicCenter
-  ).height;
+  );
+
+  let centerHeight = 0.0;
+  if (defined(centerCartographic)) {
+    centerHeight = centerCartographic.height;
+  }
 
   // Find the shift that will put the center in the right position relative
   // to relativeHeight, after it is scaled by verticalExaggeration

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -22,6 +22,9 @@ import PolylineCollection from "./PolylineCollection.js";
 import VoxelShapeType from "./VoxelShapeType.js";
 import VoxelTraversal from "./VoxelTraversal.js";
 import CustomShader from "./Model/CustomShader.js";
+import Cartographic from "../Core/Cartographic.js";
+import Ellipsoid from "../Core/Ellipsoid.js";
+import VerticalExaggeration from "../Core/VerticalExaggeration.js";
 
 /**
  * A primitive that renders voxel data from a {@link VoxelProvider}.
@@ -230,6 +233,14 @@ function VoxelPrimitive(options) {
   this._modelMatrix = Matrix4.clone(
     defaultValue(options.modelMatrix, Matrix4.IDENTITY)
   );
+
+  /**
+   * Model matrix with vertical exaggeration applied. Only used for BOX shape type.
+   *
+   * @type {Matrix4}
+   * @private
+   */
+  this._exaggeratedModelMatrix = Matrix4.clone(this._modelMatrix);
 
   /**
    * The primitive's model matrix multiplied by the provider's model matrix.
@@ -1138,6 +1149,11 @@ VoxelPrimitive.prototype.update = function (frameState) {
   frameState.commandList.push(command);
 };
 
+const scratchExaggerationScale = new Cartesian3();
+const scratchExaggerationCenter = new Cartesian3();
+const scratchCartographicCenter = new Cartographic();
+const scratchExaggerationTranslation = new Cartesian3();
+
 /**
  * Update the exaggerated bounds of a primitive to account for vertical exaggeration
  * Currently only applies to Ellipsoid shape type
@@ -1154,14 +1170,86 @@ function updateVerticalExaggeration(primitive, frameState) {
     primitive._maxBounds,
     primitive._exaggeratedMaxBounds
   );
-  if (defined(frameState) && primitive.shape === VoxelShapeType.ELLIPSOID) {
+  if (!defined(frameState)) {
+    primitive._exaggeratedModelMatrix = Matrix4.clone(
+      primitive._modelMatrix,
+      primitive._exaggeratedModelMatrix
+    );
+    return;
+  }
+  if (primitive.shape === VoxelShapeType.ELLIPSOID) {
+    // Apply the exaggeration by stretching the height bounds
     const relativeHeight = frameState.verticalExaggerationRelativeHeight;
     const exaggeration = frameState.verticalExaggeration;
     primitive._exaggeratedMinBounds.z =
       (primitive._minBounds.z - relativeHeight) * exaggeration + relativeHeight;
     primitive._exaggeratedMaxBounds.z =
       (primitive._maxBounds.z - relativeHeight) * exaggeration + relativeHeight;
+  } else if (primitive.shape === VoxelShapeType.BOX) {
+    // Apply the exaggeration via the model matrix
+    const exaggerationScale = Cartesian3.fromElements(
+      1.0,
+      1.0,
+      frameState.verticalExaggeration,
+      scratchExaggerationScale
+    );
+    primitive._exaggeratedModelMatrix = Matrix4.multiplyByScale(
+      primitive._modelMatrix,
+      exaggerationScale,
+      primitive._exaggeratedModelMatrix
+    );
+    primitive._exaggeratedModelMatrix = Matrix4.multiplyByTranslation(
+      primitive._exaggeratedModelMatrix,
+      computeBoxExaggerationTranslation(primitive, frameState),
+      primitive._exaggeratedModelMatrix
+    );
   }
+}
+
+function computeBoxExaggerationTranslation(primitive, frameState) {
+  // Compute translation based on box center, relative height, and exaggeration
+  const {
+    shapeTransform = Matrix4.IDENTITY,
+    globalTransform = Matrix4.IDENTITY,
+  } = primitive._provider;
+
+  // Find the Cartesian position of the center of the OBB
+  const initialCenter = Matrix4.getTranslation(
+    shapeTransform,
+    scratchExaggerationCenter
+  );
+  const intermediateCenter = Matrix4.multiplyByPoint(
+    primitive._modelMatrix,
+    initialCenter,
+    scratchExaggerationCenter
+  );
+  const transformedCenter = Matrix4.multiplyByPoint(
+    globalTransform,
+    intermediateCenter,
+    scratchExaggerationCenter
+  );
+
+  // Find the cartographic height
+  const ellipsoid = Ellipsoid.WGS84;
+  const centerHeight = ellipsoid.cartesianToCartographic(
+    transformedCenter,
+    scratchCartographicCenter
+  ).height;
+
+  // Find the shift that will put the center in the right position relative
+  // to relativeHeight, after it is scaled by verticalExaggeration
+  const exaggeratedHeight = VerticalExaggeration.getHeight(
+    centerHeight,
+    frameState.verticalExaggeration,
+    frameState.verticalExaggerationRelativeHeight
+  );
+
+  return Cartesian3.fromElements(
+    0.0,
+    0.0,
+    (exaggeratedHeight - centerHeight) / frameState.verticalExaggeration,
+    scratchExaggerationTranslation
+  );
 }
 
 /**
@@ -1248,7 +1336,7 @@ function checkTransformAndBounds(primitive, provider) {
   // Compound model matrix = global transform * model matrix * shape transform
   Matrix4.multiplyTransformation(
     globalTransform,
-    primitive._modelMatrix,
+    primitive._exaggeratedModelMatrix,
     primitive._compoundModelMatrix
   );
   Matrix4.multiplyTransformation(

--- a/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
@@ -119,6 +119,49 @@ describe(
       expect(primitive.maxClippingBounds.equals(setValue)).toBe(true);
     });
 
+    it("vertically exaggerates height bounds for ellipsoid-shaped voxels", function () {
+      const primitive = new VoxelPrimitive({ provider });
+      scene.primitives.add(primitive);
+      scene.renderForSpecs();
+
+      const { minBounds, maxBounds } = primitive;
+      expect(primitive._exaggeratedMinBounds).toEqual(minBounds);
+      expect(primitive._exaggeratedMaxBounds).toEqual(maxBounds);
+
+      const exaggerationFactor = 2.0;
+      scene.verticalExaggeration = exaggerationFactor;
+      scene.renderForSpecs();
+      const expectedMinBounds = minBounds.clone();
+      expectedMinBounds.z *= exaggerationFactor;
+      const expectedMaxBounds = maxBounds.clone();
+      expectedMaxBounds.z *= exaggerationFactor;
+      expect(primitive._exaggeratedMinBounds).toEqual(expectedMinBounds);
+      expect(primitive._exaggeratedMaxBounds).toEqual(expectedMaxBounds);
+    });
+
+    it("applies vertical exaggeration to box-shaped voxels by scaling the model matrix", async function () {
+      const boxProvider = await Cesium3DTilesVoxelProvider.fromUrl(
+        "./Data/Cesium3DTiles/Voxel/VoxelBox3DTiles/tileset.json"
+      );
+      const primitive = new VoxelPrimitive({ provider: boxProvider });
+      scene.primitives.add(primitive);
+      scene.renderForSpecs();
+
+      const modelMatrix = primitive.modelMatrix.clone();
+      expect(primitive._exaggeratedModelMatrix).toEqual(modelMatrix);
+
+      const exaggerationFactor = 2.0;
+      scene.verticalExaggeration = exaggerationFactor;
+      scene.renderForSpecs();
+      const scalar = Cartesian3.fromElements(1.0, 1.0, exaggerationFactor);
+      const expectedModelMatrix = Matrix4.multiplyByScale(
+        modelMatrix,
+        scalar,
+        new Matrix4()
+      );
+      expect(primitive._exaggeratedModelMatrix).toEqual(expectedModelMatrix);
+    });
+
     it("uses default style", function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR applies vertical exaggeration to BOX-shaped voxels. The voxel is assumed to be oriented with its z-axis along the local ellipsoid normal.

The exaggeration is applied by applying a scale and shift to the model transforms. The transforms for voxels are applied in the following sequence:

1. Shape transform. This scales the box to the appropriate size, and accounts for any shift in the center
2. Model matrix. This is the identity by default, but can be modified by the end user.
3. _New_: Exaggeration transform.
4. Root tile transform. This moves the box to the appropriate position on the globe.

Since the new exaggeration transform is applied before the root tile transform, the local Z coordinate is assumed to be along the "up" direction. However, the root tile transform is included in the calculation of the shift needed to honor `Scene.verticalExaggerationRelativeHeight`, by transforming the BOX center (from the shape transform) and computing its geodetic height.

<!-- Include screenshots if appropriate -->
![image](https://github.com/CesiumGS/cesium/assets/41167620/18e34dbc-a0eb-44d0-ba0c-208ab0bcba56)

![image](https://github.com/CesiumGS/cesium/assets/41167620/3e713976-1698-440c-bdd1-3b22e66783b8)


## Testing plan

Load [this local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVh7U9u4Fv8qHv5Z0wYnEOjcksBcSmGWGShMQzvdls6uYiuJLrLkK8lpzA7ffY9etuWElu7em8mMpaPz/Ono6JFyJlW0JPgbFtFRxPC36BRLUubJR0OL77ZS0z/lTCHCsLjb6kV/3rEomiKJL1GFxaEXucjRHIvKEJOZ4PmN4EuSYXEiK5bGWijyvLeE4itUTLBYkhQ7Sc9vhD8I6kRqoWlJaHbFs5JiM7p1IiVWsn+LV6oUWPbfIfgieoaEWlxc3G1tWwXms90LvL4h6b32fYaoxGZojnnKs5CmSI4phN2mIUZypAhnDfFxe3TH7pjFMQFvMMti57QlfuQrTC+YLHCquLgiK8KsTGpm4M9IppjhXpSiHAsUPcJkWEFgMkNJhqflfLLg384F8MgbLCYYhDPgVKLENV/BpQIgYdrkRAGsMpmtEEowQ1OKW9zetDYDmGIKQ2Zi8QrNYTZciFbpEgtFUkC2NWbAEJhCZ4l/xWS+UN9jfx9watCME7OSpXo4KosMKdyWiLetQ0/rBJfflfkU8rSOImm7ryGOnu1To82mTaMzjNJkU0uzwP8tsVTvYdJBVo886sjc/N8znt7zUiVKoPS+cVTz2RlQnNMp0usv42mZY6aSOVZnFOvmm+oig0x3PJDSo3XNqCho9YawjLC5bCz0vGYtM+Miiq09BvkTEdbE53Ams6iF4wLJ628MMqkA4KpYC207xnpBeg/8OtV+X08lLGqdbG1PjHjNJsupTAWZ4nh91i2yjw5E6zEwI5UuTjnlnTJlSPF2mEom/TNdCa5KqoiuNWb9+foSywUqsAtGLYhMDAE0m++oJueEveElyyQMQWhXvusUtBjRKmD03TXGDAoKk+Ck7MQBJQtaiA3jf/Ui+O+3hDR4mv8LVGMd793W12ZQVYUddJqusEKAKboFevLx7HS/xZvyvOAMsur2CaHTNkNyfnl9cjvcayn4neIlpqcQm14tQ5/qNfIbQGpyy4F8dFTvMXpSJppqzJ1dXl7cTK4v3tZpZme/PQtrcCUpBYe7O0VH8wa33M4wst/aRLICI4NksEavgL5zhdQiubmI+tHBBpYHzbI3ML96WGDYkljD5bPbFk8zBmQ8g00m2whnJ5X+B3C2cvXvw9lxqwOnHzVwNqjtNajVHFXAcbCBQ+P6FKye6Tmw/qgsJIXgiuv15Ev6W1gSYLyeD4MLL3Rb3jGHq9/BFei71MujZ5qf7Oc3+/lstnQnOrJ+6kmshaLjo7UlVk/chojqaK35oK50Ks2oYdPBeQZTOL4MvraGBWIZzydYnxOsZev7i5Z+mLCgu4pe2kA3kz+11JuyBDTwwBBEmar3xqSmarDjRkPPONtr+bQ9CuYXpi0nUs+V5HSJ4y9e/VezBYdbwt+yZ+H3JVLnKBw3rQJ7UNBcceigj3WpM8sXygCX74H50NKQLhBjjY5N5R0WYl2xDV+sY9juQN7eNs8pR2q4dyIEquKWjy8Ccx5pc2igWEV6CQ5G8BmH3kYPL1/WWVpzV5a7CrkroLS4W/wry78K+VdACfh9TBQLOJN8AqEVVIw4AHcn2vVFqCvwGwhUHYHqewKfQeChI/DgBRqRft8KLYB9UWLIe+/gC9hJDkDA29f9YT3+2fT31owvWpOtc47BfaKddPG6v3rR7yaDjql11dRsbgdr9NRlSPtQZS5hv0oaL3oRLA6oamChFxzFQhysKjiF4pWvHvb38MP6sYG0WnPSrrO9n0cH0WKBLI/fa2aUw7HRa3ypQQmDqdfNFxtQuD60xFdTxTRQwhXkZ0ruNpJzgTH7Gdm9RnZKS/wzokMt2oKiln20jcf1HbTWOQpO42kpFRS8Bcq6jwanrZHYrNuZQHN9jbE0fVE/jP5YcpLVI1eIsPjcdS5YUapoJs23B8kEl4sofch/z/U1AqYOC4IobPu24Y4ddYVY4nRoK+87LnKk052ZBnnAsVZjewCOM5EYZriPiBlKsRVqEmimiyUk5mxWSr1pwWkjHuhFkHEVt8z0jItU3w3fEoHNjnN2ut1VZBjgimYXoc06k/hGfyv9fHhJY9r7m7vyn7jUm09Bg1c8WlNg5vtpceQkHv9oHjHcK4IgOdFXXgnpnfMlPqE0br9YSH8ajJ46f765/lRfcQt3xHLp8rwL2q3by2olXBJ362+dW/lcoGJB0kTx+hhrzmmd21XNp+vaW6yXnox3dneHyd6rVwcHw/1eNHyVDF4PXw/3D6DYDQaQXc0lfcpXkxRRvPHQrFW6+7qM981JFW5w7muPrlqTR8FeN2+h/EjYA/Ogogmy2jf6jLXYmw3E55RPEd0gX5NkgpFUkJ1q8aG45edkhTPzbhR7EJvIlhZ5N9/6EtzNAJRlXUQ/BkKxW4Hew8O61XM3j1ZhOAx6huHRQR26ArUdweFOTVBeULtu3NtVh+8/RCmTW+Y9rv0Utwye3ZLmdWMt6JCgwTEvcbBTVLfc3DHAg0mxwALHHfPTYNQ9j+rsti9oumK41bXV2xpLVVF8rFn+TeDoJlRUChonSV9hCBMWruxPy/QeqySVUguN+15knJFlRLKjDY+yUUqRlDAyKymdQLm72zoe94E/EIMypB29XmJBUaVZFrvHl5aYJMm4D911qfrtyXg9Vvpt59jO61hNeVYd+7ozVuK42ZLGKjtuv+yM+0AIh9vHhDExxV+fYMEoZPIcgtAXZ+jt6hZaQesAWlLhApoArKbrerYzhV0PSEsEu+Jh8ITZiwzxg3loOox+MVZ+ccFstq1gm9JmAEZn8Qc2Am1BmNAR34HHP0BG9mXxHyC0s6urTA3Ta9dzUD2BU/iu+f9CqvN6+hysoFknFrRdxvnU/As) and verify the procedural BOX voxel exaggerates as expected.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
