### PR TITLE
Fix base color calculation for 3D Tile styles

### DIFF
--- a/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
+++ b/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
@@ -459,12 +459,11 @@ void materialStage(inout czm_modelMaterial material, ProcessedAttributes attribu
     #endif
 
     material.baseColor = baseColorWithAlpha;
+    #ifdef USE_CPU_STYLING
+        material.baseColor.rgb = blend(baseColorWithAlpha.rgb, feature.color.rgb, model_colorBlend);
+    #endif
     material.diffuse = baseColorWithAlpha.rgb;
     material.alpha = baseColorWithAlpha.a;
-
-    #ifdef USE_CPU_STYLING
-        material.diffuse = blend(material.diffuse, feature.color.rgb, model_colorBlend);
-    #endif
 
     #ifdef HAS_OCCLUSION_TEXTURE
         vec2 occlusionTexCoords = TEXCOORD_OCCLUSION;

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3312,7 +3312,7 @@ describe(
       );
     });
 
-    function testColorBlendMode(url) {
+    async function testColorBlendMode(url) {
       // Check that the feature is red
       let sourceRed;
       let sourceGreen;
@@ -3322,148 +3322,145 @@ describe(
         scene: scene,
         time: new JulianDate(2457522.154792),
       };
-      let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, url).then(function (t) {
-        tileset = t;
-        tileset.luminanceAtZenith = undefined;
+      const tileset = await Cesium3DTilesTester.loadTileset(scene, url);
+      tileset.luminanceAtZenith = undefined;
 
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          sourceRed = rgba[0];
-          sourceGreen = rgba[1];
-        });
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        sourceRed = rgba[0];
+        sourceGreen = rgba[1];
+      });
 
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toBeGreaterThan(200);
-          expect(rgba[1]).toBeLessThan(25);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toBeGreaterThan(200);
+        expect(rgba[1]).toBeLessThan(25);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Use HIGHLIGHT blending
-        tileset.colorBlendMode = Cesium3DTileColorBlendMode.HIGHLIGHT;
+      // Use HIGHLIGHT blending
+      tileset.colorBlendMode = Cesium3DTileColorBlendMode.HIGHLIGHT;
 
-        // Style with dark yellow. Expect the red channel to be darker than before.
-        tileset.style = new Cesium3DTileStyle({
-          color: "rgb(128, 128, 0)",
-        });
+      // Style with dark yellow. Expect the red channel to be darker than before.
+      tileset.style = new Cesium3DTileStyle({
+        color: "rgb(128, 128, 0)",
+      });
 
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toBeGreaterThan(100);
-          expect(rgba[0]).toBeLessThan(sourceRed);
-          expect(rgba[1]).toBeLessThan(25);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toBeGreaterThan(100);
+        expect(rgba[0]).toBeLessThan(sourceRed);
+        expect(rgba[1]).toBeLessThan(25);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Style with yellow + alpha. Expect the red channel to be darker than before.
-        tileset.style = new Cesium3DTileStyle({
-          color: "rgba(255, 255, 0, 0.5)",
-        });
+      // Style with yellow + alpha. Expect the red channel to be darker than before.
+      tileset.style = new Cesium3DTileStyle({
+        color: "rgba(255, 255, 0, 0.5)",
+      });
 
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toBeGreaterThan(100);
-          expect(rgba[0]).toBeLessThan(sourceRed);
-          expect(rgba[1]).toBeLessThan(25);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toBeGreaterThan(100);
+        expect(rgba[0]).toBeLessThan(sourceRed);
+        expect(rgba[1]).toBeLessThan(25);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Use REPLACE blending
-        tileset.colorBlendMode = Cesium3DTileColorBlendMode.REPLACE;
+      // Use REPLACE blending
+      tileset.colorBlendMode = Cesium3DTileColorBlendMode.REPLACE;
 
-        // Style with dark yellow. Expect the red and green channels to be roughly dark yellow.
-        tileset.style = new Cesium3DTileStyle({
-          color: "rgb(128, 128, 0)",
-        });
+      // Style with dark yellow. Expect the red and green channels to be roughly dark yellow.
+      tileset.style = new Cesium3DTileStyle({
+        color: "rgb(128, 128, 0)",
+      });
 
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          replaceRed = rgba[0];
-          replaceGreen = rgba[1];
-          expect(rgba[0]).toBeGreaterThan(100);
-          expect(rgba[0]).toBeLessThan(255);
-          expect(rgba[1]).toBeGreaterThan(100);
-          expect(rgba[1]).toBeLessThan(255);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        replaceRed = rgba[0];
+        replaceGreen = rgba[1];
+        expect(rgba[0]).toBeGreaterThan(100);
+        expect(rgba[0]).toBeLessThan(255);
+        expect(rgba[1]).toBeGreaterThan(100);
+        expect(rgba[1]).toBeLessThan(255);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Style with yellow + alpha. Expect the red and green channels to be a shade of yellow.
-        tileset.style = new Cesium3DTileStyle({
-          color: "rgba(255, 255, 0, 0.5)",
-        });
+      // Style with yellow + alpha. Expect the red and green channels to be a shade of yellow.
+      tileset.style = new Cesium3DTileStyle({
+        color: "rgba(255, 255, 0, 0.5)",
+      });
 
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toBeGreaterThan(100);
-          expect(rgba[0]).toBeLessThan(255);
-          expect(rgba[1]).toBeGreaterThan(100);
-          expect(rgba[1]).toBeLessThan(255);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toBeGreaterThan(100);
+        expect(rgba[0]).toBeLessThan(255);
+        expect(rgba[1]).toBeGreaterThan(100);
+        expect(rgba[1]).toBeLessThan(255);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Use MIX blending
-        tileset.colorBlendMode = Cesium3DTileColorBlendMode.MIX;
-        tileset.colorBlendAmount = 0.5;
+      // Use MIX blending
+      tileset.colorBlendMode = Cesium3DTileColorBlendMode.MIX;
+      tileset.colorBlendAmount = 0.5;
 
-        // Style with dark yellow. Expect color to be a mix of the source and style colors.
-        tileset.style = new Cesium3DTileStyle({
-          color: "rgb(128, 128, 0)",
-        });
+      // Style with dark yellow. Expect color to be a mix of the source and style colors.
+      tileset.style = new Cesium3DTileStyle({
+        color: "rgb(128, 128, 0)",
+      });
 
-        let mixRed;
-        let mixGreen;
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          mixRed = rgba[0];
-          mixGreen = rgba[1];
-          expect(rgba[0]).toBeGreaterThan(replaceRed);
-          expect(rgba[0]).toBeLessThan(sourceRed);
-          expect(rgba[1]).toBeGreaterThan(sourceGreen);
-          expect(rgba[1]).toBeLessThan(replaceGreen);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      let mixRed;
+      let mixGreen;
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        mixRed = rgba[0];
+        mixGreen = rgba[1];
+        expect(rgba[0]).toBeGreaterThan(replaceRed);
+        expect(rgba[0]).toBeLessThan(sourceRed);
+        expect(rgba[1]).toBeGreaterThan(sourceGreen);
+        expect(rgba[1]).toBeLessThan(replaceGreen);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Set colorBlendAmount to 0.25. Expect color to be closer to the source color.
-        tileset.colorBlendAmount = 0.25;
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toBeGreaterThan(mixRed);
-          expect(rgba[0]).toBeLessThan(sourceRed);
-          expect(rgba[1]).toBeGreaterThan(0);
-          expect(rgba[1]).toBeLessThan(mixGreen);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      // Set colorBlendAmount to 0.25. Expect color to be closer to the source color.
+      tileset.colorBlendAmount = 0.25;
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toBeGreaterThan(mixRed);
+        expect(rgba[0]).toBeLessThan(sourceRed);
+        expect(rgba[1]).toBeGreaterThan(0);
+        expect(rgba[1]).toBeLessThan(mixGreen);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Set colorBlendAmount to 0.0. Expect color to equal the source color
-        tileset.colorBlendAmount = 0.0;
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toEqual(sourceRed);
-          expect(rgba[1]).toBeLessThan(25);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      // Set colorBlendAmount to 0.0. Expect color to equal the source color
+      tileset.colorBlendAmount = 0.0;
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toEqual(sourceRed);
+        expect(rgba[1]).toBeLessThan(25);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Set colorBlendAmount to 1.0. Expect color to equal the style color
-        tileset.colorBlendAmount = 1.0;
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toEqual(replaceRed);
-          expect(rgba[1]).toEqual(replaceGreen);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      // Set colorBlendAmount to 1.0. Expect color to equal the style color
+      tileset.colorBlendAmount = 1.0;
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toEqual(replaceRed);
+        expect(rgba[1]).toEqual(replaceGreen);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
+      });
 
-        // Style with yellow + alpha. Expect color to be a mix of the source and style colors.
-        tileset.colorBlendAmount = 0.5;
-        tileset.style = new Cesium3DTileStyle({
-          color: "rgba(255, 255, 0, 0.5)",
-        });
+      // Style with yellow + alpha. Expect color to be a mix of the source and style colors.
+      tileset.colorBlendAmount = 0.5;
+      tileset.style = new Cesium3DTileStyle({
+        color: "rgba(255, 255, 0, 0.5)",
+      });
 
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba[0]).toBeGreaterThan(0);
-          expect(rgba[1]).toBeGreaterThan(0);
-          expect(rgba[2]).toBeLessThan(25);
-          expect(rgba[3]).toEqual(255);
-        });
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toBeGreaterThan(0);
+        expect(rgba[1]).toBeGreaterThan(0);
+        expect(rgba[2]).toBeLessThan(25);
+        expect(rgba[3]).toEqual(255);
       });
     }
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

After https://github.com/CesiumGS/cesium/pull/12043, we have separate properties on `czm_modelMaterial` for the material `baseColor` and the computed `diffuse` lighting result.

Since CPU styling is applied _before_ lighting calculations, it should now modify the `baseColor` rather `diffuse`. This explains a few spec failures when running locally.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Run Cesium3DTilesetSpec locally

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
