### PR TITLE
Change voxel sandcastle categories

### DIFF
--- a/Apps/Sandcastle/gallery/Voxel Picking.html
+++ b/Apps/Sandcastle/gallery/Voxel Picking.html
@@ -8,7 +8,7 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
     />
     <meta name="description" content="For debugging voxel picking." />
-    <meta name="cesium-sandcastle-labels" content="Development" />
+    <meta name="cesium-sandcastle-labels" content="Showcases, 3D Tiles" />
     <title>Cesium Demo</title>
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="module" src="../load-cesium-es6.js"></script>

--- a/Apps/Sandcastle/gallery/Voxels.html
+++ b/Apps/Sandcastle/gallery/Voxels.html
@@ -8,7 +8,7 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
     />
     <meta name="description" content="For debugging voxels." />
-    <meta name="cesium-sandcastle-labels" content="Development" />
+    <meta name="cesium-sandcastle-labels" content="Showcases, 3D Tiles" />
     <title>Cesium Demo</title>
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

In https://github.com/CesiumGS/cesium/pull/11909 we missed switching the `cesium-sandcastle-labels` away from `Development` so they still show up under that category even though they are in the main Gallery folder.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- `npm run build-release` to generate `gallery-list` without the development examples
- `npm start -- --production` to prevent it rebuilding the gallery list when starting
- Load Sandcastle and check for
    - http://localhost:8080/Apps/Sandcastle/index.html?src=Voxels.html loads still
    - http://localhost:8080/Apps/Sandcastle/index.html?src=Voxel%20Picking.html loads still
    - Both sandcastles show up under the "Showcases" category AND the "3D Tiles" category

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
