### PR TITLE
Fix failing render specs for MSAA defaults

### DIFF
--- a/Specs/createScene.js
+++ b/Specs/createScene.js
@@ -49,6 +49,13 @@ function createScene(options) {
   const scene = new Scene(options);
   scene.highDynamicRange = false;
 
+  if (
+    scene.context.drawingBufferWidth <= 2 ||
+    scene.context.drawingBufferHeight <= 2
+  ) {
+    scene.msaaSamples = 1;
+  }
+
   if (!!window.webglValidation) {
     const context = scene.context;
     context.validateShaderProgram = true;

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -1630,7 +1630,7 @@ Object.defineProperties(Scene.prototype, {
    * The sample rate of multisample antialiasing (values greater than 1 enable MSAA).
    * @memberof Scene.prototype
    * @type {number}
-   * @default 1
+   * @default 4
    */
   msaaSamples: {
     get: function () {

--- a/packages/engine/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -56,6 +56,7 @@ describe(
         canvas: canvas,
       });
       scene.postProcessStages.fxaa.enabled = false;
+      scene.msaaSamples = 1;
 
       context = scene.context;
 

--- a/packages/engine/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -1169,6 +1169,7 @@ describe(
         const scene = createScene({
           canvas: createCanvas(10, 10),
         });
+        scene.msaaSamples = 1;
         noAttenuationPixelCount = scene.logarithmicDepthBuffer ? 20 : 16;
         const center = new Cartesian3.fromRadians(
           centerLongitude,

--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -128,6 +128,10 @@ describe(
 
     describe("constructor", () => {
       it("has expected defaults", function () {
+        const scene = createScene({
+          canvas: createCanvas(5, 5),
+        });
+
         expect(scene.canvas).toBeInstanceOf(HTMLCanvasElement);
         expect(scene.primitives).toBeInstanceOf(PrimitiveCollection);
         expect(scene.camera).toBeInstanceOf(Camera);
@@ -146,6 +150,7 @@ describe(
         expect(contextAttributes.premultipliedAlpha).toEqual(true);
         expect(contextAttributes.preserveDrawingBuffer).toEqual(false);
         expect(scene._depthPlane._ellipsoidOffset).toEqual(0);
+        scene.destroyForSpecs();
       });
 
       it("respects default log depth buffer override", () => {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Many rendering specs were failing locally after [adjusting the MSAA default](https://github.com/CesiumGS/cesium/pull/12158). This fixes them.

1. When the rendering context is too small (like many of the test, which run in a 1x1 canvas), it always appears black when MSAA is enabled.
2. Some tests explicitly need MSAA to be turned off, ie. line weight tests.

## Issue number and link

N/A

## Testing plan

Run specs locally. They should be passing (or in a similar state to `main` pre-https://github.com/CesiumGS/cesium/pull/12158)

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
