### PR TITLE
Update Viewer timeline when data sources change

### DIFF
--- a/Apps/Sandcastle/gallery/CZML Model - Node Transformations.html
+++ b/Apps/Sandcastle/gallery/CZML Model - Node Transformations.html
@@ -36,8 +36,8 @@
             name: "CZML Model",
             version: "1.0",
             clock: {
-              interval: "2015-01-01T00:00:00Z/2015-01-01T00:00:20Z",
-              currentTime: "2015-01-01T00:00:00Z",
+              interval: "2015-01-01T12:00:00Z/2015-01-01T12:00:20Z",
+              currentTime: "2015-01-01T12:00:00Z",
               multiplier: 20,
             },
           },
@@ -55,7 +55,7 @@
               nodeTransformations: {
                 Skeleton_arm_joint_L__3_: {
                   rotation: {
-                    epoch: "2015-01-01T00:00:00Z",
+                    epoch: "2015-01-01T12:00:00Z",
                     unitQuaternion: [
                       0, -0.23381920887303329, -0.6909886782144156, -0.0938384854833712,
                       0.6775378681547408, 10, -0.4924076887347565, -0.6304934596091216,

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -1926,6 +1926,14 @@ Viewer.prototype._onDataSourceAdded = function (
   dataSourceCollection,
   dataSource,
 ) {
+  if (
+    this._cesiumWidget._automaticallyTrackDataSourceClocks &&
+    dataSource === this.clockTrackedDataSource
+  ) {
+    // When data sources are added to the CesiumWidget they may be automatically
+    // tracked in that class but we also need to update the timeline in this class
+    linkTimelineToDataSourceClock(this._timeline, dataSource);
+  }
   const id = dataSource.entities.id;
   const removalFunc = this._eventHelper.add(
     dataSource.changedEvent,


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

In https://github.com/CesiumGS/cesium/pull/12202 we moved most of the tracking logic into the `CesiumWidget` class. However this skipped the update for the timeline to zoom it to the correct time period when data sources are added, like in this [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=CZML%20Model%20-%20Node%20Transformations.html)

There may be a cleaner solution here but I think this closely matches the previous behavior. Longer term I would've expected the timeline to reflect the values of the `clock` closer including the start/end times like the Animation widget does.

(We also noticed the model disappears but that's a separate issue https://github.com/CesiumGS/cesium/issues/12282)

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Open the [CZML Model - Node Transformation](http://localhost:8080/Apps/Sandcastle/index.html?src=CZML%20Model%20-%20Node%20Transformations.html) sandcastle
- Make sure the timeline is zoomed to the correct time frame for the model's availability
- Make sure the timeline head is still looping the full timeline correcly.

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
