### PR TITLE
Fix built sandcastle images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -235,7 +235,7 @@ export const buildWatch = gulp.series(build, async function buildWatch() {
     }
 
     specs.dispose();
-    // eslint-disable-next-line n/no-process-exit
+
     process.exit(0);
   });
 });
@@ -1163,7 +1163,7 @@ function generateTypeScriptDefinitions(
   const regex = /^declare[ const ]*(function|class|namespace|enum) (.+)/gm;
   let matches;
   let publicModules = new Set();
-  //eslint-disable-next-line no-cond-assign
+
   while ((matches = regex.exec(source))) {
     const moduleName = matches[2].match(/([^<\s|\(]+)/);
     publicModules.add(moduleName[1]);
@@ -1370,7 +1370,7 @@ function createTypeScriptDefinitions() {
   const regex = /^declare (function|class|namespace|enum) (.+)/gm;
   let matches;
   const publicModules = new Set();
-  //eslint-disable-next-line no-cond-assign
+
   while ((matches = regex.exec(source))) {
     const moduleName = matches[2].match(/([^<\s|\(]+)/);
     publicModules.add(moduleName[1]);
@@ -1671,7 +1671,6 @@ async function buildSandcastle() {
     ["Apps/Sandcastle/gallery/**.jpg", "Apps/Sandcastle/images/**"],
     {
       base: "Apps/Sandcastle",
-      buffer: false,
       encoding: false,
     }
   );


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

Fixes the missing thumbnails on sandcastle.cesium.com:
![image](https://github.com/CesiumGS/cesium/assets/4439461/58453ec2-23ad-41f3-8006-d99ccb51ce2d)

This was a misconfiguration of gulp.

The comments were auto-removed on the format step since they are no longer needed.

## Issue number and link

N/A

## Testing plan

1. Run:
`npm run build-apps`
`npm start`

2. Go to localhost
3. Click Sandcastle ([built version](http://localhost:8080/Build/Apps/Sandcastle/index.html))

And thumbnails should be there in this branch.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change`
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [ ] ~I have update the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
