### PR TITLE
Fix artifact in from specular calculation in PBR direct lighting

### DIFF
--- a/packages/engine/Source/Shaders/Builtin/Functions/pbrLighting.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/pbrLighting.glsl
@@ -96,8 +96,8 @@ float GGX(float alphaRoughness, float NdotH)
  */
 float computeDirectSpecularStrength(vec3 normal, vec3 lightDirection, vec3 viewDirection, vec3 halfwayDirection, float alphaRoughness)
 {
-    float NdotL = dot(normal, lightDirection);
-    float NdotV = abs(dot(normal, viewDirection));
+    float NdotL = clamp(dot(normal, lightDirection), 0.0, 1.0);
+    float NdotV = clamp(dot(normal, viewDirection), 0.0, 1.0);
     float G = smithVisibilityGGX(alphaRoughness, NdotL, NdotV);
     float NdotH = clamp(dot(normal, halfwayDirection), 0.0, 1.0);
     float D = GGX(alphaRoughness, NdotH);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

When computing the specular contribution from PBR direct lighting, the dot products used in the BRDF need to be clamped to the range `[0.0, 1.0]`. Our code was missing the clamp, but the artifacts didn't appear until we updated the BRDF in https://github.com/CesiumGS/cesium/pull/12063.

This PR adds the clamps in `computeDirectSpecularStrength` in `pbrLighting.glsl`.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12109.

## Testing plan

1. Load @javagl 's [Sandcastle](https://sandcastle.cesium.com/index.html#c=xVdtU+M2EP4rmnxKpkZ+fwscUxHgLtdAGAjXXptOR7GVRIctZ2Q5QDv575VsQpzgUMp1pv4ged+0z65k7TrKWC7AkpJ7wsEHwMg96JGcFin8UvLa41ZU0r2MCUwZ4eOWBv4aMwBmSTYhXTDFSU60MVt1DsdszKYFiwTNGIg4wYKcpRMSxyS+ZVT0ign5mIhpu1MtEJW+OcmLREjfJQ8AHEmHecbzLvit4oC1SD2TYjolXIHrAkOr8R8FGU6nORHb/ChLFxkjTIweFxKta1r2lrRg0sD2ajxRKo5bNz00QNcy3I0oxQ8SlWX/XudRJnnGhrXS/gG2+S7Y3kvYltMA+8tZz24AbUJDA+uhAb+SrIf/IBYrCP7HaA5K0WZ8GdCag/MS7nN0MyKPOBYZV84/z5LROZjyLAVzIRZ5V9dnVMyLCZQB6d/wEs8SvVSqQVwSnsvzr+wtaDwL1o6r5O053AWnyi7GAnfxYpHQCKtvSZ/Jr+agsjyc4Jx4joYQ6iF0Jid0ilAfnSD0EaFbNX9C6KsS/oTQnZoHCGVKaYiQoeYrhBxleYNOztQ8Qid9dI7Qz+jkVs2/oJOv6OXTQ1f3L+nZabCltaFr+n2kbynV6FK/pGvr1ehG/6/o7+Jp9N+IdxdPczyNdGM8u/6b8b/p6ff076PRO+hX8v9Gevld9Cv782/owfvorUtH3WwDwmZi3gWeE+y9TTY346vV622Vq+7Ut+p3I+YzpWw7oWe/5are729r3bpD1/d2JDeC01jeyeY+KNbetKQkn5M9GVlwmlJBl1vyHZ3yohbS/6QQSm9HBMDV8KY/6g8vt+tR9VwOry/QQJaXHclqh6YsppFa3dgRpJkK29ni1o33FxcmLfeErVJSd7XatswjWYc28pLcs9Layd4itzpUIyei4Oyp25KclWrWqg5MBZjIBgzfYyrW7d+FYkJV+1TLhvJHFrVLr6r+XGF1Rsat9fsf4xb4AVzIN8gxi7O03dGqFlFMu692guvGsUIipHU+zXgq0TzhGK1ZOSQ4F5cZF/PbxSg7pw8kPuc4JW3l6Um7h7k8IRQzu4R+SmackLx94LvQdC3HCDRghzB0vNB3NWAZHeW7jB+WowyB0wfp/RmJlFfdMSw3AW7OK8Rx3C6tOodAZXNLL5LIOIbyK1PXQZU6uVGCsrKkd+ut9gZ127Rcx7csaAeBaXp2YPiyg3F82zbMAFquEdjy3dKAY/i2E3gwdE3bDCXXrTKecSrbrJcuPhEcUza7oiKaX2dJ0jZg4AVe6NqeGdheEAahdGRA1/VMmRzT9g3fCn1HAx60AtsMXCvw5WCF4fOePcUbJVl0B6OCc9Xg0ZRsNu9zkcioTuXul9vRz7PAM0z5T2EZlnNgBAeGPzL8rml0DePXcav6g2hpraNcPCbkeH2ef6SyfeRCtkdJG0JdkHSRyDVzfVJEd0TAKM87h5XykV43PYrpEtD4Q8NPDIgS2ftJybRIkhv6Jxm3jo90qf/CNMnK1A1lY5fgR6U2N48HFRNCeKRLstlSZFkywXxn5b8B) and verify that the artifacts are gone after this PR.
2. Load the [glTF PBR Extensions Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=glTF%20PBR%20Extensions.html) and view models with "Direct lighting only", rotating them to the side opposite the light source.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
