### PR TITLE
Change `toBeCloseTo` to `toEqualEpsilon` where appropriate

### DIFF
--- a/packages/engine/Specs/Scene/I3SNodeSpec.js
+++ b/packages/engine/Specs/Scene/I3SNodeSpec.js
@@ -698,17 +698,17 @@ describe("Scene/I3SNode", function () {
           expectedHeight,
         );
 
-        expect(cartographicOrigin.longitude).toBeCloseTo(
+        expect(cartographicOrigin.longitude).toEqualEpsilon(
           expectedPosition.longitude,
-          -3,
+          CesiumMath.EPSILON3,
         );
-        expect(cartographicOrigin.latitude).toBeCloseTo(
+        expect(cartographicOrigin.latitude).toEqualEpsilon(
           expectedPosition.latitude,
-          -3,
+          CesiumMath.EPSILON3,
         );
-        expect(cartographicOrigin.height).toBeCloseTo(
+        expect(cartographicOrigin.height).toEqualEpsilon(
           expectedPosition.height,
-          -3,
+          CesiumMath.EPSILON3,
         );
       });
   });

--- a/packages/engine/Specs/Scene/OpenStreetMapImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/OpenStreetMapImageryProviderSpec.js
@@ -168,19 +168,19 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
     expect(provider.tileHeight).toEqual(256);
     expect(provider.maximumLevel).toBeUndefined();
     expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
-    expect(provider.rectangle.west).toBeCloseTo(
+    expect(provider.rectangle.west).toEqualEpsilon(
       rectangle.west,
       CesiumMath.EPSILON10,
     );
-    expect(provider.rectangle.south).toBeCloseTo(
+    expect(provider.rectangle.south).toEqualEpsilon(
       rectangle.south,
       CesiumMath.EPSILON10,
     );
-    expect(provider.rectangle.east).toBeCloseTo(
+    expect(provider.rectangle.east).toEqualEpsilon(
       rectangle.east,
       CesiumMath.EPSILON10,
     );
-    expect(provider.rectangle.north).toBeCloseTo(
+    expect(provider.rectangle.north).toEqualEpsilon(
       rectangle.north,
       CesiumMath.EPSILON10,
     );

--- a/packages/engine/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -586,7 +586,7 @@ describe("Scene/TileMapServiceImageryProvider", function () {
 
     expect(provider.rectangle.west).toEqual(expectedSW.longitude);
     expect(provider.rectangle.south).toEqual(expectedSW.latitude);
-    expect(provider.rectangle.east).toBeCloseTo(
+    expect(provider.rectangle.east).toEqualEpsilon(
       expectedNE.longitude,
       CesiumMath.EPSILON14,
     );
@@ -620,12 +620,12 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     const expectedSW = Cartographic.fromDegrees(-123.0, -10.0);
     const expectedNE = Cartographic.fromDegrees(-110.0, 11.0);
 
-    expect(provider.rectangle.west).toBeCloseTo(
+    expect(provider.rectangle.west).toEqualEpsilon(
       expectedSW.longitude,
       CesiumMath.EPSILON14,
     );
     expect(provider.rectangle.south).toEqual(expectedSW.latitude);
-    expect(provider.rectangle.east).toBeCloseTo(
+    expect(provider.rectangle.east).toEqualEpsilon(
       expectedNE.longitude,
       CesiumMath.EPSILON14,
     );
@@ -663,12 +663,12 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     const expectedSW = Cartographic.fromDegrees(-123.0, -10.0);
     const expectedNE = Cartographic.fromDegrees(-110.0, 11.0);
 
-    expect(provider.rectangle.west).toBeCloseTo(
+    expect(provider.rectangle.west).toEqualEpsilon(
       expectedSW.longitude,
       CesiumMath.EPSILON14,
     );
     expect(provider.rectangle.south).toEqual(expectedSW.latitude);
-    expect(provider.rectangle.east).toBeCloseTo(
+    expect(provider.rectangle.east).toEqualEpsilon(
       expectedNE.longitude,
       CesiumMath.EPSILON14,
     );
@@ -706,12 +706,12 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     const expectedSW = Cartographic.fromDegrees(-123.0, -10.0);
     const expectedNE = Cartographic.fromDegrees(-110.0, 11.0);
 
-    expect(provider.rectangle.west).toBeCloseTo(
+    expect(provider.rectangle.west).toEqualEpsilon(
       expectedSW.longitude,
       CesiumMath.EPSILON14,
     );
     expect(provider.rectangle.south).toEqual(expectedSW.latitude);
-    expect(provider.rectangle.east).toBeCloseTo(
+    expect(provider.rectangle.east).toEqualEpsilon(
       expectedNE.longitude,
       CesiumMath.EPSILON14,
     );


### PR DESCRIPTION
# Description

For https://github.com/CesiumGS/cesium/issues/12273 , I reviewed the places that called the Jasmine `toBeCloseTo` matcher, to see whether they are making wrong assumptions about the use of the `precision` argument. Fortunately, there haven't been many of them. 
(There are still many uses of `toBeCloseTo`, but they are used correctly).

The ones that have obviously been wrong have been changed to `toEqualEpsilon`.

---

Just to illustrate: This is what Jasmine `toBeCloseTo` is computing internally:
```javascript


function test(actual, expected, precision) 
{
  const pow = Math.pow(10, precision + 1);
  const delta = Math.abs(expected - actual);
  const maxDelta = Math.pow(10, -precision) / 2;
  const a = Math.round(delta * pow);
  const b = maxDelta * pow;
  const pass =  a <= b;
  console.log("expected "+expected);
  console.log("actual "+actual);
  console.log("precision "+precision);
  console.log("pow "+pow);
  console.log("maxDelta "+maxDelta);
  console.log("pass "+pass+" because "+ a +" <= " + b);
  return pass;
}

test(0.1, 0.3, 0.0001);
```
With the given numbers, this prints
```
expected 0.3
actual 0.1
precision 0.0001
pow 10.002302850208247
maxDelta 0.49988488399907827
pass true because 2 <= 4.999999999999999
```


## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12273

## Testing plan

This is only about the specs...

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
