### PR TITLE
Add support for css parts for cesium-viewer div

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -391,3 +391,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Peter A. Jonsson](https://github.com/pjonsson)
 - [Zhongxiang Wang](https://github.com/plainheart)
 - [Tim Schneider](https://github.com/Tim-S)
+- [Levi Montgomery](https://github.com/Levi-Montgomery)

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -452,6 +452,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
   const viewerContainer = document.createElement("div");
   viewerContainer.className = "cesium-viewer";
+  viewerContainer.setAttribute("part", "cesium-viewer");
   container.appendChild(viewerContainer);
 
   // Cesium widget container


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/::part

Currently if you set the size of the CSS of the cesium-container div using a css part because that div is inside a shadow dom, the size of the container is set to the original size not the size that it's set to in the part.

Being able to adjust the size of the container after the fact with a CSS part would fix this.