### PR TITLE
Adjust credits spacing and alignment

### DIFF
--- a/packages/engine/Source/Core/Credit.js
+++ b/packages/engine/Source/Core/Credit.js
@@ -95,6 +95,7 @@ Object.defineProperties(Credit.prototype, {
         const html = DOMPurify.sanitize(this._html);
 
         const div = document.createElement("div");
+        div.className = "cesium-credit-wrapper";
         div._creditId = this._id;
         div.style.display = "inline";
         div.innerHTML = html;

--- a/packages/engine/Source/Core/GoogleMaps.js
+++ b/packages/engine/Source/Core/GoogleMaps.js
@@ -33,7 +33,7 @@ GoogleMaps.mapTilesApiEndpoint = new Resource({
 
 GoogleMaps.getDefaultCredit = function () {
   return new Credit(
-    `<img src="https://assets.ion-development.cesium.com/google-credit.png" alt="Google">`,
+    `<img src="https://assets.ion.cesium.com/google-credit.png" style="vertical-align: -5px" alt="Google">`,
     true
   );
 };

--- a/packages/engine/Source/Scene/CreditDisplay.js
+++ b/packages/engine/Source/Scene/CreditDisplay.js
@@ -163,112 +163,100 @@ function styleLightboxContainer(that) {
   }
 }
 
-function addStyle(selector, styles) {
-  let style = `${selector} {`;
-  for (const attribute in styles) {
-    if (styles.hasOwnProperty(attribute)) {
-      style += `${attribute}: ${styles[attribute]}; `;
-    }
-  }
-  style += " }\n";
-  return style;
+function appendCss(container) {
+  const style = /*css*/ `
+.cesium-credit-lightbox-overlay {
+  display: none;
+  z-index: 1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(80, 80, 80, 0.8);
 }
 
-function appendCss(container) {
-  let style = "";
-  style += addStyle(".cesium-credit-lightbox-overlay", {
-    display: "none",
-    "z-index": "1", //must be at least 1 to draw over top other Cesium widgets
-    position: "absolute",
-    top: "0",
-    left: "0",
-    width: "100%",
-    height: "100%",
-    "background-color": "rgba(80, 80, 80, 0.8)",
-  });
+.cesium-credit-lightbox {
+  background-color: #303336;
+  color: ${textColor};
+  position: relative;
+  min-height: ${lightboxHeight}px;
+  margin: auto;
+}
+.cesium-credit-lightbox > ul > li a,
+.cesium-credit-lightbox > ul > li a:visited {
+  color: #${textColor};
+}
+.cesium-credit-lightbox > ul > li a:hover {
+  color: ${highlightColor};
+}
+.cesium-credit-lightbox.cesium-credit-lightbox-expanded {
+  border: 1px solid #444;
+  border-radius: 5px;
+  max-width: 370px;
+}
+.cesium-credit-lightbox.cesium-credit-lightbox-mobile {
+  height: 100%;
+  width: 100%;
+}
+.cesium-credit-lightbox-title {
+  padding: 20px 20px 0 20px;
+}
+.cesium-credit-lightbox-close {
+  font-size: 18pt;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  right: 6px;
+  color: ${textColor};
+}
+.cesium-credit-lightbox-close:hover {
+  color: ${highlightColor};
+}
+.cesium-credit-lightbox > ul {
+  margin: 0;
+  padding: 12px 20px 12px 40px;
+  font-size: 13px;
+}
+.cesium-credit-lightbox > ul > li {
+  padding-bottom: 6px;
+}
+.cesium-credit-lightbox > ul > li * {
+  padding: 0;
+  margin: 0;
+}
 
-  style += addStyle(".cesium-credit-lightbox", {
-    "background-color": "#303336",
-    color: textColor,
-    position: "relative",
-    "min-height": `${lightboxHeight}px`,
-    margin: "auto",
-  });
+.cesium-credit-expand-link {
+  padding-left: 5px;
+  cursor: pointer;
+  text-decoration: underline;
+  color: ${textColor};
+}
+.cesium-credit-expand-link:hover {
+  color: ${highlightColor};
+}
 
-  style += addStyle(
-    ".cesium-credit-lightbox > ul > li a, .cesium-credit-lightbox > ul > li a:visited",
-    {
-      color: textColor,
-    }
-  );
+.cesium-credit-text {
+  color: ${textColor};
+}
 
-  style += addStyle(".cesium-credit-lightbox > ul > li a:hover", {
-    color: highlightColor,
-  });
+.cesium-credit-delimiter {
+  padding: 0 5px;
+}
 
-  style += addStyle(".cesium-credit-lightbox.cesium-credit-lightbox-expanded", {
-    border: "1px solid #444",
-    "border-radius": "5px",
-    "max-width": "370px",
-  });
+.cesium-credit-screenContainer *,
+.cesium-credit-cesiumCreditContainer * {
+  display: inline;
+}
 
-  style += addStyle(".cesium-credit-lightbox.cesium-credit-lightbox-mobile", {
-    height: "100%",
-    width: "100%",
-  });
+.cesium-credit-screenContainer a:hover {
+  color: ${highlightColor}
+}
 
-  style += addStyle(".cesium-credit-lightbox-title", {
-    padding: "20px 20px 0 20px",
-  });
-
-  style += addStyle(".cesium-credit-lightbox-close", {
-    "font-size": "18pt",
-    cursor: "pointer",
-    position: "absolute",
-    top: "0",
-    right: "6px",
-    color: textColor,
-  });
-
-  style += addStyle(".cesium-credit-lightbox-close:hover", {
-    color: highlightColor,
-  });
-
-  style += addStyle(".cesium-credit-lightbox > ul", {
-    margin: "0",
-    padding: "12px 20px 12px 40px",
-    "font-size": "13px",
-  });
-
-  style += addStyle(".cesium-credit-lightbox > ul > li", {
-    "padding-bottom": "6px",
-  });
-
-  style += addStyle(".cesium-credit-lightbox > ul > li *", {
-    padding: "0",
-    margin: "0",
-  });
-
-  style += addStyle(".cesium-credit-expand-link", {
-    "padding-left": "5px",
-    cursor: "pointer",
-    "text-decoration": "underline",
-    color: textColor,
-  });
-  style += addStyle(".cesium-credit-expand-link:hover", {
-    color: highlightColor,
-  });
-
-  style += addStyle(".cesium-credit-text", {
-    color: textColor,
-  });
-
-  style += addStyle(
-    ".cesium-credit-textContainer *, .cesium-credit-logoContainer *",
-    {
-      display: "inline",
-    }
-  );
+.cesium-credit-screenContainer .cesium-credit-wrapper:first-of-type {
+  padding-left: 5px;
+}
+`;
 
   function getShadowRoot(container) {
     if (container.shadowRoot) {
@@ -287,16 +275,16 @@ function appendCss(container) {
     getShadowRoot(container),
     document.head
   );
-  const css = document.createElement("style");
-  css.innerHTML = style;
-  shadowRootOrDocumentHead.appendChild(css);
+  const styleElem = document.createElement("style");
+  styleElem.innerHTML = style;
+  shadowRootOrDocumentHead.appendChild(styleElem);
 }
 
 /**
  * The credit display is responsible for displaying credits on screen.
  *
  * @param {HTMLElement} container The HTML element where credits will be displayed
- * @param {string} [delimiter= ' • '] The string to separate text credits
+ * @param {string} [delimiter= '•'] The string to separate text credits
  * @param {HTMLElement} [viewport=document.body] The HTML element that will contain the credits popup
  *
  * @alias CreditDisplay
@@ -351,12 +339,12 @@ function CreditDisplay(container, delimiter, viewport) {
   lightboxCredits.appendChild(creditList);
 
   const cesiumCreditContainer = document.createElement("div");
-  cesiumCreditContainer.className = "cesium-credit-logoContainer";
+  cesiumCreditContainer.className = "cesium-credit-cesiumCreditContainer";
   cesiumCreditContainer.style.display = "inline";
   container.appendChild(cesiumCreditContainer);
 
   const screenContainer = document.createElement("div");
-  screenContainer.className = "cesium-credit-textContainer";
+  screenContainer.className = "cesium-credit-screenContainer";
   screenContainer.style.display = "inline";
   container.appendChild(screenContainer);
 
@@ -369,7 +357,7 @@ function CreditDisplay(container, delimiter, viewport) {
   appendCss(container);
   const cesiumCredit = Credit.clone(CreditDisplay.cesiumCredit);
 
-  this._delimiter = defaultValue(delimiter, " • ");
+  this._delimiter = defaultValue(delimiter, "•");
   this._screenContainer = screenContainer;
   this._cesiumCreditContainer = cesiumCreditContainer;
   this._lastViewportHeight = undefined;
@@ -634,7 +622,7 @@ function getDefaultCredit() {
     }
 
     defaultCredit = new Credit(
-      `<a href="https://cesium.com/" target="_blank"><img src="${logo}" title="Cesium ion"/></a>`,
+      `<a href="https://cesium.com/" target="_blank"><img src="${logo}" style="vertical-align: -7px" title="Cesium ion"/></a>`,
       true
     );
   }

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -156,7 +156,7 @@ function Scene(options) {
   this._jobScheduler = new JobScheduler();
   this._frameState = new FrameState(
     context,
-    new CreditDisplay(creditContainer, " • ", creditViewport),
+    new CreditDisplay(creditContainer, "•", creditViewport),
     this._jobScheduler
   );
   this._frameState.scene3DOnly = defaultValue(options.scene3DOnly, false);

--- a/packages/engine/Source/Widget/CesiumWidget.css
+++ b/packages/engine/Source/Widget/CesiumWidget.css
@@ -28,11 +28,6 @@
   padding-right: 5px;
 }
 
-.cesium-widget-credits a,
-.cesium-widget-credits a:visited {
-  color: #fff;
-}
-
 .cesium-widget-errorPanel {
   position: absolute;
   top: 0;

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -1639,8 +1639,9 @@ Viewer.prototype.resize = function () {
   const timeline = this._timeline;
   let animationContainer;
   let animationWidth = 0;
-  let creditLeft = 0;
-  let creditBottom = 0;
+  let creditLeft = 5;
+  let creditBottom = 3;
+  let creditRight = 0;
 
   if (
     animationExists &&
@@ -1697,8 +1698,14 @@ Viewer.prototype.resize = function () {
     timeline.resize();
   }
 
+  if (!timelineExists && defined(this._fullscreenButton)) {
+    // don't let long credits (like the default ion token) go behind the fullscreen button
+    creditRight = this._fullscreenButton.container.clientWidth;
+  }
+
   this._bottomContainer.style.left = `${creditLeft}px`;
   this._bottomContainer.style.bottom = `${creditBottom}px`;
+  this._bottomContainer.style.right = `${creditRight}px`;
 
   this._lastWidth = width;
   this._lastHeight = height;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

- Adjust attribution styles slightly to provide better alignment
    - All elements should lean into the `inline` nature of how they're displayed. If you have an image the recommendation now is to make sure any text in the log aligns how you want with other text using `vertical-align` or transparent padding in the image itself.
- Change `Viewer` behavior slightly to avoid long credits clipping behind the fullscreen button

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes: https://github.com/CesiumGS/cesium/issues/11912

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Open any sandcastle and check the credits
- Open the google 3d tiles sandcastles and see how they align (will require a change in ion)
- Test with both the default ion token and your own to show with and without the long "default token" warning

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
