### PR TITLE
Fix point cloud performance issue when points are filtered via "show"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ##### Fixes :wrench:
 
 - Fix label rendering bug in WebGL1 contexts. [#12301](https://github.com/CesiumGS/cesium/pull/12301)
+- Fix point cloud filtering performance on certain hardware [#12317](https://github.com/CesiumGS/cesium/pull/12317)
 
 #### @cesium/widgets
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -416,3 +416,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jérôme Fayot](https://github.com/jfayot)
 - [Kirn Kim](https://github.com/squrki)
 - [Emanuele Mastaglia](https://github.com/Masty88)
+- [Connor Manning](https://github.com/connormanning)

--- a/packages/engine/Source/Scene/Model/PointCloudStylingPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/PointCloudStylingPipelineStage.js
@@ -333,9 +333,10 @@ function addShaderFunctionsAndDefines(shaderBuilder, shaderFunctionInfo) {
     shaderBuilder.addDefine(
       "HAS_POINT_CLOUD_SHOW_STYLE",
       undefined,
-      ShaderDestination.VERTEX,
+      ShaderDestination.BOTH,
     );
     shaderBuilder.addVertexLines(showStyleFunction);
+    shaderBuilder.addVarying("float", "v_pointCloudShow");
   }
 
   const pointSizeStyleFunction = shaderFunctionInfo.pointSizeStyleFunction;

--- a/packages/engine/Source/Shaders/Model/ModelFS.glsl
+++ b/packages/engine/Source/Shaders/Model/ModelFS.glsl
@@ -28,6 +28,13 @@ SelectedFeature selectedFeature;
 
 void main()
 {
+    #ifdef HAS_POINT_CLOUD_SHOW_STYLE
+        if (v_pointCloudShow == 0.0)
+        {
+            discard;
+        }
+    #endif
+
     #ifdef HAS_MODEL_SPLITTER
     modelSplitterStage();
     #endif

--- a/packages/engine/Source/Shaders/Model/ModelVS.glsl
+++ b/packages/engine/Source/Shaders/Model/ModelVS.glsl
@@ -145,5 +145,13 @@ void main()
         gl_PointSize *= show;
     #endif
 
-    gl_Position = show * positionClip;
+    // Important NOT to compute gl_Position = show * positionClip or we hit:
+    // https://github.com/CesiumGS/cesium/issues/11270
+    //
+    // We will discard points with v_pointCloudShow == 0 in the fragment shader.
+    gl_Position = positionClip;
+
+    #ifdef HAS_POINT_CLOUD_SHOW_STYLE
+    v_pointCloudShow = show;
+    #endif
 }

--- a/packages/engine/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
+++ b/packages/engine/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
@@ -314,7 +314,9 @@ describe(
         "HAS_POINT_CLOUD_SHOW_STYLE",
         "COMPUTE_POSITION_WC_STYLE",
       ]);
-      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+        "HAS_POINT_CLOUD_SHOW_STYLE",
+      ]);
 
       ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
         "uniform vec4 model_pointCloudParameters;",


### PR DESCRIPTION
Discard hidden points in the fragment shader, rather than moving them to 0 in the vertex shader. Fixes #11270.

# Description

## The problem

I was running into an issue when points from a 3D Tiles point cloud dataset were being filtered out via a `show` condition.  For example showing only Ground points or only Noise points - the more points that were filtered away, the worse the performance got.  Some investigation showed that this was only an issue on Apple silicon, and is most noticeable in Firefox.  On my M2 MacBook with Firefox, the second link in #12140 slows my entire computer to a crawl until the tab is closed.  I submitted that issue which was found to be a duplicate of #11270, which has some investigation and suggestions.  Unfortunately the one-line fix described [here](https://github.com/CesiumGS/cesium/issues/11270#issuecomment-1667527953) had no effect for me.

## Investigation details

The offending line is [here](https://github.com/CesiumGS/cesium/blob/91821cc54d274ad7a28ecc164a4c5c867849e111/packages/engine/Source/Shaders/Model/ModelVS.glsl#L148), which multiplies the point position by `show`, in order to zero out the position when when the point should be hidden due to `show == 0`.

It seems that when the point position is set to `0` though, that something in the rendering pipeline degenerates significantly on Apple silicon.

## Changes

- Remove the repositioning of hidden points, which causes the issue (see note below)
- Add a varying `float v_pointCloudShow`, populated in the vertex shader
- When `v_pointCloudShow` is 0, `discard` the point in the fragment shader

It's not quite clear to my why the line `gl_Position = show * positionClip` still causes the issue even with the other changes applied.  I'd have thought that since the point will be discarded immediately in the fragment shader, that this line could be left as-is.  But as mentioned in the code comment there, this position adjustment *must* be removed to fix the performance issue.

That said, I just started learning about shaders a few hours ago to look into this issue, so I don't really know what any of this means.  Suggestions are very welcome from anyone who knows what they're doing.

For example, is this the best place to perform the discard?  Maybe somewhere around [here](https://github.com/CesiumGS/cesium/blob/91821cc54d274ad7a28ecc164a4c5c867849e111/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl#L447) would be more appropriate?  There may easily be tens of thousands of points hidden in common scenarios, so I tried to discard them as early as possible.

## Issue number and link

- #11270
- #12140 

## Testing plan

The fix should be tested both on hardware that is affected as well as hardware that is *not* affected by the original issue to make sure this doesn't have any side-effects on non-affected hardware.

I've built a bundle containing these changes, so people can compare their performance, making sure that the "fix" both fixes the issue and does not cause new ones.  Open the below links, with only one open at a time, and try to drag the point cloud around in little circles to see the performance.

Here is an example of what it looks like if you are experiencing the issue (yes, it's a recording of a screen, but I can't capture it via screen recording since the computer itself is lagging):

https://github.com/user-attachments/assets/f66a1ca8-6320-4dad-a665-42171fe08dd3

- [Before - laggy (maybe)](https://sandcastle.cesium.com/#c=jZKPb9o4FMf/FV80aVRiTgjltutodYxuNAzoNtLu6OU0GedRXPwjZztkMPV/n03gVk6T7hRFtp8/74ff+4YhGmgiLeqDYaUYThGhFIxBVqGNKjViSiJiDFiTyZrBiZI4hwUpue3t4FStQKJzlAWwGS7nA8qu2TC52SatCUtMIj91aD/5NVkVf9z2h79hB/2dD1YOStqTy5voTsw6437UmQw+xqP0YzzeJnaW3sR3/dbqOu3FY5FE4y0X15eUjfrD4s4Fc36t8bRiNJ6s6eB2mzwU80S821KfUOQPCY/cype5Y8fpTTROe51JOovGMsJXs/Td8kX71ekoLy/fxJNT2nZ5PnU+f3l51du8gvfzyXD24faqGlVZ8DqTVElj0ZpBBdq9UkK17xa+3dkaWUB3576SljAJOgtOnJ/VG/QtkwjVASzj4ProIpCKsEPHcb20L9P6Gi+0Eq7DPd/zJG/EL6PTThQ360gICfKViVJMqQaQ04JQeKu10meo1fTAo0+MDrmwsRsOxzU/zTf114195EIxaadsC2eo3axNVHEfeg/sHpIz6yRhztCfByNy2+DZtz53MmELRokHHtEv5+cozoKmU8UuTOP5vS/5+UkW/NU88rW6hCOwYHK14w7YfvO49zNLVf13VWGIPjO7RHYJaA5cVYi72aDSzVMIkBby5hFcgF4oLYikgCrGOcrhXpMczv7/QxeEG/hJ3f9Mxm/8X4sJGwoScKGZcPWvwWCS54397OpB1lLZ41ulRKqeAv57RK4SukQN8EI4+SE5xQFzdb+3O9rVETSD7k4UF576nYlCaYtKzRsYhxZEwYkFE85LunLyocZ4v254cOnmbI1Yfv4TxSPq++JuFiXnXkZZcNENHX/kxhXJmby/XoPmZOMQX0Z32boY1RcY427ojj7pv32tUnxO9JO43wE) - this is a link to the official Cesium Sandcastle - if you click this and your computer lags, maybe to the point where it can be difficult to close the tab, then you *are* experiencing the issue.  Note that you might not see any issues at all if you do not have the affected hardware, and it may vary per browser.  Firefox seems to be the most noticeable.
- [After - fixed (hopefully)](https://na-c.entwine.io/cesiumdev/fix/Apps/Sandcastle/index.html#c=pZJ/c9IwGMffSux5N3aHoZTh5oSdCI4VKbhRUGY9L6RhZKRJTVIQdrx3E1p0eP7n9XpJnnyeH/k+T6UCuhJxDdpE0SzpjQDCmCgFtAAbkUlABQdIKaJVxHMG+oLDmMxRxnRrD4diSThogsghm95i1sV0SHv+eOtXB9RXPr+r47b/2l+mXybt3htooB9xd2kgvzbojN37ZFoP2m590L31+uGtF2x9PQ3H3n27uhyGLS9IfDfYsmTYwbTf7qX3JpjxqwajNcXeYIW7k63/mM785HqLbcIkfvSZa1a2iA0bhGM3CFv1QTh1A+7Cm2l4vXhVuzjrx1nnvTc4wzWT567++fv5TWtzQT7OBr3pp8nNur+OnLcRx4IrDVaUrIk0r+RkXagFJ3tbKXLw/twWXCPKiYycU+On5QY8RRyAPICmjBgdTQS0RvSgOMyXWifMr+FcisQo3LKa+3HJO3fP6q5XziMBkKCfNMmSEZaE8FGKMPkgpZCXoFq2wM4mBodcUOkNI8c1P883stelInIqKNcjuiWXoFbOTVgwG7oA9g+JqTYjoS7B14MRmK3z8qnNzJjQOcXIAjvwotkEXuSUzVTsw5ROHmzJJ6eR86185KtlRo7AlPLlnjtgxWZX+KmFWP9/VXPEFPlHkt8y2o39885DhQknMJU0MclWREEUx6VC6Fz1vK8FvhUiCcVzwH47YCrBC1Aitmunf+ZDMAKZeCjshjZ1OGWnse/glaXe0SQVUoNMshKEFU2SlCFNVGWW4aXpNVbK+jUqB5dGTFeAxs1/jCfAVhdzM88Ysz2PnKtGxfBHbkygmPKH4YpIhjYGsWU0FtWrfn4BIWxUzNEm/dtXC8FmSD6L+ws) - the same Cesium setup but with this fix applied.  It should show a pink point cloud that can be dragged around easily and should not lag your computer.  If you were experiencing the issue in the first link, then this one should be noticeably better.

| CPU/GPU | Browser | Before lags? | After lags? |
| --- | --- | --- | --- |
| Apple M2 Max (integrated GPU) | Firefox | Yes | No |

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
