### PR TITLE
Update TS definition to fix #10498

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fixed leaked CSS styling from `I3SBuildingSceneLayerExplorer` widget. [#11959](https://github.com/CesiumGS/cesium/pull/11959)
 - Fixed a bug where a data source was not automatically rendered after is was added in request render mode. [#11934](https://github.com/CesiumGS/cesium/pull/11934)
+- Fixes Typescript definition for `Event.raiseEvent`. [#10498](https://github.com/CesiumGS/cesium/issues/10498)
 
 ### 1.116 - 2024-04-01
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1197,6 +1197,11 @@ function generateTypeScriptDefinitions(
     .replace(
       /\/\*\*[\*\s\w]*?\*\/\nexport const Check: any;/m,
       `\n${readFileSync("./packages/engine/Source/Core/Check.d.ts").toString()}`
+    )
+    // Fix https://github.com/CesiumGS/cesium/issues/10498 so we can use the rest parameter expand tuple
+    .replace(
+      "raiseEvent(...arguments: Parameters<Listener>[]): void;",
+      "raiseEvent(...arguments: Parameters<Listener>): void;"
     );
 
   // Wrap the source to actually be inside of a declared cesium module
@@ -1399,6 +1404,11 @@ function createTypeScriptDefinitions() {
     .replace(
       /\/\*\*[\*\s\w]*?\*\/\nexport const Check: any;/m,
       `\n${readFileSync("./packages/engine/Source/Core/Check.d.ts").toString()}`
+    )
+    // Fix https://github.com/CesiumGS/cesium/issues/10498 to have rest parameter expand tuple
+    .replace(
+      "raiseEvent(...arguments: Parameters<Listener>[]): void;",
+      "raiseEvent(...arguments: Parameters<Listener>): void;"
     );
 
   // Wrap the source to actually be inside of a declared cesium module


### PR DESCRIPTION


# Description

Fixes Typescript definition for `Event.raiseEvent` to have the correct typing.

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

https://github.com/CesiumGS/cesium/issues/10498

## Testing plan

Create a typescript file with the following code
```
import {Event} from "@cesium/engine";
const event = new Event<(value:number)=>void>();
event.raiseEvent(3);
```

Verify that on main, that the last line displays an error.

![image](https://github.com/CesiumGS/cesium/assets/48362463/f2595267-64c4-4cf9-b9d5-8c1dc0790e24)


Check out this branch and run `npm run build-ts`

Verify that no error is displayed now.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [NA] I have added or updated unit tests to ensure consistent code coverage
- [NA] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
