### PR TITLE
Update specular BRDF for image-based lighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Updated geometric self-shadowing function to improve direct lighting on models using physically-based rendering. [#12063](https://github.com/CesiumGS/cesium/pull/12063)
 - Fixed environment map LOD selection in image-based lighting. [#12070](https://github.com/CesiumGS/cesium/pull/12070)
 - Corrected calculation of diffuse component in image-based lighting. [#12082](https://github.com/CesiumGS/cesium/pull/12082)
+- Updated specular BRDF for image-based lighting. [#12083](https://github.com/CesiumGS/cesium/pull/12083)
 
 ### 1.119 - 2024-07-01
 

--- a/packages/engine/Source/Shaders/BrdfLutGeneratorFS.glsl
+++ b/packages/engine/Source/Shaders/BrdfLutGeneratorFS.glsl
@@ -27,11 +27,11 @@ vec2 hammersley2D(int i, int N)
     return vec2(float(i) / float(N), vdcRadicalInverse(i));
 }
 
-vec3 importanceSampleGGX(vec2 xi, float roughness, vec3 N)
+vec3 importanceSampleGGX(vec2 xi, float alphaRoughness, vec3 N)
 {
-    float a = roughness * roughness;
+    float alphaRoughnessSquared = alphaRoughness * alphaRoughness;
     float phi = 2.0 * M_PI * xi.x;
-    float cosTheta = sqrt((1.0 - xi.y) / (1.0 + (a * a - 1.0) * xi.y));
+    float cosTheta = sqrt((1.0 - xi.y) / (1.0 + (alphaRoughnessSquared - 1.0) * xi.y));
     float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
     vec3 H = vec3(sinTheta * cos(phi), sinTheta * sin(phi), cosTheta);
     vec3 upVector = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
@@ -40,15 +40,31 @@ vec3 importanceSampleGGX(vec2 xi, float roughness, vec3 N)
     return tangentX * H.x + tangentY * H.y + N * H.z;
 }
 
-float G1_Smith(float NdotV, float k)
+/**
+ * Estimate the geometric self-shadowing of the microfacets in a surface,
+ * using the Smith Joint GGX visibility function.
+ * Note: Vis = G / (4 * NdotL * NdotV)
+ * see Eric Heitz. 2014. Understanding the Masking-Shadowing Function in Microfacet-Based BRDFs. Journal of Computer Graphics Techniques, 3
+ * see Real-Time Rendering. Page 331 to 336.
+ * see https://google.github.io/filament/Filament.md.html#materialsystem/specularbrdf/geometricshadowing(specularg)
+ *
+ * @param {float} alphaRoughness The roughness of the material, expressed as the square of perceptual roughness.
+ * @param {float} NdotL The cosine of the angle between the surface normal and the direction to the light source.
+ * @param {float} NdotV The cosine of the angle between the surface normal and the direction to the camera.
+ */
+float smithVisibilityGGX(float alphaRoughness, float NdotL, float NdotV)
 {
-    return NdotV / (NdotV * (1.0 - k) + k);
-}
+    float alphaRoughnessSq = alphaRoughness * alphaRoughness;
 
-float G_Smith(float roughness, float NdotV, float NdotL)
-{
-    float k = roughness * roughness / 2.0;
-    return G1_Smith(NdotV, k) * G1_Smith(NdotL, k);
+    float GGXV = NdotL * sqrt(NdotV * NdotV * (1.0 - alphaRoughnessSq) + alphaRoughnessSq);
+    float GGXL = NdotV * sqrt(NdotL * NdotL * (1.0 - alphaRoughnessSq) + alphaRoughnessSq);
+
+    float GGX = GGXV + GGXL; // 2.0 if NdotL = NdotV = 1.0
+    if (GGX > 0.0)
+    {
+        return 0.5 / GGX; // 1/4 if NdotL = NdotV = 1.0
+    }
+    return 0.0;
 }
 
 vec2 integrateBrdf(float roughness, float NdotV)
@@ -57,18 +73,19 @@ vec2 integrateBrdf(float roughness, float NdotV)
     float A = 0.0;
     float B = 0.0;
     const int NumSamples = 1024;
+    float alphaRoughness = roughness * roughness;
     for (int i = 0; i < NumSamples; i++)
     {
         vec2 xi = hammersley2D(i, NumSamples);
-        vec3 H = importanceSampleGGX(xi, roughness, vec3(0.0, 0.0, 1.0));
+        vec3 H = importanceSampleGGX(xi, alphaRoughness, vec3(0.0, 0.0, 1.0));
         vec3 L = 2.0 * dot(V, H) * H - V;
         float NdotL = clamp(L.z, 0.0, 1.0);
         float NdotH = clamp(H.z, 0.0, 1.0);
         float VdotH = clamp(dot(V, H), 0.0, 1.0);
         if (NdotL > 0.0)
         {
-            float G = G_Smith(roughness, NdotV, NdotL);
-            float G_Vis = G * VdotH / (NdotH * NdotV);
+            float G = smithVisibilityGGX(alphaRoughness, NdotL, NdotV);
+            float G_Vis = 4.0 * G * VdotH * NdotL / NdotH;
             float Fc = pow(1.0 - VdotH, 5.0);
             A += (1.0 - Fc) * G_Vis;
             B += Fc * G_Vis;

--- a/packages/engine/Source/Shaders/Builtin/Functions/pbrLighting.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/pbrLighting.glsl
@@ -13,14 +13,14 @@ vec3 fresnelSchlick2(vec3 f0, vec3 f90, float VdotH)
 
 #ifdef USE_ANISOTROPY
 /**
- * @param {float} roughness Material roughness (along the anisotropy bitangent)
+ * @param {float} bitangentRoughness Material roughness (along the anisotropy bitangent)
  * @param {float} tangentialRoughness Anisotropic roughness (along the anisotropy tangent)
  * @param {vec3} lightDirection The direction from the fragment to the light source, transformed to tangent-bitangent-normal coordinates
  * @param {vec3} viewDirection The direction from the fragment to the camera, transformed to tangent-bitangent-normal coordinates
  */
-float smithVisibilityGGX_anisotropic(float roughness, float tangentialRoughness, vec3 lightDirection, vec3 viewDirection)
+float smithVisibilityGGX_anisotropic(float bitangentRoughness, float tangentialRoughness, vec3 lightDirection, vec3 viewDirection)
 {
-    vec3 roughnessScale = vec3(tangentialRoughness, roughness, 1.0);
+    vec3 roughnessScale = vec3(tangentialRoughness, bitangentRoughness, 1.0);
     float GGXV = lightDirection.z * length(roughnessScale * viewDirection);
     float GGXL = viewDirection.z * length(roughnessScale * lightDirection);
     float v = 0.5 / (GGXV + GGXL);
@@ -28,14 +28,14 @@ float smithVisibilityGGX_anisotropic(float roughness, float tangentialRoughness,
 }
 
 /**
- * @param {float} roughness Material roughness (along the anisotropy bitangent)
+ * @param {float} bitangentRoughness Material roughness (along the anisotropy bitangent)
  * @param {float} tangentialRoughness Anisotropic roughness (along the anisotropy tangent)
  * @param {vec3} halfwayDirection The unit vector halfway between light and view directions, transformed to tangent-bitangent-normal coordinates
  */
-float GGX_anisotropic(float roughness, float tangentialRoughness, vec3 halfwayDirection)
+float GGX_anisotropic(float bitangentRoughness, float tangentialRoughness, vec3 halfwayDirection)
 {
-    float roughnessSquared = roughness * tangentialRoughness;
-    vec3 f = halfwayDirection * vec3(roughness, tangentialRoughness, roughnessSquared);
+    float roughnessSquared = bitangentRoughness * tangentialRoughness;
+    vec3 f = halfwayDirection * vec3(bitangentRoughness, tangentialRoughness, roughnessSquared);
     float w2 = roughnessSquared / dot(f, f);
     return roughnessSquared * w2 * w2 / czm_pi;
 }
@@ -73,15 +73,15 @@ float smithVisibilityGGX(float alphaRoughness, float NdotL, float NdotV)
  * the halfway vector, which is aligned halfway between the directions from
  * the fragment to the camera and from the fragment to the light source.
  *
- * @param {float} roughness The roughness of the material.
+ * @param {float} alphaRoughness The roughness of the material, expressed as the square of perceptual roughness.
  * @param {float} NdotH The cosine of the angle between the surface normal and the halfway vector.
  * @return {float} The fraction of microfacets aligned to the halfway vector.
  */
-float GGX(float roughness, float NdotH)
+float GGX(float alphaRoughness, float NdotH)
 {
-    float roughnessSquared = roughness * roughness;
-    float f = (NdotH * roughnessSquared - NdotH) * NdotH + 1.0;
-    return roughnessSquared / (czm_pi * f * f);
+    float alphaRoughnessSquared = alphaRoughness * alphaRoughness;
+    float f = (NdotH * alphaRoughnessSquared - NdotH) * NdotH + 1.0;
+    return alphaRoughnessSquared / (czm_pi * f * f);
 }
 
 /**
@@ -91,16 +91,16 @@ float GGX(float roughness, float NdotH)
  * @param {vec3} lightDirection The unit vector pointing from the fragment to the light source.
  * @param {vec3} viewDirection The unit vector pointing from the fragment to the camera.
  * @param {vec3} halfwayDirection The unit vector pointing from the fragment to halfway between the light source and the camera.
- * @param {float} roughness The roughness of the material.
+ * @param {float} alphaRoughness The roughness of the material, expressed as the square of perceptual roughness.
  * @return {float} The strength of the specular reflection.
  */
-float computeDirectSpecularStrength(vec3 normal, vec3 lightDirection, vec3 viewDirection, vec3 halfwayDirection, float roughness)
+float computeDirectSpecularStrength(vec3 normal, vec3 lightDirection, vec3 viewDirection, vec3 halfwayDirection, float alphaRoughness)
 {
     float NdotL = dot(normal, lightDirection);
     float NdotV = abs(dot(normal, viewDirection));
-    float G = smithVisibilityGGX(roughness, NdotL, NdotV);
+    float G = smithVisibilityGGX(alphaRoughness, NdotL, NdotV);
     float NdotH = clamp(dot(normal, halfwayDirection), 0.0, 1.0);
-    float D = GGX(roughness, NdotH);
+    float D = GGX(alphaRoughness, NdotH);
     return G * D;
 }
 
@@ -138,19 +138,20 @@ vec3 czm_pbrLighting(vec3 viewDirectionEC, vec3 normalEC, vec3 lightDirectionEC,
         F *= material.specularWeight;
     #endif
 
-    float alpha = material.roughness;
+    float alphaRoughness = material.roughness * material.roughness;
     #ifdef USE_ANISOTROPY
         mat3 tbn = mat3(material.anisotropicT, material.anisotropicB, normalEC);
         vec3 lightDirection = lightDirectionEC * tbn;
         vec3 viewDirection = viewDirectionEC * tbn;
         vec3 halfwayDirection = halfwayDirectionEC * tbn;
         float anisotropyStrength = material.anisotropyStrength;
-        float tangentialRoughness = mix(alpha, 1.0, anisotropyStrength * anisotropyStrength);
-        float G = smithVisibilityGGX_anisotropic(alpha, tangentialRoughness, lightDirection, viewDirection);
-        float D = GGX_anisotropic(alpha, tangentialRoughness, halfwayDirection);
+        float tangentialRoughness = mix(alphaRoughness, 1.0, anisotropyStrength * anisotropyStrength);
+        float bitangentRoughness = clamp(alphaRoughness, 0.001, 1.0);
+        float G = smithVisibilityGGX_anisotropic(bitangentRoughness, tangentialRoughness, lightDirection, viewDirection);
+        float D = GGX_anisotropic(bitangentRoughness, tangentialRoughness, halfwayDirection);
         vec3 specularContribution = F * G * D;
     #else
-        float specularStrength = computeDirectSpecularStrength(normalEC, lightDirectionEC, viewDirectionEC, halfwayDirectionEC, alpha);
+        float specularStrength = computeDirectSpecularStrength(normalEC, lightDirectionEC, viewDirectionEC, halfwayDirectionEC, alphaRoughness);
         vec3 specularContribution = F * specularStrength;
     #endif
 

--- a/packages/engine/Source/Shaders/Model/ImageBasedLightingStageFS.glsl
+++ b/packages/engine/Source/Shaders/Model/ImageBasedLightingStageFS.glsl
@@ -227,7 +227,7 @@ vec3 textureIBL(
 
     #ifdef SPECULAR_IBL
         vec3 reflectMC = normalize(model_iblReferenceFrameMatrix * reflectEC);
-        float NdotV = abs(dot(normalEC, viewDirectionEC));
+        float NdotV = clamp(dot(normalEC, viewDirectionEC), 0.0, 1.0);
         vec3 f0 = material.specular;
         vec3 specularContribution = computeSpecularIBL(reflectMC, NdotV, f0, material.roughness);
     #else

--- a/packages/engine/Source/Shaders/Model/ImageBasedLightingStageFS.glsl
+++ b/packages/engine/Source/Shaders/Model/ImageBasedLightingStageFS.glsl
@@ -16,10 +16,10 @@ vec3 getProceduralSkyMetrics(vec3 positionWC, vec3 reflectionWC)
 }
 
 /**
- * Compute the diffuse irradiance for a procedural sky lighting model
+ * Compute the diffuse irradiance for a procedural sky lighting model.
  *
  * @param {vec3} skyMetrics The dot products of the horizon and reflection directions with the nadir, and an atmosphere boundary distance.
- * @return {vec3} The computed diffuse irradiance
+ * @return {vec3} The computed diffuse irradiance.
  */
 vec3 getProceduralDiffuseIrradiance(vec3 skyMetrics)
 {
@@ -30,10 +30,12 @@ vec3 getProceduralDiffuseIrradiance(vec3 skyMetrics)
 }
 
 /**
- * Compute the specular irradiance for a procedural sky lighting model
+ * Compute the specular irradiance for a procedural sky lighting model.
  *
+ * @param {vec3} reflectionWC The reflection vector in world coordinates.
  * @param {vec3} skyMetrics The dot products of the horizon and reflection directions with the nadir, and an atmosphere boundary distance.
- * @return {vec3} The computed specular irradiance
+ * @param {float} roughness The roughness of the material.
+ * @return {vec3} The computed specular irradiance.
  */
 vec3 getProceduralSpecularIrradiance(vec3 reflectionWC, vec3 skyMetrics, float roughness)
 {
@@ -42,7 +44,7 @@ vec3 getProceduralSpecularIrradiance(vec3 reflectionWC, vec3 skyMetrics, float r
     reflectionWC = -normalize(czm_temeToPseudoFixed * reflectionWC);
     reflectionWC.x = -reflectionWC.x;
 
-    float inverseRoughness = 1.04 - roughness;
+    float inverseRoughness = 1.0 - roughness;
     inverseRoughness *= inverseRoughness;
     vec3 sceneSkyBox = czm_textureCube(czm_environmentMap, reflectionWC).rgb * inverseRoughness;
 
@@ -173,11 +175,12 @@ vec3 sampleSpecularEnvironment(vec3 cubeDir, float roughness)
         return czm_sampleOctahedralProjection(czm_specularEnvironmentMaps, czm_specularEnvironmentMapSize, cubeDir, lod, maxLod);
     #endif
 }
-vec3 computeSpecularIBL(vec3 cubeDir, float NdotV, float VdotH, vec3 f0, float roughness)
+vec3 computeSpecularIBL(vec3 cubeDir, float NdotV, vec3 f0, float roughness)
 {
-    float reflectance = czm_maximumComponent(f0);
-    vec3 f90 = vec3(clamp(reflectance * 25.0, 0.0, 1.0));
-    vec3 F = fresnelSchlick2(f0, f90, VdotH);
+    // see https://bruop.github.io/ibl/ at Single Scattering Results
+    // Roughness dependent fresnel, from Fdez-Aguera
+    vec3 f90 = max(vec3(1.0 - roughness), f0);
+    vec3 F = fresnelSchlick2(f0, f90, NdotV);
 
     vec2 brdfLut = texture(czm_brdfLut, vec2(NdotV, roughness)).rg;
     vec3 specularSample = sampleSpecularEnvironment(cubeDir, roughness);
@@ -224,11 +227,9 @@ vec3 textureIBL(
 
     #ifdef SPECULAR_IBL
         vec3 reflectMC = normalize(model_iblReferenceFrameMatrix * reflectEC);
-        float NdotV = abs(dot(normalEC, viewDirectionEC)) + 0.001;
-        vec3 halfwayDirectionEC = normalize(viewDirectionEC + lightDirectionEC);
-        float VdotH = clamp(dot(viewDirectionEC, halfwayDirectionEC), 0.0, 1.0);
+        float NdotV = abs(dot(normalEC, viewDirectionEC));
         vec3 f0 = material.specular;
-        vec3 specularContribution = computeSpecularIBL(reflectMC, NdotV, VdotH, f0, material.roughness);
+        vec3 specularContribution = computeSpecularIBL(reflectMC, NdotV, f0, material.roughness);
     #else
         vec3 specularContribution = vec3(0.0); 
     #endif

--- a/packages/engine/Source/Shaders/Model/LightingStageFS.glsl
+++ b/packages/engine/Source/Shaders/Model/LightingStageFS.glsl
@@ -34,14 +34,15 @@ vec3 addClearcoatReflection(vec3 baseLayerColor, vec3 position, vec3 lightDirect
 
     // compute specular reflection from direct lighting
     float roughness = material.clearcoatRoughness;
-    float directStrength = computeDirectSpecularStrength(normal, lightDirection, viewDirection, halfwayDirection, roughness);
+    float alphaRoughness = roughness * roughness;
+    float directStrength = computeDirectSpecularStrength(normal, lightDirection, viewDirection, halfwayDirection, alphaRoughness);
     vec3 directReflection = F * directStrength * NdotL;
     vec3 color = lightColorHdr * directReflection;
 
     #ifdef SPECULAR_IBL
         // Find the direction in which to sample the environment map
         vec3 reflectMC = normalize(model_iblReferenceFrameMatrix * reflect(-viewDirection, normal));
-        vec3 iblColor = computeSpecularIBL(reflectMC, NdotV, NdotV, f0, roughness);
+        vec3 iblColor = computeSpecularIBL(reflectMC, NdotV, f0, roughness);
         color += iblColor * material.occlusion;
     #elif defined(USE_IBL_LIGHTING)
         vec3 positionWC = vec3(czm_inverseView * vec4(position, 1.0));

--- a/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
+++ b/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
@@ -258,8 +258,7 @@ void setSpecularGlossiness(inout czm_modelMaterial material)
     material.specular = specular;
 
     // glossiness is the opposite of roughness, but easier for artists to use.
-    float roughness = 1.0 - glossiness;
-    material.roughness = roughness * roughness;
+    material.roughness = 1.0 - glossiness;
 }
 #elif defined(LIGHTING_PBR)
 float setMetallicRoughness(inout czm_modelMaterial material)
@@ -272,7 +271,7 @@ float setMetallicRoughness(inout czm_modelMaterial material)
 
         vec3 metallicRoughness = texture(u_metallicRoughnessTexture, metallicRoughnessTexCoords).rgb;
         float metalness = clamp(metallicRoughness.b, 0.0, 1.0);
-        float roughness = clamp(metallicRoughness.g, 0.04, 1.0);
+        float roughness = clamp(metallicRoughness.g, 0.0, 1.0);
         #ifdef HAS_METALLIC_FACTOR
             metalness = clamp(metalness * u_metallicFactor, 0.0, 1.0);
         #endif
@@ -288,7 +287,7 @@ float setMetallicRoughness(inout czm_modelMaterial material)
         #endif
 
         #ifdef HAS_ROUGHNESS_FACTOR
-            float roughness = clamp(u_roughnessFactor, 0.04, 1.0);
+            float roughness = clamp(u_roughnessFactor, 0.0, 1.0);
         #else
             float roughness = 1.0;
         #endif
@@ -303,9 +302,8 @@ float setMetallicRoughness(inout czm_modelMaterial material)
     // diffuse only applies to dielectrics.
     material.diffuse = mix(material.baseColor.rgb, vec3(0.0), metalness);
 
-    // roughness is authored as perceptual roughness
-    // square it to get material roughness
-    material.roughness = roughness * roughness;
+    // This is perceptual roughness. The square of this value is used for direct lighting
+    material.roughness = roughness;
 
     return metalness;
 }
@@ -418,9 +416,8 @@ void setClearcoat(inout czm_modelMaterial material, in ProcessedAttributes attri
     #endif
 
     material.clearcoatFactor = clearcoatFactor;
-    // roughness is authored as perceptual roughness
-    // square it to get material roughness
-    material.clearcoatRoughness = clearcoatRoughness * clearcoatRoughness;
+    // This is perceptual roughness. The square of this value is used for direct lighting
+    material.clearcoatRoughness = clearcoatRoughness;
     #ifdef HAS_CLEARCOAT_NORMAL_TEXTURE
         material.clearcoatNormal = getClearcoatNormalFromTexture(attributes, attributes.normalEC);
     #else


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

**Merge https://github.com/CesiumGS/cesium/pull/12082 first!**

# Description

This PR updates the specular calculations for image-based lighting. 

## Key changes

### Use perceptual roughness
The raw "perceptual" roughness as encoded in the glTF is now retained in `MaterialStageFS`. Where the squared "alpha" roughness is needed (e.g. for direct lighting), it is squared when used, and more consistently named "alphaRoughness" for clarity.

This change to un-squared roughness is significant for the rendering result in two places:
- Selecting the LOD of the environment map, from which the incident specular radiance is sampled
- Computing the surface "bent normal" for determining the specular incident angle in anisotropic materials

### Update self-shadowing function in BRDF look-up texture
Image-based lighting uses a pre-computed texture from which BRDF parameters are read. The calculation of these parameters includes a self-shadowing function. This PR updates the self-shadowing function to be consistent with the one used for direct lighting, as implemented in #12063.

### Fix clamping errors
`MaterialStageFS` was clamping roughness to a minimum of `0.04`. This has been removed, to allow sharper reflections on materials like the [Clearcoat Car Paint test model](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/ClearCoatCarPaint/README.md).

Also, in `ImageBasedLightingStageFS`, the calculation of `NdotV` for specular IBL calculation applied an `abs` for negative values. This has been updated to a `clamp(NdotV, 0.0, 1.0)`.

## Rendering comparisons
Clearcoat Wicker, before
![image](https://github.com/user-attachments/assets/97f76407-2018-4eb2-ab20-f57f096d53ab)

Clearcoat Wicker, after
![image](https://github.com/user-attachments/assets/a72fdd1e-03d0-4c6e-9a48-1d9bfd03ea5e)
Note the brighter and broader specular reflection.

Barn Lamp, before
![image](https://github.com/user-attachments/assets/e31df632-547a-4541-8e6f-1137df2f0459)

Barn Lamp, after
![image](https://github.com/user-attachments/assets/a6027914-17e5-4de1-8eaa-0539f87f8ca3)
Note the more natural appearance of the brushed metal.

Clearcoat Test, before
![image](https://github.com/user-attachments/assets/a6fd4a0f-e396-4135-b035-1abfe654cc66)

Clearcoat Test, after
![image](https://github.com/user-attachments/assets/89fafe88-97cd-41e6-8318-888721610cb6)
Note the improved clarity of the "Roughness variations", now that we are using perceptual roughness. Also note the changed appearance of the "Partial coating" after fixing the clamp of `NdotV`.

## Issue number and link

Addresses part of https://github.com/CesiumGS/cesium/issues/12028.

## Testing plan

Load the "glTF PBR Extensions" and "Image Based Lighting" Sandcastles, and compare the rendering to the `main` branch.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- ~[ ] I have added or updated unit tests to ensure consistent code coverage~ See #12065
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
