### PR TITLE
Fix Label position height may not be correctly updated when its HeightReference is relative.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.117
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Fixed a bug that Label position height may not be correctly updated when its HeightReference is relative. [#11929](https://github.com/CesiumGS/cesium/pull/11929)
+
 ### 1.116 - 2024-04-01
 
 #### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -386,3 +386,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Taylor Huffman](https://github.com/huffmantayler)
 - [蒋宇梁](https://github.com/s3xysteak)
 - [dslming](https://github.com/dslming)
+- [Zhongxiang Wang](https://github.com/plainheart)

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -1139,7 +1139,7 @@ Billboard._updateClamping = function (collection, owner) {
   }
 
   function updateFunction(clampedPosition) {
-    owner._clampedPosition = ellipsoid.cartographicToCartesian(
+    const updatedClampedPosition = ellipsoid.cartographicToCartesian(
       clampedPosition,
       owner._clampedPosition
     );
@@ -1149,12 +1149,14 @@ Billboard._updateClamping = function (collection, owner) {
         clampedPosition.height += position.height;
         ellipsoid.cartographicToCartesian(
           clampedPosition,
-          owner._clampedPosition
+          updatedClampedPosition
         );
       } else {
-        owner._clampedPosition.x += position.height;
+        updatedClampedPosition.x += position.height;
       }
     }
+
+    owner._clampedPosition = updatedClampedPosition;
   }
 
   owner._removeCallbackFunc = scene.updateHeight(


### PR DESCRIPTION
# Description

Hi,

I noticed Label position height doesn't work anymore when its `HeightReference` is relative since the commit 8e271f10e549854e9c1aec27098dec0bc3160094 ([diff](https://github.com/CesiumGS/cesium/commit/8e271f10e549854e9c1aec27098dec0bc3160094#diff-3bcb704a66884dfe84fe3b2c3590a4cbbf129d03717790337d0f74e391dd356eR1108)).

This bug might be caused by a premature assignment to `owner._clampedPosition` [1].  As the `_clampedPosition` setter of `Label` clones the inputted value, the following modification for the `owner_clampedPosition` won't be applied to the Label glyph billboard [2], which causes the user-specified height not to work as expected. So I moved the assignment to the last line to fix this issue.

[1] https://github.com/CesiumGS/cesium/blob/1.116/packages/engine/Source/Scene/Billboard.js#L1141-L1145
[2] https://github.com/CesiumGS/cesium/tree/1.116/packages/engine/Source/Scene/Label.js#L1155-L1172 

| Stage | Before | After |
| :----: | :----: | :----: |
| Initial | ![](https://github.com/CesiumGS/cesium/assets/26999792/85c977fc-2ca9-4a3c-9553-51ddaf38f5a2) |  ![](https://github.com/CesiumGS/cesium/assets/26999792/967a76c4-1442-4d5d-b93e-8e6dc0a62be3) |
| After Update | ![Unexpectedly clamped to ground](https://github.com/CesiumGS/cesium/assets/26999792/59061c7e-5d65-4ea1-bcb5-902ac433591f) | ![](https://github.com/CesiumGS/cesium/assets/26999792/6b6c0e35-77fe-479a-9c67-8c440c5269da) |

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
