### PR TITLE
Fix documentation about default values for Label origins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Added multiscattering terms to diffuse BRDF in image-based lighting. [#12118](https://github.com/CesiumGS/cesium/pull/12118)
 - Fixed CallbackProperty type not being present on entity position. [#12120](https://github.com/CesiumGS/cesium/pull/12120)
 - Additional TypeScript types export in package.json to assist some project configurations using Cesium. [#12122](https://github.com/CesiumGS/cesium/pull/12122)
+- Fixed documentation about default values for Label origins [#12139](https://github.com/CesiumGS/cesium/pull/12139)
 
 ##### Breaking Changes :mega:
 

--- a/packages/engine/Source/Scene/Label.js
+++ b/packages/engine/Source/Scene/Label.js
@@ -102,8 +102,8 @@ function parseFont(label) {
  * @property {Cartesian2} [backgroundPadding=new Cartesian2(7, 5)] A {@link Cartesian2} Specifying the horizontal and vertical background padding in pixels.
  * @property {Cartesian2} [pixelOffset=Cartesian2.ZERO] A {@link Cartesian2} specifying the pixel offset in screen space from the origin of this label.
  * @property {Cartesian3} [eyeOffset=Cartesian3.ZERO] A {@link Cartesian3} specifying the 3D Cartesian offset applied to this label in eye coordinates.
- * @property {HorizontalOrigin} [horizontalOrigin=HorizontalOrigin.CENTER] A {@link HorizontalOrigin} specifying the horizontal origin of this label.
- * @property {VerticalOrigin} [verticalOrigin=VerticalOrigin.CENTER] A {@link VerticalOrigin} specifying the vertical origin of this label.
+ * @property {HorizontalOrigin} [horizontalOrigin=HorizontalOrigin.LEFT] A {@link HorizontalOrigin} specifying the horizontal origin of this label.
+ * @property {VerticalOrigin} [verticalOrigin=VerticalOrigin.BASELINE] A {@link VerticalOrigin} specifying the vertical origin of this label.
  * @property {HeightReference} [heightReference=HeightReference.NONE] A {@link HeightReference} specifying the height reference of this label.
  * @property {Color} [fillColor=Color.WHITE] A {@link Color} specifying the fill color of the label.
  * @property {Color} [outlineColor=Color.BLACK] A {@link Color} specifying the outline color of the label.


### PR DESCRIPTION
# Description

Updated the documentation to reflect the current default values for `HorizontalOrigin` and `VerticalOrigin` in `Label.ConstructorOptions`.

While working with labels, i noticed that the default values for `HorizontalOrigin` and `VerticalOrigin` are documented as `CENTER` in both `Label.ConstructorOptions` and `LabelGraphics.ConstructorOptions`. But this is only true for labels as entities (`LabelGraphics` with `LabelVisualizer`), but not true for labels as `Label` in a `LabelCollection`, which use `VerticalOrigin.BASELINE` and `HorizontalOrigin.LEFT`.

## Testing plan

Look at the documentation for `Label.html#.ConstructorOptions`

# Author checklist

- [x] I had **previously** submitted a Contributor License Agreement
- [x] I had **previously** added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- ~~[ ] I have added or updated unit tests to ensure consistent code coverage~~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
