### PR TITLE
Fix LOD selection for image-based lighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Fixes :wrench:
 
 - Updated geometric self-shadowing function to improve direct lighting on models using physically-based rendering. [#12063](https://github.com/CesiumGS/cesium/pull/12063)
+- Fixed environment map LOD selection in image-based lighting. [#12070](https://github.com/CesiumGS/cesium/pull/12070)
 
 ### 1.119 - 2024-07-01
 

--- a/packages/engine/Source/Renderer/AutomaticUniforms.js
+++ b/packages/engine/Source/Renderer/AutomaticUniforms.js
@@ -1454,7 +1454,7 @@ const AutomaticUniforms = {
    * // Example: For a given roughness and NdotV value, find the material's BRDF information in the red and green channels
    * float roughness = 0.5;
    * float NdotV = dot(normal, view);
-   * vec2 brdfLut = texture(czm_brdfLut, vec2(NdotV, 1.0 - roughness)).rg;
+   * vec2 brdfLut = texture(czm_brdfLut, vec2(NdotV, roughness)).rg;
    */
   czm_brdfLut: new AutomaticUniform({
     size: 1,

--- a/packages/engine/Source/Scene/OctahedralProjectedCubeMap.js
+++ b/packages/engine/Source/Scene/OctahedralProjectedCubeMap.js
@@ -337,11 +337,10 @@ OctahedralProjectedCubeMap.prototype.update = function (frameState) {
     },
   });
 
-  // We only need up to 6 mip levels to avoid artifacts.
-  const length = Math.min(cubeMapBuffers.length, 6);
-  this._maximumMipmapLevel = length - 1;
-  const cubeMaps = (this._cubeMaps = new Array(length));
-  const mipTextures = (this._mipTextures = new Array(length));
+  const mipLevels = cubeMapBuffers.length;
+  this._maximumMipmapLevel = mipLevels - 1;
+  const cubeMaps = (this._cubeMaps = new Array(mipLevels));
+  const mipTextures = (this._mipTextures = new Array(mipLevels));
   const originalSize = cubeMapBuffers[0].positiveX.width * 2.0;
   const uniformMap = {
     originalSize: function () {
@@ -350,7 +349,7 @@ OctahedralProjectedCubeMap.prototype.update = function (frameState) {
   };
 
   // First we project each cubemap onto a flat octahedron, and write that to a texture.
-  for (let i = 0; i < length; ++i) {
+  for (let i = 0; i < mipLevels; ++i) {
     // Swap +Y/-Y faces since the octahedral projection expects this order.
     const positiveY = cubeMapBuffers[i].positiveY;
     cubeMapBuffers[i].positiveY = cubeMapBuffers[i].negativeY;

--- a/packages/engine/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
@@ -68,7 +68,7 @@ vec3 czm_sampleOctahedralProjectionWithFiltering(sampler2D projectedMap, vec2 te
  * @returns {vec3} The color of the cube map at the direction.
  */
 vec3 czm_sampleOctahedralProjection(sampler2D projectedMap, vec2 textureSize, vec3 direction, float lod, float maxLod) {
-    float currentLod = floor(lod + 0.5);
+    float currentLod = floor(lod);
     float nextLod = min(currentLod + 1.0, maxLod);
 
     vec3 colorCurrentLod = czm_sampleOctahedralProjectionWithFiltering(projectedMap, textureSize, direction, currentLod);

--- a/packages/engine/Specs/Scene/OctahedralProjectedCubeMapSpec.js
+++ b/packages/engine/Specs/Scene/OctahedralProjectedCubeMapSpec.js
@@ -120,7 +120,7 @@ describe(
       });
     }
 
-    it("creates a packed texture with the right dimensions", function () {
+    it("creates a packed texture with the right dimensions", async function () {
       if (!OctahedralProjectedCubeMap.isSupported(context)) {
         return;
       }
@@ -128,17 +128,16 @@ describe(
       octahedralMap = new OctahedralProjectedCubeMap(environmentMapUrl);
       const frameState = createFrameState(context);
 
-      return pollToPromise(function () {
+      await pollToPromise(function () {
         octahedralMap.update(frameState);
         return octahedralMap.ready;
-      }).then(function () {
-        expect(octahedralMap.texture.width).toEqual(770);
-        expect(octahedralMap.texture.height).toEqual(512);
-        expect(octahedralMap.maximumMipmapLevel).toEqual(5);
       });
+      expect(octahedralMap.texture.width).toEqual(770);
+      expect(octahedralMap.texture.height).toEqual(512);
+      expect(octahedralMap.maximumMipmapLevel).toEqual(7);
     });
 
-    it("correctly projects the given cube map and all mip levels", function () {
+    it("correctly projects the given cube map and all mip levels", async function () {
       if (!OctahedralProjectedCubeMap.isSupported(context)) {
         return;
       }
@@ -146,7 +145,7 @@ describe(
       octahedralMap = new OctahedralProjectedCubeMap(environmentMapUrl);
       const frameState = createFrameState(context);
 
-      return pollToPromise(function () {
+      await pollToPromise(function () {
         // We manually call update and execute the commands
         // because calling scene.renderForSpecs does not
         // actually execute these commands, and we need
@@ -155,34 +154,32 @@ describe(
         executeCommands(frameState);
 
         return octahedralMap.ready;
-      }).then(function () {
-        const directions = {
-          positiveX: new Cartesian3(1, 0, 0),
-          negativeX: new Cartesian3(-1, 0, 0),
-          positiveY: new Cartesian3(0, 1, 0),
-          negativeY: new Cartesian3(0, -1, 0),
-          positiveZ: new Cartesian3(0, 0, 1),
-          negativeZ: new Cartesian3(0, 0, -1),
-        };
+      });
+      const directions = {
+        positiveX: new Cartesian3(1, 0, 0),
+        negativeX: new Cartesian3(-1, 0, 0),
+        positiveY: new Cartesian3(0, 1, 0),
+        negativeY: new Cartesian3(0, -1, 0),
+        positiveZ: new Cartesian3(0, 0, 1),
+        negativeZ: new Cartesian3(0, 0, -1),
+      };
 
-        for (
-          let mipLevel = 0;
-          mipLevel < octahedralMap.maximumMipmapLevel;
-          mipLevel++
-        ) {
-          for (const key in directions) {
-            if (directions.hasOwnProperty(key)) {
-              const direction = directions[key];
+      // The projection is less accurate for the last mip levels,
+      // where the input cubemap only has a few samples.
+      const lastAccurateMip = octahedralMap.maximumMipmapLevel - 2;
+      for (let mipLevel = 0; mipLevel < lastAccurateMip; mipLevel++) {
+        for (const key in directions) {
+          if (directions.hasOwnProperty(key)) {
+            const direction = directions[key];
 
-              expectCubeMapAndOctahedralMapEqual(
-                octahedralMap,
-                direction,
-                mipLevel
-              );
-            }
+            expectCubeMapAndOctahedralMapEqual(
+              octahedralMap,
+              direction,
+              mipLevel
+            );
           }
         }
-      });
+      }
     });
 
     it("caches projected textures", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR fixes two errors in LOD sampling of environment maps for image-based lighting:
1. In `czm_sampleOctahedralProjection`, the interpolation of mip levels was sometimes starting from the wrong lower-bound mip level.
2. In `OctahedralProjectedCubeMap`, the number of mip levels was limited to 6. This limit meant that the lowest-resolution versions of the environment map were not used. For rough materials lit by high-res environment maps, this could sometimes result in specular reflections with too much detail.

The improvement in LOD sampling from this PR is most visible on the [Barn Lamp sample model](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/AnisotropyBarnLamp/README.md), which has a lot of variation in the material roughness.

Before this PR:
![image](https://github.com/CesiumGS/cesium/assets/41167620/1bb4e285-2503-4a91-ac5b-06d26f188bc0)

After fixing mip level interpolation:
![image](https://github.com/CesiumGS/cesium/assets/41167620/3c3cd6e3-87d6-4984-a51c-e3ecfc1d250d)

After allowing more mip levels:
![image](https://github.com/CesiumGS/cesium/assets/41167620/ab0224a7-87fa-49b7-9745-53288c24bba9)

Clearcoat Wicker model, before this PR:
![image](https://github.com/CesiumGS/cesium/assets/41167620/2b3dfa9e-70ef-43c5-ad91-35d043273f18)

After fixing mip level interpolation:
![image](https://github.com/CesiumGS/cesium/assets/41167620/ff7eec66-2cf1-4961-abda-b29301313395)

After allowing more mip levels:
![image](https://github.com/CesiumGS/cesium/assets/41167620/7cfe7d89-ae52-40e3-bb83-b9418b76692f)
Note how the specular reflection is slightly broader and brighter when an appropriately low-res version of the environment map is used.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12069.

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Load the [glTF PBR Extensions Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=glTF%20PBR%20Extensions.html) and compare the results to the [same Sandcastle in main](https://sandcastle.cesium.com/?src=glTF%20PBR%20Extensions.html). Most models should show some improvement, but the effect is most dramatic on the "Barn Lamp" model.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
