### PR TITLE
Fix SampleData via gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1688,7 +1688,7 @@ async function buildSandcastle() {
     streams.push(fileStream);
 
     const dataStream = gulp
-      .src(["Apps/SampleData/**"])
+      .src(["Apps/SampleData/**"], { encoding: false })
       .pipe(gulp.dest("Build/Sandcastle/SampleData"));
     streams.push(dataStream);
   }


### PR DESCRIPTION
# Description

Fixes erroneous sample data deployed to sandcastle.cesium.com.

Similar to https://github.com/CesiumGS/cesium/pull/12016, this was a misconfiguration of gulp.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12022

## Testing plan

1. Run `PROD=true npm run website-release`
2. Run `PROD=true npm run build-apps`
3. Run `npm start -- --production` and navigate to `http://localhost:8080/Build/Sandcastle/index.html?src=3D%20Models.html`

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [ ] ~I have update the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
