### PR TITLE
Fix incorrect entity occlusion when the camera is below the planet's radius and no terrain tiles are in view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 ##### Fixes :wrench:
 
 - Use first geometryBuffer if no best match found in I3SNode [#12132](https://github.com/CesiumGS/cesium/pull/12132)
+- Fix incorrect entity occlusion when the camera is below the planet's radius and no terrain tiles are in view. [#12190](https://github.com/CesiumGS/cesium/pull/12190)
 
 ### 1.121.1 - 2024-09-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,6 @@
 
 - Use first geometryBuffer if no best match found in I3SNode [#12132](https://github.com/CesiumGS/cesium/pull/12132)
 - Fixed incorrect entity occlusion when the camera is below the planet's radius and no terrain tiles are in view. [#12190](https://github.com/CesiumGS/cesium/pull/12190)
-- Update type definitions to allow undefined for optional parameters [#12193](https://github.com/CesiumGS/cesium/pull/12193)
 
 ### 1.121.1 - 2024-09-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 ##### Fixes :wrench:
 
 - Use first geometryBuffer if no best match found in I3SNode [#12132](https://github.com/CesiumGS/cesium/pull/12132)
-- Fix incorrect entity occlusion when the camera is below the planet's radius and no terrain tiles are in view. [#12190](https://github.com/CesiumGS/cesium/pull/12190)
+- Fixed incorrect entity occlusion when the camera is below the planet's radius and no terrain tiles are in view. [#12190](https://github.com/CesiumGS/cesium/pull/12190)
 
 ### 1.121.1 - 2024-09-04
 

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -532,10 +532,13 @@ GlobeSurfaceTileProvider.prototype.endUpdate = function (frameState) {
       const tile = tilesToRender[tileIndex];
       const tileBoundingRegion = tile.data.tileBoundingRegion;
       addDrawCommandsForTile(this, tile, frameState);
-      frameState.minimumTerrainHeight = Math.min(
-        frameState.minimumTerrainHeight,
-        tileBoundingRegion.minimumHeight
-      );
+      frameState.minimumTerrainHeight =
+        tileIndex === 0
+          ? tileBoundingRegion.minimumHeight
+          : Math.min(
+              frameState.minimumTerrainHeight,
+              tileBoundingRegion.minimumHeight
+            );
     }
   }
 };

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -1,3 +1,4 @@
+import ApproximateTerrainHeights from "../Core/ApproximateTerrainHeights.js";
 import BoundingRectangle from "../Core/BoundingRectangle.js";
 import BoundingSphere from "../Core/BoundingSphere.js";
 import BoxGeometry from "../Core/BoxGeometry.js";
@@ -1938,7 +1939,8 @@ Scene.prototype.updateFrameState = function () {
     camera.upWC
   );
   frameState.occluder = getOccluder(this);
-  frameState.minimumTerrainHeight = 0.0;
+  frameState.minimumTerrainHeight =
+    ApproximateTerrainHeights._defaultMinTerrainHeight;
   frameState.minimumDisableDepthTestDistance = this._minimumDisableDepthTestDistance;
   frameState.invertClassification = this.invertClassification;
   frameState.useLogDepth =


### PR DESCRIPTION
# Description

Fixes issue #10932

When the camera is below average planet radius and no tiles are in view, the `frame.minimumTerrainHeight` is set to a default value of 0.0. This causes entities in view to not be rendered, as they are incorrectly considered occluded.

The proposed solution uses `ApproximateTerrainHeights._defaultMinTerrainHeight` as the default value for  `frame.minimumTerrainHeight`.

For non-Earth planets, it is possible to override `ApproximateTerrainHeights._defaultMinTerrainHeight` to achieve the desired behaviour, as demonstrated in the following example:

[sandcastle](https://sandcastle.cesium.com/#c=zVcLb9s2EP4rRDAgMuDQjzRe5qbZktRAM8RtsaQtsHnoaOlscaFIjaTsuEX++44PKX6kWzpswJwAtu6Od+Tddx9PEzmRnQ65BktsDgSE4KVRPCNWkSl4WaGUxN8zpYGkGpjlcu4VCw5L0BN5AYZXBR3Va2kGM1YJS16QHdX4zZvXzyfS/aVKGhudoKmEZW3+3suS/dQ/XihpGZeg99vk80QSYkFrFLzVasEz0EPClozbenH4utm0oTOtindaJG79fm5taYadzowLMJSlds4s0FQVnei6IyrJ9Me5yHrd7n7bLfKRCdHwRwXGvgdt4e610gUTZkisrsDp71vONlia29WZLZQpc9AwJDM0hHZU5SxTS/MgDGKswyvcLKmkBDy6YXpF3l3GJSAgtVzJS5nxlFmlN11OmYErtgL9lqe3sKW0vACBGQwbjcI5qFRl26ZcztS5utvabwoSxmj8mHMmecHczh7E9y1fYjzPWfZ7hUWuAVGwu07BZV1BkgOf59YQxFYDtQZPZ2Wp1Z1zDrGar4I5/Rj9jbnc0CCKDnqH3W73+dc4YXfbTnrdb48HEaUBn9SngM7UnIJkUwEZmvnjotmCaYIR5qBXvgQGdXHZhhhNN54py7LLIKhxmqx1wQeYjll5DXrBU9i2i3CstCDDB0AvYVqwkgqtUspMRSGrOvuxTiJsDa0duD8uWYr4VlMmaoOSaVaADUbRv0ePZtKgEqQlGwhyn5lrASff90frlHK+H7T3DfgEfOCZzYfkqNdfE4Z0e6mDTIOZG0SrR0TOFjXVmEoSh5vIOk1ZUqHSW5pW2u3OL2w458dKcCZfus52zX9p1PGg20sme/1uv3/Q6x90+ze9w2G3i/8UMfPzZK/ZwthR3s0qzRU2/Jyrhq0wnMc6hvlcp9VyW2XYWwfPDulgMDh+VidcyXlUHT47pr3jo0EvqvJ4dIdV1y9NXA9A5F1GSsEk2DpuYJGRxFirB3SBe+bggRQQIbGCQzLZu/b2kz0fryH1pqyaZZwP1yn3giGhGUzYYdI7wny0yfpXK+7btZHmTAybZUooTc+v3o3oktv8TJQ5S7r0qF5gBGL3LfrmLmvIeP06O8ay9HZdczjYZscY49o/O/qho9dn51ejl94w4KtUhgfy2TmIL/tLmGsAk9SIrQtIm+q0d1WxpLuaULcob20wHdbJaiUISbEEmjUbm0iBd2sQBsSfTdXC4fTQ89S29hyEWjoiC+pZJT3tIzUu4MLb+fXJCkwrlHPbAy5GJfn+kaDD3VDPH3rJq+hMrG5UzS8Z3nVcBsgP48X2xEz/s1Sv7y+ASGmOOI83zBot5YAgRnpoKj9mNqdW/YRiJKzkO49bd6kCM7bd3EELJiog3BDUk0QqbfPWg9eS2zT/O5/hrt50mAilbt1+qnLNHSLCEbQL9VefbW+RQSO+7h3EGiC4OGf2Fablk5KJx8DXFnDTvkbq/y7bT0g2EoP8T9I9kddMZimeRYCj1xulxJTpMcgq+WVtHsQp0DrCjV3PfJt5wnVDtHZZq0zkYcyuDHMcjkp1OZNWk+btFndXrdvQw2163/5y6Kknjn8ptB9tnhA7DzB8YpQt6O64/zWw6Zfy4Hm21BznEKPwqnezak2g2qoLpXRmNt8kHEepuWZlzlMfcBP6LtJIZq7AowXi/oobi3OeTnDTL07Dvjd9P+LXs19DhpH/Hm+xcGR3pSuElVDz5LdYvXCzkG8+r4WL1839b2EZHn5zGHXj2rV1Aw7O1LxoXnriNeCajixzkEQqP3A5CQ5RYYDy/lJWmfCSN2UZUWkqkIt1fPdDVbazXR+a+NAkRt2a5vEMX7XN+njYe3vtvRNjVwJO65b+gRclcoabcxNK8fWswLkIE92ZVvgmYmlqTA2jk8760pOMLwjPXmB7bL5ETvZIKpgxqJlVQlzzTzgmnZ500H5nqVCe9N4sQOP07Mzy3ulVEFJKTzr4+PhKG+hiy/Of)

## Issue number and link
#10932

## Testing plan
Fixes a bug visible in this [example](https://sandcastle.cesium.com/#c=zVcLb9s2EP4rhDHAMuDQjzRB5qbZktRAMiRtMactsHloaelsEaFJlaTsukX++44Pya90S4cNmBPA1r15993xNJZj2emQEVhicyAgBC+M4hmxikzA0+ZKSfw9VRpIqoFZLmeeseCwBD2Wl2B4OafDSpdmMGWlsOQF2WPdvn796vlYur9USWOjERSVsKzE33la0kz946WSlnEJutkmX8eSEAtaI+GNVguegR4QtmTcVsrh625bhk61mr/VInH6zdzawgw6nSkXYChL7YxZoKmad6Lpjigl0x9mIut1u822U/KeCdHwqQRj34G28PmV0nMmzIBYXYLjP7ScbJA096tzO1emyEHDgExRENqRlbNMLc2aGMhYhysMlpRSAh7dML0ib6+jCghILVfyWmY8ZVbpbZMTZuCGrUC/4ek97DAtn4PADIZAI3EGKlXZriiXU3WhPu/Em4KEWxR+zDiTfM5cZGvyQ8uXOJSWem06VTMKkk0EZFhsL4lCC6YJqs9Ar3z0BnlRbYuMolvPlGXZdSBUJU42APQeJresGIFe8BR25WIlSy3IYI2FJUzmrKBCq5QyU1LIyk4zHlGE0FDa4eLDkqUIDTVhohIomGZzsEEo2veJ10waZIK0ZCv57jN16HH0pj9ap5CzZuA+1HUT8J5nNh+Qo15/g3gFfJZbT3XZDulG+NxhoZ1dkrNF1aWmlFjVumHrsqRCpfc0LbWLzivW7fpLKTiTL11TuL65NurkuNtLxo1+t98/6PUPuv273uGg28V/2u12fxs36hBu3bS4W6W5wl6ZISyqRkd3Hibo5muVVsttmSEsD54d0uPj45NnVcKVnEXW4bMT2js5Ou5FVh6Pfoh+HdRqv47sRhYjhWASbOU3NOBQoq/VGl3gnjl4IAVESKzggIwbIy8/bnh/9Tysy6pZxvlgc1pdMpwFBhN2mPSOMB9tsvnVinFjqUFzJga1mhJK04ubt0O65DY/F0XOki49qhSMQOy+QdvcZQ2HRb/KjrEsvd/kHB7vDpboY+SfXefS4avzi5vhSy8Y8FUow0Pf7h3El/0lzDSASSrEVgWkdXXa+6xY0n1OqFukt9ZDAkuHdbJaCUJSLIFmdWBjKfBaCsSA+POJWjicYvGf73MvQKglcg8Ce1pKPzHxAlvApZfz+skKTCuUc9cCKiOT/PSI08G+q+frXvIsOhWrO1XNlwyvCS4D5AfxTnhipv9ZqjfjCyBSmiPO43DeGEs5IIhxPNSVv2U2p1b9imQcWMmPHrfuPgJmbJtU9/mCiRIINwT5JJFK27y1tlpwm+Z/ZzNcc9sGE6HUvYunLDbMISLcgHau/uqzay1O0IivBwexGgjOz7m9wrR8UTLxGPjeAm7LV0j932X7CcnGwSD/k3SP5YjJLMWzCHDj9U4pMWH6FmSZ/L6xSuECZd3AjV3PfJv5gev2T+2yVpo4hzG7MqxAuGVU5UxadZp3W9xdtS6g9W360P6264kfHP+Sa7/aPMF3HmD4RC870N0z/0eYpt/Kg5+zhea4hxiFV71b86oBqq26VEpnZnsJdzNKzTQrcp56h9vQd56GMnMFHi4Q9zfcWNzzdIJBvzgLcW/bfsSun371MIzz7/EWC0d2V7pCWAk1Sz7G6oWbhfzwdcNdvG4ePgY1PPz2MurWtZF1C86c42ZZvy/Ea8A1HVnmIIlUfuFyFFyiwgLl7aWsNOH9aMIyotJU4CzW8bUJWdleuN418a5J9Fq9yqzP8F1hVsfD3mu0G6fGrgScVS39M58XODPcnptQim82c9yLMNGdSYlLvKWpMRWMTjubqqcZXxCevcD22H7/GjdIKpgxyJmWQoz4F1yTzk47KL+nKpQfeq8XoHF7dmJ57+wmECmlpx18fFzThnGxY/lP)

when the camera is below planet radius the sun and the sphere (it could be a planet) is not rendered


# Author checklist
- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code


