### PR TITLE
Deprecated defaultValue.EMPTY_OBJECT and created EmptyObject standalone constant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+##### Deprecated :hourglass_flowing_sand:
+
+- `defaultValue.EMPTY_OBJECT` has been deprecated and will be removed in 1.125. Use `EmptyObject` instead.
+
 ### 1.122 - 2024-10-01
 
 #### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -207,6 +207,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 
+- [Paul An](https://github.com/anpaulan)
 - [Brandon Landry](https://github.com/hotpocket)
 - [Victor Berchet](https://github.com/vicb)
 - [Caleb Morse](https://github.com/cmorse)

--- a/packages/engine/Source/Core/EmptyObject.js
+++ b/packages/engine/Source/Core/EmptyObject.js
@@ -1,0 +1,8 @@
+/**
+ * A global immutable empty object for performance reasons
+ *
+ * @type {object}
+ */
+const EmptyObject = {};
+
+export default Object.freeze(EmptyObject);

--- a/packages/engine/Source/Core/defaultValue.js
+++ b/packages/engine/Source/Core/defaultValue.js
@@ -1,19 +1,16 @@
 /**
  * Returns the first parameter if not undefined, otherwise the second parameter.
  * Useful for setting a default value for a parameter.
- * @namespace defaultValue
- * @global
  * @function
- * 
+ *
  * @param {*} a
  * @param {*} b
  * @returns {*} Returns the first parameter if not undefined, otherwise the second parameter.
  *
  * @example
  * param = Cesium.defaultValue(param, 'default');
- * 
- * @property {object} EMPTY_OBJECT - A frozen empty object that can be used as the default value 
- * for options passed as an object literal.
+ *
+ * @property {object} EMPTY_OBJECT - A frozen empty object that can be used as the default value for options passed as an object literal.
  */
 function defaultValue(a, b) {
   if (a !== undefined && a !== null) {

--- a/packages/engine/Source/Core/defaultValue.js
+++ b/packages/engine/Source/Core/defaultValue.js
@@ -1,15 +1,19 @@
 /**
  * Returns the first parameter if not undefined, otherwise the second parameter.
  * Useful for setting a default value for a parameter.
- *
+ * @namespace defaultValue
+ * @global
  * @function
- *
+ * 
  * @param {*} a
  * @param {*} b
  * @returns {*} Returns the first parameter if not undefined, otherwise the second parameter.
  *
  * @example
  * param = Cesium.defaultValue(param, 'default');
+ * 
+ * @property {object} EMPTY_OBJECT - A frozen empty object that can be used as the default value 
+ * for options passed as an object literal.
  */
 function defaultValue(a, b) {
   if (a !== undefined && a !== null) {
@@ -19,10 +23,8 @@ function defaultValue(a, b) {
 }
 
 /**
- * A frozen empty object that can be used as the default value for options passed as
- * an object literal.
  * @type {object}
- * @memberof defaultValue
+ * @constant
  */
 defaultValue.EMPTY_OBJECT = Object.freeze({});
 

--- a/packages/engine/Source/Core/defaultValue.js
+++ b/packages/engine/Source/Core/defaultValue.js
@@ -1,3 +1,6 @@
+import EmptyObject from "./EmptyObject.js";
+import deprecationWarning from "./deprecationWarning.js";
+
 /**
  * Returns the first parameter if not undefined, otherwise the second parameter.
  * Useful for setting a default value for a parameter.
@@ -10,7 +13,8 @@
  * @example
  * param = Cesium.defaultValue(param, 'default');
  *
- * @property {object} EMPTY_OBJECT - A frozen empty object that can be used as the default value for options passed as an object literal.
+ * @property {object} EMPTY_OBJECT - DEPRECATED (use EmptyObject). <br>
+ * A frozen empty object that can be used as the default value for options passed as an object literal.
  */
 function defaultValue(a, b) {
   if (a !== undefined && a !== null) {
@@ -22,7 +26,17 @@ function defaultValue(a, b) {
 /**
  * @type {object}
  * @constant
+ * @deprecated This property is deprecated and will be removed in Cesium 1.122. See <a href="https://github.com/CesiumGS/cesium/issues/11326">Issue 113216</a>
  */
-defaultValue.EMPTY_OBJECT = Object.freeze({});
+Object.defineProperty(defaultValue, "EMPTY_OBJECT", {
+  get: function () {
+    deprecationWarning(
+      "defaultValue.EMPTY_OBJECT",
+      "defaultValue.EMPTY_OBJECT is deprecated and will be removed in Cesium 1.122. See https://github.com/CesiumGS/cesium/issues/11326",
+    );
+    return EmptyObject;
+  },
+  configurable: false,
+});
 
 export default defaultValue;

--- a/packages/engine/Source/Core/defaultValue.js
+++ b/packages/engine/Source/Core/defaultValue.js
@@ -26,13 +26,13 @@ function defaultValue(a, b) {
 /**
  * @type {object}
  * @constant
- * @deprecated This property is deprecated and will be removed in Cesium 1.122. See <a href="https://github.com/CesiumGS/cesium/issues/11326">Issue 113216</a>
+ * @deprecated This property is deprecated and will be removed in Cesium 1.125. See <a href="https://github.com/CesiumGS/cesium/issues/11326">Issue 113216</a>
  */
 Object.defineProperty(defaultValue, "EMPTY_OBJECT", {
   get: function () {
     deprecationWarning(
       "defaultValue.EMPTY_OBJECT",
-      "defaultValue.EMPTY_OBJECT is deprecated and will be removed in Cesium 1.122. See https://github.com/CesiumGS/cesium/issues/11326",
+      "defaultValue.EMPTY_OBJECT is deprecated and will be removed in Cesium 1.125. See https://github.com/CesiumGS/cesium/issues/11326",
     );
     return EmptyObject;
   },


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

- Fixed missing JSDOC for `EMPTY_OBJECT`
- Deprecated `EMPTY_OBJECT` property in `defaultValue` 
- Created standalone `EmptyObject` constant (via `EmptyObject.js`) per recommendation

Collaborated with @hotpocket 

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

Fixes Issue #11326 

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

Tried to run this test in defaultValueSpec.js, but console.warn was not called: test did not run as expected.

```javascript
it("Calls console.warn", function () {
    spyOn(console, 'warn');
    defaultValue.EMPTY_OBJECT
    expect(console.warn).toHaveBeenCalled();
  });
```
# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code