### PR TITLE
Add fallback spherical harmonics when dynamic environment lighting is unsupported

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Change Log
 
+### 1.123.1 - 2024-11-07
+
+#### @cesium/engine
+
+##### Additions :tada:
+
+- Added fallback diffuse lighting, `DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS`, that is used when `DynamicEnvironmentMapManager` is disabled or unsupported. [#12292](https://github.com/CesiumGS/cesium/pull/12292)
+- Added `DynamicEnvironmentMapManager.isDynamicUpdateSupported` to check if dynamic environment map updates are supported. [#12292](https://github.com/CesiumGS/cesium/pull/12292)
+
 ### 1.123 - 2024-11-01
 
 #### @cesium/engine

--- a/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
+++ b/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
@@ -729,6 +729,8 @@ function updateSphericalHarmonicCoefficients(manager, frameState) {
 DynamicEnvironmentMapManager.prototype.update = function (frameState) {
   const mode = frameState.mode;
   const isSupported =
+    // A FrameState type works here because the function only references the context parameter.
+    // @ts-ignore
     DynamicEnvironmentMapManager.isDynamicUpdateSupported(frameState);
 
   if (
@@ -849,13 +851,11 @@ DynamicEnvironmentMapManager.prototype.destroy = function () {
  * Returns <code>true</code> if dynamic updates are supported in the current WebGL rendering context.
  * Dynamic updates requires the EXT_color_buffer_float or EXT_color_buffer_half_float extension.
  *
- * @param {Scene} contextOption The object containing the rendering context
+ * @param {Scene} scene The object containing the rendering context
  * @returns {boolean} true if supported
  */
-DynamicEnvironmentMapManager.isDynamicUpdateSupported = function (
-  contextOption,
-) {
-  const context = contextOption.context;
+DynamicEnvironmentMapManager.isDynamicUpdateSupported = function (scene) {
+  const context = scene.context;
   return context.halfFloatingPointTexture || context.colorBufferFloat;
 };
 

--- a/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
+++ b/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
@@ -96,7 +96,7 @@ function DynamicEnvironmentMapManager(options) {
   this._irradianceMapTexture = undefined;
 
   this._sphericalHarmonicCoefficients =
-    DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS.slice();
+    DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS.slice();
 
   this._lastTime = new JulianDate();
   const width = Math.pow(2, mipmapLevels - 1);
@@ -849,7 +849,7 @@ DynamicEnvironmentMapManager.prototype.destroy = function () {
  * Returns <code>true</code> if dynamic updates are supported in the current WebGL rendering context.
  * Dynamic updates requires the EXT_color_buffer_float or EXT_color_buffer_half_float extension.
  *
- * @param {Scene|FrameState} contextOption The object containing the rendering context
+ * @param {Scene} contextOption The object containing the rendering context
  * @returns {boolean} true if supported
  */
 DynamicEnvironmentMapManager.isDynamicUpdateSupported = function (
@@ -878,7 +878,7 @@ DynamicEnvironmentMapManager.AVERAGE_EARTH_GROUND_COLOR = Object.freeze(
  * @type {Cartesian3[]}
  * @see {@link https://graphics.stanford.edu/papers/envmap/envmap.pdf|An Efficient Representation for Irradiance Environment Maps}
  */
-DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS =
+DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS =
   Object.freeze([
     Object.freeze(new Cartesian3(0.35449, 0.35449, 0.35449)),
     Cartesian3.ZERO,

--- a/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
+++ b/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
@@ -95,7 +95,8 @@ function DynamicEnvironmentMapManager(options) {
   this._radianceCubeMap = undefined;
   this._irradianceMapTexture = undefined;
 
-  this._sphericalHarmonicCoefficients = new Array(9);
+  this._sphericalHarmonicCoefficients =
+    DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS.slice();
 
   this._lastTime = new JulianDate();
   const width = Math.pow(2, mipmapLevels - 1);
@@ -727,8 +728,11 @@ function updateSphericalHarmonicCoefficients(manager, frameState) {
  */
 DynamicEnvironmentMapManager.prototype.update = function (frameState) {
   const mode = frameState.mode;
+  const isSupported =
+    DynamicEnvironmentMapManager.isDynamicUpdateSupported(frameState);
 
   if (
+    !isSupported ||
     !this.enabled ||
     !this.shouldUpdate ||
     !defined(this._position) ||
@@ -842,11 +846,49 @@ DynamicEnvironmentMapManager.prototype.destroy = function () {
 };
 
 /**
+ * Returns <code>true</code> if dynamic updates are supported in the current WebGL rendering context.
+ * Dynamic updates requires the EXT_color_buffer_float or EXT_color_buffer_half_float extension.
+ *
+ * @param {Scene|FrameState} contextOption The object containing the rendering context
+ * @returns {boolean} true if supported
+ */
+DynamicEnvironmentMapManager.isDynamicUpdateSupported = function (
+  contextOption,
+) {
+  const context = contextOption.context;
+  return context.halfFloatingPointTexture || context.colorBufferFloat;
+};
+
+/**
  * Average hue of ground color on earth, a warm green-gray.
  * @type {Color}
+ * @readonly
  */
 DynamicEnvironmentMapManager.AVERAGE_EARTH_GROUND_COLOR = Object.freeze(
   Color.fromCssColorString("#717145"),
 );
+
+/**
+ * The default third order spherical harmonic coefficients used for the diffuse color of image-based lighting, a white ambient light with low intensity.
+ * <p>
+ * There are nine <code>Cartesian3</code> coefficients.
+ * The order of the coefficients is: L<sub>0,0</sub>, L<sub>1,-1</sub>, L<sub>1,0</sub>, L<sub>1,1</sub>, L<sub>2,-2</sub>, L<sub>2,-1</sub>, L<sub>2,0</sub>, L<sub>2,1</sub>, L<sub>2,2</sub>
+ * </p>
+ * @readonly
+ * @type {Cartesian3[]}
+ * @see {@link https://graphics.stanford.edu/papers/envmap/envmap.pdf|An Efficient Representation for Irradiance Environment Maps}
+ */
+DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS =
+  Object.freeze([
+    Object.freeze(new Cartesian3(0.35449, 0.35449, 0.35449)),
+    Cartesian3.ZERO,
+    Cartesian3.ZERO,
+    Cartesian3.ZERO,
+    Cartesian3.ZERO,
+    Cartesian3.ZERO,
+    Cartesian3.ZERO,
+    Cartesian3.ZERO,
+    Cartesian3.ZERO,
+  ]);
 
 export default DynamicEnvironmentMapManager;

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -211,9 +211,6 @@ describe(
 
       options = {
         cullRequestsWhileMoving: false,
-        environmentMapOptions: {
-          enabled: scene.highDynamicRangeSupported,
-        },
       };
     });
 

--- a/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
+++ b/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
@@ -61,7 +61,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
 
     expect(manager.sphericalHarmonicCoefficients.length).toBe(9);
     expect(manager.sphericalHarmonicCoefficients).toEqual(
-      DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+      DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS,
     );
   });
 
@@ -111,7 +111,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         scene.renderForSpecs();
 
         expect(manager.sphericalHarmonicCoefficients).toEqual(
-          DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+          DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS,
         );
       });
 
@@ -133,7 +133,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         scene.renderForSpecs();
 
         expect(manager.sphericalHarmonicCoefficients).toEqual(
-          DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+          DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS,
         );
       });
 
@@ -159,7 +159,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         scene.renderForSpecs();
 
         expect(manager.sphericalHarmonicCoefficients).toEqual(
-          DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+          DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS,
         );
       });
 

--- a/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
+++ b/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
@@ -31,6 +31,40 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
     expect(manager.groundAlbedo).toBe(0.31);
   });
 
+  it("constructs with options", function () {
+    const manager = new DynamicEnvironmentMapManager({
+      enabled: false,
+      maximumSecondsDifference: 0,
+      maximumPositionEpsilon: 0,
+      atmosphereScatteringIntensity: 0,
+      gamma: 0,
+      brightness: 0,
+      saturation: 0,
+      groundColor: Color.BLUE,
+      groundAlbedo: 0,
+    });
+
+    expect(manager.enabled).toBeFalse();
+    expect(manager.shouldUpdate).toBeTrue();
+    expect(manager.maximumSecondsDifference).toBe(0);
+    expect(manager.maximumPositionEpsilon).toBe(0);
+    expect(manager.atmosphereScatteringIntensity).toBe(0);
+    expect(manager.gamma).toBe(0);
+    expect(manager.brightness).toBe(0);
+    expect(manager.saturation).toBe(0);
+    expect(manager.groundColor).toEqual(Color.BLUE);
+    expect(manager.groundAlbedo).toBe(0);
+  });
+
+  it("uses default spherical harmonic coefficients", () => {
+    const manager = new DynamicEnvironmentMapManager();
+
+    expect(manager.sphericalHarmonicCoefficients.length).toBe(9);
+    expect(manager.sphericalHarmonicCoefficients).toEqual(
+      DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+    );
+  });
+
   describe(
     "render tests",
     () => {
@@ -53,7 +87,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         scene.atmosphere = new Atmosphere();
       });
 
-      // Allows the compute commands to be added to the command list at the right point in the pipeline
+      // A pared-down Primitive. Allows the compute commands to be added to the command list at the right point in the pipeline.
       function EnvironmentMockPrimitive(manager) {
         this.update = function (frameState) {
           manager.update(frameState);
@@ -64,8 +98,74 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         };
       }
 
+      it("does not update if position is undefined", async function () {
+        const manager = new DynamicEnvironmentMapManager();
+
+        const primitive = new EnvironmentMockPrimitive(manager);
+        scene.primitives.add(primitive);
+
+        scene.renderForSpecs();
+
+        expect(manager.radianceCubeMap).toBeUndefined();
+
+        scene.renderForSpecs();
+
+        expect(manager.sphericalHarmonicCoefficients).toEqual(
+          DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+        );
+      });
+
+      it("does not update if enabled is false", async function () {
+        const manager = new DynamicEnvironmentMapManager();
+
+        const cartographic = Cartographic.fromDegrees(-75.165222, 39.952583);
+        manager.position =
+          Ellipsoid.WGS84.cartographicToCartesian(cartographic);
+        manager.enabled = false;
+
+        const primitive = new EnvironmentMockPrimitive(manager);
+        scene.primitives.add(primitive);
+
+        scene.renderForSpecs();
+
+        expect(manager.radianceCubeMap).toBeUndefined();
+
+        scene.renderForSpecs();
+
+        expect(manager.sphericalHarmonicCoefficients).toEqual(
+          DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+        );
+      });
+
+      it("does not update if requires extensions are not available", async function () {
+        spyOn(
+          DynamicEnvironmentMapManager,
+          "isDynamicUpdateSupported",
+        ).and.returnValue(false);
+
+        const manager = new DynamicEnvironmentMapManager();
+
+        const cartographic = Cartographic.fromDegrees(-75.165222, 39.952583);
+        manager.position =
+          Ellipsoid.WGS84.cartographicToCartesian(cartographic);
+
+        const primitive = new EnvironmentMockPrimitive(manager);
+        scene.primitives.add(primitive);
+
+        scene.renderForSpecs();
+
+        expect(manager.radianceCubeMap).toBeUndefined();
+
+        scene.renderForSpecs();
+
+        expect(manager.sphericalHarmonicCoefficients).toEqual(
+          DynamicEnvironmentMapManager.DEAFULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+        );
+      });
+
       it("creates environment map and spherical harmonics at surface in Philadelphia with static lighting", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -146,7 +246,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("creates environment map and spherical harmonics at altitude in Philadelphia with static lighting", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -231,7 +332,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("creates environment map and spherical harmonics above Earth's atmosphere with static lighting", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -317,7 +419,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("creates environment map and spherical harmonics at surface in Philadelphia with dynamic lighting", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -401,7 +504,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("creates environment map and spherical harmonics at surface in Sydney with dynamic lighting", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -485,7 +589,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("lighting uses atmosphere properties", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -572,10 +677,10 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("lighting uses atmosphereScatteringIntensity value", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
-
         const manager = new DynamicEnvironmentMapManager();
         manager.atmosphereScatteringIntensity = 1.0;
 
@@ -654,7 +759,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("lighting uses gamma value", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -736,7 +842,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("lighting uses brightness value", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -818,7 +925,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("lighting uses saturation value", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -900,7 +1008,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("lighting uses ground color value", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -982,7 +1091,8 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("lighting uses ground albedo value", async function () {
-        if (!scene.highDynamicRangeSupported) {
+        // Skip if required WebGL extensions are not supported
+        if (!DynamicEnvironmentMapManager.isDynamicUpdateSupported(scene)) {
           return;
         }
 
@@ -1064,18 +1174,6 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
       });
 
       it("destroys", function () {
-        if (!scene.highDynamicRangeSupported) {
-          const manager = new DynamicEnvironmentMapManager();
-          const cartographic = Cartographic.fromDegrees(-75.165222, 39.952583);
-          manager.position =
-            Ellipsoid.WGS84.cartographicToCartesian(cartographic);
-
-          manager.destroy();
-
-          expect(manager.isDestroyed()).toBe(true);
-          return;
-        }
-
         const manager = new DynamicEnvironmentMapManager();
         const cartographic = Cartographic.fromDegrees(-75.165222, 39.952583);
         manager.position =

--- a/packages/engine/Specs/Scene/Model/ModelSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelSpec.js
@@ -3113,10 +3113,13 @@ describe(
           {
             gltf: boxTexturedGltfUrl,
             lightColor: Cartesian3.ZERO,
-            imageBasedLighting: undefined,
           },
           scene,
         );
+
+        // ignore any image-based lighting– Test directional light only
+        model.imageBasedLighting.imageBasedLightingFactor = Cartesian2.ZERO;
+
         verifyRender(model, false);
       });
 
@@ -3125,6 +3128,10 @@ describe(
           { gltf: boxTexturedGltfUrl, imageBasedLighting: undefined },
           scene,
         );
+
+        // ignore any image-based lighting– Test directional light only
+        model.imageBasedLighting.imageBasedLightingFactor = Cartesian2.ZERO;
+
         model.lightColor = Cartesian3.ZERO;
         verifyRender(model, false);
 
@@ -3193,7 +3200,7 @@ describe(
       it("changing imageBasedLighting works", async function () {
         const imageBasedLighting = new ImageBasedLighting({
           sphericalHarmonicCoefficients: [
-            new Cartesian3(0.35449, 0.35449, 0.35449),
+            new Cartesian3(1.0, 0.0, 0.0),
             Cartesian3.ZERO,
             Cartesian3.ZERO,
             Cartesian3.ZERO,

--- a/packages/engine/Specs/Scene/Model/loadAndZoomToModelAsync.js
+++ b/packages/engine/Specs/Scene/Model/loadAndZoomToModelAsync.js
@@ -1,20 +1,5 @@
-import { Model, ImageBasedLighting, Cartesian3 } from "../../../index.js";
+import { Model } from "../../../index.js";
 import pollToPromise from "../../../../../Specs/pollToPromise.js";
-
-// A white ambient light with low intensity
-const defaultIbl = new ImageBasedLighting({
-  sphericalHarmonicCoefficients: [
-    new Cartesian3(0.35449, 0.35449, 0.35449),
-    Cartesian3.ZERO,
-    Cartesian3.ZERO,
-    Cartesian3.ZERO,
-    Cartesian3.ZERO,
-    Cartesian3.ZERO,
-    Cartesian3.ZERO,
-    Cartesian3.ZERO,
-    Cartesian3.ZERO,
-  ],
-});
 
 async function loadAndZoomToModelAsync(options, scene) {
   options = {
@@ -22,7 +7,6 @@ async function loadAndZoomToModelAsync(options, scene) {
       enabled: false, // disable other diffuse lighting by default
       ...options.environmentMapOptions,
     },
-    imageBasedLighting: defaultIbl,
     ...options,
   };
 

--- a/packages/engine/Specs/Scene/ShadowMapSpec.js
+++ b/packages/engine/Specs/Scene/ShadowMapSpec.js
@@ -11,7 +11,6 @@ import {
   HeadingPitchRange,
   HeadingPitchRoll,
   HeightmapTerrainData,
-  ImageBasedLighting,
   JulianDate,
   Math as CesiumMath,
   Matrix4,
@@ -282,26 +281,11 @@ describe(
     }
 
     async function loadModel(options) {
-      // A white ambient light with low intensity
-      const defaultIbl = new ImageBasedLighting({
-        sphericalHarmonicCoefficients: [
-          new Cartesian3(0.35449, 0.35449, 0.35449),
-          Cartesian3.ZERO,
-          Cartesian3.ZERO,
-          Cartesian3.ZERO,
-          Cartesian3.ZERO,
-          Cartesian3.ZERO,
-          Cartesian3.ZERO,
-          Cartesian3.ZERO,
-          Cartesian3.ZERO,
-        ],
-      });
       const model = scene.primitives.add(
         await Model.fromGltfAsync({
           environmentMapOptions: {
             enabled: false,
           },
-          imageBasedLighting: defaultIbl,
           ...options,
         }),
       );


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

While the extensions needed for dynamic environment lighting are available in most systems, we were seeing downstream testing difficulties when using a WebGL stub that didn't support the required WebGL extensions.

This change:
 * Is more explicit about requirements for dynamic updates to the environment map, adding a new function `DynamicEnvironmentMapManager.isDynamicUpdateSupported` to allow for checking.
 * Provides a default diffuse lighting when dynamic updates are _not_ supported. I picked an white ambient light with low intensity, as this is what we were already using in unit tests. This is accessible in `DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS` for convenience. 
 * Cleans up and adds tests

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

<img width="473" alt="image" src="https://github.com/user-attachments/assets/6a87de6f-daed-42c7-90de-967f577338fa">

_Diffuse lighting when dynamic updates are disabled or not supported_

<img width="422" alt="image" src="https://github.com/user-attachments/assets/ece61c2d-9c44-488f-b32a-aa9367f08dd7">

_Before: No diffuse light if dynamic updates were disabled_

## Issue number and link

N/A

## Testing plan

1. CI should pass (CI runs with `--webgl-stub`)
2. Local tests should pass
3. For extra credit, checkout the effect when setting `enabled` to `false`, as in [this Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dVTvb9owEP1XLLQPYUqdQGm7UYpWQbdVateqsEmb8qEmOcCqY0e2gbKK/30XOwTaUQkF/7j37t3z2amSxpIlhxVockEkrMgADF/k9JdbC5JG6uYDJS3jEnTSaJ4nMpGpQ+YqA/Hz4QaxSYPSCH8jlhcChsyyyO2a6J6tZPWlMzFJGnsEc+CzuUV4TOPzerF4I+Y7sIzL2T236fxBCRFgdEi2n2YNVJrPuERshRswbXHE5DGdapUPYaYBTHDUah/T+KzTOW19DkmnQ+OT+PgsPg0rOTtCV8Ets5o/71jHmkkzVTo3dP5G2Fh95c+QfdUsh8CrCctyvGdWr8lLIgnZI0dabz81KUigheY5t3wJhrIsC8poQtiKcbtNf1vCXD3fhJ1emrVMgxcfR8hCi259KuF2da+M7v5kF8Alzxf5PYoXI/4XuqTV/lTvglxyrWQO0t6y4q6wHPV3SZ20jGATAVmXTJkwsF3f+MGm6Zi8B5UYqtG59dUSKcs63eCGG4sW6CBokov+lt57laKhmu3M8vOKkZAoIn+UyolVnv4VFFtX49m4Dn/ltUmxHeSoYCkMHN+gDj3fZyiBbRqTjwRtm9OcPQe+iIlayPL8R8UcNFCNzbAwYSUWj2hhLB6YBOYaoCKsMtDK81L3ECtnMgXMozFLTE/qyqoa0B6n/2Bev/tKctWYu6Z1yq16wGXs3qB9XF2cHaQom/hdwFF7H+ALFEo9XdrApw/fvbBMziCoBIU+TejqRE+bBynrGxbsxGC7duj18OrH+Hr826M25d8GoaXwALRWuunbZsVlplaUoc82eLwqd4hQ3hJnYZd8eHGAzaMjSWQjbPSMXQvob9v3C88LpW15pwJ82Czgw8bwPYkmi/QJLE2N2arvRfvQXsaXhGcXBx5PkgpmDO5MF8LdtKTR70UY/x+0knu3BC3Yugybt/o3fpFS2otwehhplRITpt8w/wM)

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
