### PR TITLE
Debugging CI failures

### DIFF
--- a/Specs/pollToPromise.js
+++ b/Specs/pollToPromise.js
@@ -15,6 +15,8 @@ function pollToPromise(f, options) {
       try {
         result = f();
       } catch (e) {
+        console.error(`Error '${e}' thrown in polled function ${f}`);
+        console.trace();
         reject(e);
         return;
       }

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -4170,6 +4170,11 @@ function tryAndCatchError(scene, functionToExecute) {
   try {
     functionToExecute(scene);
   } catch (error) {
+    console.error(
+      `Error '${error}' thrown in delegate function ${functionToExecute}`,
+    );
+    console.trace();
+
     scene._renderError.raiseEvent(scene, error);
 
     if (scene.rethrowRenderErrors) {


### PR DESCRIPTION
This mainly refers to https://github.com/CesiumGS/cesium/issues/11958 (and the tests that already have been excluded due to this error). 

Unfortunately, these errors **only** seem to happen in CI (at least, I could not yet reproduce them locally). But they nearly **always** happen there (and I had to re-run CI several times for the last PRs). 

I don't know a sensible way of debugging something like that. If someone knows a _deterministic_ way: Let me know. 
And I cannot imagine why someone should throw `undefined` anywhere to begin with. If someone knows a reason (and a way how to even figure out where it was thrown): Let me know. 

Until then, let's see whether I can make that annoying, frustrating green checkmark that I already see below turn into an ❌ ...

