### PR TITLE
Fixes #12036 - Types for SceneTransforms functions

### DIFF
--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -34,7 +34,7 @@ const scratchWindowCoord1 = new Cartesian2();
  * @param {Scene} scene The scene.
  * @param {Cartesian3} position The position in world (WGS84 or alternative ellipsoid) coordinates.
  * @param {Cartesian2} [result] An optional object to return the input position transformed to window coordinates.
- * @returns {Cartesian2} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
+ * @returns {Cartesian2|undefined} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
  *
  * @example
  * // Output the window position of longitude/latitude (0, 0) every time the mouse moves.
@@ -60,7 +60,7 @@ SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
  * @param {Scene} scene The scene.
  * @param {Cartesian3} position The position in WGS84 (world) coordinates.
  * @param {Cartesian2} [result] An optional object to return the input position transformed to window coordinates.
- * @returns {Cartesian2} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
+ * @returns {Cartesian2|undefined} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
  *
  * @example
  * // Output the window position of longitude/latitude (0, 0) every time the mouse moves.
@@ -297,7 +297,7 @@ SceneTransforms.worldWithEyeOffsetToWindowCoordinates = function (
  * @param {Scene} scene The scene.
  * @param {Cartesian3} position The position in world (WGS84 or alternative ellipsoid) coordinates.
  * @param {Cartesian2} [result] An optional object to return the input position transformed to window coordinates.
- * @returns {Cartesian2} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
+ * @returns {Cartesian2|undefined} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
  *
  * @example
  * // Output the window position of longitude/latitude (0, 0) every time the mouse moves.
@@ -327,7 +327,7 @@ SceneTransforms.worldToDrawingBufferCoordinates = function (
  * @param {Scene} scene The scene.
  * @param {Cartesian3} position The position in world (WGS84 or alternative ellipsoid) coordinates.
  * @param {Cartesian2} [result] An optional object to return the input position transformed to window coordinates.
- * @returns {Cartesian2} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
+ * @returns {Cartesian2|undefined} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
  *
  * @example
  * // Output the window position of longitude/latitude (0, 0) every time the mouse moves.


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12036

## Testing plan

Fixes types for new `Scene.worldTo` functions added in #12000, and the deprecated functions they were renamed from.

I have not mentioned this in `CHANGES.md` because the functions are newly added or deprecated for this upcoming release.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~ I have not mentioned this in `CHANGES.md` because the functions are newly added or deprecated for this upcoming release.
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
