### PR TITLE
Added TrackingReferenceFrame.ENU

### DIFF
--- a/Apps/Sandcastle/gallery/Entity tracking.html
+++ b/Apps/Sandcastle/gallery/Entity tracking.html
@@ -94,6 +94,13 @@
               drone.trackingReferenceFrame = Cesium.TrackingReferenceFrame.VELOCITY;
             },
           },
+          {
+            text: "Tracking reference frame: East-North-Up",
+            onselect: function () {
+              satellite.trackingReferenceFrame = Cesium.TrackingReferenceFrame.ENU;
+              drone.trackingReferenceFrame = Cesium.TrackingReferenceFrame.ENU;
+            },
+          },
         ]);
         //Sandcastle_End
       };

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -158,7 +158,7 @@
           {
             text: "Tracking reference frame: East-North-Up",
             onselect: function () {
-              entity.trackingReferenceFrame = Cesium.TrackingReferenceFrame.EAST_NORTH_UP;
+              entity.trackingReferenceFrame = Cesium.TrackingReferenceFrame.ENU;
             },
           },
           {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,11 @@
 ##### Additions :tada:
 
 - Added `getSample` to `SampledProperty` to get the time of samples. [#12253](https://github.com/CesiumGS/cesium/pull/12253)
-- Added `Entity.trackingReferenceFrame` property to allow tracking entities in their own inertial reference frame. [#12194](https://github.com/CesiumGS/cesium/pull/12194)
+- Added `Entity.trackingReferenceFrame` property to allow tracking entities in various reference frames. [#12194](https://github.com/CesiumGS/cesium/pull/12194), [#12314](https://github.com/CesiumGS/cesium/pull/12314)
+  - `TrackingReferenceFrame.AUTODETECT` (default): uses either VVLH or ENU dependeding on entity's dynamic. Use `TrackingReferenceFrame.ENU` if your camera orientation flips abruptly from time to time.
+  - `TrackingReferenceFrame.ENU`: uses the entity's local East-North-Up reference frame.
+  - `TrackingReferenceFrame.INERTIAL`: uses the entity's inertial reference frame.
+  - `TrackingReferenceFrame.VELOCITY`: uses entity's `VelocityOrientationProperty` as orientation.
 
 ##### Fixes :wrench:
 

--- a/packages/engine/Source/Core/TrackingReferenceFrame.js
+++ b/packages/engine/Source/Core/TrackingReferenceFrame.js
@@ -17,33 +17,29 @@ const TrackingReferenceFrame = {
   AUTODETECT: 0,
 
   /**
-   * The entity's inertial reference frame. If entity has no defined orientation
-   * property, a {@link VelocityOrientationProperty} is used instead, thus
-   * falling back to <code>TrackingReferenceFrame.VELOCITY</code>.
-   * When selected, the auto-detect algorithm is overridden.
+   * The entity's local East-North-Up reference frame.
    *
    * @type {number}
    * @constant
    */
-  INERTIAL: 1,
+  ENU: 1,
+
+  /**
+   * The entity's inertial reference frame. If entity has no defined orientation
+   * property, it falls back to auto-detect algorithm.
+   *
+   * @type {number}
+   * @constant
+   */
+  INERTIAL: 2,
 
   /**
    * The entity's inertial reference frame with orientation fixed to its
    * {@link VelocityOrientationProperty}, ignoring its own orientation.
-   * When selected, the auto-detect algorithm is overridden.
    *
    * @type {number}
    * @constant
    */
-  VELOCITY: 2,
-
-  /**
-   * The entity's local East-North-Up reference frame.
-   * When selected, the auto-detect algorithm is overridden.
-   *
-   * @type {number}
-   * @constant
-   */
-  ENU: 3,
+  VELOCITY: 3,
 };
 export default Object.freeze(TrackingReferenceFrame);

--- a/packages/engine/Source/Core/TrackingReferenceFrame.js
+++ b/packages/engine/Source/Core/TrackingReferenceFrame.js
@@ -36,5 +36,14 @@ const TrackingReferenceFrame = {
    * @constant
    */
   VELOCITY: 2,
+
+  /**
+   * The entity's local East-North-Up reference frame.
+   * When selected, the auto-detect algorithm is overridden.
+   *
+   * @type {number}
+   * @constant
+   */
+  ENU: 3,
 };
 export default Object.freeze(TrackingReferenceFrame);

--- a/packages/engine/Source/DataSources/EntityView.js
+++ b/packages/engine/Source/DataSources/EntityView.js
@@ -269,7 +269,12 @@ function updateTransform(
         rotationScratch,
       );
       Matrix4.fromRotationTranslation(rotation, cartesian, transform);
-    } else if (hasBasis) {
+    } else if (
+      trackingReferenceFrame === TrackingReferenceFrame.ENU ||
+      !hasBasis
+    ) {
+      Transforms.eastNorthUpToFixedFrame(cartesian, ellipsoid, transform);
+    } else {
       transform[0] = xBasis.x;
       transform[1] = xBasis.y;
       transform[2] = xBasis.z;
@@ -286,9 +291,6 @@ function updateTransform(
       transform[13] = cartesian.y;
       transform[14] = cartesian.z;
       transform[15] = 0.0;
-    } else {
-      // Stationary or slow-moving, low-altitude objects use East-North-Up.
-      Transforms.eastNorthUpToFixedFrame(cartesian, ellipsoid, transform);
     }
 
     camera._setTransform(transform);

--- a/packages/engine/Specs/DataSources/EntityViewSpec.js
+++ b/packages/engine/Specs/DataSources/EntityViewSpec.js
@@ -83,6 +83,10 @@ describe(
       entity.trackingReferenceFrame = TrackingReferenceFrame.VELOCITY;
       view.update(JulianDate.now());
       expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
+
+      entity.trackingReferenceFrame = TrackingReferenceFrame.ENU;
+      view.update(JulianDate.now());
+      expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
     });
 
     it("uses entity bounding sphere", function () {
@@ -115,6 +119,13 @@ describe(
         new BoundingSphere(new Cartesian3(3, 4, 5), 6),
       );
       expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
+
+      entity.trackingReferenceFrame = TrackingReferenceFrame.ENU;
+      view.update(
+        JulianDate.now(),
+        new BoundingSphere(new Cartesian3(3, 4, 5), 6),
+      );
+      expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
     });
 
     it("uses entity viewFrom if available and boundingsphere is supplied", function () {
@@ -138,6 +149,10 @@ describe(
       expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
 
       entity.trackingReferenceFrame = TrackingReferenceFrame.VELOCITY;
+      view.update(JulianDate.now());
+      expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
+
+      entity.trackingReferenceFrame = TrackingReferenceFrame.ENU;
       view.update(JulianDate.now());
       expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
     });


### PR DESCRIPTION
# Description

Follows-up #12194 . 
Added TrackingReferenceFrame.ENU to allow tracking entities in their local East-North-Up reference frame. 

## Issue number and link

Fixes #12313 

## Testing plan

- Updated EntityViewSpec.js
- Updated Entity Tracking sandcastle
- Tested sandcastle provided in #12313 with entity's trackingReferenceFrame set to ENU.

# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [X] I have updated `CHANGES.md` with a short summary of my change
- [X] I have added or updated unit tests to ensure consistent code coverage
- [X] I have updated the inline documentation, and included code examples where relevant
- [X] I have performed a self-review of my code
