### PR TITLE
Update dependencies esbuild, earcut, and rbush

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "chokidar": "^3.5.3",
     "cloc": "^2.0.0-cloc",
     "compression": "^1.7.4",
-    "esbuild": "^0.21.4",
+    "esbuild": "^0.23.0",
     "eslint": "^9.1.1",
     "eslint-config-cesium": "^11.0.1",
     "eslint-plugin-html": "^8.1.1",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -38,7 +38,7 @@
     "bitmap-sdf": "^1.0.3",
     "dompurify": "^3.0.2",
     "draco3d": "^1.5.1",
-    "earcut": "^2.2.4",
+    "earcut": "^3.0.0",
     "grapheme-splitter": "^1.0.4",
     "jsep": "^1.3.8",
     "kdbush": "^4.0.1",
@@ -48,7 +48,7 @@
     "meshoptimizer": "^0.21.0",
     "pako": "^2.0.4",
     "protobufjs": "^7.1.0",
-    "rbush": "^3.0.1",
+    "rbush": "^4.0.0",
     "topojson-client": "^3.1.0",
     "urijs": "^1.19.7"
   },


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Dependencies updated:
- esbuild minor version
- earcut and rbush major versions: these were dropping support for CommonJS bundles. We are already importing them as ESM, so everything just works.

Dependencies NOT updated:
- tween.js: This has had 2 major version changes in the past week. I think it might be safer to wait till next release to update on our end.
- rimraf: The update from v5 to v6 drops support for Node versions <v20. We are still supporting v18, so we can hold off on this one for now.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
