### PR TITLE
Return first geometryBuffer if no best match found

### DIFF
--- a/packages/engine/Source/Scene/I3SLayer.js
+++ b/packages/engine/Source/Scene/I3SLayer.js
@@ -291,9 +291,15 @@ I3SLayer.prototype._findBestGeometryBuffers = function (
         };
       }
     }
+    // If no match found return first geometryBuffer
+    if (defined(geometryDefinition[0])) {
+      return {
+        bufferIndex: 0,
+        definition: geometryDefinition,
+        geometryBufferInfo: geometryDefinition[0],
+      };
+    }
   }
-
-  return 0;
 };
 
 /**


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

If no exact match by attribute is found in `_findBestGeometryBuffers` return the first one.  I believe this was the original intention with this function returning `0` for the index.

This allows I3S Scenes to render with geometries missing either `["position", "uv0"]` (See issue / sandcastle).

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes #12114

## Testing plan

- Create sandcastle with the following added as an I3S dataProvider:
   - `https://basemaps3d.arcgis.com/arcgis/rest/services/OpenStreetMap3D_Buildings_v1/SceneServer?layers=ca0470dbbddb4db28bad74ed39949e25`
- Verify the scene renders and errors are no longer thrown
- Confirm other I3S scenes are rendering fine

[Sandcastle Link](https://sandcastle.cesium.com/#c=jVcLcxu3Ef4rWzYT303lO0VSGtsi2dq07GoiW2qotNMJMzZ4AElEIHAD4EjTDv97d3E48o5iHh6NpQN2F/v49lugMNp5WEmxFhYGoMUaRsLJapn9J6wlk14RvkdGeya1sJPeCXyZaAAvrMWVF43Cff2dzaxZ/tdYxeNCkp6QONNyybw0qDBjyomw6OVSKLS6X9umlxM90XkO74wVwJlnTngH3uBPZaFgGqYCGOeCw0JYkWVZEL9fCKisgpI5h1sof30+fo3qd9asJMfwXFWWxqItZRiXeg4MHP5SAq41F59Q6fw1jAuhBSSom4JiG1RLsv7COD/Mw9ZY2JWwedhyeV/yYQrGoqnCKCUKChDMDFwwU0sdtZAC5Qn1WmsYSBHqQZE6LEfI86T3HqvyP2MfJr0XtEBLC+9L9yLPp5idJSvdOc+YLebSZYVZ5vWfuRXO5w5NS6xhflsKPfZWCP+OleevP7yqpKI0uA+rb9qe/aP2elCw04vvTvl0yvn0gk/Pnk0Z/+5C8PPnzy+ei7NvEQhYrlAtbze1r1iHay29ZEp+xiI1GIGyqcF6IYtF8+lgLozkmDqN5zpK3VT4tRAa5patpN+AFYp5rEziN6UsmFIbKusOFinCioNQSpYOLTEFlBAeXVkIOV94cBvnxRLLUAMVAjghojPNGr9n4BfSAf5og0qlKORMCn5C5fUIrh9/uKFNqVcYHUehx96vpVIBnWWpULUxTdB0WNKixjNUBFDMSjjPW6ZdYQIgY61gzRyaXZZSoWDASVNvwaxfPJV6ZjI9Z9lSqvyvnk0/rOfu2cXTYJ0ygnZDIgCdunr77uz09Bm8jSl9Z7hQ5FmNtRDEOB48ALZm0jct/dIWb6/H9+TGlRKr0L4xb01XhXb/0arkEJketVwblGEh/3zm9fWDvfn32asfPtu/3x3HavQ5v16yeYTlpEcnEDuEnI6sQGCAPHdgSvIrUAQ1f/xmRAWWLYWnFsSUzyoFM6wlF9NqPg/9j5laSVcRWvF7nxO0ehuNxiaEOk8hFQcZeNFJ4Qk5F9wgzNQIiWGRnbpf2hE0cN71SMeNHXkdVOaA2w6qEPjjpzZx/HxS7+wja7IZvXnJefCYElrz3q5nEYzknVxiY68ihLEdQzz15MgC3WU7Gaw750nL/dZBI6GxIsjjS2EZ4ZMSYDSCT/onNTdTAyO1oIxHskgw3Qb58kuTGKNEpsw8xvrxnqZAaBkcDUEWCkotVZgiIvuUK9gX7KsvQW77sUnCNs6cl2hBe+oSM/0F2TzyVejrhVHUtTMDbGoqH2wXlbWogKzkBLE/tSseXaFDBDWSnppPwKUrMakNvTeyV/VRnbFbryXkFPozXpg1IIRZSHqgDJpWM/PKfEJ22WUfWV2PS1aIqxW68y8EtqJ14a91WfmXYSwls0rH+aRvxMyPlCweQhKXZiWWqDfR6Y7G73ATy06exYj2uEQmfhD8TQx0cAACstpYzErjJJ1Z962cQfKXGCgXMxz8POkYS9Om3azAbx20tjV22mffRbPHDm/2jjvRuFGf8nu+IGkhUrVP4euv/7x0RjSXIfTfI82mAV9NSLumpi30/I/1L2PTor/duHc2obGXUeO8kUJxl6QZwqRV76QlDqCERw5EzMgyphCJAkHtvZXTygs36V12pTX2akxd/a+OZBZOQ/3GhbnwtQdvjL3r+JvsdeGghPudtHUshXwbWjB7EBuX1GelmRJ67hcwhNNOTNCNqL0B8KSPExJveYVCWh40F9owRLGNnmI5WaX8PclMesO+nxq+GT65bBuhZk5aUb/HjFA7Rre6rtTeN0mpRbIFc7drmhmlsNjfOyvpI+VuLH8bwMe+t+jWYvjVl53atp/jQt/z4cfLP1KPau6nnfbPpM6H+J89on+sSwkC1Ah4syADfy4OCMhBgDw6/9GZ2+5C53P7W3UOucnreuFvKmAnnG0XT0djOnA7OjzpVfpBm7Xu9ELLXpfCs6gWG+U3hLpN1/pqqTRsdjghugs7hW3TM9tIlFuc8zHM8cFUuMeRnd1cvbn/MLq5Hn1fk+GOIw7qWsY/Qmn3o9c3CWrvZ97cGPR6hDfOZE/0tWMkj9yEV3cxwhstswKflLQ46aUwGAzgFH799XdEcQ53pDuMWg8JvEJXopkUu8XwoKTRDr2TXt/5DYKjSds/5ZJegvReTLIsx9dBSc8Ml08rpCafFc41ie3nbdU+lyuQfHDkVbyjF7xnqjE+f4hLcpR/pBqfn7d4qaVLQW/nVn/xzfCm3sRXbT/Hz8aJY3a8MWrK7ME5/wc)

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
