### PR TITLE
Fix memory usage for environment map manager

### DIFF
--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -487,6 +487,8 @@ describe(
         }),
       );
       expect(root.contentFailed).toBeTrue();
+
+      await Cesium3DTilesTester.waitForTilesLoaded(scene, tileset);
     });
 
     it("handles failed tile requests", async function () {

--- a/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
+++ b/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
@@ -202,7 +202,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.13869766891002655,
             0.17165547609329224,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -210,7 +210,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.11016352474689484,
             0.15077166259288788,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -218,7 +218,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0013909616973251104,
             -0.00141593546140939,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -226,7 +226,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.00016706169117242098,
             0.00006681153899990022,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
@@ -288,7 +288,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.03880387544631958,
             0.050429586321115494,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -296,7 +296,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.00047372994595207274,
             0.011921915225684643,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -304,7 +304,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0005534383235499263,
             -0.001172146643511951,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -312,22 +312,22 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.00010014028521254659,
             -0.0005452318582683802,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].y).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].z).toBeLessThan(0.0);
 
         expect(manager.sphericalHarmonicCoefficients[6].x).toBeGreaterThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[6].y).toBeGreaterThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[6].z).toBeGreaterThan(0.0);
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toBeLessThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
 
@@ -374,7 +374,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.3365404009819031,
             0.3376566469669342,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -382,7 +382,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.25208908319473267,
             0.25084879994392395,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -390,7 +390,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.0009837104007601738,
             0.0008832928724586964,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
@@ -399,7 +399,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0015308377332985401,
             -0.0012394117657095194,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeGreaterThan(0.0);
@@ -460,7 +460,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.04265068098902702,
             0.04163559526205063,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -468,7 +468,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.023243442177772522,
             0.025639381259679794,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -476,7 +476,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0033528741914778948,
             -0.0031588575802743435,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -484,7 +484,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.007121194154024124,
             0.005899451207369566,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeGreaterThan(0.0);
@@ -545,7 +545,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.0054358793422579765,
             0.0027179396711289883,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -553,7 +553,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.0037772462237626314,
             0.0018886231118813157,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -561,7 +561,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.000007333524990826845,
             -0.0000036667624954134226,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -569,7 +569,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.000008501945558236912,
             0.000004250972779118456,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
@@ -633,7 +633,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.04545757919549942,
             0.02313476987183094,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -641,7 +641,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.004114487674087286,
             -0.0017214358085766435,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -649,7 +649,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0008244783966802061,
             -0.00026270488160662353,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -657,16 +657,16 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.000012375472579151392,
             0.0005265426589176059,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].y).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].z).toBeLessThan(0.0);
 
         expect(manager.sphericalHarmonicCoefficients[6].x).toBeGreaterThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[6].y).toBeGreaterThan(0.0);
@@ -715,7 +715,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.039464931935071945,
             0.047749463468790054,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -723,7 +723,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.031872138381004333,
             0.04223670810461044,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -731,7 +731,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0008044499554671347,
             -0.0008345510577782989,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -739,7 +739,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.000017321406630799174,
             -0.000006108442903496325,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
@@ -798,7 +798,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.21367456018924713,
             0.23666927218437195,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -806,7 +806,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.15787045657634735,
             0.19085952639579773,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -814,7 +814,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0010327763156965375,
             -0.001100384397432208,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -822,7 +822,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.00028964842204004526,
             0.00021805899450555444,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
@@ -881,7 +881,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.07419705390930176,
             0.09077795594930649,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -889,7 +889,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.06336799263954163,
             0.08409948647022247,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -897,7 +897,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0006284310948103666,
             -0.000669674074742943,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -905,7 +905,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.000024254957679659128,
             0.00004792874096892774,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
@@ -964,7 +964,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.13499368727207184,
             0.13499368727207184,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -972,7 +972,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.1081928238272667,
             0.1081928238272667,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -980,7 +980,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0013909616973251104,
             -0.00141593546140939,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -988,7 +988,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.00016706169117242098,
             0.00006681153899990022,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
@@ -1047,7 +1047,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.11958353966474533,
             0.15991388261318207,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -1055,7 +1055,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.11915278434753418,
             0.15629366040229797,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -1063,7 +1063,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.0016134318429976702,
             -0.0015525781782343984,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -1071,16 +1071,16 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.000019326049368828535,
             -0.000023931264877319336,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
 
         expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
 
         expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
         expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
@@ -1130,7 +1130,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.1812949925661087,
             0.19759616255760193,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
           new Cartesian3(
@@ -1138,7 +1138,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.09013032913208008,
             0.13857196271419525,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
           new Cartesian3(
@@ -1146,7 +1146,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             -0.000895244418643415,
             -0.0011140345595777035,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
           new Cartesian3(
@@ -1154,7 +1154,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
             0.0004962628008797765,
             0.0002673182752914727,
           ),
-          CesiumMath.EPSILON4,
+          CesiumMath.EPSILON2,
         );
 
         expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

* Addresses memory leak brought up [in this community forum thread](https://community.cesium.com/t/procedural-ibl-gpu-memory-leak/36760)
* This is more or less a follow up from https://github.com/CesiumGS/cesium/pull/12320 that hopes to address some lingering memory use concerns
* This would complement, not replace, https://github.com/CesiumGS/cesium/pull/12358 as it would hope to address lower-level causes of https://github.com/CesiumGS/cesium/issues/12356

**Changes include**:

* Adjust default number of mipmap levels for the specular maps. This trades off a bit of visual quality for a MUCH smaller overall memory footprint by default.
* More aggressively destroy textures rather than peristing them for future updates.
* Fixes memory leaks.

## Issue number and link

Addresses https://github.com/CesiumGS/cesium/issues/12356

## Testing plan

I found it really helpful to use [this webgl memory tool](https://greggman.github.io/webgl-memory/) for testing. Thanks to @javagl for pointing it out!

```js
await import("https://greggman.github.io/webgl-memory/webgl-memory.js");

// Create viewer as normal

viewer.scene.debugShowFramesPerSecond = true;
Sandcastle.addToolbarButton("Check memory", function () {
  const ext = viewer.scene.context._gl.getExtension("GMAN_webgl_memory");
  if (ext) {
    // Overall memory info
    const info = ext.getMemoryInfo();
    console.log(info);
    // Every texture, it's size, a stack of where it was created and a stack of where it was last updated.
    const textures = ext.getResourcesInfo(WebGLTexture);
    console.log(textures);
  } else {
    console.log("There was an issue loading the extension");
  }
});
```

**Texture memory results**

Scenario | Before (MB) | After (MB) | % change |
| --- | --- | --- | --- |
| [Procedural IBL](https://sandcastle.cesium.com/#c=dVYNb+M2DP0rXDZgzpAqadq73vULu6W9rkBzK5psw4YAPcVmbK2yFEhy0+yQ/z5KsvPRpUAQWBL5+Ejx0eYLLhyIcq6NSyatwrm5Pe12c4N5XnLFcuGKasqE7i5wmsuDEkttljsL9o+dtNpnEzVRqVbWwbPABRq4AIULGKAVVcn+CHsUIQ3rgVaOC4Wm8Yw+zKaokGU4rfJRoRefDS/R3qMZIUFnBOlMheQw4ipLuXUSGc+ysdZyys0vlXNaUYxBgekTRHaTVgdmlUqd0AqSNnybKIDIE18cIe5EpgNH2+wxlyxHd/3iUFkRQG+Gn748hrwfG2RPHUDMICGfGhqg24XfntFwKWsKINRMx7MY2K8psg9EQYbB6Jb2kggYzTTlJnWeeONmn6CvCXoJnmRlsAPC/WjBin/pkYN1nPLWM1gUaJDOYMEtpAa5wwyoZG/aSKolVPPMG7JtqnUgu6H7gFZXhq4xMP4Tpzd342i0j33jH89WgNJiU6htu0lrHPh4MlyBsLZCkJpnQuXgCvTR41U0ZV9N1Cr2jr+A73au0c4xrSQ319RXRqsSlRvyuR1Vc9/nmNV3tRAq0wvGJYbmHxfCwtTohaXuzTQlrbQDG52gwQTcgEJJqCwyWm0EUOoM5e8Pd1S0SYuxLv1GvJxLvOKOd8Op7d7zhar/WS6nk9aWggoUeeGbs8d6Z+vN+StN/YqhPPfCpcWDljIh6w40f+21ozYiF4p8a78BpxpYwdURmxldXiGpHW1ycNg/Yr2T4+P3hx87cHzMeu96Rye9952azgYwZDDkzoiXDerYcGVn2pSWFa+IjfVn8YJZUHMS2XR8OvH6HPXzlioD+Gtdzo0ohRPPaL3ek9g/PMyuOvzQu4V8bqSbfbJLlSZ1nwFURp6ub6XT7G6lcbq92BgIJcqqvCfyckQaO4XD/of6dNUODzGFGouR0rIlKVQ5TzM83AlLjUujj2bPxeV26ztIqR6Gb3KN6xoxqP1vrUtwOsLvuNKgMlTaMGd3e5/0jmo05ykOAt5gbXq2jeAd+6wHPwFlXbCSvyQxiamulL++0dwrkhm6y8p2arJU4co6qrdCbrYEX0dgdck87yvKnKsUKY6hKD32bp1ZnQOVJ/DfGzee7lCu+2rTc4G50w+0Tc2X9I/qvt+4zH0Pvulw0N92iAlKrZ8+uSSG77ypN65yTGpCnRimE/Kkmrb3Qq4FkmzIULcds9ur6y/j2/Ff7XV9YkFwZ3oNueI5VTg3vk4DLTWVrunURtl+N4hgYG1YjCiE8uP1+/7H/ofDk/X0DCOLCPryJGiMNvuG4tdrf7IexIHXKfzwLTisvtZzr9VpnVu3lHjZ8Pk5flF44SU0/RzS9KN3i+1Oq/QJHUutbWp03t12Pc/EM4jsYs+HAqT0lrJ0MqtkkOOkdXneJfv/udZ0/VtY8qU3Kw4v7+ImY+y8S8v9ni5+SbxC/g8) | 110.334 | 91.591 | -16.99% |
| [Unlit boxes](https://sandcastle.cesium.com/#c=vVbbcts2EP2VHb2UbmSQ8iVpFdlTx3HSzMSta7ntQ9XxQOSKhA0CGgC07Hr0710QpELKSh7zIgHYs7tnL1iQr7hwIMqlNi6aDQrnlnYcx7nBPC+5YrlwRTVnQscrnOdyv8RSm6feht3Z2WDv7UylWlkHDwJXaOAEFK7gHK2oSvZXfUb203p/rpXjQqGZDYbwPFMAQi30O/04hgWXFof+yKLE1AmtPqlMpNxp05MWPNMrOwZnqvZEVzI7U6LkDjfna09spgIpZlNUyDKcV/m00KsPhpdor9BMkbhnxNlrkcKUqyzl1klkPMtutJZzbt5VzmlFQZwXmN5DCN5HsKhUTRSivRBNSAQ+OrLY80wCR8fsNpcsR3fx6FBZURv9eHn2222d1tvWsqdOqVlARDqNaYA4ht8f0HApGwp18oIsOPZ78uwdkZPLGvSJzqJgMMA0xSZ1Hnlwe06mL8j0E3iSlcEhCPeDBSv+oyUH6zjFrRewKtAgyWDFLaQGKeEZUMq+ipGUS6iWmQeyLtXGkf1C9xqtrgz1Sc34b5x//HwTQLvYt/pBtgak/mgT1cXNBjc1H0+GKxDWVghS80yoHFyB3nsoRZv29aZ3NuUNkV7qDGVUGTmEAkVeOEpNqSvliz1qqtQUHZUTTqBlhmrwgGdSNiVYaAORRCoVKSVv6W/SGKH1q1d7zxBC6CDvAvKug7zrIXvo+4C+76DvG3QXH4qw1FbUAZ609/WcG0crrg7ZwujyPdI8QBt1VQH2RweHLHlzdPR69DO8ohh+hIQlSTIa9nFHRyw5Tg7fJK8Jdfc1VMglIe4JMUp60rbyXdIFhuJtOF9yVzCnr+mYKxuNDo93qS2FS4s6OS9lRtOd2i0qllsT7dfg/sqbuya9qOEzDB6GtbFdBLQR1Ba8n+8bQ5SpeKVlxZbhPyrqOaP8kGjrNPR0Qm9uW6877unL2Nl0II2x6LmfcUXDbwy+kfvnrZvxZrUF6IQw7m62YKW/KGPY8grkUexy66dPKWh8V+WVeEQ5pakzhtHBT9s4KPmjR01TLglxQM2UbGHWvf26X4cmNc7QpMLsos1YSF0HuW6X63Ye+Iy3z5xe+pD94PqHxE2QfhyNYTb4U0mafPSgwT6M6IkIUoLXb9r45YtRV7AzXmYDxuIpL5cS33PH4zqXNiaLtenNguXSLfwbNKJLRb9tpCEB9a9ffIPeMaTVHLPvSPJ4B8lvJjD57hRHyc5E/lvfuZ0fB5eoqqjpiaA7GA5mamLdk8TTltov4UPLd39ExBwSMeJq43lFvehYam3reBJ3VSeZeACRnez4goKUXldLkkUl60szG5xOYsK/UG3eO//1IPmThxWj08/hkDE2iWm7W9OFILcs/w8) – 5 cubed | 2065.118 | 162.067 | -92.15% | 
| without reoloading, back to 1 cube | 156.448 | 128.029 | -18.17% |

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
