### PR TITLE
Fixes unhandled rejection in Skybox.update  #12306

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.124.0
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Handle uncaught promise rejection in `Skybox.update` that could cause tests to fail[#12307](https://github.com/CesiumGS/cesium/pull/12307)
+
 ### 1.123.1 - 2024-11-07
 
 #### @cesium/engine

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,5 @@
 # Change Log
 
-### 1.124.0
-
-#### @cesium/engine
-
-##### Fixes :wrench:
-
-- Handle uncaught promise rejection in `Skybox.update` that could cause tests to fail[#12307](https://github.com/CesiumGS/cesium/pull/12307)
-
 ### 1.123.1 - 2024-11-07
 
 #### @cesium/engine

--- a/packages/engine/Source/Scene/SkyBox.js
+++ b/packages/engine/Source/Scene/SkyBox.js
@@ -81,6 +81,8 @@ function SkyBox(options) {
 
   this._attributeLocations = undefined;
   this._useHdr = undefined;
+  this._hasError = false;
+  this._error = false;
 }
 
 /**
@@ -109,6 +111,15 @@ SkyBox.prototype.update = function (frameState, useHdr) {
   // The sky box is only rendered during the render pass; it is not pickable, it doesn't cast shadows, etc.
   if (!passes.render) {
     return undefined;
+  }
+
+  // Throw any errors that had previously occurred asynchronously so they aren't
+  // ignored when running.  See https://github.com/CesiumGS/cesium/pull/12307
+  if (this._hasError) {
+    const error = this._error;
+    this._hasError = false;
+    this._error = undefined;
+    throw error;
   }
 
   if (this._sources !== this.sources) {
@@ -141,15 +152,18 @@ SkyBox.prototype.update = function (frameState, useHdr) {
 
     if (typeof sources.positiveX === "string") {
       // Given urls for cube-map images.  Load them.
-      loadCubeMap(context, this._sources).then(
-        function (cubeMap) {
+      loadCubeMap(context, this._sources)
+        .then(function (cubeMap) {
           that._cubeMap = that._cubeMap && that._cubeMap.destroy();
           that._cubeMap = cubeMap;
-        },
-        function (error) {
-          console.error("Skybox cube map failed to load", error);
-        },
-      );
+        })
+        .catch((error) => {
+          // Defer throwing the error until the next call to update to prevent
+          // test from failing in `afterAll` if this is rejected after the test
+          // using the Skybox ends.  See https://github.com/CesiumGS/cesium/pull/12307
+          this._hasError = true;
+          this._error = error;
+        });
     } else {
       this._cubeMap = this._cubeMap && this._cubeMap.destroy();
       this._cubeMap = new CubeMap({

--- a/packages/engine/Source/Scene/SkyBox.js
+++ b/packages/engine/Source/Scene/SkyBox.js
@@ -82,7 +82,7 @@ function SkyBox(options) {
   this._attributeLocations = undefined;
   this._useHdr = undefined;
   this._hasError = false;
-  this._error = false;
+  this._error = undefined;
 }
 
 /**

--- a/packages/engine/Source/Scene/SkyBox.js
+++ b/packages/engine/Source/Scene/SkyBox.js
@@ -141,10 +141,15 @@ SkyBox.prototype.update = function (frameState, useHdr) {
 
     if (typeof sources.positiveX === "string") {
       // Given urls for cube-map images.  Load them.
-      loadCubeMap(context, this._sources).then(function (cubeMap) {
-        that._cubeMap = that._cubeMap && that._cubeMap.destroy();
-        that._cubeMap = cubeMap;
-      });
+      loadCubeMap(context, this._sources).then(
+        function (cubeMap) {
+          that._cubeMap = that._cubeMap && that._cubeMap.destroy();
+          that._cubeMap = cubeMap;
+        },
+        function (error) {
+          console.error("Skybox cube map failed to load", error);
+        },
+      );
     } else {
       this._cubeMap = this._cubeMap && this._cubeMap.destroy();
       this._cubeMap = new CubeMap({

--- a/packages/engine/Specs/Scene/SkyBoxSpec.js
+++ b/packages/engine/Specs/Scene/SkyBoxSpec.js
@@ -1,6 +1,7 @@
-import { Resource, SceneMode, SkyBox } from "../../index.js";
+import { defined, Resource, SceneMode, SkyBox } from "../../index.js";
 
 import createScene from "../../../../Specs/createScene.js";
+import pollToPromise from "../../../../Specs/pollToPromise.js";
 
 describe(
   "Scene/SkyBox",
@@ -375,8 +376,7 @@ describe(
       scene.skyBox = skyBox;
       skyBox.update(scene.frameState);
 
-      // Flush macro task queue to allow the rejections to be thrown
-      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      await pollToPromise(() => defined(skyBox._cubeMap) || skyBox._hasError);
 
       expect(skyBox._hasError).toBeTrue();
       expect(skyBox._error).toEqual(error);

--- a/packages/engine/Specs/Scene/SkyBoxSpec.js
+++ b/packages/engine/Specs/Scene/SkyBoxSpec.js
@@ -11,8 +11,6 @@ describe(
     let loadedImage;
 
     beforeAll(function () {
-      scene = createScene();
-
       return Resource.fetchImage("./Data/Images/Blue.png").then(
         function (image) {
           loadedImage = image;
@@ -25,6 +23,7 @@ describe(
     });
 
     beforeEach(function () {
+      scene = createScene();
       scene.mode = SceneMode.SCENE3D;
     });
 

--- a/packages/engine/Specs/Scene/SkyBoxSpec.js
+++ b/packages/engine/Specs/Scene/SkyBoxSpec.js
@@ -355,6 +355,31 @@ describe(
         return scene.render();
       }).toThrowDeveloperError();
     });
+
+    it("handles error when Resources fail to load", async () => {
+      spyOn(Resource.prototype, "fetchImage").and.rejectWith(
+        "intentional error for test",
+      );
+
+      skyBox = new SkyBox({
+        sources: {
+          positiveX: "./Data/Images/Blue.png",
+          negativeX: "./Data/Images/Blue.png",
+          positiveY: "./Data/Images/Blue.png",
+          negativeY: "./Data/Images/Blue.png",
+          positiveZ: "./Data/Images/Blue.png",
+          negativeZ: "./Data/Images/Blue.png",
+        },
+      });
+
+      scene.frameState.passes.render = true;
+      scene.skyBox = skyBox;
+      skyBox.update(scene.frameState);
+
+      // Flush macro task queue to allow the rejections to be throw in this
+      // function, otherwise the error ends up happening in `afterAll`
+      await new Promise((resolve) => window.setTimeout(resolve, 1));
+    });
   },
   "WebGL",
 );

--- a/packages/engine/Specs/Scene/SkyBoxSpec.js
+++ b/packages/engine/Specs/Scene/SkyBoxSpec.js
@@ -18,10 +18,6 @@ describe(
       );
     });
 
-    afterAll(function () {
-      scene.destroyForSpecs();
-    });
-
     beforeEach(function () {
       scene = createScene();
       scene.mode = SceneMode.SCENE3D;
@@ -30,6 +26,7 @@ describe(
     afterEach(function () {
       skyBox = skyBox && skyBox.destroy();
       scene.skyBox = undefined;
+      scene.destroyForSpecs();
     });
 
     it("draws a sky box from Images", function () {


### PR DESCRIPTION

# Description

Adds an error handler to `loadCubeMap` in `Skybox.update` and then throw any errors during the next call.

This allows the error to be thrown in normal usage when `update` is called repeatedly.  It prevents throwing the error after the end of a test because `update` is not called after the test ends.   Previously the error would be thrown in `afterAll` when the tests were running.

## Issue number and link

Fixes  #12306

## Testing plan

1. Checkout this branch
2. Focus the "handles error when Resources fail to load" spec
3. Run `npm run tests`. 
    - Verify the tests pass
5. Run `git checkout main -- packages/engine/Source/Scene/SkyBox.js` to get the previous version
3. Run `npm run tests`. 
    - Verify the tests fails with an error in `afterAll`

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
