### PR TITLE
Fix for PointCloudShading.normalShading parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Fixed the PointCloudShading.normalShading parameter. Now it disables shading using normals if point cloud contains normals, but the parameter is set to false.
+
 ### 1.120 - 2024-08-01
 
 #### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -391,3 +391,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Peter A. Jonsson](https://github.com/pjonsson)
 - [Zhongxiang Wang](https://github.com/plainheart)
 - [Tim Schneider](https://github.com/Tim-S)
+- [Vladislav Yunev](https://github.com/YunVlad)

--- a/packages/engine/Source/Scene/Model/MaterialPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/MaterialPipelineStage.js
@@ -148,9 +148,21 @@ MaterialPipelineStage.process = function (
     VertexAttributeSemantic.NORMAL
   );
 
+  //Disable normals if PointCloud has them, but the parameter is set
+  //to false in PointCloudShading.normalShading.
+  let hasNormalsDisabling = false;
+  if (defined(model.pointCloudShading)) {
+    hasNormalsDisabling = !model.pointCloudShading.normalShading;
+  }
+
   // Classification models will be rendered as unlit.
   const lightingOptions = renderResources.lightingOptions;
-  if (material.unlit || !hasNormals || hasClassification) {
+  if (
+    material.unlit ||
+    !hasNormals ||
+    hasClassification ||
+    hasNormalsDisabling
+  ) {
     lightingOptions.lightingModel = LightingModel.UNLIT;
   } else {
     lightingOptions.lightingModel = LightingModel.PBR;


### PR DESCRIPTION
# Description

Fixed the operation of the `PointCloudShading.normalShading` parameter. This parameter exists, but is not used when working with `Cesium3DTileset`.

Now if the point cloud contains normals and the `PointCloudShading.normalShading` parameter is set to `false`, the point cloud is drawn as if it did not contain normals.

## Issue number and link

Related Issue [#11196]([https://github.com/CesiumGS/cesium/issues/11196](https://vk.com/away.php?utf=1&to=https%3A%2F%2Fgithub.com%2FCesiumGS%2Fcesium%2Fissues%2F11196))

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have performed a self-review of my code
