### PR TITLE
Fix flakey test epsilon check

### DIFF
--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2599,7 +2599,7 @@ describe(
         tileset.boundingSphere.center
       );
       const height = tileset.getHeight(center, scene);
-      expect(height).toEqualEpsilon(78.1558019795064, CesiumMath.EPSILON12);
+      expect(height).toEqualEpsilon(78.1558019795064, CesiumMath.EPSILON8);
     });
 
     it("getHeight samples height accounting for vertical exaggeration", async function () {
@@ -2615,7 +2615,7 @@ describe(
         tileset.boundingSphere.center
       );
       const height = tileset.getHeight(center, scene);
-      expect(height).toEqualEpsilon(156.31161477299992, CesiumMath.EPSILON12);
+      expect(height).toEqualEpsilon(156.31161477299992, CesiumMath.EPSILON8);
     });
 
     it("destroys", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

I've been seeing some flakey failures in CI due to these tests:

<img width="995" alt="image" src="https://github.com/user-attachments/assets/b83034cf-147f-403f-b687-572fe69e0f7b">

Epsilon 12 (.000000000001) is really tiny. Being within epsilon 8 (.00000001) is still plenty of precision for this case, and should make tests more stable.

## Issue number and link

N/A

## Testing plan

1. CI should pass. You can possibly re-run test or coverage workflows multiple times to confirm.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
