### PR TITLE
Fix issue with copying to a texture from a HTMLVideoElement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 ##### Fixes :wrench:
 
+- Fix Texture errors when using a `HTMLVideoElement`. [#12219](https://github.com/CesiumGS/cesium/issues/12219)
 - Use first geometryBuffer if no best match found in I3SNode [#12132](https://github.com/CesiumGS/cesium/pull/12132)
 - Update type definitions to allow undefined for optional parameters [#12193](https://github.com/CesiumGS/cesium/pull/12193)
 - Reverts Firefox OIT temporary fix [#4815] and Firefox test failure fix [#5047]

--- a/packages/engine/Source/Renderer/Texture.js
+++ b/packages/engine/Source/Renderer/Texture.js
@@ -815,14 +815,12 @@ Texture.prototype.copyFrom = function (options) {
   const arrayBufferView = source.arrayBufferView;
 
   // Make sure we are using the element's intrinsic width and height where available
-  if (defined(source.naturalWidth) && defined(source.naturalHeight)) {
-    width = source.naturalWidth;
-    height = source.naturalHeight;
-  }
-
   if (defined(source.videoWidth) && defined(source.videoHeight)) {
     width = source.videoWidth;
     height = source.videoHeight;
+  } else if (defined(source.naturalWidth) && defined(source.naturalHeight)) {
+    width = source.naturalWidth;
+    height = source.naturalHeight;
   }
 
   const textureWidth = this._width;

--- a/packages/engine/Source/Renderer/Texture.js
+++ b/packages/engine/Source/Renderer/Texture.js
@@ -60,11 +60,12 @@ function Texture(options) {
 
   let { width, height } = options;
   if (defined(source)) {
+    // Make sure we are using the element's intrinsic width and height where available
     if (!defined(width)) {
-      width = defaultValue(source.videoWidth, source.width);
+      width = source.videoWidth ?? source.naturalWidth ?? source.width;
     }
     if (!defined(height)) {
-      height = defaultValue(source.videoHeight, source.height);
+      height = source.videoHeight ?? source.naturalHeight ?? source.height;
     }
   }
 
@@ -810,7 +811,19 @@ Texture.prototype.copyFrom = function (options) {
   gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(target, this._texture);
 
-  const { width, height, arrayBufferView } = source;
+  let { width, height } = source;
+  const arrayBufferView = source.arrayBufferView;
+
+  // Make sure we are using the element's intrinsic width and height where available
+  if (defined(source.naturalWidth) && defined(source.naturalHeight)) {
+    width = source.naturalWidth;
+    height = source.naturalHeight;
+  }
+
+  if (defined(source.videoWidth) && defined(source.videoHeight)) {
+    width = source.videoWidth;
+    height = source.videoHeight;
+  }
 
   const textureWidth = this._width;
   const textureHeight = this._height;

--- a/packages/engine/Specs/Renderer/TextureSpec.js
+++ b/packages/engine/Specs/Renderer/TextureSpec.js
@@ -114,7 +114,15 @@ describe(
       context.destroyForSpecs();
     });
 
+    let blueImageHeight, blueImageWidth;
+    beforeEach(function () {
+      blueImageHeight = blueImage.height;
+      blueImageWidth = blueImage.width;
+    });
+
     afterEach(function () {
+      blueImage.height = blueImageHeight;
+      blueImage.width = blueImageWidth;
       texture = texture && texture.destroy();
     });
 
@@ -656,6 +664,29 @@ describe(
         pixelDatatype: PixelDatatype.UNSIGNED_BYTE,
         width: blueImage.width,
         height: blueImage.height,
+      });
+
+      texture.copyFrom({
+        source: blueImage,
+      });
+
+      expect({
+        context: context,
+        fragmentShader: fs,
+        uniformMap: uniformMap,
+        epsilon: 1,
+      }).contextToRender([0, 0, 255, 255]);
+    });
+
+    it("can copy from a DOM element when display dimensions are 0", function () {
+      blueImage.height = 0;
+      blueImage.width = 0;
+
+      texture = new Texture({
+        context: context,
+        pixelFormat: PixelFormat.RGB,
+        pixelDatatype: PixelDatatype.UNSIGNED_BYTE,
+        source: blueImage,
       });
 
       texture.copyFrom({


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

A `HTMLVideoElement` has additional `videoHeight` and `videoWidth` properties. These are the [intrinsic dimensions](
https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoHeight#about_intrinsic_width_and_height). If we rely on the `height` and `width` values, we can get sub optimal values, and – as in the case of the reported bug – sometimes `0` values, which can break the WebGL operation entirely.

While I was in that code, I also opted to use [`naturalHeight`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/naturalHeight) and `naturalWidth` for `HTMLImageElement`, as those the intrinsic, not scaled, dimensions.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12219

## Testing plan

1. Visit the `Video.html` Sandcastle example
2. Ensure the video is running on the sphere
3. Open the development console and ensure no WebGL errors are reported


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
