### PR TITLE
Fix properties assigned to wrong object

### DIFF
--- a/packages/engine/Source/Scene/Terrain.js
+++ b/packages/engine/Source/Scene/Terrain.js
@@ -83,7 +83,7 @@ Object.defineProperties(Terrain.prototype, {
 
   /**
    * Returns true when the terrain provider has been successfully created. Otherwise, returns false.
-   * @memberof Viewer.prototype
+   * @memberof Terrain.prototype
    *
    * @type {boolean}
    * @readonly
@@ -96,7 +96,7 @@ Object.defineProperties(Terrain.prototype, {
 
   /**
    * The terrain provider providing surface geometry to a globe. Do not use until {@link Terrain.readyEvent} is raised.
-   * @memberof Viewer.prototype
+   * @memberof Terrain.prototype
    *
    * @type {TerrainProvider}
    * @readonly


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Two properties in the `Terrain` object were set as `@memberOf Viewer.prototpye` instead of on the Terrain object. I believe this is just a fix of docs and not missing implementation, @ggetz please confirm?

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/11932

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `npm run build-docs`
- `npm start`
- Check the [Viewer docs](http://localhost:8080/Build/Documentation/Viewer.html) locally and make sure `provider` and `ready` are not defined
- Check the [Terrain docs](http://localhost:8080/Build/Documentation/Terrain.html) locally and make sure they _do_ show up there

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
