### PR TITLE
iTwin Reality Data integration

### DIFF
--- a/Apps/Sandcastle/gallery/iTwin Demo.html
+++ b/Apps/Sandcastle/gallery/iTwin Demo.html
@@ -120,18 +120,28 @@
         scene.primitives.add(surroundingArea);
         scene.primitives.add(station);
 
+        // Create tileset of the reality data mesh
+        const iTwinId = "535a24a3-9b29-4e23-bb5d-9cedb524c743";
+        const realityMeshId = "85897090-3bcc-470b-bec7-20bb639cc1b9";
+        const realityMesh = await Cesium.ITwinData.createTilesetForRealityDataId(
+          iTwinId,
+          realityMeshId,
+        );
+        scene.primitives.add(realityMesh);
+
         Sandcastle.addToolbarButton(
           "Toggle Surrounding Area",
-          function () {
-            surroundingArea.show = !surroundingArea.show;
-          },
+          () => (surroundingArea.show = !surroundingArea.show),
           "layers",
         );
         Sandcastle.addToolbarButton(
           "Toggle Station Model",
-          function () {
-            station.show = !station.show;
-          },
+          () => (station.show = !station.show),
+          "layers",
+        );
+        Sandcastle.addToolbarButton(
+          "Toggle Reality Mesh",
+          () => (realityMesh.show = !realityMesh.show),
           "layers",
         );
 

--- a/packages/engine/Source/Core/ITwinPlatform.js
+++ b/packages/engine/Source/Core/ITwinPlatform.js
@@ -93,8 +93,6 @@ ITwinPlatform.SupportedRealityDataTypes = [
   ITwinPlatform.RealityDataType.PNTS,
   ITwinPlatform.RealityDataType.RealityMesh3DTiles,
   ITwinPlatform.RealityDataType.Terrain3DTiles,
-  ITwinPlatform.RealityDataType.KML,
-  ITwinPlatform.RealityDataType.Unstructured,
 ];
 
 /**

--- a/packages/engine/Source/Core/ITwinPlatform.js
+++ b/packages/engine/Source/Core/ITwinPlatform.js
@@ -38,6 +38,66 @@ ITwinPlatform.ExportType = Object.freeze({
 });
 
 /**
+ * Types of Reality data
+ * https://developer.bentley.com/apis/reality-management/rm-rd-details/#types
+ * @enum {string}
+ */
+ITwinPlatform.RealityDataType = Object.freeze({
+  Cesium3DTiles: "Cesium3DTiles",
+  PNTS: "PNTS",
+  OPC: "OPC",
+  RealityMesh3DTiles: "RealityMesh3DTiles",
+  Terrain3DTiles: "Terrain3DTiles",
+  "3MX": "3MX",
+  "3SM": "3SM",
+  CCCloudProject: "CCCloudProject",
+  CCImageCollection: "CCImageCollection",
+  CCOrientations: "CCOrientations",
+  ContextCaptureInputs: "ContextCaptureInputs",
+  ContextDetector: "ContextDetector",
+  ContextScene: "ContextScene",
+  DAE: "DAE",
+  DGN: "DGN",
+  DSM: "DSM",
+  FBX: "FBX",
+  GLB: "GLB",
+  GLTF: "GLTF",
+  KML: "KML",
+  LAS: "LAS",
+  LAZ: "LAZ",
+  LOD: "LOD",
+  LodTree: "LodTree",
+  OBJ: "OBJ",
+  OMI: "OMI",
+  OMR: "OMR",
+  Orthophoto: "Orthophoto",
+  OrthophotoDSM: "OrthophotoDSM",
+  OSGB: "OSGB",
+  OVF: "OVF",
+  OBT: "OBT",
+  PLY: "PLY",
+  PointCloud: "PointCloud",
+  S3C: "S3C",
+  ScanCollection: "ScanCollection",
+  SHP: "SHP",
+  SLPK: "SLPK",
+  SpaceEyes3D: "SpaceEyes3D",
+  STL: "STL",
+  TSM: "TSM",
+  Unstructured: "Unstructured",
+  Other: "Other",
+});
+
+ITwinPlatform.SupportedRealityDataTypes = [
+  ITwinPlatform.RealityDataType.Cesium3DTiles,
+  ITwinPlatform.RealityDataType.PNTS,
+  ITwinPlatform.RealityDataType.RealityMesh3DTiles,
+  ITwinPlatform.RealityDataType.Terrain3DTiles,
+  ITwinPlatform.RealityDataType.KML,
+  ITwinPlatform.RealityDataType.Unstructured,
+];
+
+/**
  * Gets or sets the default iTwin access token. This token should have the <code>itwin-platform</code> scope.
  *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
@@ -144,6 +204,138 @@ ITwinPlatform.getExports = async function (iModelId) {
     } else if (error.statusCode === 403) {
       console.error(result.error.code, result.error.message);
       throw new RuntimeError("Not allowed, forbidden");
+    } else if (error.statusCode === 422) {
+      throw new RuntimeError(
+        `Unprocessable Entity:${result.error.code} ${result.error.message}`,
+      );
+    } else if (error.statusCode === 429) {
+      throw new RuntimeError("Too many requests");
+    }
+    throw new RuntimeError(`Unknown request failure ${error.statusCode}`);
+  }
+};
+
+/**
+ * @typedef {Object} RealityDataExtent
+ * @privage
+ * @property {{latitude: number, longitude: number}} southWest
+ * @property {{latitude: number, longitude: number}} northEast
+ */
+
+/**
+ * @typedef {Object} RealityDataRepresentation
+ * @privage
+ * @property {string} id "95d8dccd-d89e-4287-bb5f-3219acbc71ae",
+ * @property {string} displayName "Name of reality data",
+ * @property {string} dataset "Dataset",
+ * @property {string} group "73d09423-28c3-4fdb-ab4a-03a47a5b04f8",
+ * @property {string} description "Description of reality data",
+ * @property {string} rootDocument "Directory/SubDirectory/realityData.3mx",
+ * @property {number} size 6521212,
+ * @property {string} classification "Model",
+ * @property {ITwinPlatform.RealityDataType} type "3MX",
+ * @property {{startDateTime: string, endDateTime: string, acquirer: string}} acquisition
+ * @property {RealityDataExtent} extent
+ * @property {boolean} authoring false,
+ * @property {string} dataCenterLocation "North Europe",
+ * @property {string} modifiedDateTime "2021-04-09T19:03:12Z",
+ * @property {string} lastAccessedDateTime "2021-04-09T00:00:00Z",
+ * @property {string} createdDateTime "2021-02-22T20:03:40Z",
+ * @property {string} ownerId "f1d49cc7-f9b3-494f-9c67-563ea5597063",
+ */
+
+/**
+ * @param {string} iTwinId
+ * @param {string} realityDataId
+ * @returns {Promise<RealityDataRepresentation>}
+ */
+ITwinPlatform.getRealityDataMetadata = async function (iTwinId, realityDataId) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("iTwinId", iTwinId);
+  Check.typeOf.string("realityDataId", realityDataId);
+  if (!defined(ITwinPlatform.defaultAccessToken)) {
+    throw new DeveloperError("Must set ITwinPlatform.defaultAccessToken first");
+  }
+  //>>includeEnd('debug')
+
+  const resource = new Resource({
+    url: `${ITwinPlatform.apiEndpoint}reality-management/reality-data/${realityDataId}`,
+    headers: {
+      Authorization: `Bearer ${ITwinPlatform.defaultAccessToken}`,
+      Accept: "application/vnd.bentley.itwin-platform.v1+json",
+    },
+    queryParameters: { iTwinId: iTwinId },
+  });
+
+  try {
+    const response = await resource.fetchJson();
+    return response.realityData;
+  } catch (error) {
+    const result = JSON.parse(error.response);
+    if (error.statusCode === 401) {
+      throw new RuntimeError(
+        `Unauthorized, bad token, wrong scopes or headers bad. ${result.error.details[0].code}`,
+      );
+    } else if (error.statusCode === 403) {
+      console.error(result.error.code, result.error.message);
+      throw new RuntimeError("Not allowed, forbidden");
+    } else if (error.statusCode === 404) {
+      throw new RuntimeError(
+        `Reality data not found: ${iTwinId}, ${realityDataId}`,
+      );
+    } else if (error.statusCode === 422) {
+      throw new RuntimeError(
+        `Unprocessable Entity:${result.error.code} ${result.error.message}`,
+      );
+    } else if (error.statusCode === 429) {
+      throw new RuntimeError("Too many requests");
+    }
+    throw new RuntimeError(`Unknown request failure ${error.statusCode}`);
+  }
+};
+
+ITwinPlatform.getRealityDataURL = async function (
+  iTwinId,
+  realityDataId,
+  rootDocument,
+) {
+  const resource = new Resource({
+    url: `${ITwinPlatform.apiEndpoint}reality-management/reality-data/${realityDataId}/readaccess`,
+    headers: {
+      Authorization: `Bearer ${ITwinPlatform.defaultAccessToken}`,
+      Accept: "application/vnd.bentley.itwin-platform.v1+json",
+    },
+    queryParameters: { iTwinId: iTwinId },
+  });
+
+  try {
+    const result = await resource.fetchJson();
+
+    const containerUrl = result._links.containerUrl.href;
+    const tilesetUrl = new URL(containerUrl);
+    tilesetUrl.pathname = `${tilesetUrl.pathname}/${rootDocument}`;
+
+    return tilesetUrl.toString();
+    // console.log("container url", tilesetUrl.toString());
+    // if (rootDocument.includes(".geojson")) {
+    //   await loadGeoJson(tilesetUrl.toString());
+    //   return;
+    // }
+    // await loadTileset(tilesetUrl.toString());
+    // return result.realityData;
+  } catch (error) {
+    const result = JSON.parse(error.response);
+    if (error.statusCode === 401) {
+      throw new RuntimeError(
+        `Unauthorized, bad token, wrong scopes or headers bad. ${result.error.details[0].code}`,
+      );
+    } else if (error.statusCode === 403) {
+      console.error(result.error.code, result.error.message);
+      throw new RuntimeError("Not allowed, forbidden");
+    } else if (error.statusCode === 404) {
+      throw new RuntimeError(
+        `Reality data not found: ${iTwinId}, ${realityDataId}`,
+      );
     } else if (error.statusCode === 422) {
       throw new RuntimeError(
         `Unprocessable Entity:${result.error.code} ${result.error.message}`,

--- a/packages/engine/Source/Scene/ITwinData.js
+++ b/packages/engine/Source/Scene/ITwinData.js
@@ -3,6 +3,8 @@ import defined from "../Core/defined.js";
 import Resource from "../Core/Resource.js";
 import ITwinPlatform from "../Core/ITwinPlatform.js";
 import RuntimeError from "../Core/RuntimeError.js";
+import KmlDataSource from "../DataSources/KmlDataSource.js";
+import GeoJsonDataSource from "../DataSources/GeoJsonDataSource.js";
 
 /**
  * Methods for loading iTwin platform data into CesiumJS
@@ -69,6 +71,150 @@ ITwinData.createTilesetFromIModelId = async function (iModelId, options) {
   });
 
   return Cesium3DTileset.fromUrl(resource, options);
+};
+
+/** @type {ITwinPlatform.RealityDataType[]} */
+const realityDataMeshTypes = [
+  ITwinPlatform.RealityDataType.Cesium3DTiles,
+  ITwinPlatform.RealityDataType.PNTS,
+  ITwinPlatform.RealityDataType.RealityMesh3DTiles,
+  ITwinPlatform.RealityDataType.Terrain3DTiles,
+];
+
+ITwinData.createAssetForRealitydataId = async function loadRealityData(
+  iTwinId,
+  realityDataId,
+  type,
+  rootDocument,
+) {
+  if (!defined(type) || !defined(rootDocument)) {
+    const metadata = await ITwinPlatform.getRealityDataMetadata(
+      iTwinId,
+      realityDataId,
+    );
+    rootDocument = metadata.rootDocument;
+    type = metadata.type;
+  }
+
+  if (realityDataMeshTypes.includes(type)) {
+    return ITwinData.createTilesetForRealityDataId(
+      iTwinId,
+      realityDataId,
+      type,
+      rootDocument,
+    );
+  }
+
+  return ITwinData.createDataSourceForRealityDataId(
+    iTwinId,
+    realityDataId,
+    type,
+    rootDocument,
+  );
+};
+
+ITwinData.isRealityDataAMeshType = function (type) {
+  return realityDataMeshTypes.includes(type);
+};
+
+/**
+ * Create a tileset for the specified reality data id. This function only works
+ * with 3D Tiles meshes and pointclouds
+ *
+ * @param {string} iTwinId
+ * @param {string} realityDataId
+ * @param {ITwinPlatform.RealityDataType} type
+ * @param {string} rootDocument
+ * @returns {Promise<Cesium3DTileset>}
+ */
+ITwinData.createTilesetForRealityDataId = async function (
+  iTwinId,
+  realityDataId,
+  type,
+  rootDocument,
+) {
+  if (!defined(type) || !defined(rootDocument)) {
+    const metadata = await ITwinPlatform.getRealityDataMetadata(
+      iTwinId,
+      realityDataId,
+    );
+    rootDocument = metadata.rootDocument;
+    type = metadata.type;
+  }
+
+  if (!realityDataMeshTypes.includes(type)) {
+    throw new RuntimeError(`Reality data type is not a mesh type: ${type}`);
+  }
+
+  const tilesetAccessUrl = await ITwinPlatform.getRealityDataURL(
+    iTwinId,
+    realityDataId,
+    rootDocument,
+  );
+
+  return Cesium3DTileset.fromUrl(tilesetAccessUrl);
+};
+
+/** @type {ITwinPlatform.RealityDataType[]} */
+const realityDataDataSourceTypes = [
+  ITwinPlatform.RealityDataType.KML,
+  ITwinPlatform.RealityDataType.Unstructured,
+];
+/**
+ * Create a data source of the correct type for the specified reality data id
+ *
+ * @param {string} iTwinId
+ * @param {string} realityDataId
+ * @param {ITwinPlatform.RealityDataType} type
+ * @param {string} rootDocument
+ * @returns {Promise<GeoJsonDataSource | KmlDataSource | undefined>}
+ */
+ITwinData.createDataSourceForRealityDataId = async function loadRealityData(
+  iTwinId,
+  realityDataId,
+  type,
+  rootDocument,
+) {
+  if (!defined(type) || !defined(rootDocument)) {
+    const metadata = await ITwinPlatform.getRealityDataMetadata(
+      iTwinId,
+      realityDataId,
+    );
+    rootDocument = metadata.rootDocument;
+    type = metadata.type;
+  }
+
+  if (!realityDataDataSourceTypes.includes(type)) {
+    throw new RuntimeError(
+      `Reality data type is not a data source type: ${type}`,
+    );
+  }
+
+  if (type === ITwinPlatform.RealityDataType.Unstructured) {
+    if (!rootDocument.includes(".geojson")) {
+      // In testing some Unstructured data was GEOJSONs so we might want to support that
+      throw new RuntimeError(`Reality data type is not supported`);
+    }
+  }
+
+  const tilesetAccessUrl = await ITwinPlatform.getRealityDataURL(
+    iTwinId,
+    realityDataId,
+    rootDocument,
+  );
+
+  console.log("container url", tilesetAccessUrl);
+
+  if (
+    type === ITwinPlatform.RealityDataType.Unstructured &&
+    rootDocument.includes(".geojson")
+  ) {
+    return GeoJsonDataSource.load(tilesetAccessUrl);
+  }
+
+  if (type === ITwinPlatform.RealityDataType.KML) {
+    return KmlDataSource.load(tilesetAccessUrl);
+  }
 };
 
 export default ITwinData;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR is building off of #12289 to add an easy function to load Reality Data meshes. Currently we are only supporting 3D Tiles meshes and pointcloud types of Reality Data to keep the initial integration simple. More can be added in the future but they will require different datasources and constructors in CesiumJS and will require a little more thought on how to design the API.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Running the test sandcastle
    - Load the [new sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=iTwin%20Demo.html) and make sure it loads.
    - Check that the reality mesh in that iTwin loads and shows in the surrounding area.
<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
