### PR TITLE
fix scene.updateHeight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.121 - 2024-09-01
 
+##### Fixes :wrench:
+
+- Fixed a performance issue where `Scene.updateHeight` would be called too many times.
+
 #### @cesium/engine
 
 ##### Additions :tada:

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -2715,6 +2715,7 @@ function processUpdateHeight(tileset, tile, frameState) {
       Cartesian3.distance(position, boundingSphere.center) <=
       boundingSphere.radius
     ) {
+      callbackData.invoked = true;
       frameState.afterRender.push(() => {
         // Callback can be removed before it actually invoked at the end of the frame
         if (defined(callbackData.callback)) {

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3746,7 +3746,22 @@ Scene.prototype.updateHeight = function (
   Check.typeOf.func("callback", callback);
   //>>includeEnd('debug');
 
+  let callbackWrapperCalledForFrameState = -1;
+  let removed = false;
+
   const callbackWrapper = () => {
+    if (
+      removed ||
+      this.frameState.frameNumber <= callbackWrapperCalledForFrameState
+    ) {
+      return;
+    }
+    console.log(
+      "executing for frame number: ",
+      this.frameState.frameNumber,
+      callbackWrapperCalledForFrameState
+    );
+    callbackWrapperCalledForFrameState = this.frameState.frameNumber;
     Cartographic.clone(cartographic, updateHeightScratchCartographic);
 
     const height = this.getHeight(cartographic, heightReference);
@@ -3822,6 +3837,7 @@ Scene.prototype.updateHeight = function (
     tilesetRemoveCallbacks = {};
     removeAddedListener();
     removeRemovedListener();
+    removed = true;
   };
 
   return removeCallback;

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3756,11 +3756,6 @@ Scene.prototype.updateHeight = function (
     ) {
       return;
     }
-    console.log(
-      "executing for frame number: ",
-      this.frameState.frameNumber,
-      callbackWrapperCalledForFrameState
-    );
     callbackWrapperCalledForFrameState = this.frameState.frameNumber;
     Cartographic.clone(cartographic, updateHeightScratchCartographic);
 


### PR DESCRIPTION
# Description

There where some performance issues in `Scene.updateHeight` which made working with large (mesh surfaces in general) 3D Tiles difficult to very clunky.

## Proposed fixes
- In `Cesium3DTileset.js`, update height callbacks where wrapped in an object, with an `invoked` property. This property was always `false`. In the PR, we set it to true, once an update has been added to the frame state and set it back to false on flush.
- In `Scene.updateHeight` a callback can be called more then once for the same frame number. We now ensure it is only called once.
- In `Scene.updateHeight` a callback which was removed would still be called with a new height. When loading a mesh surface, multiple callbacks are added, one for each initialized frame. For each new one added, the old one is removed, but still called once. We now only call callbacks which where not removed.

## Testing plan

Add a mesh surface with `enableCollision` and watch your performance drop.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
