### PR TITLE
Add description to DrawCommand

### DIFF
--- a/packages/engine/Source/Renderer/ComputeEngine.js
+++ b/packages/engine/Source/Renderer/ComputeEngine.js
@@ -21,6 +21,7 @@ function ComputeEngine(context) {
 
 let renderStateScratch;
 const drawCommandScratch = new DrawCommand({
+  description: "ComputeEngine.drawCommandScratch",
   primitiveType: PrimitiveType.TRIANGLES,
 });
 const clearCommandScratch = new ClearCommand({

--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -1549,6 +1549,7 @@ Context.prototype.createViewportQuadCommand = function (
   overrides = defaultValue(overrides, defaultValue.EMPTY_OBJECT);
 
   return new DrawCommand({
+    description: "viewportQuadCommand",
     vertexArray: this.getViewportQuadVertexArray(),
     primitiveType: PrimitiveType.TRIANGLES,
     renderState: overrides.renderState,

--- a/packages/engine/Source/Renderer/DrawCommand.js
+++ b/packages/engine/Source/Renderer/DrawCommand.js
@@ -21,6 +21,7 @@ const Flags = {
 function DrawCommand(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
+  this._description = defaultValue(options.description, "<unknown>");
   this._boundingVolume = options.boundingVolume;
   this._orientedBoundingBox = options.orientedBoundingBox;
   this._modelMatrix = options.modelMatrix;
@@ -83,6 +84,23 @@ function setFlag(command, flag, value) {
 }
 
 Object.defineProperties(DrawCommand.prototype, {
+  /**
+   * A short description of this draw command.
+   * <p>
+   * This is supposed to be a short description that may not be human-readable,
+   * but developer-readable, and that helps to identify this command. The exact
+   * structure of this string is not specified.
+   * </p>
+   *
+   * @memberof DrawCommand.prototype
+   * @type {string}
+   */
+  description: {
+    get: function () {
+      return this._description;
+    },
+  },
+
   /**
    * The bounding volume of the geometry in world space.  This is used for culling and frustum selection.
    * <p>
@@ -566,14 +584,18 @@ Object.defineProperties(DrawCommand.prototype, {
 /**
  * @private
  */
-DrawCommand.shallowClone = function (command, result) {
+DrawCommand.shallowClone = function (command, suffix, result) {
   if (!defined(command)) {
     return undefined;
   }
   if (!defined(result)) {
     result = new DrawCommand();
   }
-
+  if (!defined(suffix)) {
+    result._description = `${command._description}.<unknown>`;
+  } else {
+    result._description = `${command._description}${suffix}`;
+  }
   result._boundingVolume = command._boundingVolume;
   result._orientedBoundingBox = command._orientedBoundingBox;
   result._modelMatrix = command._modelMatrix;

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -2376,7 +2376,9 @@ BillboardCollection.prototype.update = function (frameState) {
     for (let j = 0; j < totalLength; ++j) {
       let command = colorList[j];
       if (!defined(command)) {
-        command = colorList[j] = new DrawCommand();
+        command = colorList[j] = new DrawCommand({
+          description: `billboardCollection.colorList[${j}]`,
+        });
       }
 
       const opaqueCommand = opaque || (opaqueAndTranslucent && j % 2 === 0);

--- a/packages/engine/Source/Scene/Cesium3DTileBatchTable.js
+++ b/packages/engine/Source/Scene/Cesium3DTileBatchTable.js
@@ -1010,7 +1010,7 @@ function getStyleCommandsNeeded(batchTable) {
 }
 
 function deriveCommand(command) {
-  const derivedCommand = DrawCommand.shallowClone(command);
+  const derivedCommand = DrawCommand.shallowClone(command, ".derived");
 
   // Add a uniform to indicate if the original command was translucent so
   // the shader knows not to cull vertices that were originally transparent
@@ -1028,14 +1028,14 @@ function deriveCommand(command) {
 }
 
 function deriveTranslucentCommand(command) {
-  const derivedCommand = DrawCommand.shallowClone(command);
+  const derivedCommand = DrawCommand.shallowClone(command, ".translucent");
   derivedCommand.pass = Pass.TRANSLUCENT;
   derivedCommand.renderState = getTranslucentRenderState(command.renderState);
   return derivedCommand;
 }
 
 function deriveOpaqueCommand(command) {
-  const derivedCommand = DrawCommand.shallowClone(command);
+  const derivedCommand = DrawCommand.shallowClone(command, ".opaque");
   derivedCommand.renderState = getOpaqueRenderState(command.renderState);
   return derivedCommand;
 }
@@ -1066,7 +1066,7 @@ function getLogDepthPolygonOffsetFragmentShaderProgram(context, shaderProgram) {
 
 function deriveZBackfaceCommand(context, command) {
   // Write just backface depth of unresolved tiles so resolved stenciled tiles do not appear in front
-  const derivedCommand = DrawCommand.shallowClone(command);
+  const derivedCommand = DrawCommand.shallowClone(command, ".zBackface");
   const rs = clone(derivedCommand.renderState, true);
   rs.cull.enabled = true;
   rs.cull.face = CullFace.FRONT;
@@ -1111,7 +1111,7 @@ function deriveZBackfaceCommand(context, command) {
 function deriveStencilCommand(command, reference) {
   // Tiles only draw if their selection depth is >= the tile drawn already. They write their
   // selection depth to the stencil buffer to prevent ancestor tiles from drawing on top
-  const derivedCommand = DrawCommand.shallowClone(command);
+  const derivedCommand = DrawCommand.shallowClone(command, ".stencil");
   const rs = clone(derivedCommand.renderState, true);
   // Stencil test is masked to the most significant 3 bits so the reference is shifted. Writes 0 for the terrain bit
   rs.stencilTest.enabled = true;

--- a/packages/engine/Source/Scene/ClassificationPrimitive.js
+++ b/packages/engine/Source/Scene/ClassificationPrimitive.js
@@ -674,6 +674,7 @@ function createColorCommands(classificationPrimitive, colorCommands) {
     command = colorCommands[i];
     if (!defined(command)) {
       command = colorCommands[i] = new DrawCommand({
+        description: `classificationPrimitive.colorCommands[${i}]`,
         owner: classificationPrimitive,
         primitiveType: primitive._primitiveType,
       });
@@ -687,6 +688,7 @@ function createColorCommands(classificationPrimitive, colorCommands) {
 
     derivedCommand = DrawCommand.shallowClone(
       command,
+      ".tileset",
       command.derivedCommands.tileset
     );
     derivedCommand.renderState =
@@ -698,6 +700,7 @@ function createColorCommands(classificationPrimitive, colorCommands) {
     command = colorCommands[i + 1];
     if (!defined(command)) {
       command = colorCommands[i + 1] = new DrawCommand({
+        description: `classificationPrimitive.colorCommands[${i + 1}]`,
         owner: classificationPrimitive,
         primitiveType: primitive._primitiveType,
       });
@@ -718,6 +721,7 @@ function createColorCommands(classificationPrimitive, colorCommands) {
 
     derivedCommand = DrawCommand.shallowClone(
       command,
+      ".tileset",
       command.derivedCommands.tileset
     );
     derivedCommand.pass = Pass.CESIUM_3D_TILE_CLASSIFICATION;
@@ -728,6 +732,7 @@ function createColorCommands(classificationPrimitive, colorCommands) {
       // First derive from the terrain command
       let derived2DCommand = DrawCommand.shallowClone(
         command,
+        ".2d",
         command.derivedCommands.appearance2D
       );
       derived2DCommand.shaderProgram = classificationPrimitive._spColor2D;
@@ -736,6 +741,7 @@ function createColorCommands(classificationPrimitive, colorCommands) {
       // Then derive from the 3D Tiles command
       derived2DCommand = DrawCommand.shallowClone(
         derivedCommand,
+        ".2d",
         derivedCommand.derivedCommands.appearance2D
       );
       derived2DCommand.shaderProgram = classificationPrimitive._spColor2D;
@@ -752,6 +758,7 @@ function createColorCommands(classificationPrimitive, colorCommands) {
   for (let j = 0; j < length; ++j) {
     const commandIgnoreShow = (commandsIgnoreShow[j] = DrawCommand.shallowClone(
       colorCommands[commandIndex],
+      ".ignoreShow",
       commandsIgnoreShow[j]
     ));
     commandIgnoreShow.shaderProgram = spStencil;
@@ -799,6 +806,7 @@ function createPickCommands(classificationPrimitive, pickCommands) {
     command = pickCommands[j];
     if (!defined(command)) {
       command = pickCommands[j] = new DrawCommand({
+        description: `classificationPrimitive.pickCommands[${j}]`,
         owner: classificationPrimitive,
         primitiveType: primitive._primitiveType,
         pickOnly: true,
@@ -818,6 +826,7 @@ function createPickCommands(classificationPrimitive, pickCommands) {
     // Derive for 3D Tiles classification
     derivedCommand = DrawCommand.shallowClone(
       command,
+      ".tilesetClassification",
       command.derivedCommands.tileset
     );
     derivedCommand.renderState =
@@ -829,6 +838,7 @@ function createPickCommands(classificationPrimitive, pickCommands) {
     command = pickCommands[j + 1];
     if (!defined(command)) {
       command = pickCommands[j + 1] = new DrawCommand({
+        description: `classificationPrimitive.pickCommands[${j + 1}]`,
         owner: classificationPrimitive,
         primitiveType: primitive._primitiveType,
         pickOnly: true,
@@ -847,6 +857,7 @@ function createPickCommands(classificationPrimitive, pickCommands) {
 
     derivedCommand = DrawCommand.shallowClone(
       command,
+      ".tileClassification",
       command.derivedCommands.tileset
     );
     derivedCommand.pass = Pass.CESIUM_3D_TILE_CLASSIFICATION;
@@ -857,6 +868,7 @@ function createPickCommands(classificationPrimitive, pickCommands) {
       // First derive from the terrain command
       let derived2DCommand = DrawCommand.shallowClone(
         command,
+        ".2d",
         command.derivedCommands.pick2D
       );
       derived2DCommand.shaderProgram = classificationPrimitive._spPick2D;
@@ -865,6 +877,7 @@ function createPickCommands(classificationPrimitive, pickCommands) {
       // Then derive from the 3D Tiles command
       derived2DCommand = DrawCommand.shallowClone(
         derivedCommand,
+        ".2d",
         derivedCommand.derivedCommands.pick2D
       );
       derived2DCommand.shaderProgram = classificationPrimitive._spPick2D;

--- a/packages/engine/Source/Scene/CloudCollection.js
+++ b/packages/engine/Source/Scene/CloudCollection.js
@@ -926,7 +926,9 @@ function createDrawCommands(cloudCollection, frameState) {
     for (let i = 0; i < vaLength; i++) {
       let command = colorList[i];
       if (!defined(command)) {
-        command = colorList[i] = new DrawCommand();
+        command = colorList[i] = new DrawCommand({
+          description: `cloudCollection.colorList[${i}]`,
+        });
       }
       command.pass = Pass.TRANSLUCENT;
       command.owner = cloudCollection;

--- a/packages/engine/Source/Scene/DebugInspector.js
+++ b/packages/engine/Source/Scene/DebugInspector.js
@@ -122,7 +122,9 @@ function createDebugShowFrustumsUniformMap(scene, command) {
   return debugUniformMap;
 }
 
-const scratchShowFrustumCommand = new DrawCommand();
+const scratchShowFrustumCommand = new DrawCommand({
+  description: `DebugInspector.scratchShowFrustumCommand`,
+});
 DebugInspector.prototype.executeDebugShowFrustumsCommand = function (
   scene,
   command,
@@ -142,6 +144,7 @@ DebugInspector.prototype.executeDebugShowFrustumsCommand = function (
 
   const debugCommand = DrawCommand.shallowClone(
     command,
+    ".debug",
     scratchShowFrustumCommand
   );
   debugCommand.shaderProgram = debugShaderProgram;

--- a/packages/engine/Source/Scene/DepthPlane.js
+++ b/packages/engine/Source/Scene/DepthPlane.js
@@ -153,6 +153,7 @@ DepthPlane.prototype.update = function (frameState) {
     });
 
     this._command = new DrawCommand({
+      description: `depthPlane._command`,
       renderState: this._rs,
       boundingVolume: new BoundingSphere(
         Cartesian3.ZERO,

--- a/packages/engine/Source/Scene/DerivedCommand.js
+++ b/packages/engine/Source/Scene/DerivedCommand.js
@@ -122,6 +122,7 @@ DerivedCommand.createDepthOnlyDerivedCommand = function (
 
   result.depthOnlyCommand = DrawCommand.shallowClone(
     command,
+    ".depthOnly",
     result.depthOnlyCommand
   );
 
@@ -251,7 +252,11 @@ DerivedCommand.createLogDepthCommand = function (command, context, result) {
     shader = result.command.shaderProgram;
   }
 
-  result.command = DrawCommand.shallowClone(command, result.command);
+  result.command = DrawCommand.shallowClone(
+    command,
+    ".logDepth",
+    result.command
+  );
 
   if (!defined(shader) || result.shaderProgramId !== command.shaderProgram.id) {
     result.command.shaderProgram = getLogDepthShaderProgram(
@@ -354,7 +359,11 @@ DerivedCommand.createPickDerivedCommand = function (
     renderState = result.pickCommand.renderState;
   }
 
-  result.pickCommand = DrawCommand.shallowClone(command, result.pickCommand);
+  result.pickCommand = DrawCommand.shallowClone(
+    command,
+    ".pick",
+    result.pickCommand
+  );
 
   if (!defined(shader) || result.shaderProgramId !== command.shaderProgram.id) {
     result.pickCommand.shaderProgram = getPickShaderProgram(
@@ -414,7 +423,7 @@ DerivedCommand.createHdrCommand = function (command, context, result) {
     shader = result.command.shaderProgram;
   }
 
-  result.command = DrawCommand.shallowClone(command, result.command);
+  result.command = DrawCommand.shallowClone(command, ".hdr", result.command);
 
   if (!defined(shader) || result.shaderProgramId !== command.shaderProgram.id) {
     result.command.shaderProgram = getHdrShaderProgram(

--- a/packages/engine/Source/Scene/EllipsoidPrimitive.js
+++ b/packages/engine/Source/Scene/EllipsoidPrimitive.js
@@ -188,9 +188,11 @@ function EllipsoidPrimitive(options) {
   this._pickId = undefined;
 
   this._colorCommand = new DrawCommand({
+    description: `ellipsoidPrimitive._colorCommand`,
     owner: defaultValue(options._owner, this),
   });
   this._pickCommand = new DrawCommand({
+    description: `ellipsoidPrimitive._pickCommand`,
     owner: defaultValue(options._owner, this),
     pickOnly: true,
   });

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -2400,7 +2400,9 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
     let uniformMap;
 
     if (tileProvider._drawCommands.length <= tileProvider._usedDrawCommands) {
-      command = new DrawCommand();
+      command = new DrawCommand({
+        description: `tileProvider._drawCommands[${tileProvider._drawCommands.length}]`,
+      });
       command.owner = tile;
       command.cull = false;
       command.boundingVolume = new BoundingSphere();

--- a/packages/engine/Source/Scene/GlobeTranslucencyState.js
+++ b/packages/engine/Source/Scene/GlobeTranslucencyState.js
@@ -861,7 +861,11 @@ function updateDerivedCommands(
         derivedRenderState = undefined;
       }
 
-      derivedCommand = DrawCommand.shallowClone(command, derivedCommand);
+      derivedCommand = DrawCommand.shallowClone(
+        command,
+        `.derived${i}`,
+        derivedCommand
+      );
       derivedCommandsObject[derivedCommandName] = derivedCommand;
 
       const derivedUniformMapDirtyFrame = defaultValue(

--- a/packages/engine/Source/Scene/GroundPolylinePrimitive.js
+++ b/packages/engine/Source/Scene/GroundPolylinePrimitive.js
@@ -521,6 +521,7 @@ function createCommands(
     let command = colorCommands[i];
     if (!defined(command)) {
       command = colorCommands[i] = new DrawCommand({
+        description: `groundPolylinePrimitive.colorCommands[${i}]`,
         owner: groundPolylinePrimitive,
         primitiveType: primitive._primitiveType,
       });
@@ -535,6 +536,7 @@ function createCommands(
 
     const derivedTilesetCommand = DrawCommand.shallowClone(
       command,
+      ".tileset",
       command.derivedCommands.tileset
     );
     derivedTilesetCommand.renderState =
@@ -545,6 +547,7 @@ function createCommands(
     // derive for 2D
     const derived2DCommand = DrawCommand.shallowClone(
       command,
+      ".2d",
       command.derivedCommands.color2D
     );
     derived2DCommand.shaderProgram = groundPolylinePrimitive._sp2D;
@@ -552,6 +555,7 @@ function createCommands(
 
     const derived2DTilesetCommand = DrawCommand.shallowClone(
       derivedTilesetCommand,
+      ".2d",
       derivedTilesetCommand.derivedCommands.color2D
     );
     derived2DTilesetCommand.shaderProgram = groundPolylinePrimitive._sp2D;
@@ -560,6 +564,7 @@ function createCommands(
     // derive for Morph
     const derivedMorphCommand = DrawCommand.shallowClone(
       command,
+      ".morph",
       command.derivedCommands.colorMorph
     );
     derivedMorphCommand.renderState = groundPolylinePrimitive._renderStateMorph;

--- a/packages/engine/Source/Scene/Model/ClassificationModelDrawCommand.js
+++ b/packages/engine/Source/Scene/Model/ClassificationModelDrawCommand.js
@@ -254,7 +254,10 @@ function createBatchCommands(drawCommand, derivedCommands, result) {
     // they must be added in a certain order even within the batches.
     for (let j = 0; j < numDerivedCommands; j++) {
       const derivedCommand = derivedCommands[j];
-      const batchCommand = DrawCommand.shallowClone(derivedCommand);
+      const batchCommand = DrawCommand.shallowClone(
+        derivedCommand,
+        `.batch${j}`
+      );
       batchCommand.count = batchLength;
       batchCommand.offset = batchOffset;
       result.push(batchCommand);
@@ -265,7 +268,10 @@ function createBatchCommands(drawCommand, derivedCommands, result) {
 }
 
 function deriveStencilDepthCommand(command, pass) {
-  const stencilDepthCommand = DrawCommand.shallowClone(command);
+  const stencilDepthCommand = DrawCommand.shallowClone(
+    command,
+    ".stencilDepth"
+  );
   stencilDepthCommand.cull = false;
   stencilDepthCommand.pass = pass;
 
@@ -280,7 +286,7 @@ function deriveStencilDepthCommand(command, pass) {
 }
 
 function deriveColorCommand(command, pass) {
-  const colorCommand = DrawCommand.shallowClone(command);
+  const colorCommand = DrawCommand.shallowClone(command, ".color");
   colorCommand.cull = false;
   colorCommand.pass = pass;
 
@@ -296,11 +302,14 @@ function createPickCommands(drawCommand, derivedCommands, commandList) {
   const stencilDepthCommand = derivedCommands[0];
   const colorCommand = derivedCommands[1];
 
-  const pickStencilDepthCommand = DrawCommand.shallowClone(stencilDepthCommand);
+  const pickStencilDepthCommand = DrawCommand.shallowClone(
+    stencilDepthCommand,
+    ".pick"
+  );
   pickStencilDepthCommand.cull = true;
   pickStencilDepthCommand.pickOnly = true;
 
-  const pickColorCommand = DrawCommand.shallowClone(colorCommand);
+  const pickColorCommand = DrawCommand.shallowClone(colorCommand, ".pick");
   pickColorCommand.cull = true;
   pickColorCommand.pickOnly = true;
   pickColorCommand.renderState = renderState;

--- a/packages/engine/Source/Scene/Model/ModelDrawCommand.js
+++ b/packages/engine/Source/Scene/Model/ModelDrawCommand.js
@@ -623,7 +623,7 @@ function derive2DCommand(drawCommand, derivedCommand) {
   // in one viewport is drawn in the other.
   const derivedCommand2D = ModelDerivedCommand.clone(derivedCommand);
 
-  const command2D = DrawCommand.shallowClone(derivedCommand.command);
+  const command2D = DrawCommand.shallowClone(derivedCommand.command, ".2d");
   command2D.modelMatrix = drawCommand._modelMatrix2D;
   command2D.boundingVolume = drawCommand._boundingVolume2D;
 
@@ -647,7 +647,7 @@ function derive2DCommands(drawCommand) {
 }
 
 function deriveTranslucentCommand(command) {
-  const derivedCommand = DrawCommand.shallowClone(command);
+  const derivedCommand = DrawCommand.shallowClone(command, ".translucent");
   derivedCommand.pass = Pass.TRANSLUCENT;
   const rs = clone(command.renderState, true);
   rs.cull.enabled = false;
@@ -662,7 +662,10 @@ function deriveSilhouetteModelCommand(command, model) {
   // Wrap around after exceeding the 8-bit stencil limit.
   // The reference is unique to each model until this point.
   const stencilReference = model._silhouetteId % 255;
-  const silhouetteModelCommand = DrawCommand.shallowClone(command);
+  const silhouetteModelCommand = DrawCommand.shallowClone(
+    command,
+    ".silhouette"
+  );
   const renderState = clone(command.renderState, true);
 
   // Write the reference value into the stencil buffer.
@@ -702,7 +705,10 @@ function deriveSilhouetteColorCommand(command, model) {
   // Wrap around after exceeding the 8-bit stencil limit.
   // The reference is unique to each model until this point.
   const stencilReference = model._silhouetteId % 255;
-  const silhouetteColorCommand = DrawCommand.shallowClone(command);
+  const silhouetteColorCommand = DrawCommand.shallowClone(
+    command,
+    ".silhouetteColor"
+  );
   const renderState = clone(command.renderState, true);
   renderState.cull.enabled = false;
 
@@ -792,7 +798,7 @@ function getStencilReference(selectionDepth) {
 function deriveSkipLodBackfaceCommand(command) {
   // Write just backface depth of unresolved tiles so resolved stenciled tiles
   // do not appear in front.
-  const backfaceCommand = DrawCommand.shallowClone(command);
+  const backfaceCommand = DrawCommand.shallowClone(command, ".backface");
   const renderState = clone(command.renderState, true);
   renderState.cull.enabled = true;
   renderState.cull.face = CullFace.FRONT;
@@ -831,7 +837,7 @@ function deriveSkipLodBackfaceCommand(command) {
 function deriveSkipLodStencilCommand(command) {
   // Tiles only draw if their selection depth is >= the tile drawn already. They write their
   // selection depth to the stencil buffer to prevent ancestor tiles from drawing on top
-  const stencilCommand = DrawCommand.shallowClone(command);
+  const stencilCommand = DrawCommand.shallowClone(command, ".skipLodStencil");
   const renderState = clone(command.renderState, true);
   // The stencil reference is updated dynamically; see updateSkipLodStencilCommand().
   const { stencilTest } = renderState;

--- a/packages/engine/Source/Scene/Model/ModelSceneGraph.js
+++ b/packages/engine/Source/Scene/Model/ModelSceneGraph.js
@@ -560,7 +560,15 @@ ModelSceneGraph.prototype.buildDrawCommands = function (frameState) {
         modelPositionMax
       );
 
+      let description = "model";
+      if (defined(model._resource?._url)) {
+        description += `-${model._resource._url}`;
+      }
+      description += `-node[${i}]`;
+      description += `-primitive[${j}]`;
+
       const drawCommand = buildDrawCommand(
+        description,
         primitiveRenderResources,
         frameState
       );

--- a/packages/engine/Source/Scene/Model/buildDrawCommand.js
+++ b/packages/engine/Source/Scene/Model/buildDrawCommand.js
@@ -19,6 +19,7 @@ import ModelDrawCommand from "./ModelDrawCommand.js";
  * using its render resources. If the model classifies another asset, it
  * builds a {@link ClassificationModelDrawCommand} instead.
  *
+ * @param {string} description The description that will become the DrawCommand.description
  * @param {PrimitiveRenderResources} primitiveRenderResources The render resources for a primitive.
  * @param {FrameState} frameState The frame state for creating GPU resources.
  *
@@ -26,7 +27,7 @@ import ModelDrawCommand from "./ModelDrawCommand.js";
  *
  * @private
  */
-function buildDrawCommand(primitiveRenderResources, frameState) {
+function buildDrawCommand(description, primitiveRenderResources, frameState) {
   const shaderBuilder = primitiveRenderResources.shaderBuilder;
   shaderBuilder.addVertexLines(ModelVS);
   shaderBuilder.addFragmentLines(ModelFS);
@@ -104,6 +105,7 @@ function buildDrawCommand(primitiveRenderResources, frameState) {
     : primitiveRenderResources.pickId;
 
   const command = new DrawCommand({
+    description: description,
     boundingVolume: boundingSphere,
     modelMatrix: modelMatrix,
     uniformMap: primitiveRenderResources.uniformMap,

--- a/packages/engine/Source/Scene/OIT.js
+++ b/packages/engine/Source/Scene/OIT.js
@@ -619,6 +619,7 @@ OIT.prototype.createDerivedCommands = function (command, context, result) {
 
     result.translucentCommand = DrawCommand.shallowClone(
       command,
+      ".translucent",
       result.translucentCommand
     );
 
@@ -656,9 +657,14 @@ OIT.prototype.createDerivedCommands = function (command, context, result) {
 
   result.translucentCommand = DrawCommand.shallowClone(
     command,
+    ".translucent",
     result.translucentCommand
   );
-  result.alphaCommand = DrawCommand.shallowClone(command, result.alphaCommand);
+  result.alphaCommand = DrawCommand.shallowClone(
+    command,
+    ".alpha",
+    result.alphaCommand
+  );
 
   if (
     !defined(colorShader) ||

--- a/packages/engine/Source/Scene/PointCloud.js
+++ b/packages/engine/Source/Scene/PointCloud.js
@@ -594,6 +594,7 @@ function createResources(pointCloud, frameState) {
   );
 
   pointCloud._drawCommand = new DrawCommand({
+    description: `pointCloud._drawCommand`,
     boundingVolume: new BoundingSphere(),
     cull: pointCloud._cull,
     modelMatrix: new Matrix4(),

--- a/packages/engine/Source/Scene/PointCloudEyeDomeLighting.js
+++ b/packages/engine/Source/Scene/PointCloudEyeDomeLighting.js
@@ -215,7 +215,11 @@ PointCloudEyeDomeLighting.prototype.update = function (
     ) {
       // Prevent crash when tiles out-of-view come in-view during context size change or
       // when the underlying shader changes while EDL is disabled
-      derivedCommand = DrawCommand.shallowClone(command, derivedCommand);
+      derivedCommand = DrawCommand.shallowClone(
+        command,
+        ".derived",
+        derivedCommand
+      );
       derivedCommand.framebuffer = this.framebuffer;
       derivedCommand.shaderProgram = getECShaderProgram(
         frameState.context,

--- a/packages/engine/Source/Scene/PointPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/PointPrimitiveCollection.js
@@ -1163,7 +1163,9 @@ PointPrimitiveCollection.prototype.update = function (frameState) {
 
       command = colorList[j];
       if (!defined(command)) {
-        command = colorList[j] = new DrawCommand();
+        command = colorList[j] = new DrawCommand({
+          description: `pointPrimitiveCollection.colorList[${j}]`,
+        });
       }
 
       command.primitiveType = PrimitiveType.POINTS;

--- a/packages/engine/Source/Scene/PolylineCollection.js
+++ b/packages/engine/Source/Scene/PolylineCollection.js
@@ -642,6 +642,7 @@ function createCommandLists(
 
             if (commandIndex >= commandsLength) {
               command = new DrawCommand({
+                description: `polylineCollection.commands[${s}]`,
                 owner: polylineCollection,
               });
               commands.push(command);
@@ -734,6 +735,7 @@ function createCommandLists(
       if (defined(currentId) && count > 0) {
         if (commandIndex >= commandsLength) {
           command = new DrawCommand({
+            description: `polylineCollection.commands[${commands.length}]`,
             owner: polylineCollection,
           });
           commands.push(command);

--- a/packages/engine/Source/Scene/Primitive.js
+++ b/packages/engine/Source/Scene/Primitive.js
@@ -1886,6 +1886,7 @@ function createCommands(
       colorCommand = colorCommands[i];
       if (!defined(colorCommand)) {
         colorCommand = colorCommands[i] = new DrawCommand({
+          description: `primitive.colorCommands[${i}]`,
           owner: primitive,
           primitiveType: primitive._primitiveType,
         });
@@ -1902,6 +1903,7 @@ function createCommands(
     colorCommand = colorCommands[i];
     if (!defined(colorCommand)) {
       colorCommand = colorCommands[i] = new DrawCommand({
+        description: `primitive.colorCommands[${i}]`,
         owner: primitive,
         primitiveType: primitive._primitiveType,
       });
@@ -1919,6 +1921,7 @@ function createCommands(
         colorCommand = colorCommands[i];
         if (!defined(colorCommand)) {
           colorCommand = colorCommands[i] = new DrawCommand({
+            description: `primitive.colorCommands[${i}]`,
             owner: primitive,
             primitiveType: primitive._primitiveType,
           });
@@ -1935,6 +1938,7 @@ function createCommands(
       colorCommand = colorCommands[i];
       if (!defined(colorCommand)) {
         colorCommand = colorCommands[i] = new DrawCommand({
+          description: `primitive.colorCommands[${i}]`,
           owner: primitive,
           primitiveType: primitive._primitiveType,
         });

--- a/packages/engine/Source/Scene/ShadowMap.js
+++ b/packages/engine/Source/Scene/ShadowMap.js
@@ -1705,7 +1705,7 @@ function createCastDerivedCommand(
     castUniformMap = result.uniformMap;
   }
 
-  result = DrawCommand.shallowClone(command, result);
+  result = DrawCommand.shallowClone(command, ".cast", result);
   result.castShadows = true;
   result.receiveShadows = false;
 
@@ -1818,6 +1818,7 @@ ShadowMap.createReceiveDerivedCommand = function (
 
     result.receiveCommand = DrawCommand.shallowClone(
       command,
+      ".receive",
       result.receiveCommand
     );
     result.castShadows = false;

--- a/packages/engine/Source/Scene/SkyAtmosphere.js
+++ b/packages/engine/Source/Scene/SkyAtmosphere.js
@@ -72,6 +72,7 @@ function SkyAtmosphere(ellipsoid) {
   this._modelMatrix = new Matrix4();
 
   this._command = new DrawCommand({
+    description: `skyAtmosphere._command`,
     owner: this,
     modelMatrix: this._modelMatrix,
   });

--- a/packages/engine/Source/Scene/SkyBox.js
+++ b/packages/engine/Source/Scene/SkyBox.js
@@ -74,6 +74,7 @@ function SkyBox(options) {
   this.show = defaultValue(options.show, true);
 
   this._command = new DrawCommand({
+    description: `skyBox.command`,
     modelMatrix: Matrix4.clone(Matrix4.IDENTITY),
     owner: this,
   });

--- a/packages/engine/Source/Scene/Sun.js
+++ b/packages/engine/Source/Scene/Sun.js
@@ -49,6 +49,7 @@ function Sun() {
   this.show = true;
 
   this._drawCommand = new DrawCommand({
+    description: `sun._drawCommand`,
     primitiveType: PrimitiveType.TRIANGLES,
     boundingVolume: new BoundingSphere(),
     owner: this,

--- a/packages/engine/Source/Scene/TranslucentTileClassification.js
+++ b/packages/engine/Source/Scene/TranslucentTileClassification.js
@@ -208,7 +208,10 @@ function updateResources(
         attributeLocations: compositeProgram._attributeLocations,
       }
     );
-    const compositePickCommand = DrawCommand.shallowClone(compositeCommand);
+    const compositePickCommand = DrawCommand.shallowClone(
+      compositeCommand,
+      ".pick"
+    );
     compositePickCommand.shaderProgram = compositePickProgram;
     compositeCommand.derivedCommands.pick = compositePickCommand;
   }

--- a/packages/engine/Source/Scene/Vector3DTileClampedPolylines.js
+++ b/packages/engine/Source/Scene/Vector3DTileClampedPolylines.js
@@ -584,6 +584,7 @@ function queueCommands(primitive, frameState) {
       primitive._uniformMap
     );
     command = primitive._command = new DrawCommand({
+      description: `vector3DTileClampedPolylines.primitive._command`,
       owner: primitive,
       vertexArray: primitive._va,
       renderState: primitive._rs,
@@ -596,6 +597,7 @@ function queueCommands(primitive, frameState) {
 
     const derivedTilesetCommand = DrawCommand.shallowClone(
       command,
+      ".tileset",
       command.derivedCommands.tileset
     );
     derivedTilesetCommand.renderState = primitive._rs3DTiles;

--- a/packages/engine/Source/Scene/Vector3DTilePolylines.js
+++ b/packages/engine/Source/Scene/Vector3DTilePolylines.js
@@ -482,6 +482,7 @@ function queueCommands(primitive, frameState) {
       primitive._uniformMap
     );
     primitive._command = new DrawCommand({
+      description: `vector3DTilePolylines.primitive._command`,
       owner: primitive,
       vertexArray: primitive._va,
       renderState: primitive._rs,

--- a/packages/engine/Source/Scene/Vector3DTilePrimitive.js
+++ b/packages/engine/Source/Scene/Vector3DTilePrimitive.js
@@ -781,6 +781,7 @@ function createColorCommands(primitive, context) {
     let stencilDepthCommand = commands[j * 2];
     if (!defined(stencilDepthCommand)) {
       stencilDepthCommand = commands[j * 2] = new DrawCommand({
+        description: `vector3DTilePrimitive.stencilDepthCommand[${j}]`,
         owner: primitive,
       });
     }
@@ -798,6 +799,7 @@ function createColorCommands(primitive, context) {
 
     const stencilDepthDerivedCommand = DrawCommand.shallowClone(
       stencilDepthCommand,
+      ".tileset",
       stencilDepthCommand.derivedCommands.tileset
     );
     stencilDepthDerivedCommand.renderState =
@@ -808,6 +810,7 @@ function createColorCommands(primitive, context) {
     let colorCommand = commands[j * 2 + 1];
     if (!defined(colorCommand)) {
       colorCommand = commands[j * 2 + 1] = new DrawCommand({
+        description: `vector3DTilePrimitive.colorCommand[${j}]`,
         owner: primitive,
       });
     }
@@ -825,6 +828,7 @@ function createColorCommands(primitive, context) {
 
     const colorDerivedCommand = DrawCommand.shallowClone(
       colorCommand,
+      ".classification",
       colorCommand.derivedCommands.tileset
     );
     colorDerivedCommand.pass = Pass.CESIUM_3D_TILE_CLASSIFICATION;
@@ -854,6 +858,7 @@ function createColorCommandsIgnoreShow(primitive, frameState) {
   for (let j = 0; j < length; ++j) {
     const commandIgnoreShow = (commandsIgnoreShow[j] = DrawCommand.shallowClone(
       commands[commandIndex],
+      ".ignoreShow",
       commandsIgnoreShow[j]
     ));
     commandIgnoreShow.shaderProgram = spStencil;
@@ -890,6 +895,7 @@ function createPickCommands(primitive) {
     let stencilDepthCommand = pickCommands[j * 2];
     if (!defined(stencilDepthCommand)) {
       stencilDepthCommand = pickCommands[j * 2] = new DrawCommand({
+        description: `vector3DTilePrimitive.stencilDepthCommand[${j}]`,
         owner: primitive,
         pickOnly: true,
       });
@@ -907,6 +913,7 @@ function createPickCommands(primitive) {
 
     const stencilDepthDerivedCommand = DrawCommand.shallowClone(
       stencilDepthCommand,
+      ".classification",
       stencilDepthCommand.derivedCommands.tileset
     );
     stencilDepthDerivedCommand.renderState =
@@ -917,6 +924,7 @@ function createPickCommands(primitive) {
     let colorCommand = pickCommands[j * 2 + 1];
     if (!defined(colorCommand)) {
       colorCommand = pickCommands[j * 2 + 1] = new DrawCommand({
+        description: `vector3DTilePrimitive.pickCommand[${j}]`,
         owner: primitive,
         pickOnly: true,
       });
@@ -934,6 +942,7 @@ function createPickCommands(primitive) {
 
     const colorDerivedCommand = DrawCommand.shallowClone(
       colorCommand,
+      ".classification",
       colorCommand.derivedCommands.tileset
     );
     colorDerivedCommand.pass = Pass.CESIUM_3D_TILE_CLASSIFICATION;

--- a/packages/engine/Source/Scene/buildVoxelDrawCommands.js
+++ b/packages/engine/Source/Scene/buildVoxelDrawCommands.js
@@ -86,6 +86,7 @@ function buildVoxelDrawCommands(primitive, context) {
   const viewportQuadVertexArray = context.getViewportQuadVertexArray();
   const depthTest = primitive._depthTest;
   const drawCommand = new DrawCommand({
+    description: `voxelDrawCommand`,
     vertexArray: viewportQuadVertexArray,
     primitiveType: PrimitiveType.TRIANGLES,
     renderState: renderState,
@@ -102,6 +103,7 @@ function buildVoxelDrawCommands(primitive, context) {
   // Create the pick draw command
   const drawCommandPick = DrawCommand.shallowClone(
     drawCommand,
+    ".pick",
     new DrawCommand()
   );
   drawCommandPick.shaderProgram = shaderProgramPick;
@@ -110,6 +112,7 @@ function buildVoxelDrawCommands(primitive, context) {
   // Create the pick voxels draw command
   const drawCommandPickVoxel = DrawCommand.shallowClone(
     drawCommand,
+    ".pickVoxel",
     new DrawCommand()
   );
   drawCommandPickVoxel.shaderProgram = shaderProgramPickVoxel;

--- a/packages/engine/Specs/Renderer/DrawCommandSpec.js
+++ b/packages/engine/Specs/Renderer/DrawCommandSpec.js
@@ -94,6 +94,7 @@ describe("Renderer/DrawCommand", function () {
 
   it("shallow clones", function () {
     const c = new DrawCommand({
+      description: "spec",
       boundingVolume: {},
       orientedBoundingBox: {},
       cull: false,
@@ -147,6 +148,7 @@ describe("Renderer/DrawCommand", function () {
 
   it("shallow clones with result", function () {
     const c = new DrawCommand({
+      desciption: "spec",
       boundingVolume: {},
       orientedBoundingBox: {},
       cull: false,
@@ -172,7 +174,7 @@ describe("Renderer/DrawCommand", function () {
     });
 
     const result = new DrawCommand();
-    const clone = DrawCommand.shallowClone(c, result);
+    const clone = DrawCommand.shallowClone(c, "", result);
 
     expect(result).toBe(clone);
     expect(clone.boundingVolume).toBe(c.boundingVolume);


### PR DESCRIPTION
I recently tried to address some features/issues that are touching the innermost guts of the CesiumJS rendering system (https://github.com/CesiumGS/cesium/pull/12075 , https://github.com/CesiumGS/cesium/pull/12105, https://github.com/CesiumGS/cesium/pull/12112 ...). And I found myself spending way more than 90% of my time not with _implementing the feature_ or _fixing the bug_, but with reading, reading, reading, and debugging, debugging, debugging. (It's closer to 100%, actually...). This is not really productive. 

One reason for that is that it is essentially impossible to figure out what is actually happening during "rendering": Draw commands are "created", "derived", and "updated", and eventually, some of them are "executed". 

<sup>(Each of the terms in quotes should have a meaning of which it should be possible to describe it in a `/** Single-line comment */`, but certainly none of them does. I _tried_ to shrug off the lack of documentation, but this is one reason for bugs, and one of the reasons why it takes so much time to _fix_ the bugs. Ignoring this problem embiggens it in the long run)</sup>

This PR adds a `description` to the `DrawCommand`. Whenever a `DrawCommand` is created, a `description` is passed in that tries to capture _some_ of the context about what that draw command **is**. (Right now, it's a first shot - one could always add further details). Whenever a draw command is "derived" with `DrawCommand.shallowClone`, then a suffix is passed in that will be appended to the `description`. 

Of course, this is just a crutch. It should not be necessary to debug-step through the code in order to trace one particular draw command. Doing what is necessary to achieve a state where this is not necessary is beyond what a single person can accomplish in reasonable time. But _when_ it is necessary, then this simple string could already be helpful - for example, to figure out which primitives have wrong bounding volumes (c.f. [#12108](https://github.com/CesiumGS/cesium/issues/12108)):

![Cesium Draw Command Description 0001](https://github.com/user-attachments/assets/b7bbf481-a1b5-45ad-9ac2-1170d35d6bd6)

So I'm just opening this as a suggestion. 

(I'll probably do my debugging locally based on this state, try to implement the fix, and in doubt, carve out the 'isolated' fix into a PR that does _not_ contain the changes from _this_ PR...)

## Testing plan

Maybe debug-step though the code and track what is happening in terms of commands that are executed...?

# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [X] I have updated the inline documentation, and included code examples where relevant
- [X] I have performed a self-review of my code
