### PR TITLE
Update self-shadowing function for direct lighting

### DIFF
--- a/Apps/Sandcastle/gallery/glTF PBR Extensions.html
+++ b/Apps/Sandcastle/gallery/glTF PBR Extensions.html
@@ -140,6 +140,8 @@
             onselect: () => {
               imageBasedLighting.sphericalHarmonicCoefficients = coefficients;
               imageBasedLighting.specularEnvironmentMaps = environmentMapURL;
+              imageBasedLighting.imageBasedLightingFactor =
+                Cesium.Cartesian2.ONE;
             },
           },
           {
@@ -147,6 +149,15 @@
             onselect: () => {
               imageBasedLighting.sphericalHarmonicCoefficients = undefined;
               imageBasedLighting.specularEnvironmentMaps = undefined;
+              imageBasedLighting.imageBasedLightingFactor =
+                Cesium.Cartesian2.ONE;
+            },
+          },
+          {
+            text: "Direct lighting only",
+            onselect: () => {
+              imageBasedLighting.imageBasedLightingFactor =
+                Cesium.Cartesian2.ZERO;
             },
           },
         ];
@@ -193,6 +204,10 @@
           {
             text: "Barn Lamp",
             onselect: () => loadModel(2583726),
+          },
+          {
+            text: "Metal-Roughness Spheres",
+            onselect: () => loadModel(2635364),
           },
         ];
         Sandcastle.addToolbarMenu(modelOptions, "modelsToolbar");

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.120 - 2024-08-01
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Updated geometric self-shadowing function to improve direct lighting on models using physically-based rendering. [#12063](https://github.com/CesiumGS/cesium/pull/12063)
+
 ### 1.119 - 2024-07-01
 
 #### @cesium/engine


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR updates the geometric shadowing function used for direct lighting in physically-based rendering. 

Our existing code was using a Schlick-Smith approximation. The limitations of this approximation have been explained by [Eric Heitz in a 2014 paper](https://jcgt.org/published/0003/02/03/paper.pdf). This PR updates the approach to follow the recommendations of the paper, using code similar to the [glTF Sample Viewer](https://github.com/KhronosGroup/glTF-Sample-Viewer).

The effect of the change is subtle, but it makes specular reflections slightly brighter on models with medium roughness.

## Issue number and link

Resolves https://github.com/CesiumGS/cesium/issues/12010.

## Testing plan

Load the [glTF PBR Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=glTF%20PBR%20Extensions.html), and select the lighting option "Direct Lighting Only". See especially the "Metal-Roughness Spheres" model. Compared to the [same Sandcastle in main](https://sandcastle.cesium.com/#c=tVj/b9u4Ff9XuGDAOYMjS5RkSWlSLE3TXrd0LZzcBtw8pIxE27xQpEBSSX1F//c9UpItO67rHrZfbIl67/O+Pz4yl0Ib9MjoE1XoHAn6hC6pZnXp/dOtDaZHuXu/lMIQJqiaHg3Rl6lAiAhWEsOkOEUzwjUd2kXDSsqBrL9Wa/pKySdN1YTmsiypKGgxoVryepP96/GLqZiK3On0BemcCjpEOSmpIvDPZf6AvoKWjbqOls3Q4E+O0NMVzWtO1JV4ZEoKEGPek0rf1FUllaHFcaP2ExOFfPIIp8oM7AJC06PbBdPovlESFZJqJKRBumFFHTKia2hUArY3PbIIVu2vVptGkVITckPKigPMOYp6Ni0omy8MLGLf81+sVqst1/9MScHE/CMz+WIiOR8A9RB1P8crRqnYnAngbfkuCdipGRGhN1OyfE3nilLtjDwJcOj5SRSNg8wFJYo8P/bDxB+710azqViDl7Kg/D0xin1eS7hVROiZVKX2FltK3so37DMt3igIlxPZaNegV6qB7lw05/KeelSQe06vrWRAAilG1bRHxVtv9Vzzmima26wh3PENXEyLbvW0T7t2Rxtn38NRHOEkDX0/jvwgC4bdhzSN8DiEj3GQhVnrI/shzBKcRWkQZHEUp6kfu4Cvk3U0Qi55tlIDPRGNKiWheDQtoASsgX9fAIXUP2k057dv0LtX16jJE+WhW9mRo6WsFZJP4tShB+gEvYY3LkkBNVeg+5rxApkF7fCeoaHBwphKn45Gc2YW9b0HVTdqid8qWVcjy3ECHCctx7HnZGGQNakF+pRzhk6YqGrzkZgFGlXwOzJyBBU/p96iUOhE1uayvqdQYuvPsAYs3oP5jD95PaTFJwRJgwjnSFY2TlA5bZrRjWr9ZXKNzq2Hp0edCU37cSZU9T1n+egGvJATbThttH9NDBk9MKLI3fiOzAxVQkpxhx/u2D13ykyPVrGSaA6ppYihzoW6WlDFcsLRgqhSCpajXNLZjOUMNIKeQLl8GtoWht5KOecUgveGceLiDAH7DfJuR5ws9IpMUU4JAOyKytyBjmYt7ail1c8CUoLa6OTELCt6DibBY0ErLpfnW87fESsIxQdQSNkYQMfWiCgKsdCya3C08DalLCivdoUMNApBo1vy0Hivc2Wx6TSbpZ0bSgQdqinIv90gKAq9ACc1fl0lwbXvb5b5VukGHg6jxM/G2I+SOBk35QmrOICGhrOxnwZxFHarSRjE4zQNwhBD+fab2nVwF3xHUhDGGQ4C7I+jcByMW8wgCXCQJFkWpOPETzpJaTKOoiSyHSNMwk1J3zUpsr0mCbJ0HKYZHq5WYxCSpGnmZ22DsoJwCosZ9Cc/StNNQfstOgHl/XEW+kmIE5z4cYNplwMcYxwBdIJ9P1stxyHolIYpDkPofBuy8B3+njA/HWM8zqC9xrGPV6h+kkFYsijAOAyieCXMdmEcZSl4ETy8Jey7sUqzFBIjCLMwTuPOhUEaZz7EH2yNonVWBFEINEngJzjcciHeHyvYdCH2qR/FkGrjNvtgEfsBRD2OXL6tFsF9YTzOcAhB2zIoOMB5KTgPw9achWG6cl4KaR6ADmAP7ELrAEKaRj6kBs7iZMuk7wQKNI1xFERpBKHyW9/Z1Qh2RxDtQ01BJq6XA6gyKAE/Tsdx1he1Ufrn6N9QzENXaPbXPdonyBz3657tKnZP+D+98ch1rFfQ/oreTNCz4d2z7832z+uSCSJyemF+pQKa6ykEoqnRVX//uW3vlz1tTzd0b+l3DpGnz/ep7XmVtyp9aLql9YQF/NIMEoZ+Nqewq11tjQkdF0zVDSGwwhYAmwoaHKPzlx0/2uEcb69xoEDfuhd7cXYaDQjPrN4H83zpDcmNVDsGVOx9+MdVi/XVWd78bnnro52IilrB9qwflv9fZ9VwKpnByaX4Y546iP1/76FmHl55BjzCl3/IPT+k2q9Xkw/PdLOVvB7NPFIUt1Lye6LeU1EPtspjCLp3Sy3Z9KgpJ07bw8fmUWR/XV3C2KTQpSQG/YvlD+6YutsJdjB5bwEHOE6jEGfH3/buTXfwu6XaHIQIO2yyD/FCMC2NktUS3RhFxRym64PB0zDG48PAXzOd/whwGqeHAU+kcYf+HwPf55Je6A7HhMCND8OEtEUfCROHA+/zxK1cWsRDscJgD9ZHCUf4mdWS64MB/T2Ar4gS6BrORAfGJdnrw/fUEH4ykfV8Ieyx9MY2UHqQpnCSDsfR8YGtoV/eti+4d73RFZ4XrWsVRC9Fjma1cIf/ngbwdgEHb/Ouu/UxatnZ1/QUsASO2TmFfkKeCDOrGUOKSfvJXaK0MH3EtvM5NbfZnXjH+Jab2YXVb7Bqu7XipyvBw261d9Fy2n8Zfrtbt5/a+cM+NhcmlWIlM+yRak/RUj7SC84Hnb7PSCAMje/XMO4VeEmxvHqEzc3SuIdrpo097A22dpLfpSxvZeP0FdZKN/hDOTH5Ag2oUlIdd4wbl3Cfruw3Fz27hTmYU/TnL47l66cWqL1iWwX7ueQGvBtKBfQrzt2tZns/mCtKxU1FcnrprhQvVzQvWsb21YNxkpV1+SuIgEZq7GhpxynHBcGttYFQC2gx24x3LafrknRibxnO4ezhtw62W9sXpMDOWrubzMbf9xKmBzC9qTCHae81W7ozFNhbv851cAa/+bYl7vJS/GTQAsqNU6RLe4JvKgo9Uc77NaBhGnIKAj4atXq18evy2aVi5JU1N6ziy1fLXwSz9wg3lnewkcPeruR1MobfpGs+dEnTWvyX84atC/w6rO2l43ooAZSFZ+QElonQAzjfNhekHUNlryeBvLlvRV0MuZQPF931764geJAyhqpW8W/dzRIxp4NWp2Eja7gyAmFQpXc9fDQ8OtNmyenLzht/ZaW7X4a+MPC8kaFlxSFl9Oi+hhHGeLnWnWfORn3Ws4I9Ilac77icRzknWsOXWc35DfudTo9eno2A/hlrW28fHqniZGnJFsHL62bR87yzEbzu5jRda15Z0kPdHuo2MPqUW21+U1bv+b8), the specular reflection should be slightly brighter and broader in this branch.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
