### PR TITLE
Fix package.json exports order

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "./Build/*": "./Build/*",
     "./Build/*.js": null,
     ".": {
+      "types": "./Source/Cesium.d.ts",
       "require": "./index.cjs",
-      "import": "./Source/Cesium.js",
-      "types": "./Source/Cesium.d.ts"
+      "import": "./Source/Cesium.js"
     }
   },
   "type": "module",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Apparently the order of keys in the exports object matters: 

> Within the ["exports"](https://nodejs.org/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries. The general rule is that conditions should be from most specific to least specific in object order.

It's very bizarre to me that key order matters in an _object_ not an array but apparently it does. `esbuild` now seems to warn about it which is why I noticed: 

![2024-08-22_13-12](https://github.com/user-attachments/assets/dda533bf-4240-46f5-9cb6-2c9cca099d58)

This PR just fixes that order and the warnings are gone. I don't think this changes our build and if I understand it correctly I don't think it should change downstream users but would appreciate someone double checking me on that.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

1. `git clean -dxf`
2. `npm install`
3. `npm run build`
4. Make sure there are no warnings

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
