### PR TITLE
Types export from package.json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fixed specular reflection artifact in PBR direct lighting. [#12116](https://github.com/CesiumGS/cesium/pull/12116)
 - Added multiscattering terms to diffuse BRDF in image-based lighting. [#12118](https://github.com/CesiumGS/cesium/pull/12118)
 - Fixed CallbackProperty type not being present on entity position. [#12120](https://github.com/CesiumGS/cesium/pull/12120)
+- Additional TypeScript types export in package.json to assist some project configurations using Cesium. [#12122](https://github.com/CesiumGS/cesium/pull/12122)
 
 ##### Breaking Changes :mega:
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "./Build/*.js": null,
     ".": {
       "require": "./index.cjs",
-      "import": "./Source/Cesium.js"
+      "import": "./Source/Cesium.js",
+      "types": "./Source/Cesium.d.ts"
     }
   },
   "type": "module",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

We have a project that is failing to find TypeScript types when importing from `cesium`.  It works when importing from `@cesium/engine`, (though that package doesn't have an `exports` section in the `package.json`).

This is the error:
```
Could not find a declaration file for module 'cesium'. '...my_project/node_modules/cesium/index.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/cesium` if it exists or add a new declaration (.d.ts) file containing `declare module 'cesium';`

```

The change in this PR allows the types to be found.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
