### PR TITLE
fix Property 'availability' is missing in type 'CustomHeightmapTerrai…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 ##### Fixes :wrench:
 
 - Fixed issue where Entities would not use a custom ellipsoid. [#3543](https://github.com/CesiumGS/cesium/issues/3543)
+- Fixed issue where Property 'availability' is missing in type 'CustomHeightmapTerrainProvider' but required in type 'TerrainProvider' when using with typescript
 
 ##### Breaking Changes :mega:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -390,3 +390,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [dslming](https://github.com/dslming)
 - [Peter A. Jonsson](https://github.com/pjonsson)
 - [Zhongxiang Wang](https://github.com/plainheart)
+- [Tim Schneider](https://github.com/Tim-S)

--- a/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
+++ b/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
@@ -161,6 +161,20 @@ Object.defineProperties(CustomHeightmapTerrainProvider.prototype, {
   },
 
   /**
+   * Gets an object that can be used to determine availability of terrain from this provider, such as
+   * at points and in rectangles. This property may be undefined if availability
+   * information is not available.
+   * @memberof CustomHeightmapTerrainProvider.prototype
+   * @type {TileAvailability}
+   * @readonly
+   */
+  availability: {
+    get: function () {
+      return undefined;
+    },
+  },
+
+  /**
    * Gets the number of columns per heightmap tile.
    * @memberof CustomHeightmapTerrainProvider.prototype
    * @type {boolean}


### PR DESCRIPTION
…nProvider' but required in type 'TerrainProvider' when using with typescript

# Description

When try using CustomHeightmapTerrainProvider from a small typescript toy-project I got a 

Property 'availability' is missing in type 'CustomHeightmapTerrainProvider' but required in type 'TerrainProvider' 

added simple default Implementation in CustomHeightmapTerrainProvider (basically same as in EllipsoidTerrainProvider)

to make the basic CustomHeightmapTerrainProvider from the doc work 

## Issue number and link

## Testing plan

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have update the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
