### PR TITLE
Fix icons in deployed Sandcastle

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1683,7 +1683,7 @@ async function buildSandcastle() {
 
   if (isProduction) {
     const fileStream = gulp
-      .src(["ThirdParty/**"])
+      .src(["ThirdParty/**"], { encoding: false })
       .pipe(gulp.dest("Build/Sandcastle/ThirdParty"));
     streams.push(fileStream);
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Fixes erroneous icon files deployed to sandcastle.cesium.com.

Similar to https://github.com/CesiumGS/cesium/pull/12016, this was a misconfiguration of gulp.

I'm pretty sure that this is the last of the issues with deployed Sandcastle, but please double check me.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12026

## Testing plan


1. Run `PROD=true npm run website-release`
2. Run `PROD=true npm run build-apps`
3. Run `npm start -- --production` and navigate to `http://localhost:8080/Build/Sandcastle/index.html?src=3D%20Models.html`

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [ ] ~I have update the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
