### PR TITLE
Fix sandcastle contributors guide link

### DIFF
--- a/Apps/Sandcastle/Sandcastle-header.js
+++ b/Apps/Sandcastle/Sandcastle-header.js
@@ -105,7 +105,7 @@
       )
     ) {
       window.location =
-        "https://github.com/CesiumGS/cesium/wiki/Contributor%27s-Guide";
+        "https://github.com/CesiumGS/cesium/blob/main/Documentation/Contributors/BuildGuide/README.md#quickstart";
     }
   }
 })();


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This is a very small edgecase scenario that happens when someone tries to open a sandcastle html file directly instead of using the local server. The page it was trying to direct to is on the Wiki we don't really use anymore and instead tried to create a page (if you have access) or redirects to the home page instead of the info you need.
There was one other instance of this check that _did_ have a valid link so this just updates it to match that one
https://github.com/CesiumGS/cesium/blob/fddd0f17573373275d3026eaf502f8ede03c895d/Apps/Sandcastle/index.html#L36-L37

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Open the Sandcastle gallery in your file explorer
- Open any html file directly
- You should see an alert about using the local server and when clicking OK it should redirect you to the contributor docs.

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
