### PR TITLE
Fix uniform name for scaling clearcoat normals

### DIFF
--- a/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
+++ b/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
@@ -140,7 +140,7 @@ vec3 getClearcoatNormalFromTexture(ProcessedAttributes attributes, vec3 geometry
     vec3 normalSample = texture(u_clearcoatNormalTexture, normalTexCoords).rgb;
     normalSample = 2.0 * normalSample - 1.0;
     #ifdef HAS_CLEARCOAT_NORMAL_TEXTURE_SCALE
-        normalSample.xy *= u_normalTextureScale;
+        normalSample.xy *= u_clearcoatNormalTextureScale;
     #endif
     return normalize(tbn * normalSample);
 }


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Fixes a bug introduced in https://github.com/CesiumGS/cesium/pull/12018, which added support for scaling of normal textures. The uniform name for scaling a _clearcoat_ normal texture was incorrect.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12051.

## Testing plan

Run `ModelSpec` locally.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- ~[ ] I have updated `CHANGES.md` with a short summary of my change~ This is fixing something that was introduced AFTER the last release.
- ~[ ] I have added or updated unit tests to ensure consistent code coverage~
- ~[ ] I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
