### PR TITLE
Fix geocode typo in Clipping Regions sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/Clipping Regions.html
+++ b/Apps/Sandcastle/gallery/Clipping Regions.html
@@ -43,7 +43,7 @@
           animation: false,
           sceneModePicker: false,
           baseLayerPicker: false,
-          geocoder: Cesium.IonGeocoderProviderType.GOOGLE,
+          geocoder: Cesium.IonGeocodeProviderType.GOOGLE,
         });
         const scene = viewer.scene;
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The Clipping regions sandcaslte was referencing an undefined variable because of a typo.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Related to #12299 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Load the [Clipping Regions](http://localhost:8080/Apps/Sandcastle/index.html?src=Clipping%20Regions.html) sandcastle and make sure it loads

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
