### PR TITLE
Remove deprecated createGooglePhotorealistic3DTileset key option in 1.126 #12328

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,9 +20,12 @@
 - Updated WMS example URL in UrlTemplateImageryProvider documentation to use an active service. [#12323](https://github.com/CesiumGS/cesium/pull/12323)
 - Fix point cloud filtering performance on certain hardware [#12317](https://github.com/CesiumGS/cesium/pull/12317)
 
-##### Deprecated :hourglass_flowing_sand:
 
-- `createGooglePhotorealistic3DTileset(key)` has been deprecated. Use `createGooglePhotorealistic3DTileset({key})` instead. It will be removed in 1.126.
+
+##### Removed :x:
+
+- `createGooglePhotorealistic3DTileset(key)` has been removed. Use `createGooglePhotorealistic3DTileset({key})` instead.
+
 
 #### @cesium/widgets
 

--- a/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
+++ b/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
@@ -5,7 +5,6 @@ import IonResource from "../Core/IonResource.js";
 import GoogleMaps from "../Core/GoogleMaps.js";
 import Resource from "../Core/Resource.js";
 import oneTimeWarning from "../Core/oneTimeWarning.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 
 /**
  * Creates a {@link Cesium3DTileset} instance for the Google Photorealistic 3D
@@ -73,13 +72,6 @@ async function createGooglePhotorealistic3DTileset(apiOptions, tilesetOptions) {
   );
 
   apiOptions = defaultValue(apiOptions, defaultValue.EMPTY_OBJECT);
-  if (typeof apiOptions === "string") {
-    deprecationWarning(
-      "createGooglePhotorealistic3DTileset(key)",
-      "createGooglePhotorealistic3DTileset(key) has been deprecated.   It is replaced by createGooglePhotorealistic3DTileset({key}).  It will be removed in Cesium 1.126.",
-    );
-    apiOptions = { key: apiOptions };
-  }
   if (!apiOptions.onlyUsingWithGoogleGeocoder) {
     oneTimeWarning(
       "google-tiles-with-google-geocoder",


### PR DESCRIPTION
### Summary
This pull request addresses issue #12328 by removing the deprecated `createGooglePhotorealistic3DTileset(key)` function. The function has been replaced with the new format `createGooglePhotorealistic3DTileset({key})`.

### Changes
- Removed the deprecated `createGooglePhotorealistic3DTileset(key)` function.
- Updated the `createGooglePhotorealistic3DTileset` function to use the new options object format.
- Updated `CHANGES.md` to reflect the removal of the deprecated function.

### Verification
- Verified that the deprecated function is no longer present in the codebase.
- Ensured that the new format is being used correctly in the `createGooglePhotorealistic3DTileset` function.
- Ran tests to confirm that the changes do not introduce any new issues.

### Additional Notes
Please let me know if there are any additional documentation updates or other changes needed.

Thank you!

### Issue number and link
Fixes #12328


### Author checklist

[x] I have submitted a Contributor License Agreement

[x] I have added my name to CONTRIBUTORS.md

[x] I have updated CHANGES.md with a short summary of my change

[x] I have added or updated unit tests to ensure consistent code coverage

[x] I have updated the inline documentation, and included code examples where relevant

[x] I have performed a self-review of my code