### PR TITLE
Don't rebuild during the release process

### DIFF
--- a/Documentation/Contributors/ReleaseGuide/README.md
+++ b/Documentation/Contributors/ReleaseGuide/README.md
@@ -41,7 +41,7 @@ There is no release manager; instead, our community shares the responsibility. A
 13. Run `npm install`.
 14. Make sure `ThirdParty.json` is up to date by running `npm run build-third-party`. If there are any changes, verify and commit them.
 15. Create the release zip `npm run make-zip`.
-16. Run tests against the release `npm run test -- --failTaskOnError --release`. Test **in all browsers** with the `--browsers` flag (i.e. `--browsers Firefox,Chrome`). Alternatively, test with the browser Spec Runner by starting a local server (`npm start`) and browsing to http://localhost:8080/Specs/SpecRunner.html?built=true&release=true.
+16. Run tests against the release `npm run test -- --failTaskOnError --release`. Test **in all browsers** with the `--browsers` flag (i.e. `--browsers Firefox,Chrome`). Alternatively, test with the browser Spec Runner by starting a local server (`npm start -- --production`) and browsing to http://localhost:8080/Specs/SpecRunner.html?built=true&release=true.
 17. Run end to end tests against the release with `npm run test-e2e-release`, or multiple browsers with `npm run test-e2e-release-all`.
 18. Unpack the release zip to the directory of your choice and start the server by running `npm install` and then `npm start`
 19. Browse to http://localhost:8080 and confirm that the home page loads as expected and all links work.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1006,7 +1006,7 @@ export async function test() {
     workspace = workspace.replaceAll(`@${scope}/`, ``);
   }
 
-  if (!isProduction) {
+  if (!isProduction && !release) {
     console.log("Building specs...");
     await buildCesium({
       iife: true,


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The past couple releases we've had some extra `.map.js` files bleed through into the published version. These cause warnings for users downstream. See https://github.com/CesiumGS/cesium/issues/12182

It seems these are generated when we run `npm run test` even with the `--release` option. I also noticed these would be generated any time we run `npm start` without `--production` as the dev server does a build when it starts up.

This PR adds a check for the release flag to skip building for `npm run test`. It also updates the release guide to specify the dev server should only be started with the `--production` flag.

One extra precaution we could add is a `prepublishOnly` [lifecycle script](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts) to our `package.json` that calls `npm run make-zip` right before publish. Would make the publish command slower but guarantee we always build the version of files we want published.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12182

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `git clean -dxf` to remove all extra files
- Run `npm run make-zip` like you would during the release
- Run `npm run test -- --failTaskOnError --release` like in the [release guide](https://github.com/CesiumGS/cesium/blob/main/Documentation/Contributors/ReleaseGuide/README.md)
- Make sure there are no messages about building and no `.map.js` files generated

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
