### PR TITLE
Fix `Billboard` and `Label` id types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fixed a bug where `TaskProcessor` worker loading would check the worker module ID rather than the absolute URL when determining if it is cross-origin. [#11833](https://github.com/CesiumGS/cesium/pull/11833)
 - Fixed a bug where cross-origin workers would error when loaded with the CommonJS `importScripts` shim instead of an ESM `import`. [#11833](https://github.com/CesiumGS/cesium/pull/11833)
+- Corrected the Typescript types for `Billboard.id` and `Label.id` to be `any` [#11973](https://github.com/CesiumGS/cesium/issues/11973)
 
 ### 1.117
 

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -28,7 +28,7 @@ import VerticalOrigin from "./VerticalOrigin.js";
  * Initialization options for the first param of Billboard constructor
  *
  * @property {Cartesian3} position The cartesian position of the billboard.
- * @property {string} [id] A user-defined object to return when the billboard is picked with {@link Scene#pick}.
+ * @property {any} [id] A user-defined object to return when the billboard is picked with {@link Scene#pick}.
  * @property {boolean} [show=true] Determines if this billboard will be shown.
  * @property {string | HTMLCanvasElement} [image] A loaded HTMLImageElement, ImageData, or a url to an image to use for the billboard.
  * @property {number} [scale=1.0] A number specifying the uniform scale that is multiplied with the billboard's image size in pixels.

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -28,7 +28,7 @@ import VerticalOrigin from "./VerticalOrigin.js";
  * Initialization options for the first param of Billboard constructor
  *
  * @property {Cartesian3} position The cartesian position of the billboard.
- * @property {any} [id] A user-defined object to return when the billboard is picked with {@link Scene#pick}.
+ * @property {*} [id] A user-defined object to return when the billboard is picked with {@link Scene#pick}.
  * @property {boolean} [show=true] Determines if this billboard will be shown.
  * @property {string | HTMLCanvasElement} [image] A loaded HTMLImageElement, ImageData, or a url to an image to use for the billboard.
  * @property {number} [scale=1.0] A number specifying the uniform scale that is multiplied with the billboard's image size in pixels.
@@ -892,7 +892,7 @@ Object.defineProperties(Billboard.prototype, {
   /**
    * Gets or sets the user-defined object returned when the billboard is picked.
    * @memberof Billboard.prototype
-   * @type {object}
+   * @type {*}
    */
   id: {
     get: function () {

--- a/packages/engine/Source/Scene/Label.js
+++ b/packages/engine/Source/Scene/Label.js
@@ -91,7 +91,7 @@ function parseFont(label) {
  * Initialization options for the Label constructor
  *
  * @property {Cartesian3} position The cartesian position of the label.
- * @property {any} [id] A user-defined object to return when the label is picked with {@link Scene#pick}.
+ * @property {*} [id] A user-defined object to return when the label is picked with {@link Scene#pick}.
  * @property {boolean} [show=true] Determines if this label will be shown.
  * @property {string} [text] A string specifying the text of the label.
  * @property {string} [font='30px sans-serif'] A string specifying the font used to draw this label. Fonts are specified using the same syntax as the CSS 'font' property.

--- a/packages/engine/Source/Scene/Label.js
+++ b/packages/engine/Source/Scene/Label.js
@@ -91,7 +91,7 @@ function parseFont(label) {
  * Initialization options for the Label constructor
  *
  * @property {Cartesian3} position The cartesian position of the label.
- * @property {string} [id] A user-defined object to return when the label is picked with {@link Scene#pick}.
+ * @property {any} [id] A user-defined object to return when the label is picked with {@link Scene#pick}.
  * @property {boolean} [show=true] Determines if this label will be shown.
  * @property {string} [text] A string specifying the text of the label.
  * @property {string} [font='30px sans-serif'] A string specifying the font used to draw this label. Fonts are specified using the same syntax as the CSS 'font' property.


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The type for `Billboard.id` and `Label.id` were incorrectly assigned to `string` instead of  `any`. This PR just fixes that

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/11973

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `npm run build-docs` and `npm run build-ts`
- Check the docs for `Billboard` and `Label` and make sure the id is shown as an object
- check the generated `.d.ts` files we generate and and show the id for each object is now `any`

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have update the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
