### PR TITLE
Draft for fixing disappearing I3DM models

### DIFF
--- a/packages/engine/Source/Scene/Model/buildDrawCommand.js
+++ b/packages/engine/Source/Scene/Model/buildDrawCommand.js
@@ -73,8 +73,7 @@ function buildDrawCommand(primitiveRenderResources, frameState) {
 
     boundingSphere = BoundingSphere.transform(
       primitiveRenderResources.boundingSphere,
-      modelMatrix,
-      primitiveRenderResources.boundingSphere
+      modelMatrix
     );
   }
 

--- a/packages/engine/Source/Scene/Model/buildDrawCommand.js
+++ b/packages/engine/Source/Scene/Model/buildDrawCommand.js
@@ -78,6 +78,27 @@ function buildDrawCommand(primitiveRenderResources, frameState) {
     );
   }
 
+  console.log("buildDrawCommand");
+  console.log("  positionMin", primitiveRenderResources.positionMin);
+  console.log("  positionMax", primitiveRenderResources.positionMax);
+  console.log(
+    "  instancingTranslationMin ",
+    primitiveRenderResources.runtimeNode.instancingTranslationMin
+  );
+  console.log(
+    "  instancingTranslationMax ",
+    primitiveRenderResources.runtimeNode.instancingTranslationMax
+  );
+  console.log(
+    "  node scale ",
+    primitiveRenderResources.runtimeNode.computedTransform[0]
+  );
+  console.log(
+    "  instances transformInWorldSpace ",
+    primitiveRenderResources.runtimeNode.node?.instances?.transformInWorldSpace
+  );
+  console.log("  radius", primitiveRenderResources.boundingSphere.radius);
+
   // Initialize render state with default values
   let renderState = clone(
     RenderState.fromCache(primitiveRenderResources.renderStateOptions),
@@ -117,7 +138,7 @@ function buildDrawCommand(primitiveRenderResources, frameState) {
     pickId: pickId,
     instanceCount: primitiveRenderResources.instanceCount,
     primitiveType: primitiveRenderResources.primitiveType,
-    debugShowBoundingVolume: model.debugShowBoundingVolume,
+    debugShowBoundingVolume: true, //model.debugShowBoundingVolume,
     castShadows: castShadows,
     receiveShadows: receiveShadows,
   });


### PR DESCRIPTION
# Description

Under certain conditions, parts of models in I3DM could disappear in certain view configurations. This has been reported in several forum threads. Most recently, in https://community.cesium.com/t/disappearing-i3dms-on-map-navigation-again/34035 . It is currently tracked in https://github.com/CesiumGS/cesium/issues/11176.

A short ping @bertt : Maybe you want to try this out. It's not yet tested extensively, but might fix the issue. 

---

#### For the reviewers:

Some details from investigating the _reason_ for the error are summarized in https://github.com/CesiumGS/cesium/issues/11176#issuecomment-2254227941 

The attempt of a **tl;dr** summary:

- The `boundingVolume` that is associated with a `DrawCommand` determines whether that command is executed or not (depending on the view configuration)
- For a glTF model, the bounding volume of the draw command was computed from the [`PrimitiveRenderResources.positionMin`/`positionMax`](https://github.com/CesiumGS/cesium/blob/3cdc3e1872767d607d758a1e4c5660abbadb3753/packages/engine/Source/Scene/Model/PrimitiveRenderResources.js#L235) properties. These `positionMin/positionMax` properties already include the _instancing_ translation
- The bounding sphere that was computed from these values was [transformed with the node matrix](https://github.com/CesiumGS/cesium/blob/3cdc3e1872767d607d758a1e4c5660abbadb3753/packages/engine/Source/Scene/Model/buildDrawCommand.js#L74)
- This means that the contribution of the instancing translation was affected by the node transform

For nodes with different transforms, this _had_ to be inconsistent. 

This PR is currently a **DRAFT** state, also because it contains some debug output. Some of this output - from the example that was posted at the bottom of https://github.com/CesiumGS/cesium/issues/11176#issuecomment-2260871932 - is shown here to convey the idea. It is an I3DM with 4 instances of a GLB that contains 4 primitives with different sizes that are attached to nodes with different scaling factors.

Before the fix, the output is this:
```
buildDrawCommand
  positionMin Cartesian3 {x: -5, y: -5, z: 0}
  positionMax Cartesian3 {x: 6, y: 6, z: 1}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  1
  instances transformInWorldSpace  true
  radius 7.794228634059948
buildDrawCommand
  positionMin Cartesian3 {x: -5, y: -5, z: 0}
  positionMax Cartesian3 {x: 5.1, y: 5.1, z: 0.1}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  10
  instances transformInWorldSpace  true
  radius 71.41953514270448
buildDrawCommand
  positionMin Cartesian3 {x: -5, y: -5, z: 0}
  positionMax Cartesian3 {x: 15, y: 15, z: 10}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  0.1
  instances transformInWorldSpace  true
  radius 1.5
buildDrawCommand
  positionMin Cartesian3 {x: -5, y: -5, z: 0}
  positionMax Cartesian3 {x: 6, y: 6, z: 1}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  1
  instances transformInWorldSpace  true
  radius 7.794228634059948
```

The `instancingTranslationMin/Max` are always the same. They are determined directly from the instancing information.
The computed `positionMin/Max` show differences that depend on the `node scale ...`
The most obvious (and relevant) effect is on the bounding shere radius: 

- When the node scale is 1, then the radius is 7.79
- When the node scale is 10, then the radius is 71.4
- When the node scale is 0.1, then the radius is 1.5 (which is already smaller than the instancing translations...)

Shown in this screenshot:

![screenshotBefore](https://github.com/user-attachments/assets/13c5c460-469c-40ff-ba1f-9314b7d06d03)

----

I considered different approaches for fixing this. One difficulty is...

- the `positionMin/Max` do not say whether they are in world space or object space
- some places already assume that they are in world space (and have to be transformed with the node transform to obtain their "true value")
- the `instancingTranslationMin/Max` does not say whether it is in world space. But there is a subtle hint via [`ModelComponents/Instances.transformInWorldSpace`](https://github.com/CesiumGS/cesium/blob/49da5c832f6caf8a235440ab9020c1f664bcfa85/packages/engine/Source/Scene/ModelComponents.js#L659) which says that it can be both...

The suggested fix is [summarized in this comment](https://github.com/CesiumGS/cesium/commit/d381c1dd309fe9331d5b47e1bcf10b5f7a43c267#diff-eb3a015c9afe04119db54bff6fa810de3498c2b8274ead37cc26e73821d0ae95R236). 

It's a bit... pragmatic, and having to compute the inverse of the node transform is ... not so nice. But other approaches had a larger potential for messing up other uses of the `positionMin/Max` (for which I now added a few lines of comments, by the way).

With this fix, the log output is as follows:
```
buildDrawCommand
  positionMin Cartesian3 {x: -5, y: -5, z: 0}
  positionMax Cartesian3 {x: 6, y: 6, z: 1}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  1
  instances transformInWorldSpace  true
  radius 7.794228634059948
buildDrawCommand
  positionMin Cartesian3 {x: -0.7, y: -0.5, z: 0}
  positionMax Cartesian3 {x: 0.4, y: 0.6, z: 0.1}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  10
  instances transformInWorldSpace  true
  radius 7.794228634059948
buildDrawCommand
  positionMin Cartesian3 {x: -50, y: -70, z: 0}
  positionMax Cartesian3 {x: 60, y: 40, z: 10}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  0.1
  instances transformInWorldSpace  true
  radius 7.794228634059948
buildDrawCommand
  positionMin Cartesian3 {x: -7, y: -7, z: 0}
  positionMax Cartesian3 {x: 4, y: 4, z: 1}
  instancingTranslationMin  Cartesian3 {x: -5, y: -5, z: 0}
  instancingTranslationMax  Cartesian3 {x: 5, y: 5, z: 0}
  node scale  1
  instances transformInWorldSpace  true
  radius 7.794228634059948
```

One can see that the `positionMin/Max` now all have to be transformed with the node transform, but then yield the actual, correct result - and it computes the same bounding sphere radius for all cases. The result is shown here:

![screenshotAfter](https://github.com/user-attachments/assets/b14bd076-bc4f-43be-96a9-850ff5a6b36f)

(Yes, I see that the bounding sphere does not really include the whole model - where the mouse cursor is. Should I fix this? Is this my fault? We can talk about that...)

## Issue number and link

Addresses https://github.com/CesiumGS/cesium/issues/11176

## Testing plan

What remains to be investigated is the effect of other instancing transforms. Right now, the transforms only contain _translations_. I would _expect unexpected_ effects when the instancing transforms contain additional rotations ot scaling. (But... maybe not, if the `instanceTranslationMin/Max` are already computed properly and taking this into account 🤞 )

For testing: Locally load the tileset (+Sandcastle) that are attached at the bottom of https://github.com/CesiumGS/cesium/issues/11176#issuecomment-2260871932 , and check whether there is still a view configuration where parts of the model disappear. Maybe also try out some of the examples that had been posted in https://community.cesium.com/t/disappearing-i3dms-on-map-navigation-again/34035 (that's also still on my TODO list)

# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

(This is a **DRAFT** state with debug/log output and TODO comments - only for an early review)

