### PR TITLE
Pin `rbush` version for use in Commonjs

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -48,7 +48,7 @@
     "meshoptimizer": "^0.21.0",
     "pako": "^2.0.4",
     "protobufjs": "^7.1.0",
-    "rbush": "^4.0.0",
+    "rbush": "3.0.1",
     "topojson-client": "^3.1.0",
     "urijs": "^1.19.7"
   },


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

`rbush` `v4` updated to only support ES modules but CesiumJS supports ESM and Common JS which means downstream builds using Cesium JS don't work. This pins the version to `3.0.1` which is the one before `4.0`

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Addresses the error in #12191 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm install` to make sure you have the pinned version of `rbush`
- Make sure CI and tests pass
- Make sure the `RectangleCollisionChecker` still works as expected. This is used in clustering, make sure that [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=Clustering.html) works

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
