### PR TITLE
Fix for possible normalization issue for line corner points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 - Fix flickering issue caused by bounding sphere retrieval being blocked by the bounding sphere of another entity. [#12230](https://github.com/CesiumGS/cesium/pull/12230)
 
+- Fix error with normalization of corner points for lines and corridors with collinear points.
+
 ### 1.122 - 2024-10-01
 
 #### @cesium/engine

--- a/packages/engine/Source/Core/CorridorGeometryLibrary.js
+++ b/packages/engine/Source/Core/CorridorGeometryLibrary.js
@@ -256,10 +256,6 @@ CorridorGeometryLibrary.computePositions = function (params) {
       Cartesian3.subtract(nextPosition, position, forward),
       forward,
     );
-    cornerDirection = Cartesian3.normalize(
-      Cartesian3.add(forward, backward, cornerDirection),
-      cornerDirection,
-    );
 
     const forwardProjection = Cartesian3.multiplyByScalar(
       normal,
@@ -284,6 +280,10 @@ CorridorGeometryLibrary.computePositions = function (params) {
     );
 
     if (doCorner) {
+      cornerDirection = Cartesian3.normalize(
+        Cartesian3.add(forward, backward, cornerDirection),
+        cornerDirection,
+      );
       cornerDirection = Cartesian3.cross(
         cornerDirection,
         normal,

--- a/packages/engine/Source/Core/PolylineVolumeGeometryLibrary.js
+++ b/packages/engine/Source/Core/PolylineVolumeGeometryLibrary.js
@@ -434,8 +434,6 @@ PolylineVolumeGeometryLibrary.computePositions = function (
     }
     forward = Cartesian3.subtract(nextPosition, position, forward);
     forward = Cartesian3.normalize(forward, forward);
-    cornerDirection = Cartesian3.add(forward, backward, cornerDirection);
-    cornerDirection = Cartesian3.normalize(cornerDirection, cornerDirection);
     surfaceNormal = ellipsoid.geodeticSurfaceNormal(position, surfaceNormal);
 
     const forwardProjection = Cartesian3.multiplyByScalar(
@@ -461,6 +459,8 @@ PolylineVolumeGeometryLibrary.computePositions = function (
     );
 
     if (doCorner) {
+      cornerDirection = Cartesian3.add(forward, backward, cornerDirection);
+      cornerDirection = Cartesian3.normalize(cornerDirection, cornerDirection);
       cornerDirection = Cartesian3.cross(
         cornerDirection,
         surfaceNormal,


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

If points in PolylineVolume or Corridor are collinear, computation fails with error "Normalized result is not a number" in the line below, because sum of normalized forward and backward vectors is zero.

https://github.com/CesiumGS/cesium/blob/0e9a425b475cd3cfdd90f35e9cdbdda453e448d8/packages/engine/Source/Core/PolylineVolumeGeometryLibrary.js#L438

The `cornerDirection` variable is only used within the `doCorner === true` execution branch, so I moved it inside the branch for better scoping. From my understanding, the forward and backward projection checks within the `doCorner` condition exclude the computation of corners for collinear points. As a result, normalizing `cornerDirection` in this execution branch should not cause any errors.

## Issue number and link

Fixes #12254

## Testing plan

This issue is difficult to replicate. I encountered it by chance, with the data shown in Sandcastle example attached to related issue.
I haven't yet found a way to generate synthetic data to reproduce the issue, mainly due to the `scaleToSurface` call, which modifies coordinates based on a specific location.

https://github.com/CesiumGS/cesium/blob/0e9a425b475cd3cfdd90f35e9cdbdda453e448d8/packages/engine/Source/Core/PolylineVolumeGeometryLibrary.js#L35

To test it, I followed this approach:
- I created a simplified version of `computePositions` that omits the scaleToSurface call and other irrelevant operations. This resulted in a "Normalized result is not a number" error when passing a simple collinear line like `[[0,0,0], [1,1,1], [2,2,2], [3,3,3]]` as the `positions` input.
- I also tested the problematic data locally, both before and after the changes. The error was resolved after applying the changes.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
