### PR TITLE
Locked protobufjs version

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -47,7 +47,7 @@
     "mersenne-twister": "^1.1.0",
     "meshoptimizer": "^0.21.0",
     "pako": "^2.0.4",
-    "protobufjs": "^7.1.0",
+    "protobufjs": "7.3.2",
     "rbush": "^4.0.0",
     "topojson-client": "^3.1.0",
     "urijs": "^1.19.7"


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The `build` command errors on a fresh `npm install` due to https://github.com/protobufjs/protobuf.js/issues/2022. This locks the version to the latest working version.

## Issue number and link

https://github.com/CesiumGS/cesium/issues/12143, though I'd like to leave that issue open to track why we have the locked version. We can close it when protobuf addressed the issue.

## Testing plan

1. `git clean -dxf`
2. `npm install`
3. `npm run build`

The last command should succeed without error.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
