### PR TITLE
Fix depth sampling for ambient occlusion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - Use first geometryBuffer if no best match found in I3SNode [#12132](https://github.com/CesiumGS/cesium/pull/12132)
 - Update type definitions to allow undefined for optional parameters [#12193](https://github.com/CesiumGS/cesium/pull/12193)
-- Fixed depth sampling for ambient occlusion. [#12201](https://github.com/CesiumGS/cesium/pull/12201)
+- Fixed noise in ambient occlusion post process. [#12201](https://github.com/CesiumGS/cesium/pull/12201)
 
 ### 1.121.1 - 2024-09-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 - Use first geometryBuffer if no best match found in I3SNode [#12132](https://github.com/CesiumGS/cesium/pull/12132)
 - Update type definitions to allow undefined for optional parameters [#12193](https://github.com/CesiumGS/cesium/pull/12193)
+- Fixed depth sampling for ambient occlusion. [#12201](https://github.com/CesiumGS/cesium/pull/12201)
 
 ### 1.121.1 - 2024-09-04
 

--- a/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
+++ b/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
@@ -46,6 +46,9 @@ vec3 getNormalXEdge(vec3 positionEC, vec2 pixelSize)
 
 void main(void)
 {
+    //vec2 pixelSize = czm_pixelRatio / czm_viewport.zw;
+    vec2 pixelSize = 1.0 / vec2(textureSize(depthTexture, 0));
+
     vec3 positionEC = screenToEye(v_textureCoordinates);
 
     if (positionEC.z > frustumLength)
@@ -54,7 +57,6 @@ void main(void)
         return;
     }
 
-    vec2 pixelSize = czm_pixelRatio / czm_viewport.zw;
     vec3 normalEC = getNormalXEdge(positionEC, pixelSize);
 
     float ao = 0.0;
@@ -78,12 +80,14 @@ void main(void)
         sampleDirection = rotateStep * sampleDirection;
 
         float localAO = 0.0;
-        vec2 radialStep = radialStepSize;
+        vec2 radialStep = radialStepSize * sampleDirection;
 
         for (int j = 0; j < 6; j++)
         {
             // Step along sampling direction, away from output pixel
-            vec2 newCoords = v_textureCoordinates + sampleDirection * radialStep;
+            vec2 newCoords = v_textureCoordinates + float(j + 1) * radialStep;
+            // Snap to grid
+            //newCoords = round(newCoords / pixelSize) * pixelSize;
 
             // Exit if we stepped off the screen
             if (newCoords.x > 1.0 || newCoords.y > 1.0 || newCoords.x < 0.0 || newCoords.y < 0.0)
@@ -109,7 +113,6 @@ void main(void)
             float weight = stepLength / lengthCap;
             weight = 1.0 - weight * weight;
             localAO = max(localAO, dotVal * weight);
-            radialStep += radialStepSize;
         }
         ao += localAO;
     }

--- a/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
+++ b/packages/engine/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
@@ -10,105 +10,111 @@ in vec2 v_textureCoordinates;
 
 vec4 clipToEye(vec2 uv, float depth)
 {
-    vec2 xy = vec2((uv.x * 2.0 - 1.0), ((1.0 - uv.y) * 2.0 - 1.0));
+    vec2 xy = 2.0 * uv - vec2(1.0);
     vec4 posEC = czm_inverseProjection * vec4(xy, depth, 1.0);
     posEC = posEC / posEC.w;
     return posEC;
 }
 
-//Reconstruct Normal Without Edge Removation
-vec3 getNormalXEdge(vec3 posInCamera, float depthU, float depthD, float depthL, float depthR, vec2 pixelSize)
+vec3 screenToEye(vec2 screenCoordinate)
 {
-    vec4 posInCameraUp = clipToEye(v_textureCoordinates - vec2(0.0, pixelSize.y), depthU);
-    vec4 posInCameraDown = clipToEye(v_textureCoordinates + vec2(0.0, pixelSize.y), depthD);
-    vec4 posInCameraLeft = clipToEye(v_textureCoordinates - vec2(pixelSize.x, 0.0), depthL);
-    vec4 posInCameraRight = clipToEye(v_textureCoordinates + vec2(pixelSize.x, 0.0), depthR);
+    float depth = czm_readDepth(depthTexture, screenCoordinate);
+    return clipToEye(screenCoordinate, depth).xyz;
+}
 
-    vec3 up = posInCamera.xyz - posInCameraUp.xyz;
-    vec3 down = posInCameraDown.xyz - posInCamera.xyz;
-    vec3 left = posInCamera.xyz - posInCameraLeft.xyz;
-    vec3 right = posInCameraRight.xyz - posInCamera.xyz;
+// Reconstruct surface normal in eye coordinates, avoiding edges
+vec3 getNormalXEdge(vec3 positionEC, vec2 pixelSize)
+{
+    // Find the 3D surface positions at adjacent screen pixels
+    vec3 positionLeft = screenToEye(v_textureCoordinates - vec2(pixelSize.x, 0.0));
+    vec3 positionRight = screenToEye(v_textureCoordinates + vec2(pixelSize.x, 0.0));
+    vec3 positionUp = screenToEye(v_textureCoordinates + vec2(0.0, pixelSize.y));
+    vec3 positionDown = screenToEye(v_textureCoordinates - vec2(0.0, pixelSize.y));
 
-    vec3 DX = length(left) < length(right) ? left : right;
-    vec3 DY = length(up) < length(down) ? up : down;
+    // Compute potential tangent vectors
+    vec3 dx0 = positionEC - positionLeft;
+    vec3 dx1 = positionRight - positionEC;
+    vec3 dy0 = positionEC - positionDown;
+    vec3 dy1 = positionUp - positionEC;
 
-    return normalize(cross(DY, DX));
+    // The shorter tangent is more likely to be on the same surface
+    vec3 dx = length(dx0) < length(dx1) ? dx0 : dx1;
+    vec3 dy = length(dy0) < length(dy1) ? dy0 : dy1;
+
+    return normalize(cross(dx, dy));
 }
 
 void main(void)
 {
-    float depth = czm_readDepth(depthTexture, v_textureCoordinates);
-    vec4 posInCamera = clipToEye(v_textureCoordinates, depth);
+    vec3 positionEC = screenToEye(v_textureCoordinates);
 
-    if (posInCamera.z > frustumLength)
+    if (positionEC.z > frustumLength)
     {
         out_FragColor = vec4(1.0);
         return;
     }
 
     vec2 pixelSize = czm_pixelRatio / czm_viewport.zw;
-    float depthU = czm_readDepth(depthTexture, v_textureCoordinates - vec2(0.0, pixelSize.y));
-    float depthD = czm_readDepth(depthTexture, v_textureCoordinates + vec2(0.0, pixelSize.y));
-    float depthL = czm_readDepth(depthTexture, v_textureCoordinates - vec2(pixelSize.x, 0.0));
-    float depthR = czm_readDepth(depthTexture, v_textureCoordinates + vec2(pixelSize.x, 0.0));
-    vec3 normalInCamera = getNormalXEdge(posInCamera.xyz, depthU, depthD, depthL, depthR, pixelSize);
+    vec3 normalEC = getNormalXEdge(positionEC, pixelSize);
 
     float ao = 0.0;
-    vec2 sampleDirection = vec2(1.0, 0.0);
-    float gapAngle = 90.0 * czm_radiansPerDegree;
 
-    // RandomNoise
+    const int ANGLE_STEPS = 4;
+    float angleStepScale = 1.0 / float(ANGLE_STEPS);
+    float angleStep = angleStepScale * czm_twoPi;
+    float cosStep = cos(angleStep);
+    float sinStep = sin(angleStep);
+    mat2 rotateStep = mat2(cosStep, sinStep, -sinStep, cosStep);
+
+    // Initial sampling direction (different for each pixel)
     float randomVal = texture(randomTexture, v_textureCoordinates / pixelSize / 255.0).x;
+    vec2 sampleDirection = vec2(cos(angleStep * randomVal), sin(angleStep * randomVal));
 
-    //Loop for each direction
-    for (int i = 0; i < 4; i++)
+    vec2 radialStepSize = stepSize * pixelSize;
+
+    // Loop over sampling directions
+    for (int i = 0; i < ANGLE_STEPS; i++)
     {
-        float newGapAngle = gapAngle * (float(i) + randomVal);
-        float cosVal = cos(newGapAngle);
-        float sinVal = sin(newGapAngle);
+        sampleDirection = rotateStep * sampleDirection;
 
-        //Rotate Sampling Direction
-        vec2 rotatedSampleDirection = vec2(cosVal * sampleDirection.x - sinVal * sampleDirection.y, sinVal * sampleDirection.x + cosVal * sampleDirection.y);
         float localAO = 0.0;
-        float localStepSize = stepSize;
+        vec2 radialStep = radialStepSize;
 
-        //Loop for each step
         for (int j = 0; j < 6; j++)
         {
-            vec2 newCoords = v_textureCoordinates + rotatedSampleDirection * localStepSize * pixelSize;
+            // Step along sampling direction, away from output pixel
+            vec2 newCoords = v_textureCoordinates + sampleDirection * radialStep;
 
-            //Exception Handling
-            if(newCoords.x > 1.0 || newCoords.y > 1.0 || newCoords.x < 0.0 || newCoords.y < 0.0)
+            // Exit if we stepped off the screen
+            if (newCoords.x > 1.0 || newCoords.y > 1.0 || newCoords.x < 0.0 || newCoords.y < 0.0)
             {
                 break;
             }
 
-            float stepDepthInfo = czm_readDepth(depthTexture, newCoords);
-            vec4 stepPosInCamera = clipToEye(newCoords, stepDepthInfo);
-            vec3 diffVec = stepPosInCamera.xyz - posInCamera.xyz;
-            float len = length(diffVec);
+            vec3 stepPositionEC = screenToEye(newCoords);
+            vec3 stepVector = stepPositionEC - positionEC;
+            float stepLength = length(stepVector);
 
-            if (len > lengthCap)
+            if (stepLength > lengthCap)
             {
                 break;
             }
 
-            float dotVal = clamp(dot(normalInCamera, normalize(diffVec)), 0.0, 1.0 );
-            float weight = len / lengthCap;
-            weight = 1.0 - weight * weight;
-
+            float dotVal = clamp(dot(normalEC, normalize(stepVector)), 0.0, 1.0);
             if (dotVal < bias)
             {
                 dotVal = 0.0;
             }
 
+            float weight = stepLength / lengthCap;
+            weight = 1.0 - weight * weight;
             localAO = max(localAO, dotVal * weight);
-            localStepSize += stepSize;
+            radialStep += radialStepSize;
         }
         ao += localAO;
     }
 
-    ao /= 4.0;
+    ao *= angleStepScale;
     ao = 1.0 - clamp(ao, 0.0, 1.0);
     ao = pow(ao, intensity);
     out_FragColor = vec4(vec3(ao), 1.0);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR fixes sampling of the depth texture in `AmbientOcclusionGenerate.glsl`.

Our ambient occlusion shader was developed when depth buffers still used linear sampling. After https://github.com/CesiumGS/cesium/pull/9966, the depth buffer uses nearest sampling. And in a WebGL2 context, linear sampling of a depth buffer is not allowed. This meant that:

- The depth value read from `depthTexture` actually corresponded to the center of the pixel.
- X and Y values were still assumed to be at un-centered positions.

The inconsistency between depth and XY values produced enough geometry error to create a background occlusion factor everywhere, including on flat surfaces which should have no occlusion.

This PR adjusts the shader calculations to explicitly shift all sampling points to pixel centers.

Along the way, I rewrote the shader to better reflect the geometry of the various inputs.

## Rendering results
Before this PR:
![image](https://github.com/user-attachments/assets/d26e6664-2af0-4729-a3b4-22dd2e38f76b)

After this PR, with a WebGL2 context (default):
![image](https://github.com/user-attachments/assets/7bb45d3c-bd7f-41b0-b08a-6ddca82bcc94)

After this PR, with a WebGL1 context:
![image](https://github.com/user-attachments/assets/7916c74f-2a9d-4806-8e25-9a5dc267c14e)

## Issue number and link

Partially addresses https://github.com/CesiumGS/cesium/issues/10106.

## Testing plan

- Load the [Ambient Occlusion Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=Ambient%20Occlusion.html) and compare to the main branch.
- Load the [same Sandcastle with a WebGL1 context](http://localhost:8080/Apps/Sandcastle/index.html#c=vVZtb9s2EP4rnDGgDuDQerP8UjdYk/ZDi24JkGwDBn8oJTE2EZrUSMqu1+a/70i9WHaUZSuSBQYiPuS9PHfHO6ZSaIM2jG6pQm+QoFt0QTUr1vg3h/UXvdStL6QwhAmqFr0B+roQCKWA0C/mMjcMlMzQV6TonwXV5neaLLk/Q0YVFN0PFuL+5PVCLERpBadcpnc4LZSiwtywNQW7lc2PBWdEvCOG4lsl1x+0nMSe37fWFr3AC4JTb3Lq+TeeN3O/Pxa9hSiVs1vkzv1QqbqS2lwpCc7ra0OW9BNLFFE7zPTbdcLA8mWa8kKD69dFnktlaObkURUMrFMqqEVOwETJeMtEJreYcKpMdXjRu1kxjRIltxoimEmqkZAG6VIpMiuKSGkQydoiysE5lJfeYcsBrACLe0skbTLys8woh+A423olt2VIB3ZJjkhcCr6boVvCdbnPIDdCMwNgiD0HJYxAljzsuxWnYmlWFyS3kBc6TBuaX7O/6Az5tQwv1HWDengS23SCq8NhO0w4JWuqCCSt0AaCLyix1QRaXG6qlNwJSLwsDDaKpHf9hqKlXrI2UvLEiWYyLdZAEC+pec+p/TzffYAU9aozi54VO9ZM8pzvziFNTCz13sKg1mxlbqVC/dKeALchVPtoV4m2xdRgeEX05VZAMeWQ913fCp1UBxE68qAEEbJ+XyZQEhuScNr2xIk3x3SR6FSxhPaLPIO6b5Wt9RWh+6osbguR2ouGHpzrnzT3ESgdFwZ687CqcX50OTQ+FnvdVWSYCssmq3WeQ1ApEa1Q2So9Qd++dWx1VexJt5kCbrNUa90pA8VRK98ze9xEfbf+yUxzWUD3L8U6gba3V9psPqXF3q8uBRZ/Sra5jV0Kms2ntNT3t0tJvfcki9aN3+s5jnT7VKt7ddTm631PK5sEKO1oHbYFlD0EapO5Qj+YRhcEOrSG4RA6X/wgjPxgjINgGo19z48j165OR54dGD6O4ziKQjjh4DAO4W+MvcgPw5HvRaNyalQWM6Zo+qTJUw+PQt/z4iicxoHvx2HZSAEPvWA69fxw4k+8ySTy43pjPPXDKI688SSeBCM/OjCr2HJlnjI5ieLJaBp441EUxN641Aw9fDSOvJHvw140iqNxBY+88XQyDSZwNIIwHJgr8v2c3dvBqZKQJtc/Wm4NWkATHgd2e3tSj2GjdmU3Gg7RlbSPiitOYPZlcHAp0NqNNJh8G5ZBH0l26BzKkNMdut5Bha71vpEZxqmmNkBkS5hpjLp/4bubcrt8J0jxVsMC5kMA4Y5Hflnlhz1PsTUU1sY2uyzrV+pd4QJTk65QnyolVaubQpfBXC77n9/bDcQlsXOl9myGfvzqJO4/l1p6g95cmx2nZ3V7/4mt3SugULyP8RAI5hwuiB4mRXoHzqd1l0doPmyLzjO2QSx70/H6QiknWsPObcG5u3+9s/kQzj8Qrfy93FDFyc4eW/lnn0oQYzwfwrJbspmxDZO5sZ2/WVogkdmuBVhIHawtkp1Vzy3U9Jr5ENCH5+ZM5AWkfZdTS3tF07tEfgG+0FLIaQIzvYZpNnPPIUf8SBcA6nucQnZWPOLZIQLYf/K0cyj1js18J48P9XD6LtcVEUsoH7RmAla+/SJf7JcHn3ZgVGib14bwAp6CzVQcIIf86jr/DL1yBl49G8FPbvYhGH7PwNDbM9wThNfvIxybufvCHO0gRfYmv1gSH+dYPwtemOI5vIH+/wTal9dLE4OHEHrOBO4pRv+KYush9kxUYXnQ2mHd6v3tgfE3).

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
