### PR TITLE
Remove deprecated `Globe.terrainExaggeration`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Breaking Changes :mega:
 
 - `Cesium3DTileset.disableCollision` has been removed. Use `Cesium3DTileset.enableCollision` instead.
+- `Globe.terrainExaggeration` and `Globe.terrainExaggerationRelativeHeight` have been removed. Use `Scene.verticalExaggeration` and `Scene.verticalExaggerationRelativeHeight` instead.
 
 ##### Fixes :wrench:
 

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -28,7 +28,6 @@ import ImageryLayerCollection from "./ImageryLayerCollection.js";
 import QuadtreePrimitive from "./QuadtreePrimitive.js";
 import SceneMode from "./SceneMode.js";
 import ShadowMode from "./ShadowMode.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 
 /**
  * The globe rendered in the scene, including its terrain ({@link Globe#terrainProvider})
@@ -341,10 +340,6 @@ function Globe(ellipsoid) {
    */
   this.atmosphereBrightnessShift = 0.0;
 
-  this._terrainExaggerationChanged = false;
-  this._terrainExaggeration = 1.0;
-  this._terrainExaggerationRelativeHeight = 0.0;
-
   /**
    * Whether to show terrain skirts. Terrain skirts are geometry extending downwards from a tile's edges used to hide seams between neighboring tiles.
    * Skirts are always hidden when the camera is underground or translucency is enabled.
@@ -521,68 +516,6 @@ Object.defineProperties(Globe.prototype, {
   terrainProviderChanged: {
     get: function () {
       return this._terrainProviderChanged;
-    },
-  },
-  /**
-   * A scalar used to exaggerate the terrain. Defaults to <code>1.0</code> (no exaggeration).
-   * A value of <code>2.0</code> scales the terrain by 2x.
-   * A value of <code>0.0</code> makes the terrain completely flat.
-   * Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
-   *
-   * @memberof Globe.prototype
-   * @type {number}
-   * @default 1.0
-   *
-   * @deprecated
-   */
-  terrainExaggeration: {
-    get: function () {
-      deprecationWarning(
-        "Globe.terrainExaggeration",
-        "Globe.terrainExaggeration was deprecated in CesiumJS 1.113.  It will be removed in CesiumJS 1.116. Use Scene.verticalExaggeration instead."
-      );
-      return this._terrainExaggeration;
-    },
-    set: function (value) {
-      deprecationWarning(
-        "Globe.terrainExaggeration",
-        "Globe.terrainExaggeration was deprecated in CesiumJS 1.113.  It will be removed in CesiumJS 1.116. Use Scene.verticalExaggeration instead."
-      );
-      if (value !== this._terrainExaggeration) {
-        this._terrainExaggeration = value;
-        this._terrainExaggerationChanged = true;
-      }
-    },
-  },
-  /**
-   * The height from which terrain is exaggerated. Defaults to <code>0.0</code> (scaled relative to ellipsoid surface).
-   * Terrain that is above this height will scale upwards and terrain that is below this height will scale downwards.
-   * Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
-   * If {@link Globe#terrainExaggeration} is <code>1.0</code> this value will have no effect.
-   *
-   * @memberof Globe.prototype
-   * @type {number}
-   * @default 0.0
-   *
-   * @deprecated
-   */
-  terrainExaggerationRelativeHeight: {
-    get: function () {
-      deprecationWarning(
-        "Globe.terrainExaggerationRelativeHeight",
-        "Globe.terrainExaggerationRelativeHeight was deprecated in CesiumJS 1.113.  It will be removed in CesiumJS 1.116. Use Scene.verticalExaggerationRelativeHeight instead."
-      );
-      return this._terrainExaggerationRelativeHeight;
-    },
-    set: function (value) {
-      deprecationWarning(
-        "Globe.terrainExaggerationRelativeHeight",
-        "Globe.terrainExaggerationRelativeHeight was deprecated in CesiumJS 1.113.  It will be removed in CesiumJS 1.116. Use Scene.verticalExaggerationRelativeHeight instead."
-      );
-      if (value !== this._terrainExaggerationRelativeHeight) {
-        this._terrainExaggerationRelativeHeight = value;
-        this._terrainExaggerationChanged = true;
-      }
     },
   },
   /**

--- a/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -1384,55 +1384,6 @@ describe(
         });
     });
 
-    it("Detects change in terrain exaggeration", function () {
-      switchViewMode(
-        SceneMode.SCENE3D,
-        new GeographicProjection(Ellipsoid.WGS84)
-      );
-      scene.camera.flyHome(0.0);
-
-      return updateUntilDone(scene.globe).then(function () {
-        forEachRenderedTile(scene.globe._surface, 1, undefined, function (
-          tile
-        ) {
-          const surfaceTile = tile.data;
-          const encoding = surfaceTile.mesh.encoding;
-          const boundingSphere = surfaceTile.tileBoundingRegion.boundingSphere;
-          expect(encoding.exaggeration).toEqual(1.0);
-          expect(encoding.hasGeodeticSurfaceNormals).toEqual(false);
-          expect(boundingSphere.radius).toBeLessThan(7000000.0);
-        });
-
-        return updateUntilDone(scene.globe).then(function () {
-          forEachRenderedTile(scene.globe._surface, 1, undefined, function (
-            tile
-          ) {
-            const surfaceTile = tile.data;
-            const encoding = surfaceTile.mesh.encoding;
-            const boundingSphere =
-              surfaceTile.tileBoundingRegion.boundingSphere;
-            expect(encoding.exaggeration).toEqual(2.0);
-            expect(encoding.hasGeodeticSurfaceNormals).toEqual(true);
-            expect(boundingSphere.radius).toBeGreaterThan(7000000.0);
-          });
-
-          return updateUntilDone(scene.globe).then(function () {
-            forEachRenderedTile(scene.globe._surface, 1, undefined, function (
-              tile
-            ) {
-              const surfaceTile = tile.data;
-              const encoding = surfaceTile.mesh.encoding;
-              const boundingSphere =
-                surfaceTile.tileBoundingRegion.boundingSphere;
-              expect(encoding.exaggeration).toEqual(1.0);
-              expect(encoding.hasGeodeticSurfaceNormals).toEqual(false);
-              expect(boundingSphere.radius).toBeLessThan(7000000.0);
-            });
-          });
-        });
-      });
-    });
-
     it("Detects change in vertical exaggeration", function () {
       switchViewMode(
         SceneMode.SCENE3D,

--- a/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -1391,9 +1391,6 @@ describe(
       );
       scene.camera.flyHome(0.0);
 
-      scene.globe.terrainExaggeration = 1.0;
-      scene.globe.terrainExaggerationRelativeHeight = 0.0;
-
       return updateUntilDone(scene.globe).then(function () {
         forEachRenderedTile(scene.globe._surface, 1, undefined, function (
           tile
@@ -1405,9 +1402,6 @@ describe(
           expect(encoding.hasGeodeticSurfaceNormals).toEqual(false);
           expect(boundingSphere.radius).toBeLessThan(7000000.0);
         });
-
-        scene.globe.terrainExaggeration = 2.0;
-        scene.globe.terrainExaggerationRelativeHeight = -1000000.0;
 
         return updateUntilDone(scene.globe).then(function () {
           forEachRenderedTile(scene.globe._surface, 1, undefined, function (
@@ -1421,9 +1415,6 @@ describe(
             expect(encoding.hasGeodeticSurfaceNormals).toEqual(true);
             expect(boundingSphere.radius).toBeGreaterThan(7000000.0);
           });
-
-          scene.globe.terrainExaggeration = 1.0;
-          scene.globe.terrainExaggerationRelativeHeight = 0.0;
 
           return updateUntilDone(scene.globe).then(function () {
             forEachRenderedTile(scene.globe._surface, 1, undefined, function (


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Remove deprecated values for https://github.com/CesiumGS/cesium/issues/11719

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/11719

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run tests

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
