### PR TITLE
Draft for handling epsilon-dependence of orientation

### DIFF
--- a/packages/engine/Source/Scene/Camera.js
+++ b/packages/engine/Source/Scene/Camera.js
@@ -2302,16 +2302,30 @@ Camera.prototype.getMagnitude = function () {
 const scratchLookAtMatrix4 = new Matrix4();
 
 /**
- * Sets the camera position and orientation using a target and offset. The target must be given in
- * world coordinates. The offset can be either a cartesian or heading/pitch/range in the local east-north-up reference frame centered at the target.
- * If the offset is a cartesian, then it is an offset from the center of the reference frame defined by the transformation matrix. If the offset
- * is heading/pitch/range, then the heading and the pitch angles are defined in the reference frame defined by the transformation matrix.
- * The heading is the angle from y axis and increasing towards the x axis. Pitch is the rotation from the xy-plane. Positive pitch
- * angles are below the plane. Negative pitch angles are above the plane. The range is the distance from the center.
+ * Sets the camera position and orientation using a target and offset.
  *
- * In 2D, there must be a top down view. The camera will be placed above the target looking down. The height above the
- * target will be the magnitude of the offset. The heading will be determined from the offset. If the heading cannot be
- * determined from the offset, the heading will be north.
+ * The target must be given in world coordinates. It will be used for
+ * computing the transformation matrix that describes the local
+ * east-north-up reference frame for the given target, using
+ * {@link Transforms.eastNorthUpToFixedFrame}.
+ *
+ * The offset can be either a cartesian or heading/pitch/range in the local
+ * east-north-up reference frame centered at the target.
+ *
+ * If the offset is a cartesian, then it is an offset from the center of
+ * the reference frame defined by the transformation matrix.
+ *
+ * If the offset is heading/pitch/range, then the heading and the pitch
+ * angles are defined in the reference frame defined by the transformation
+ * matrix. The heading is the angle from y axis and increasing towards
+ * the x axis. Pitch is the rotation from the xy-plane. Positive pitch
+ * angles are below the plane. Negative pitch angles are above the plane.
+ * The range is the distance from the center.
+ *
+ * In 2D, there must be a top down view. The camera will be placed above
+ * the target looking down. The height above the target will be the magnitude
+ * of the offset. The heading will be determined from the offset. If the
+ * heading cannot be determined from the offset, the heading will be north.
  *
  * @param {Cartesian3} target The target position in world coordinates.
  * @param {Cartesian3|HeadingPitchRange} offset The offset from the target in the local east-north-up reference frame centered at the target.
@@ -2330,7 +2344,7 @@ const scratchLookAtMatrix4 = new Matrix4();
  * const range = 5000.0;
  * viewer.camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, range));
  */
-Camera.prototype.lookAt = function (target, offset) {
+Camera.prototype.lookAtOriginal = function (target, offset) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(target)) {
     throw new DeveloperError("target is required");
@@ -2350,6 +2364,100 @@ Camera.prototype.lookAt = function (target, offset) {
   );
   this.lookAtTransform(transform, offset);
 };
+Camera.prototype.lookAt = function (target, offset) {
+  //>>includeStart('debug', pragmas.debug);
+  if (!defined(target)) {
+    throw new DeveloperError("target is required");
+  }
+  if (!defined(offset)) {
+    throw new DeveloperError("offset is required");
+  }
+  if (this._mode === SceneMode.MORPHING) {
+    throw new DeveloperError("lookAt is not supported while morphing.");
+  }
+  //>>includeEnd('debug');
+
+  console.log("camera.lookAt");
+  console.log(`target ${target}`);
+  console.log(`offset HPR ${offset.heading} ${offset.pitch} ${offset.range}`);
+  console.log(`offset XYZ ${offset.x} ${offset.y} ${offset.z}`);
+
+  // The default ENU for the degenerate case:
+  const transformA = Matrix4.fromArray(
+    [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+    0,
+    new Matrix4()
+  );
+  Matrix4.setColumn(
+    transformA,
+    3,
+    new Cartesian4(target.x, target.y, target.z, 1.0),
+    transformA
+  );
+
+  // The transform based on the ENU of the target
+  const transformB = Transforms.eastNorthUpToFixedFrame(
+    target,
+    Ellipsoid.WGS84,
+    scratchLookAtMatrix4
+  );
+
+  // Compute the cartesian offset if the given one is HPR
+  function computeCartesianOffset(theOffset) {
+    if (defined(theOffset.heading)) {
+      return offsetFromHeadingPitchRange(
+        offset.heading,
+        offset.pitch,
+        offset.range
+      );
+    }
+    return theOffset;
+  }
+  const cartesianOffset = computeCartesianOffset(offset);
+
+  // Compute the distance of the target to the origin,
+  // and the distance of the eye to the target. When
+  // the eye is far away from the target, then small
+  // deviations in in the target position should not
+  // affect the orientation.
+  const eyeDistanceFromTarget = Cartesian3.magnitude(cartesianOffset);
+  const targetDistanceFromOrigin = Cartesian3.magnitude(target);
+  const weight = Math.min(
+    1.0,
+    targetDistanceFromOrigin / eyeDistanceFromTarget
+  );
+  console.log(`weight ${weight}`);
+
+  const transform = interpolateAffine(transformA, transformB, weight);
+
+  this.lookAtTransform(transform, offset);
+};
+
+function interpolateAffine(matrix4a, matrix4b, t) {
+  // TODO Yeah, scratch variables and such...
+  const matrix3a = Matrix4.getRotation(matrix4a, new Matrix3());
+  const matrix3b = Matrix4.getRotation(matrix4b, new Matrix3());
+  const quatA = Quaternion.fromRotationMatrix(matrix3a, new Quaternion());
+  const quatB = Quaternion.fromRotationMatrix(matrix3b, new Quaternion());
+  const quat = Quaternion.slerp(quatA, quatB, t, new Quaternion());
+  const matrix3 = Matrix3.fromQuaternion(quat, new Matrix3());
+
+  const translationA = Matrix4.getColumn(matrix4a, 3, new Cartesian4());
+  const translationB = Matrix4.getColumn(matrix4b, 3, new Cartesian4());
+  const translation = Cartesian4.lerp(
+    translationA,
+    translationB,
+    t,
+    new Cartesian4()
+  );
+
+  const result = Matrix4.fromRotationTranslation(
+    matrix3,
+    translation,
+    new Matrix4()
+  );
+  return result;
+}
 
 const scratchLookAtHeadingPitchRangeOffset = new Cartesian3();
 const scratchLookAtHeadingPitchRangeQuaternion1 = new Quaternion();
@@ -2391,18 +2499,31 @@ function offsetFromHeadingPitchRange(heading, pitch, range) {
 }
 
 /**
- * Sets the camera position and orientation using a target and transformation matrix. The offset can be either a cartesian or heading/pitch/range.
- * If the offset is a cartesian, then it is an offset from the center of the reference frame defined by the transformation matrix. If the offset
- * is heading/pitch/range, then the heading and the pitch angles are defined in the reference frame defined by the transformation matrix.
- * The heading is the angle from y axis and increasing towards the x axis. Pitch is the rotation from the xy-plane. Positive pitch
- * angles are below the plane. Negative pitch angles are above the plane. The range is the distance from the center.
+ * Sets the camera position and orientation using a target and transformation matrix.
  *
- * In 2D, there must be a top down view. The camera will be placed above the center of the reference frame. The height above the
- * target will be the magnitude of the offset. The heading will be determined from the offset. If the heading cannot be
- * determined from the offset, the heading will be north.
+ * The offset can be either be undefined, or a cartesian or heading/pitch/range in
+ * the local east-north-up reference frame centered at the target.
+ *
+ * If the offset is undefined, then the given transformation matrix will be
+ * used directly as the transformation matrix of the camera.
+ *
+ * If the offset is a cartesian, then it is an offset from the center of
+ * the reference frame defined by the transformation matrix.
+ *
+ * If the offset is heading/pitch/range, then the heading and the pitch
+ * angles are defined in the reference frame defined by the transformation
+ * matrix. The heading is the angle from y axis and increasing towards
+ * the x axis. Pitch is the rotation from the xy-plane. Positive pitch
+ * angles are below the plane. Negative pitch angles are above the plane.
+ * The range is the distance from the center.
+ *
+ * In 2D, there must be a top down view. The camera will be placed above
+ * the target looking down. The height above the target will be the magnitude
+ * of the offset. The heading will be determined from the offset. If the
+ * heading cannot be determined from the offset, the heading will be north.
  *
  * @param {Matrix4} transform The transformation matrix defining the reference frame.
- * @param {Cartesian3|HeadingPitchRange} [offset] The offset from the target in a reference frame centered at the target.
+ * @param {Cartesian3|HeadingPitchRange|undefined} [offset] The offset from the target in a reference frame centered at the target.
  *
  * @exception {DeveloperError} lookAtTransform is not supported while morphing.
  *


### PR DESCRIPTION
### Description

This changes the `camera.lookAt` implementation so that the orientation does no longer depends (so strongly) on certain "epsilon" values of the target position. Some additonal details are laid out in https://github.com/CesiumGS/cesium/issues/11488 .

The fact that the title _and_ the name of the branch contain the word `draft` should be a clear indicator:

**This is not supposed to be merged!**

This should just serve as a basis for figuring out how to solve the issue _sensibly_.

As pointed out in the comments to the issue: There is no one-fits-all solution. The whole `zoomTo`-functionality just _assumes_ that everything happens on the surface of the WGS84 ellipsoid. When a tileset has a distance of (0,0,100) or (5000,0,0) from the center of the ellipsoid, then trying to compute the ENU orientation from the point _on the surface_ that is _closest_ to this point hardly makes sense. Tilesets that are not "geolocated" (but have their center at the origin) will usually not be handled gracefully by that function. But basically every Sandcastle in the world will use the `zoomTo`/`flyTo` functionality. So every change here **will** inevitably be a "breaking change" in terms of the behavior. 

That said .... what is currently implemented here will do the following:

- It will compute the distance of the `target` (i.e. the center of the bounding sphere to zoom to) to the origin.
- It will compute the distance of the eye point to the `target` (based on the `offset` that is passed in)
- It will compute a "weight" from that. When the eye is "far away" from the target, then the target position will less affect the orientiation of the camera.

In terms of "testing", I focussed on the case of a tileset with a bounding sphere that covers the whole earth, but is centered at different positions. These are created (on the fly) in the sandcastle that is given below, with the 
``` 
  createSampleOption([0, 0, 0]),
  createSampleOption([1e-15, 1e-15, 1e-15]),
  ...
  createSampleOption([0, 100, 0]),
  ...
  createSampleOption([0, 0, 14000000]),
```
lines. 

Some examples of the old behavior, showing that the orientation strongly depends on that magic "epsilon":

![Cesium S2 Orientation OLD](https://github.com/CesiumGS/cesium/assets/5597569/9aeeed12-550e-46f4-8c53-28f926973c3d)

Some examples of the new behavior:

![Cesium S2 Orientation NEW](https://github.com/CesiumGS/cesium/assets/5597569/ef22674e-9573-49cd-b8db-763a809b667f)

To emphasize this again: **This is not a 'proposed solution'**. The approach feels pretty arbitrary, and I could come up with a million cases where this will lead to "unexpected results". (And the functionality of `flyTo` is not covered here at all...)

The goal is mainly to encourage people to chime in, saying what could be "The Right Orientation" for each of the `createSampleOption` cases in this sandcastle:

```javascript
const viewer = new Cesium.Viewer("cesiumContainer", {
  //globe: false
});

let currentTileset;

function createTilesetObject(center) {
  const tilesetObject = {
    asset: {
      version: "1.1",
    },
    geometricError: 1e10,
    root: {
      refine: "ADD",
      boundingVolume: {
        sphere: [
          center[0],
          center[1],
          center[2],
          12000000,
        ],
      },
      geometricError: 1.0,
    },
  };
  return tilesetObject;
}

function createTilesetUrl(center) {
  const tilesetObject = createTilesetObject(center);
  const url =
    "data:application/json;base64," + btoa(JSON.stringify(tilesetObject));
  return url;
}

function zoomToTilesetFixed(targetTileset) {
  const boundingSphere = targetTileset.boundingSphere;
  const transform = Cesium.Matrix4.fromTranslation(boundingSphere.center);
  const offset = new Cesium.Cartesian3(boundingSphere.radius, 0, 0);
  viewer.camera.lookAtTransform(transform, offset);
}

async function createTileset(center) {
  if (Cesium.defined(currentTileset)) {
    viewer.scene.primitives.remove(currentTileset);
    currentTileset = undefined;
  }
  const url = createTilesetUrl(center);
  currentTileset = viewer.scene.primitives.add(
    await Cesium.Cesium3DTileset.fromUrl(url, {
      debugShowBoundingVolume: true,
    })
  );
  viewer.zoomTo(currentTileset);
  //zoomToTilesetFixed(currentTileset);
}

function createSampleOption(center) {
  return {
    text: center.toString(),
    onselect: async function () {
      try {
        await createTileset(center);
      } catch (e) {
        console.log(e);
      }
    },
  };
}

const sampleOptions = [
  createSampleOption([0, 0, 0]),
  createSampleOption([1e-15, 1e-15, 1e-15]),
  createSampleOption([1e-12, 1e-15, 1e-15]),
  createSampleOption([1e-15, 1e-12, 1e-15]),
  createSampleOption([1e-10, 1e-10, 1e-10]),
  createSampleOption([1e-5, 1e-5, 1e-5]),
  createSampleOption([0, 0, 1]),
  createSampleOption([0, 1, 0]),
  createSampleOption([1, 0, 0]),
  createSampleOption([100, 0, 0]),
  createSampleOption([0, 100, 0]),
  createSampleOption([0, 0, 100]),
  createSampleOption([10000, 0, 0]),
  createSampleOption([0, 10000, 0]),
  createSampleOption([0, 0, 10000]),
  createSampleOption([1000000, 0, 0]),
  createSampleOption([0, 1000000, 0]),
  createSampleOption([0, 0, 1000000]),
  createSampleOption([10000000, 0, 0]),
  createSampleOption([0, 10000000, 0]),
  createSampleOption([0, 0, 10000000]),
  createSampleOption([14000000, 0, 0]),
  createSampleOption([0, 14000000, 0]),
  createSampleOption([0, 0, 14000000]),
];
Sandcastle.addToolbarMenu(sampleOptions);
```



# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
