### PR TITLE
Fix blending for CPU styling of models

### DIFF
--- a/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
+++ b/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl
@@ -455,10 +455,10 @@ void materialStage(inout czm_modelMaterial material, ProcessedAttributes attribu
         baseColorWithAlpha *= color;
     #endif
 
-    material.baseColor = baseColorWithAlpha;
     #ifdef USE_CPU_STYLING
-        material.baseColor.rgb = blend(baseColorWithAlpha.rgb, feature.color.rgb, model_colorBlend);
+        baseColorWithAlpha.rgb = blend(baseColorWithAlpha.rgb, feature.color.rgb, model_colorBlend);
     #endif
+    material.baseColor = baseColorWithAlpha;
     material.diffuse = baseColorWithAlpha.rgb;
     material.alpha = baseColorWithAlpha.a;
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Fixes an error affecting blending in https://github.com/CesiumGS/cesium/pull/12060.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

1. Run Cesium3DTilesetSpec locally
2. Load [3D Tiles 1.1 Photogrammetry Classification Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%201.1%20Photogrammetry%20Classification.html) and verify that the classification renders correctly.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
