### PR TITLE
Base zoom speed on browser refresh rate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Added `enableVerticalExaggeration` option to models. Set this value to `false` to prevent model exaggeration when `Scene.verticalExaggeration` is set to a value other than `1.0`. [#12141](https://github.com/CesiumGS/cesium/pull/12141)
 - Added `Scene.prototype.pickMetadata` and `Scene.prototype.pickMetadataSchema`, enabling experimental support for picking property textures or property attributes [#12075](https://github.com/CesiumGS/cesium/pull/12075)
 - Added experimental support for the `NGA_gpm_local` glTF extension, for GPM 1.2 [#12204](https://github.com/CesiumGS/cesium/pull/12204)
+- Use rendering rate to adjust zoom rate so zoom speed appears consistent on high or low refresh rate browsers. Use `zoomFactor` to adjust zoomRate. Added `averageFramesPerSecond` and `averageFrameRateWindow` to `FrameRateMonitor` class for getting the frame rendering rate.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Change Log
 
+### 1.123 - 2024-11-01
+
+#### @cesium/engine
+
+##### Additions :tada:
+
+- Use rendering rate to adjust zoom rate so zoom speed appears consistent on high or low refresh rate browsers. Use `zoomFactor` to adjust zoomRate. Added `averageFramesPerSecond` and `averageFrameRateWindow` to `FrameRateMonitor` class for getting the frame rendering rate.
+
+##### Fixes :wrench:
+
+##### Deprecated :hourglass_flowing_sand:
+
 ### 1.122 - 2024-10-01
 
 #### @cesium/engine
@@ -10,7 +22,6 @@
 - Added `enableVerticalExaggeration` option to models. Set this value to `false` to prevent model exaggeration when `Scene.verticalExaggeration` is set to a value other than `1.0`. [#12141](https://github.com/CesiumGS/cesium/pull/12141)
 - Added `Scene.prototype.pickMetadata` and `Scene.prototype.pickMetadataSchema`, enabling experimental support for picking property textures or property attributes [#12075](https://github.com/CesiumGS/cesium/pull/12075)
 - Added experimental support for the `NGA_gpm_local` glTF extension, for GPM 1.2 [#12204](https://github.com/CesiumGS/cesium/pull/12204)
-- Use rendering rate to adjust zoom rate so zoom speed appears consistent on high or low refresh rate browsers. Use `zoomFactor` to adjust zoomRate. Added `averageFramesPerSecond` and `averageFrameRateWindow` to `FrameRateMonitor` class for getting the frame rendering rate.
 
 ##### Fixes :wrench:
 

--- a/packages/engine/Source/Scene/FrameRateMonitor.js
+++ b/packages/engine/Source/Scene/FrameRateMonitor.js
@@ -42,7 +42,8 @@ function FrameRateMonitor(options) {
   this._scene = options.scene;
 
   /**
-   * Gets or sets the length of the sliding window over which to compute the average frame rate, in seconds.
+   * Gets or sets the length of the sliding window over which to compute the average frame rate, in seconds, for the
+   * purpose of calculating if the frame rate is lower or higher than the minimum frame rate threshold.
    * @type {number}
    */
   this.samplingWindow = defaultValue(
@@ -51,7 +52,8 @@ function FrameRateMonitor(options) {
   );
 
   /**
-   * Gets or sets the length of the sliding window over which to compute the average frame rate, in seconds.
+   * Gets or sets the length of the sliding window over which to compute the average frame rate, in number of frame,
+   * for the purpose of calculating and displaying <code>averageFramesPerSecond</code>.
    * @type {number}
    */
   this.averageFrameRateWindow = defaultValue(

--- a/packages/engine/Source/Scene/FrameRateMonitor.js
+++ b/packages/engine/Source/Scene/FrameRateMonitor.js
@@ -30,7 +30,7 @@ import TimeConstants from "../Core/TimeConstants.js";
  *        the end of the warmup period.  If the frame rate averages less than this during any samplingWindow after the warmupPeriod, the
  *        lowFrameRate event will be raised and the page will redirect to the redirectOnLowFrameRateUrl, if any.
  * @param {number} [options.averageFrameRateWindow=10] The length of the sliding window over which to compute the average frame rate, in
- *        number of frames, for the purpose of calculating and displaying <code>averageFramesPerSecond</code>
+ *        number of frames, for the purpose of calculating and displaying <code>averageFramesPerSecond</code>.
  */
 function FrameRateMonitor(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -52,7 +52,7 @@ function FrameRateMonitor(options) {
   );
 
   /**
-   * Gets or sets the length of the sliding window over which to compute the average frame rate, in number of frame,
+   * Gets or sets the length of the sliding window over which to compute the average frame rate, in number of frames,
    * for the purpose of calculating and displaying <code>averageFramesPerSecond</code>.
    * @type {number}
    */
@@ -113,7 +113,6 @@ function FrameRateMonitor(options) {
   this._warmupPeriodEndTime = 0.0;
   this._frameRateIsLow = false;
   this._lastFramesPerSecond = undefined;
-  this._averageFramesPerSecond = undefined;
   this._pauseCount = 0;
 
   const that = this;
@@ -270,23 +269,21 @@ Object.defineProperties(FrameRateMonitor.prototype, {
    * has passed. After <code>averageFrameRateWindow</code> has passed the property will be continuously
    * available, the limitations specified for <code>lastFramesPerSecond</code> do not apply to it.
    * @memberof FrameRateMonitor.prototype
-   * @type {number}
+   * @type {number|undefined}
    */
   averageFramesPerSecond: {
     get: function () {
       if (this._averageFrameRateTimes.length !== this.averageFrameRateWindow) {
-        this._averageFramesPerSecond = undefined;
-      } else {
-        const windowSize = this.averageFrameRateWindow - 1;
-        const averageTimePerFrame =
-          (this._averageFrameRateTimes[0] -
-            this._averageFrameRateTimes[windowSize]) /
-          windowSize;
-        const fps =
-          1 / (averageTimePerFrame * TimeConstants.SECONDS_PER_MILLISECOND);
-        this._averageFramesPerSecond = fps;
+        return undefined;
       }
-      return this._averageFramesPerSecond;
+      const windowSize = this.averageFrameRateWindow - 1;
+      const averageTimePerFrame =
+        (this._averageFrameRateTimes[0] -
+          this._averageFrameRateTimes[windowSize]) /
+        windowSize;
+      const fps =
+        1.0 / (averageTimePerFrame * TimeConstants.SECONDS_PER_MILLISECOND);
+      return fps;
     },
   },
 });

--- a/packages/engine/Source/Scene/FrameRateMonitor.js
+++ b/packages/engine/Source/Scene/FrameRateMonitor.js
@@ -58,7 +58,7 @@ function FrameRateMonitor(options) {
    */
   this.averageFrameRateWindow = defaultValue(
     options.averageFrameRateWindow,
-    FrameRateMonitor.defaultSettings.averageFrameRateWindow
+    FrameRateMonitor.defaultSettings.averageFrameRateWindow,
   );
 
   /**

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -79,8 +79,6 @@ import VoxelCell from "./VoxelCell.js";
 import VoxelPrimitive from "./VoxelPrimitive.js";
 import getMetadataClassProperty from "./getMetadataClassProperty.js";
 import PickedMetadataInfo from "./PickedMetadataInfo.js";
-import getTimestamp from "../Core/getTimestamp.js";
-import FpsTracker from "../Core/FpsTracker.js";
 
 const requestRenderAfterFrame = function (scene) {
   return function () {

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -79,6 +79,8 @@ import VoxelCell from "./VoxelCell.js";
 import VoxelPrimitive from "./VoxelPrimitive.js";
 import getMetadataClassProperty from "./getMetadataClassProperty.js";
 import PickedMetadataInfo from "./PickedMetadataInfo.js";
+import getTimestamp from "../Core/getTimestamp.js";
+import FpsTracker from "../Core/FpsTracker.js";
 
 const requestRenderAfterFrame = function (scene) {
   return function () {

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -578,7 +578,7 @@ function handleZoom(
   const minDistance = distanceMeasure - minHeight;
 
   let fpsMultiplier = 1;
-  const fps = object.frameRateMonitor.lastFramesPerSecond;
+  const fps = object.frameRateMonitor.averageFramesPerSecond;
   if (fps) {
     fpsMultiplier = 30 / fps;
   }

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -579,6 +579,7 @@ function handleZoom(
 
   let fpsMultiplier = 1;
   const fps = object.frameRateMonitor.averageFramesPerSecond;
+  // we set the ideal browser refresh rate to 30hz
   if (fps) {
     fpsMultiplier = 30 / fps;
   }

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -577,11 +577,11 @@ function handleZoom(
 
   const minDistance = distanceMeasure - minHeight;
 
-  let fpsMultiplier = 1;
+  let fpsMultiplier = 1.0;
   const fps = object.frameRateMonitor.averageFramesPerSecond;
-  // we set the ideal browser refresh rate to 30hz
-  if (fps) {
-    fpsMultiplier = 30 / fps;
+  // we set the ideal browser refresh rate to 60hz
+  if (defined(fps) && fps > 0) {
+    fpsMultiplier = 60.0 / fps;
   }
 
   let zoomRate = zoomFactor * minDistance * fpsMultiplier;

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -25,6 +25,7 @@ import MapMode2D from "./MapMode2D.js";
 import SceneMode from "./SceneMode.js";
 import SceneTransforms from "./SceneTransforms.js";
 import TweenCollection from "./TweenCollection.js";
+import FrameRateMonitor from "./FrameRateMonitor.js";
 
 /**
  * Modifies the camera position and orientation based on mouse input to a canvas.
@@ -144,6 +145,8 @@ function ScreenSpaceCameraController(scene) {
    * @default 5.0
    */
   this.zoomFactor = 5.0;
+
+  this.frameRateMonitor = FrameRateMonitor.fromScene(scene);
 
   /**
    * The input that allows the user to pan around the map. This only applies in 2D and Columbus view modes.
@@ -573,7 +576,15 @@ function handleZoom(
   const maxHeight = object.maximumZoomDistance;
 
   const minDistance = distanceMeasure - minHeight;
-  let zoomRate = zoomFactor * minDistance;
+
+  let fpsMultiplier = 1;
+  const fps = object.frameRateMonitor.lastFramesPerSecond;
+  if (fps) {
+    fpsMultiplier = 30 / fps;
+  }
+
+  let zoomRate = zoomFactor * minDistance * fpsMultiplier;
+
   zoomRate = CesiumMath.clamp(
     zoomRate,
     object._minimumZoomRate,

--- a/packages/engine/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/packages/engine/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -22,6 +22,7 @@ import {
 import createCamera from "../../../../Specs/createCamera.js";
 import createCanvas from "../../../../Specs/createCanvas.js";
 import DomEventSimulator from "../../../../Specs/DomEventSimulator.js";
+import Event from "../../Source/Core/Event.js";
 
 describe("Scene/ScreenSpaceCameraController", function () {
   let usePointerEvents;
@@ -41,6 +42,7 @@ describe("Scene/ScreenSpaceCameraController", function () {
     this.screenSpaceCameraController = undefined;
     this.cameraUnderground = false;
     this.globeHeight = 0.0;
+    this.preUpdate = new Event();
   }
 
   function MockGlobe(ellipsoid) {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Bases zoom speed on the render rate of the user's browser.
Added fields in FrameRateMonitor to track the timestamps of the n most recent renders.
Then when calculating the zoom distance on each frame, adjust it based on the fps zoom speed to provide consistent experience for browsers with different speeds.
If the user wants faster or slower zoom, they can still adjust zoomFactor through the public api as before with the same effects.

## Issue number and link
https://github.com/CesiumGS/cesium/issues/12187

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
