### PR TITLE
Fix `scene.pickPosition` when `depthTestAgainstTerrain` is false

### DIFF
--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -229,12 +229,7 @@
 
             const scene = viewer.scene;
             if (scene.mode !== Cesium.SceneMode.MORPHING) {
-              const pickedObject = scene.pick(movement.endPosition);
-              if (
-                scene.pickPositionSupported &&
-                Cesium.defined(pickedObject) &&
-                pickedObject.id === modelEntity
-              ) {
+              if (scene.pickPositionSupported) {
                 const cartesian = viewer.scene.pickPosition(
                   movement.endPosition
                 );

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,16 @@
 # Change Log
 
-### 1.118
+### 1.118 - 2024-06-01
 
 #### @cesium/engine
 
 ##### Fixes :wrench:
 
+- Fixed a bug where `scene.pickPosition` returned incorrect results against the globe when `depthTestAgainstTerrain` is `false`. [#4368](https://github.com/CesiumGS/cesium/issues/4368)
 - Fixed a bug where `TaskProcessor` worker loading would check the worker module ID rather than the absolute URL when determining if it is cross-origin. [#11833](https://github.com/CesiumGS/cesium/pull/11833)
 - Fixed a bug where cross-origin workers would error when loaded with the CommonJS `importScripts` shim instead of an ESM `import`. [#11833](https://github.com/CesiumGS/cesium/pull/11833)
 
-### 1.117
+### 1.117 - 2024-05-01
 
 #### @cesium/engine
 

--- a/packages/engine/Source/Scene/PickDepth.js
+++ b/packages/engine/Source/Scene/PickDepth.js
@@ -3,6 +3,8 @@ import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import FramebufferManager from "../Renderer/FramebufferManager.js";
 import RenderState from "../Renderer/RenderState.js";
+import PassThrough from "../Shaders/PostProcessStages/PassThrough.js";
+import PassThroughDepth from "../Shaders/PostProcessStages/PassThroughDepth.js";
 
 /**
  * @private
@@ -30,17 +32,19 @@ function updateFramebuffers(pickDepth, context, depthTexture) {
 
 function updateCopyCommands(pickDepth, context, depthTexture) {
   if (!defined(pickDepth._copyDepthCommand)) {
-    const fs =
-      "uniform highp sampler2D u_texture;\n" +
-      "in vec2 v_textureCoordinates;\n" +
-      "void main()\n" +
-      "{\n" +
-      "    out_FragColor = czm_packDepth(texture(u_texture, v_textureCoordinates).r);\n" +
-      "}\n";
-    pickDepth._copyDepthCommand = context.createViewportQuadCommand(fs, {
+    // pickDepth._copyDepthCommand = context.createViewportQuadCommand(PassThroughDepth, {
+    //   renderState: RenderState.fromCache(),
+    //   uniformMap: {
+    //     u_depthTexture: function () {
+    //       return pickDepth._textureToCopy;
+    //     },
+    //   },
+    //   owner: pickDepth,
+    // });
+    pickDepth._copyDepthCommand = context.createViewportQuadCommand(PassThrough, {
       renderState: RenderState.fromCache(),
       uniformMap: {
-        u_texture: function () {
+        colorTexture: function () {
           return pickDepth._textureToCopy;
         },
       },

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -2688,8 +2688,7 @@ function executeCommands(scene, passState) {
         renderTranslucentDepthForPick)
     ) {
       // PERFORMANCE_IDEA: Use MRT to avoid the extra copy.
-      //const depthStencilTexture = globeDepth.depthStencilTexture;
-      const depthStencilTexture = globeDepth._copyDepthFramebuffer.getColorTexture();
+      const depthStencilTexture = globeDepth.depthStencilTexture;
       const pickDepth = scene._picking.getPickDepth(scene, index);
       pickDepth.update(context, depthStencilTexture);
       pickDepth.executeCopyDepth(context, passState);

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -2688,7 +2688,8 @@ function executeCommands(scene, passState) {
         renderTranslucentDepthForPick)
     ) {
       // PERFORMANCE_IDEA: Use MRT to avoid the extra copy.
-      const depthStencilTexture = globeDepth.depthStencilTexture;
+      //const depthStencilTexture = globeDepth.depthStencilTexture;
+      const depthStencilTexture = globeDepth._copyDepthFramebuffer.getColorTexture();
       const pickDepth = scene._picking.getPickDepth(scene, index);
       pickDepth.update(context, depthStencilTexture);
       pickDepth.executeCopyDepth(context, passState);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Fixes inaccurate results for `scene.pickPosition` when `depthTestAgainstTerrain` is false. 

Although we were copying the initial globe depth before clearing the globe for subsequent passes, the globe depth was not getting copied into the pickDepth buffer. 

This updates `pickDepth` to resolve depth from both the original and updated globe depth values.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/4368

## Testing plan

1. Here's a [testing Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=7VZtb+JGEP4rWz4ZlazBL2ASiJrmcr1IJUEHTVXJUrWxB1jF3vXtrklom//e8RuYhOt96KdKtRDYs/O8jGfWxrbJR6lIKhUQLlZSpcxwKQh+rkHzPCW/SpXEZAlKMS56RAOQjTGZPrftqMygkUztLGGmQNexM+SwIykMCNOEnguiM1MR2aHAZW3IlsMzKDIlAp5rSfpQxqywUyGvkQchoMJOj/wZCoJHTTNXcstjUOeEPTNuGoJIATNQOv+Rmc0uBaN2V3onIqvGK/iSgzYPoAy83BVlJ/qcGJVDr0h47eLPa/eicWmYWoM5dnnNEKs5E65VQM4cLxgPHZ/2A3foOP7AG5VUZ547dsfegHp4uH3HK6NuEDi+69Ox53uDkRuMR6E4yMnVSn9Lbhj4I+r1x32n7458b1jSegOHuk7gBa4/HHuuH5RRB71Q30cpZxgMnL7jVmLVvacRS0Exmkj5dGWsqtRe7eFraUvFhC4abtX2Zswo/uLR2w83d8vb5W8FsClHRyAAq6mJysty2bbJTOYaiNziDJgNkHUiH4EYWc5ZEYiwbLlWLNvwiGRS82I8G+INE3HydnoW2H0Qi4xFcLPF+ftUJVmlLFYhtkwX7mowxSpvRZabq6igtla5KE+IlaKrFAm61dD9Yy2E8BWpJVIZA/luOj0YwugMg3R2/3n+6fbup24zxoQk2OeoaS3yVhQZj57mdbFWk0pI44iCiOf7e1GtdS+qs+a7LbABvt6YBXZIrFEj7ISdi2a98F0bjWGF2yy29n66LaPNDThqyLQ9nU2UrpRM9+Pask8OlR6C3Yu3CokUa27yGPaGDzO2oUZ+gDV2WL8j3uvvCVoqiPvIX7A454QgPvP+lV6N/5bcURu+nx6TVIuncK/txr7lCDvkL7JvZ/v7/VSVm6ucrf1mKLc07vc5Bj+znXVqwrq9Cn88Yf/PzX9qbgrHMgGscW21+Zp0TH7tfe0RutxlxcPrl8XN77P7h5sC0+l1JtrsErhs5H7gaSaVIblKLEptA2nxpwC0/ZhHT2BopHUjNrHb0EnMt4TH0xPvexIlTGtcWeVJsuB/QNi5nNiY/w6aSBZjOff4IknYrkjbDC5/roKU0omNl6eRRsrkkak3zH8D) that clearly illustrated the initiation problem. It outputs the results of `pickPosition` vs `globe.pick`. The values are wildly different before the fix, and should be similar after.
2. Copy/paste the picking code into various examples to confirm:
  * Scene with globe and model
  * Scene with globe and tileset
  * Scene with translucent globe
  * 2D scene
  * Scene with classification

```

// Mouse over the globe to see the cartographic height
const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
handler.setInputAction(function (movement) {
  const scene = viewer.scene;
  if (scene.mode !== Cesium.SceneMode.MORPHING) {
      let cartesian = scene.pickPosition(
        movement.endPosition
      );
    
    

      let heightString = "";
      if (Cesium.defined(cartesian)) {
        const cartographic = Cesium.Cartographic.fromCartesian(
          cartesian
        );
        const longitudeString = Cesium.Math.toDegrees(
          cartographic.longitude
        ).toFixed(2);
        const latitudeString = Cesium.Math.toDegrees(
          cartographic.latitude
        ).toFixed(2);
       heightString += cartographic.height.toFixed(2);
      }
    
    heightString += " | ";
    
    
    cartesian = scene.globe.pick(scene.camera.getPickRay(movement.endPosition), scene);
    
    if (Cesium.defined(cartesian)) {
        const cartographic = Cesium.Cartographic.fromCartesian(
          cartesian
        );
        const longitudeString = Cesium.Math.toDegrees(
          cartographic.longitude
        ).toFixed(2);
        const latitudeString = Cesium.Math.toDegrees(
          cartographic.latitude
        ).toFixed(2);
       heightString += cartographic.height.toFixed(2);
      }
    
    console.log(heightString);
    }
}, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
