### PR TITLE
Fix voxel picking spec

### DIFF
--- a/packages/engine/Specs/Scene/PickingSpec.js
+++ b/packages/engine/Specs/Scene/PickingSpec.js
@@ -61,7 +61,7 @@ describe(
     const pointCloudTilesetUrl =
       "Data/Cesium3DTiles/PointCloud/PointCloudWithTransform/tileset.json";
     const voxelTilesetUrl =
-      "Data/Cesium3DTiles/Voxel/VoxelEllipsoid3DTiles/tileset.json";
+      "Data/Cesium3DTiles/Voxel/VoxelBox3DTiles/tileset.json";
 
     beforeAll(function () {
       scene = createScene({
@@ -269,12 +269,18 @@ describe(
         const provider = await Cesium3DTilesVoxelProvider.fromUrl(
           voxelTilesetUrl
         );
-        const primitive = new VoxelPrimitive({ provider });
+        const modelMatrix = Matrix4.fromUniformScale(
+          Ellipsoid.WGS84.maximumRadius
+        );
+        const primitive = new VoxelPrimitive({ provider, modelMatrix });
         scene.primitives.add(primitive);
         await pollToPromise(function () {
           scene.renderForSpecs();
           const traversal = primitive._traversal;
           return traversal.isRenderable(traversal.rootNode);
+        });
+        expect(scene).toPickAndCall(function (result) {
+          expect(result.primitive).toBe(primitive);
         });
         expect(scene).toPickVoxelAndCall(function (voxelCell) {
           expect(voxelCell.tileIndex).toBe(0);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The test of `Scene.pickVoxel` in `PickingSpec` was failing due to the voxel not being visible in the current scene.

This PR switches the spec to the box-shaped tileset for simplicity, and adjusts the model matrix to ensure the voxel is within view.

## Issue number and link

Resolves https://github.com/CesiumGS/cesium/issues/11916

## Testing plan

Run `PickingSpec` locally. Note: local testing is necessary, because this spec does not run in CI. The webGL stub used in CI triggers a dummy matcher for picking specs, which always passes.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
