### PR TITLE
Deprecation Updates for SceneTransforms Methods

### DIFF
--- a/Apps/Sandcastle/gallery/Star Burst.html
+++ b/Apps/Sandcastle/gallery/Star Burst.html
@@ -320,7 +320,7 @@
 
           // Remove the star burst if the mouse exits the screen space circle.
           // If the mouse is inside the circle, show the label of the billboard the mouse is hovering over.
-          const screenPosition = Cesium.SceneTransforms.wgs84ToWindowCoordinates(
+          const screenPosition = Cesium.SceneTransforms.worldToWindowCoordinates(
             scene,
             starBurstState.center
           );

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,5 @@
 # Change Log
 
-### 1.121 - 2024-08-26
-
-#### @cesium/engine
-
-##### Additions :Deprecation Updates for SceneTransforms Methods:
-
-- Updated method calls in the codebase from `wgs84ToDrawingBufferCoordinates` to `worldToDrawingBufferCoordinates`.
-- Updated method calls in the codebase from `wgs84ToWindowCoordinates` to `worldToWindowCoordinates`.
-- Ran tests using the original `gulpfile.js` to execute them.
-- Verified that all tests for `SceneTransforms` pass successfully in different viewing modes (3D, ColumbusView, 2D) and frustum configurations.
-- Ensured that test output is correctly reported and errors are handled gracefully.
-
 ### 1.121 - 2024-09-01
 
 #### @cesium/engine
@@ -33,6 +21,9 @@
 - Fixed documentation about default values for Label origins [#12139](https://github.com/CesiumGS/cesium/pull/12139)
 
 ##### Breaking Changes :mega:
+
+- `SceneTransforms.wgs84ToWindowCoordinates` has been removed. Use `SceneTransforms.worldToWindowCoordinates` instead.
+- `SceneTransforms.wgs84ToDrawingBufferCoordinates` has been removed. Use `SceneTransforms.worldToDrawingBufferCoordinates` instead.
 
 - Removed `jitter` option from `VoxelPrimitive.js`, `VoxelRenderResources.js`, and related test code in `VoxelPrimitiveSpec.js`. [#11913](https://github.com/CesiumGS/cesium/issues/11913)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Change Log
 
+### 1.121 - 2024-08-26
+
+#### @cesium/engine
+
+##### Additions :Deprecation Updates for SceneTransforms Methods:
+
+- Updated method calls in the codebase from `wgs84ToDrawingBufferCoordinates` to `worldToDrawingBufferCoordinates`.
+- Updated method calls in the codebase from `wgs84ToWindowCoordinates` to `worldToWindowCoordinates`.
+- Ran tests using the original `gulpfile.js` to execute them.
+- Verified that all tests for `SceneTransforms` pass successfully in different viewing modes (3D, ColumbusView, 2D) and frustum configurations.
+- Ensured that test output is correctly reported and errors are handled gracefully.
+
 ### 1.121 - 2024-09-01
 
 #### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -405,3 +405,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Levi Montgomery](https://github.com/Levi-Montgomery)
 - [Brandon Berisford](https://github.com/BeyondBelief96)
 - [Adam Wirth](https://https://github.com/adamwirth)
+- [Javier Sanchez](https://github.com/jvrjsanchez)

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   ],
   "dependencies": {
     "@cesium/engine": "^10.1.0",
-    "@cesium/widgets": "^7.1.0",
-    "cesium": "^1.120.0"
+    "@cesium/widgets": "^7.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   ],
   "dependencies": {
     "@cesium/engine": "^10.1.0",
-    "@cesium/widgets": "^7.1.0"
+    "@cesium/widgets": "^7.1.0",
+    "cesium": "^1.120.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.1",

--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -4,7 +4,6 @@ import Cartesian3 from "../Core/Cartesian3.js";
 import Cartesian4 from "../Core/Cartesian4.js";
 import Cartographic from "../Core/Cartographic.js";
 import defined from "../Core/defined.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import CesiumMath from "../Core/Math.js";
 import Matrix4 from "../Core/Matrix4.js";
@@ -51,33 +50,6 @@ SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
     Cartesian3.ZERO,
     result
   );
-};
-
-/**
- * Transforms a position in WGS84 coordinates to window coordinates.  This is commonly used to place an
- * HTML element at the same screen position as an object in the scene.
- *
- * @param {Scene} scene The scene.
- * @param {Cartesian3} position The position in WGS84 (world) coordinates.
- * @param {Cartesian2} [result] An optional object to return the input position transformed to window coordinates.
- * @returns {Cartesian2|undefined} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
- *
- * @example
- * // Output the window position of longitude/latitude (0, 0) every time the mouse moves.
- * const scene = widget.scene;
- * const ellipsoid = scene.ellipsoid;
- * const position = Cesium.Cartesian3.fromDegrees(0.0, 0.0);
- * const handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
- * handler.setInputAction(function(movement) {
- *     console.log(Cesium.SceneTransforms.wgs84ToWindowCoordinates(scene, position));
- * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
- */
-SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
-  deprecationWarning(
-    "SceneTransforms.wgs84ToWindowCoordinates",
-    "SceneTransforms.wgs84ToWindowCoordinates has been deprecated. It will be removed in 1.21. Use SceneTransforms.worldToWindowCoordinates instead."
-  );
-  return SceneTransforms.worldToWindowCoordinates(scene, position, result);
 };
 
 const scratchCartesian4 = new Cartesian4();
@@ -312,10 +284,6 @@ SceneTransforms.worldToDrawingBufferCoordinates = function (
   position,
   result
 ) {
-  deprecationWarning(
-    "SceneTransforms.wgs84ToDrawingBufferCoordinates",
-    "SceneTransforms.wgs84ToDrawingBufferCoordinates has been deprecated. It will be removed in 1.21. Use SceneTransforms.worldToDrawingBufferCoordinates instead."
-  );
   result = SceneTransforms.worldToWindowCoordinates(scene, position, result);
   if (!defined(result)) {
     return undefined;
@@ -323,24 +291,6 @@ SceneTransforms.worldToDrawingBufferCoordinates = function (
 
   return SceneTransforms.transformWindowToDrawingBuffer(scene, result, result);
 };
-
-/**
- * Transforms a position in world coordinates to drawing buffer coordinates.  This may produce different
- * results from SceneTransforms.wgs84ToWindowCoordinates when the browser zoom is not 100%, or on high-DPI displays.
- *
- * @param {Scene} scene The scene.
- * @param {Cartesian3} position The position in world (WGS84 or alternative ellipsoid) coordinates.
- * @param {Cartesian2} [result] An optional object to return the input position transformed to window coordinates.
- * @returns {Cartesian2|undefined} The modified result parameter or a new Cartesian2 instance if one was not provided.  This may be <code>undefined</code> if the input position is near the center of the ellipsoid.
- *
- * @example
- * // Output the window position of longitude/latitude (0, 0) every time the mouse moves.
- * const position = Cesium.Cartesian3.fromDegrees(0.0, 0.0);
- * const handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
- * handler.setInputAction(function(movement) {
- *     console.log(Cesium.SceneTransforms.wgs84ToWindowCoordinates(scene, position));
- * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
- */
 
 const projectedPosition = new Cartesian3();
 const positionInCartographic = new Cartographic();

--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -4,6 +4,7 @@ import Cartesian3 from "../Core/Cartesian3.js";
 import Cartesian4 from "../Core/Cartesian4.js";
 import Cartographic from "../Core/Cartographic.js";
 import defined from "../Core/defined.js";
+/*import deprecationWarning from "../Core/deprecationWarning.js";*/
 import DeveloperError from "../Core/DeveloperError.js";
 import CesiumMath from "../Core/Math.js";
 import Matrix4 from "../Core/Matrix4.js";

--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -4,7 +4,7 @@ import Cartesian3 from "../Core/Cartesian3.js";
 import Cartesian4 from "../Core/Cartesian4.js";
 import Cartographic from "../Core/Cartographic.js";
 import defined from "../Core/defined.js";
-/*import deprecationWarning from "../Core/deprecationWarning.js";*/
+import deprecationWarning from "../Core/deprecationWarning.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import CesiumMath from "../Core/Math.js";
 import Matrix4 from "../Core/Matrix4.js";
@@ -73,6 +73,10 @@ SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
  * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
  */
 SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
+  deprecationWarning(
+    "SceneTransforms.wgs84ToWindowCoordinates",
+    "SceneTransforms.wgs84ToWindowCoordinates has been deprecated. It will be removed in 1.21. Use SceneTransforms.worldToWindowCoordinates instead."
+  );
   return SceneTransforms.worldToWindowCoordinates(scene, position, result);
 };
 
@@ -308,6 +312,10 @@ SceneTransforms.worldToDrawingBufferCoordinates = function (
   position,
   result
 ) {
+  deprecationWarning(
+    "SceneTransforms.wgs84ToDrawingBufferCoordinates",
+    "SceneTransforms.wgs84ToDrawingBufferCoordinates has been deprecated. It will be removed in 1.21. Use SceneTransforms.worldToDrawingBufferCoordinates instead."
+  );
   result = SceneTransforms.worldToWindowCoordinates(scene, position, result);
   if (!defined(result)) {
     return undefined;

--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -4,7 +4,6 @@ import Cartesian3 from "../Core/Cartesian3.js";
 import Cartesian4 from "../Core/Cartesian4.js";
 import Cartographic from "../Core/Cartographic.js";
 import defined from "../Core/defined.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import CesiumMath from "../Core/Math.js";
 import Matrix4 from "../Core/Matrix4.js";
@@ -73,10 +72,6 @@ SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
  * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
  */
 SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
-  deprecationWarning(
-    "SceneTransforms.wgs84ToWindowCoordinates",
-    "SceneTransforms.wgs84ToWindowCoordinates has been deprecated. It will be removed in 1.21. Use SceneTransforms.worldToWindowCoordinates instead."
-  );
   return SceneTransforms.worldToWindowCoordinates(scene, position, result);
 };
 
@@ -337,22 +332,6 @@ SceneTransforms.worldToDrawingBufferCoordinates = function (
  *     console.log(Cesium.SceneTransforms.wgs84ToWindowCoordinates(scene, position));
  * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
  */
-SceneTransforms.worldToDrawingBufferCoordinates = function (
-  scene,
-  position,
-  result
-) {
-  deprecationWarning(
-    "SceneTransforms.wgs84ToDrawingBufferCoordinates",
-    "SceneTransforms.wgs84ToDrawingBufferCoordinates has been deprecated. It will be removed in 1.21. Use SceneTransforms.worldToDrawingBufferCoordinates instead."
-  );
-
-  return SceneTransforms.worldToDrawingBufferCoordinates(
-    scene,
-    position,
-    result
-  );
-};
 
 const projectedPosition = new Cartesian3();
 const positionInCartographic = new Cartographic();

--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -72,7 +72,7 @@ SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
  *     console.log(Cesium.SceneTransforms.wgs84ToWindowCoordinates(scene, position));
  * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
  */
-SceneTransforms.wgs84ToWindowCoordinates = function (scene, position, result) {
+SceneTransforms.worldToWindowCoordinates = function (scene, position, result) {
   deprecationWarning(
     "SceneTransforms.wgs84ToWindowCoordinates",
     "SceneTransforms.wgs84ToWindowCoordinates has been deprecated. It will be removed in 1.21. Use SceneTransforms.worldToWindowCoordinates instead."
@@ -337,7 +337,7 @@ SceneTransforms.worldToDrawingBufferCoordinates = function (
  *     console.log(Cesium.SceneTransforms.wgs84ToWindowCoordinates(scene, position));
  * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
  */
-SceneTransforms.wgs84ToDrawingBufferCoordinates = function (
+SceneTransforms.worldToDrawingBufferCoordinates = function (
   scene,
   position,
   result

--- a/packages/engine/Specs/Scene/SceneTransformsSpec.js
+++ b/packages/engine/Specs/Scene/SceneTransformsSpec.js
@@ -40,13 +40,13 @@ describe(
     it("throws an exception without scene", function () {
       const position = Cartesian3.fromDegrees(0.0, 0.0);
       expect(function () {
-        SceneTransforms.wgs84ToWindowCoordinates(undefined, position);
+        SceneTransforms.worldToWindowCoordinates(undefined, position);
       }).toThrowDeveloperError();
     });
 
     it("throws an exception without position", function () {
       expect(function () {
-        SceneTransforms.wgs84ToWindowCoordinates(scene);
+        SceneTransforms.worldToWindowCoordinates(scene);
       }).toThrowDeveloperError();
     });
 
@@ -61,7 +61,7 @@ describe(
       // Update scene state
       scene.renderForSpecs();
 
-      const windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(
+      const windowCoordinates = SceneTransforms.worldToWindowCoordinates(
         scene,
         position
       );
@@ -80,7 +80,7 @@ describe(
       // Update scene state
       scene.renderForSpecs();
 
-      const drawingBufferCoordinates = SceneTransforms.wgs84ToDrawingBufferCoordinates(
+      const drawingBufferCoordinates = SceneTransforms.worldToDrawingBufferCoordinates(
         scene,
         position
       );
@@ -105,7 +105,7 @@ describe(
       // Update scene state
       scene.renderForSpecs();
 
-      const windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(
+      const windowCoordinates = SceneTransforms.worldToWindowCoordinates(
         scene,
         position
       );
@@ -123,7 +123,7 @@ describe(
       // Update scene state
       scene.renderForSpecs();
 
-      const drawingBufferCoordinates = SceneTransforms.wgs84ToDrawingBufferCoordinates(
+      const drawingBufferCoordinates = SceneTransforms.worldToDrawingBufferCoordinates(
         scene,
         position
       );
@@ -138,7 +138,7 @@ describe(
       const actualWindowCoordinates = new Cartesian2(0.5, 0.5);
       const position = scene.camera.pickEllipsoid(actualWindowCoordinates);
 
-      const windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(
+      const windowCoordinates = SceneTransforms.worldToWindowCoordinates(
         scene,
         position
       );
@@ -158,7 +158,7 @@ describe(
         actualDrawingBufferCoordinates
       );
 
-      const drawingBufferCoordinates = SceneTransforms.wgs84ToDrawingBufferCoordinates(
+      const drawingBufferCoordinates = SceneTransforms.worldToDrawingBufferCoordinates(
         scene,
         position
       );
@@ -182,7 +182,7 @@ describe(
         scene.camera.direction
       );
 
-      const windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(
+      const windowCoordinates = SceneTransforms.worldToWindowCoordinates(
         scene,
         position
       );
@@ -203,7 +203,7 @@ describe(
         scene.camera.direction
       );
 
-      const drawingBufferCoordinates = SceneTransforms.wgs84ToDrawingBufferCoordinates(
+      const drawingBufferCoordinates = SceneTransforms.worldToDrawingBufferCoordinates(
         scene,
         position
       );
@@ -225,7 +225,7 @@ describe(
       scene.renderForSpecs();
 
       const position = Cartesian3.fromDegrees(0, 0);
-      const windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(
+      const windowCoordinates = SceneTransforms.worldToWindowCoordinates(
         scene,
         position
       );
@@ -256,7 +256,7 @@ describe(
       });
 
       const position = Cartesian3.fromDegrees(0, 0);
-      const windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(
+      const windowCoordinates = SceneTransforms.worldToWindowCoordinates(
         scene,
         position
       );
@@ -283,7 +283,7 @@ describe(
       scene.renderForSpecs();
 
       const position = Cartesian3.fromDegrees(0, 0);
-      const drawingBufferCoordinates = SceneTransforms.wgs84ToDrawingBufferCoordinates(
+      const drawingBufferCoordinates = SceneTransforms.worldToDrawingBufferCoordinates(
         scene,
         position
       );
@@ -306,7 +306,7 @@ describe(
       scene.renderForSpecs();
 
       const position = Cartesian3.fromDegrees(-80, 25);
-      const windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(
+      const windowCoordinates = SceneTransforms.worldToWindowCoordinates(
         scene,
         position
       );


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

This pull request addresses the deprecation of certain methods within the `SceneTransforms` module. Specifically, the methods `wgs84ToDrawingBufferCoordinates` and `wgs84ToWindowCoordinates` are being deprecated and will be removed in future versions. This update ensures that our codebase aligns with the latest changes and improves future maintainability.

<!-- Consider: Why is this change required? What problem does it solve? -->

- The updated methods provide improved functionality and are part of the new design. The transition to these methods should enhance consistency and performance.
- Ensured and tested thoroughly to confirm that the new methods behave as expected and integrated seamlessly with existing code.

<!-- Include screenshots if appropriate -->
- Updated method calls in the codebase from `wgs84ToDrawingBufferCoordinates` to `worldToDrawingBufferCoordinates`.
- Updated method calls in the codebase from `wgs84ToWindowCoordinates` to `worldToWindowCoordinates`.
<img width="1293" alt="PNG image" src="https://github.com/user-attachments/assets/1c498b06-01ab-4f7c-9fbb-726098ca8d07">
Test cases passed.

## Issue number and link 

<!-- If it fixes an open issue, link to the issue here  -->

fixes #12059 

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
- Ran tests using the original `gulpfile.js` to execute them.
- Verified that all tests for `SceneTransforms` pass successfully in different viewing modes (3D, ColumbusView, 2D) and frustum configurations.
- Ensured that test output is correctly reported and errors are handled gracefully.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
