### PR TITLE
Add support for sparse accessors

### DIFF
--- a/packages/engine/Source/Scene/GltfDefaultVertexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfDefaultVertexBufferLoader.js
@@ -1,0 +1,96 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import GltfVertexBufferLoader from "./GltfVertexBufferLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads a vertex buffer from a glTF buffer view.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfDefaultVertexBufferLoader
+ * @constructor
+ * @augments GltfVertexBufferLoader
+ *
+ * @param {object} options Object with the properties that are required for {@link GltfVertexBufferLoader}, and the following properties:
+ * @param {number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
+ *
+ * @private
+ */
+function GltfDefaultVertexBufferLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  GltfVertexBufferLoader.call(this, options);
+
+  const bufferViewId = options.bufferViewId;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.bufferViewId", bufferViewId);
+  //>>includeEnd('debug');
+}
+
+if (defined(Object.create)) {
+  GltfDefaultVertexBufferLoader.prototype = Object.create(
+    GltfVertexBufferLoader.prototype,
+  );
+  GltfDefaultVertexBufferLoader.prototype.constructor =
+    GltfDefaultVertexBufferLoader;
+}
+
+GltfDefaultVertexBufferLoader.prototype.loadInternal = async function () {
+  this._promise = this.loadFromBufferView();
+  return this._promise;
+};
+
+GltfDefaultVertexBufferLoader.prototype.loadFromBufferView = async function () {
+  this._state = ResourceLoaderState.LOADING;
+  const resourceCache = this._resourceCache;
+  try {
+    const bufferViewLoader = resourceCache.getBufferViewLoader({
+      gltf: this._gltf,
+      bufferViewId: this._bufferViewId,
+      gltfResource: this._gltfResource,
+      baseResource: this._baseResource,
+    });
+    this._bufferViewLoader = bufferViewLoader;
+    await bufferViewLoader.load();
+
+    if (this.isDestroyed()) {
+      return;
+    }
+
+    this._typedArray = bufferViewLoader.typedArray;
+    this._state = ResourceLoaderState.PROCESSING;
+    return this;
+  } catch (error) {
+    if (this.isDestroyed()) {
+      return;
+    }
+
+    handleError(this, error);
+  }
+};
+
+function handleError(vertexBufferLoader, error) {
+  vertexBufferLoader.unload();
+  vertexBufferLoader._state = ResourceLoaderState.FAILED;
+  const errorMessage = "Failed to load vertex buffer";
+  throw vertexBufferLoader.getError(errorMessage, error);
+}
+
+GltfDefaultVertexBufferLoader.prototype.processInternal = function () {};
+
+GltfVertexBufferLoader.prototype.unloadInternal = function () {
+  const resourceCache = this._resourceCache;
+  if (
+    defined(this._bufferViewLoader) &&
+    !this._bufferViewLoader.isDestroyed()
+  ) {
+    resourceCache.unload(this._bufferViewLoader);
+  }
+
+  this._bufferViewLoader = undefined;
+};
+
+export default GltfDefaultVertexBufferLoader;

--- a/packages/engine/Source/Scene/GltfDracoLoader.js
+++ b/packages/engine/Source/Scene/GltfDracoLoader.js
@@ -93,6 +93,22 @@ Object.defineProperties(GltfDracoLoader.prototype, {
   },
 });
 
+/**
+ * The only function that is called from the "ResourceLoader.load" implementation
+ * of this class: It loads the buffer view data that is referred to by the
+ * draco extension object.
+ *
+ * When the returned promise completes, then the loaded buffer view data will
+ * be available as a typed array, namely, the "loader._bufferViewTypedArray",
+ * and the state of the given loader will be ResourceLoaderState.PROCESSING.
+ *
+ * Based on this state, the "ResourceLoader.process" function of this class
+ * will decode this typed array. The resulting decoded data will be handled
+ * in "processDecode"
+ *
+ * @param {GltfDracoLoader} loader - The loader, "this"
+ * @returns A promise that is fulfilled when the resources are loaded
+ */
 async function loadResources(loader) {
   const resourceCache = loader._resourceCache;
   try {
@@ -143,6 +159,28 @@ function handleError(dracoLoader, error) {
   throw dracoLoader.getError(errorMessage, error);
 }
 
+/**
+ * Will be called from the "ResourceLoader.process" implementation of
+ * this class, as soon as the underlying raw buffer view data has
+ * been draco-decoded from the "loader._bufferViewTypedArray" and
+ * converted into a structure that contains the "indexArray"
+ * and the "attributeData" from the Draco decoding process.
+ *
+ * The resulting data will be stored as the "loader._decodedData".
+ *
+ * The exact structure of this data is not known (by me), but it is
+ * later accessed with lines like
+ * <code><pre>
+ * dracoLoader.decodedData.indices.typedArray
+ * dracoLoader.decodedData.vertexAttributes[semantic].array
+ * </pre></code>
+ *
+ * @param {GltfDracoLoader} loader - The draco loader, "this"
+ * @param {Promise<object>} decodePromise - The promise that returns
+ * the decoded data.
+ * @returns A promise that fulfills when the decoded data is stored
+ * in the loader
+ */
 async function processDecode(loader, decodePromise) {
   try {
     const results = await decodePromise;

--- a/packages/engine/Source/Scene/GltfDracoVertexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfDracoVertexBufferLoader.js
@@ -1,0 +1,235 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import AttributeType from "./AttributeType.js";
+import GltfVertexBufferLoader from "./GltfVertexBufferLoader.js";
+import ModelComponents from "./ModelComponents.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads a vertex buffer from a glTF buffer view.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfDracoVertexBufferLoader
+ * @constructor
+ * @augments GltfVertexBufferLoader
+ *
+ * @param {object} options Object with the properties that are required for {@link GltfVertexBufferLoader}, and the following properties:
+ * @param {object} [options.draco] The Draco extension object.
+ * @param {string} [options.attributeSemantic] The attribute semantic, e.g. POSITION or NORMAL.
+ *
+ * @private
+ */
+function GltfDracoVertexBufferLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  GltfVertexBufferLoader.call(this, options);
+
+  const draco = options.draco;
+  const attributeSemantic = options.attributeSemantic;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.draco", draco);
+  Check.typeOf.string("options.attributeSemantic", attributeSemantic);
+  //>>includeEnd('debug');
+
+  this._accessorId = draco.attributes[attributeSemantic];
+  this._dracoLoader = undefined;
+  this._quantization = undefined;
+}
+
+if (defined(Object.create)) {
+  GltfDracoVertexBufferLoader.prototype = Object.create(
+    GltfVertexBufferLoader.prototype,
+  );
+  GltfDracoVertexBufferLoader.prototype.constructor =
+    GltfDracoVertexBufferLoader;
+}
+
+Object.defineProperties(GltfDracoVertexBufferLoader.prototype, {
+  /**
+   * Information about the quantized vertex attribute after Draco decode.
+   *
+   * @memberof GltfVertexBufferLoader.prototype
+   *
+   * @type {ModelComponents.Quantization}
+   * @readonly
+   * @private
+   */
+  quantization: {
+    get: function () {
+      return this._quantization;
+    },
+  },
+});
+
+GltfDracoVertexBufferLoader.prototype.loadInternal = async function () {
+  this._promise = loadFromDraco(this);
+  return this._promise;
+};
+
+async function loadFromDraco(vertexBufferLoader) {
+  vertexBufferLoader._state = ResourceLoaderState.LOADING;
+  const resourceCache = vertexBufferLoader._resourceCache;
+  try {
+    const dracoLoader = resourceCache.getDracoLoader({
+      gltf: vertexBufferLoader._gltf,
+      draco: vertexBufferLoader._draco,
+      gltfResource: vertexBufferLoader._gltfResource,
+      baseResource: vertexBufferLoader._baseResource,
+    });
+    vertexBufferLoader._dracoLoader = dracoLoader;
+    await dracoLoader.load();
+
+    if (vertexBufferLoader.isDestroyed()) {
+      return;
+    }
+
+    // Now wait for process() to run to finish loading
+    vertexBufferLoader._state = ResourceLoaderState.LOADED;
+    return vertexBufferLoader;
+  } catch {
+    if (vertexBufferLoader.isDestroyed()) {
+      return;
+    }
+
+    handleError(vertexBufferLoader);
+  }
+}
+
+GltfDracoVertexBufferLoader.prototype.processDraco = function () {
+  this._state = ResourceLoaderState.PROCESSING;
+  const dracoLoader = this._dracoLoader;
+
+  // Get the typed array and quantization information
+  const decodedVertexAttributes = dracoLoader.decodedData.vertexAttributes;
+  const attributeSemantic = this._attributeSemantic;
+  const dracoAttribute = decodedVertexAttributes[attributeSemantic];
+  const accessorId = this._accessorId;
+  const accessor = this._gltf.accessors[accessorId];
+  const type = accessor.type;
+  const typedArray = dracoAttribute.array;
+  const dracoQuantization = dracoAttribute.data.quantization;
+  if (defined(dracoQuantization)) {
+    this._quantization = getQuantizationInformation(
+      dracoQuantization,
+      dracoAttribute.data.componentDatatype,
+      dracoAttribute.data.componentsPerAttribute,
+      type,
+    );
+  }
+
+  this._typedArray = new Uint8Array(
+    typedArray.buffer,
+    typedArray.byteOffset,
+    typedArray.byteLength,
+  );
+};
+
+function getQuantizationInformation(
+  dracoQuantization,
+  componentDatatype,
+  componentCount,
+  type,
+) {
+  const quantizationBits = dracoQuantization.quantizationBits;
+  const normalizationRange = (1 << quantizationBits) - 1;
+  const normalizationDivisor = 1.0 / normalizationRange;
+
+  const quantization = new ModelComponents.Quantization();
+  quantization.componentDatatype = componentDatatype;
+  quantization.octEncoded = dracoQuantization.octEncoded;
+  quantization.octEncodedZXY = true;
+  quantization.type = type;
+
+  if (quantization.octEncoded) {
+    quantization.type = AttributeType.VEC2;
+    quantization.normalizationRange = normalizationRange;
+  } else {
+    const MathType = AttributeType.getMathType(type);
+    if (MathType === Number) {
+      const dimensions = dracoQuantization.range;
+      quantization.quantizedVolumeOffset = dracoQuantization.minValues[0];
+      quantization.quantizedVolumeDimensions = dimensions;
+      quantization.normalizationRange = normalizationRange;
+      quantization.quantizedVolumeStepSize = dimensions * normalizationDivisor;
+    } else {
+      quantization.quantizedVolumeOffset = MathType.unpack(
+        dracoQuantization.minValues,
+      );
+      quantization.normalizationRange = MathType.unpack(
+        new Array(componentCount).fill(normalizationRange),
+      );
+      const packedDimensions = new Array(componentCount).fill(
+        dracoQuantization.range,
+      );
+      quantization.quantizedVolumeDimensions =
+        MathType.unpack(packedDimensions);
+
+      // Computing the step size
+      const packedSteps = packedDimensions.map(function (dimension) {
+        return dimension * normalizationDivisor;
+      });
+      quantization.quantizedVolumeStepSize = MathType.unpack(packedSteps);
+    }
+  }
+
+  return quantization;
+}
+
+function handleError(vertexBufferLoader, error) {
+  vertexBufferLoader.unload();
+  vertexBufferLoader._state = ResourceLoaderState.FAILED;
+  const errorMessage = "Failed to load vertex buffer";
+  throw vertexBufferLoader.getError(errorMessage, error);
+}
+
+GltfDracoVertexBufferLoader.prototype.processInternal = function (frameState) {
+  try {
+    const ready = this._dracoLoader.process(frameState);
+    if (!ready) {
+      return;
+    }
+  } catch (error) {
+    handleError(this, error);
+  }
+  this.processDraco();
+};
+
+GltfDracoVertexBufferLoader.prototype.processDraco = function () {
+  this._state = ResourceLoaderState.PROCESSING;
+  const dracoLoader = this._dracoLoader;
+
+  // Get the typed array and quantization information
+  const decodedVertexAttributes = dracoLoader.decodedData.vertexAttributes;
+  const attributeSemantic = this._attributeSemantic;
+  const dracoAttribute = decodedVertexAttributes[attributeSemantic];
+  const accessorId = this._accessorId;
+  const accessor = this._gltf.accessors[accessorId];
+  const type = accessor.type;
+  const typedArray = dracoAttribute.array;
+  const dracoQuantization = dracoAttribute.data.quantization;
+  if (defined(dracoQuantization)) {
+    this._quantization = getQuantizationInformation(
+      dracoQuantization,
+      dracoAttribute.data.componentDatatype,
+      dracoAttribute.data.componentsPerAttribute,
+      type,
+    );
+  }
+
+  this._typedArray = new Uint8Array(
+    typedArray.buffer,
+    typedArray.byteOffset,
+    typedArray.byteLength,
+  );
+};
+
+GltfDracoVertexBufferLoader.prototype.unloadInternal = function () {
+  const resourceCache = this._resourceCache;
+  resourceCache.unload(this._dracoLoader);
+  this._dracoLoader = undefined;
+};
+
+export default GltfDracoVertexBufferLoader;

--- a/packages/engine/Source/Scene/GltfIndexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfIndexBufferLoader.js
@@ -240,35 +240,50 @@ function createIndicesTypedArray(indexBufferLoader, bufferViewTypedArray) {
   const accessorId = indexBufferLoader._accessorId;
   const accessor = gltf.accessors[accessorId];
   const count = accessor.count;
-  const indexDatatype = accessor.componentType;
-  const indexSize = IndexDatatype.getSizeInBytes(indexDatatype);
-
-  let arrayBuffer = bufferViewTypedArray.buffer;
-  let byteOffset = bufferViewTypedArray.byteOffset + accessor.byteOffset;
-
-  if (byteOffset % indexSize !== 0) {
-    const byteLength = count * indexSize;
-    const view = new Uint8Array(arrayBuffer, byteOffset, byteLength);
-    const copy = new Uint8Array(view);
-    arrayBuffer = copy.buffer;
-    byteOffset = 0;
-    deprecationWarning(
-      "index-buffer-unaligned",
-      `The index array is not aligned to a ${indexSize}-byte boundary.`,
-    );
-  }
-
-  let typedArray;
-  if (indexDatatype === IndexDatatype.UNSIGNED_BYTE) {
-    typedArray = new Uint8Array(arrayBuffer, byteOffset, count);
-  } else if (indexDatatype === IndexDatatype.UNSIGNED_SHORT) {
-    typedArray = new Uint16Array(arrayBuffer, byteOffset, count);
-  } else if (indexDatatype === IndexDatatype.UNSIGNED_INT) {
-    typedArray = new Uint32Array(arrayBuffer, byteOffset, count);
-  }
-
-  return typedArray;
+  const byteOffset = accessor.byteOffset;
+  const componentType = accessor.componentType;
+  return GltfIndexBufferLoader.createIndicesTypedArrayFromBufferViewTypedArray(
+    bufferViewTypedArray,
+    byteOffset,
+    componentType,
+    count,
+  );
 }
+
+GltfIndexBufferLoader.createIndicesTypedArrayFromBufferViewTypedArray =
+  function (bufferViewTypedArray, byteOffset, componentType, count) {
+    const indexSize = IndexDatatype.getSizeInBytes(componentType);
+
+    let arrayBuffer = bufferViewTypedArray.buffer;
+    let arrayBufferByteOffset = bufferViewTypedArray.byteOffset + byteOffset;
+
+    if (arrayBufferByteOffset % indexSize !== 0) {
+      const byteLength = count * indexSize;
+      const view = new Uint8Array(
+        arrayBuffer,
+        arrayBufferByteOffset,
+        byteLength,
+      );
+      const copy = new Uint8Array(view);
+      arrayBuffer = copy.buffer;
+      arrayBufferByteOffset = 0;
+      deprecationWarning(
+        "index-buffer-unaligned",
+        `The index array is not aligned to a ${indexSize}-byte boundary.`,
+      );
+    }
+
+    let typedArray;
+    if (componentType === IndexDatatype.UNSIGNED_BYTE) {
+      typedArray = new Uint8Array(arrayBuffer, arrayBufferByteOffset, count);
+    } else if (componentType === IndexDatatype.UNSIGNED_SHORT) {
+      typedArray = new Uint16Array(arrayBuffer, arrayBufferByteOffset, count);
+    } else if (componentType === IndexDatatype.UNSIGNED_INT) {
+      typedArray = new Uint32Array(arrayBuffer, arrayBufferByteOffset, count);
+    }
+
+    return typedArray;
+  };
 
 function handleError(indexBufferLoader, error) {
   indexBufferLoader.unload();

--- a/packages/engine/Source/Scene/GltfIndexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfIndexBufferLoader.js
@@ -2,11 +2,10 @@ import Check from "../Core/Check.js";
 import ComponentDatatype from "../Core/ComponentDatatype.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 import DeveloperError from "../Core/DeveloperError.js";
-import IndexDatatype from "../Core/IndexDatatype.js";
 import Buffer from "../Renderer/Buffer.js";
 import BufferUsage from "../Renderer/BufferUsage.js";
+import GltfUtil from "./GltfUtil.js";
 import JobType from "./JobType.js";
 import ResourceLoader from "./ResourceLoader.js";
 import ResourceLoaderState from "./ResourceLoaderState.js";
@@ -242,48 +241,13 @@ function createIndicesTypedArray(indexBufferLoader, bufferViewTypedArray) {
   const count = accessor.count;
   const byteOffset = accessor.byteOffset;
   const componentType = accessor.componentType;
-  return GltfIndexBufferLoader.createIndicesTypedArrayFromBufferViewTypedArray(
+  return GltfUtil.createIndicesTypedArrayFromBufferViewTypedArray(
     bufferViewTypedArray,
     byteOffset,
     componentType,
     count,
   );
 }
-
-GltfIndexBufferLoader.createIndicesTypedArrayFromBufferViewTypedArray =
-  function (bufferViewTypedArray, byteOffset, componentType, count) {
-    const indexSize = IndexDatatype.getSizeInBytes(componentType);
-
-    let arrayBuffer = bufferViewTypedArray.buffer;
-    let arrayBufferByteOffset = bufferViewTypedArray.byteOffset + byteOffset;
-
-    if (arrayBufferByteOffset % indexSize !== 0) {
-      const byteLength = count * indexSize;
-      const view = new Uint8Array(
-        arrayBuffer,
-        arrayBufferByteOffset,
-        byteLength,
-      );
-      const copy = new Uint8Array(view);
-      arrayBuffer = copy.buffer;
-      arrayBufferByteOffset = 0;
-      deprecationWarning(
-        "index-buffer-unaligned",
-        `The index array is not aligned to a ${indexSize}-byte boundary.`,
-      );
-    }
-
-    let typedArray;
-    if (componentType === IndexDatatype.UNSIGNED_BYTE) {
-      typedArray = new Uint8Array(arrayBuffer, arrayBufferByteOffset, count);
-    } else if (componentType === IndexDatatype.UNSIGNED_SHORT) {
-      typedArray = new Uint16Array(arrayBuffer, arrayBufferByteOffset, count);
-    } else if (componentType === IndexDatatype.UNSIGNED_INT) {
-      typedArray = new Uint32Array(arrayBuffer, arrayBufferByteOffset, count);
-    }
-
-    return typedArray;
-  };
 
 function handleError(indexBufferLoader, error) {
   indexBufferLoader.unload();

--- a/packages/engine/Source/Scene/GltfLoader.js
+++ b/packages/engine/Source/Scene/GltfLoader.js
@@ -748,11 +748,30 @@ function getBufferViewLoader(loader, bufferViewId) {
 }
 
 function getPackedTypedArray(gltf, accessor, bufferViewTypedArray) {
-  let byteOffset = accessor.byteOffset;
+  const byteOffset = accessor.byteOffset;
   const byteStride = getAccessorByteStride(gltf, accessor);
   const count = accessor.count;
-  const componentCount = numberOfComponentsForType(accessor.type);
   const componentType = accessor.componentType;
+  const type = accessor.type;
+  return GltfLoader.getPackedTypedArrayFromBufferViewTypedArray(
+    bufferViewTypedArray,
+    byteOffset,
+    type,
+    componentType,
+    byteStride,
+    count,
+  );
+}
+
+GltfLoader.getPackedTypedArrayFromBufferViewTypedArray = function (
+  bufferViewTypedArray,
+  byteOffset,
+  type,
+  componentType,
+  byteStride,
+  count,
+) {
+  const componentCount = numberOfComponentsForType(type);
   const componentByteLength = ComponentDatatype.getSizeInBytes(componentType);
   const defaultByteStride = componentByteLength * componentCount;
   const componentsLength = count * componentCount;
@@ -775,7 +794,7 @@ function getPackedTypedArray(gltf, accessor, bufferViewTypedArray) {
 
   const dataView = new DataView(bufferViewTypedArray.buffer);
   const components = new Array(componentCount);
-  const componentReader = getComponentReader(accessor.componentType);
+  const componentReader = getComponentReader(componentType);
   byteOffset = bufferViewTypedArray.byteOffset + byteOffset;
 
   for (let i = 0; i < count; ++i) {
@@ -793,7 +812,7 @@ function getPackedTypedArray(gltf, accessor, bufferViewTypedArray) {
   }
 
   return accessorTypedArray;
-}
+};
 
 function loadDefaultAccessorValues(accessor, values) {
   const accessorType = accessor.type;

--- a/packages/engine/Source/Scene/GltfUtil.js
+++ b/packages/engine/Source/Scene/GltfUtil.js
@@ -1,0 +1,172 @@
+import ComponentDatatype from "../Core/ComponentDatatype.js";
+import defined from "../Core/defined.js";
+import deprecationWarning from "../Core/deprecationWarning.js";
+import IndexDatatype from "../Core/IndexDatatype.js";
+import getComponentReader from "./GltfPipeline/getComponentReader.js";
+import numberOfComponentsForType from "./GltfPipeline/numberOfComponentsForType.js";
+
+/**
+ * glTF utilities.
+ *
+ * @namespace GltfUtil
+ *
+ * @private
+ */
+const GltfUtil = {};
+
+/**
+ * Returns whether the specified attribute is draco-compressed.
+ * <p>
+ * This returns whether the given draco object is defined and has
+ * an attribute with the given semantic.
+ * </p>
+ *
+ * @param {object|undefined} draco Object with the following properties:
+ * @param {any} semantic The semantic (attribute name)
+ *
+ * @returns {boolean} Whether the specified attribute is draco-compressed
+ * @private
+ */
+GltfUtil.hasDracoCompression = function (draco, semantic) {
+  return (
+    defined(draco) &&
+    defined(draco.attributes) &&
+    defined(draco.attributes[semantic])
+  );
+};
+
+/**
+ * Creates an empty (zero-initialized) Uint8Array with a size that
+ * matches the given accessor.
+ *
+ * @param {object} accessor - The glTF accessor object
+ * @returns {Uint8Array} The typed array
+ * @private
+ */
+GltfUtil.createUint8ArrayForAccessor = function (accessor) {
+  const componentType = accessor.componentType;
+  const numComponents = numberOfComponentsForType(accessor.type);
+  const componentSize = ComponentDatatype.getSizeInBytes(componentType);
+  const byteArrayLength = accessor.count * numComponents * componentSize;
+  const typedArray = new Uint8Array(byteArrayLength);
+  return typedArray;
+};
+
+/**
+ * Returns a packed typed array for the specified elements of another typed array.
+ *
+ * The given typed array is the typed array containing the data of a buffer
+ * view. The parameters describe the accessor whose data is represented
+ * with the returned typed array.
+ *
+ * @param {TypedArray} bufferViewTypedArray - The typed array of the buffer view
+ * @param {number} byteOffset - The byte offset
+ * @param {number} byteStride - The byte strode
+ * @param {number} count - The number of elements of the accessor
+ * @param {string} type - The accessor type (e.g. "VEC3")
+ * @param {number} componentType The component, i.e. the ComponentDataType,
+ * like 'UNSIGNED_SHORT'
+ * @returns The packed typed array
+ * @private
+ */
+GltfUtil.getPackedTypedArrayFromBufferViewTypedArray = function (
+  bufferViewTypedArray,
+  byteOffset,
+  byteStride,
+  count,
+  type,
+  componentType,
+) {
+  const componentCount = numberOfComponentsForType(type);
+  const componentByteLength = ComponentDatatype.getSizeInBytes(componentType);
+  const defaultByteStride = componentByteLength * componentCount;
+  const componentsLength = count * componentCount;
+
+  if (byteStride === defaultByteStride) {
+    // Copy the typed array and let the underlying ArrayBuffer be freed
+    bufferViewTypedArray = new Uint8Array(bufferViewTypedArray);
+    return ComponentDatatype.createArrayBufferView(
+      componentType,
+      bufferViewTypedArray.buffer,
+      bufferViewTypedArray.byteOffset + byteOffset,
+      componentsLength,
+    );
+  }
+
+  const typedArray = ComponentDatatype.createTypedArray(
+    componentType,
+    componentsLength,
+  );
+
+  const dataView = new DataView(bufferViewTypedArray.buffer);
+  const components = new Array(componentCount);
+  const componentReader = getComponentReader(componentType);
+  byteOffset = bufferViewTypedArray.byteOffset + byteOffset;
+
+  for (let i = 0; i < count; ++i) {
+    componentReader(
+      dataView,
+      byteOffset,
+      componentCount,
+      componentByteLength,
+      components,
+    );
+    for (let j = 0; j < componentCount; ++j) {
+      typedArray[i * componentCount + j] = components[j];
+    }
+    byteOffset += byteStride;
+  }
+
+  return typedArray;
+};
+
+/**
+ * Returns a typed array containing indices, created from a part
+ * of the given typed array.
+ *
+ * The given component type must be 'UNSIGNED_BYTE', 'UNSIGNED_SHORT',
+ * or 'UNSIGNED_INT'.
+ *
+ * @param {TypedArray} bufferViewTypedArray - The buffer view typed array
+ * @param {number} byteOffset - The byte offset
+ * @param {number} componentType The component type
+ * @param {number} count - The number of elements
+ * @returns The typed array for the indices, or undefined when
+ * the component type is not valid
+ */
+GltfUtil.createIndicesTypedArrayFromBufferViewTypedArray = function (
+  bufferViewTypedArray,
+  byteOffset,
+  componentType,
+  count,
+) {
+  const indexSize = IndexDatatype.getSizeInBytes(componentType);
+
+  let arrayBuffer = bufferViewTypedArray.buffer;
+  let arrayBufferByteOffset = bufferViewTypedArray.byteOffset + byteOffset;
+
+  if (arrayBufferByteOffset % indexSize !== 0) {
+    const byteLength = count * indexSize;
+    const view = new Uint8Array(arrayBuffer, arrayBufferByteOffset, byteLength);
+    const copy = new Uint8Array(view);
+    arrayBuffer = copy.buffer;
+    arrayBufferByteOffset = 0;
+    deprecationWarning(
+      "index-buffer-unaligned",
+      `The index array is not aligned to a ${indexSize}-byte boundary.`,
+    );
+  }
+
+  let typedArray;
+  if (componentType === IndexDatatype.UNSIGNED_BYTE) {
+    typedArray = new Uint8Array(arrayBuffer, arrayBufferByteOffset, count);
+  } else if (componentType === IndexDatatype.UNSIGNED_SHORT) {
+    typedArray = new Uint16Array(arrayBuffer, arrayBufferByteOffset, count);
+  } else if (componentType === IndexDatatype.UNSIGNED_INT) {
+    typedArray = new Uint32Array(arrayBuffer, arrayBufferByteOffset, count);
+  }
+
+  return typedArray;
+};
+
+export default GltfUtil;

--- a/packages/engine/Source/Scene/GltfVertexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfVertexBufferLoader.js
@@ -4,10 +4,7 @@ import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Buffer from "../Renderer/Buffer.js";
 import BufferUsage from "../Renderer/BufferUsage.js";
-import AttributeType from "./AttributeType.js";
-import GltfUtil from "./GltfUtil.js";
 import JobType from "./JobType.js";
-import ModelComponents from "./ModelComponents.js";
 import ResourceLoader from "./ResourceLoader.js";
 import ResourceLoaderState from "./ResourceLoaderState.js";
 
@@ -26,18 +23,10 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {object} options.gltf The glTF JSON.
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
- * @param {number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
- * @param {object} [options.draco] The Draco extension object.
- * @param {string} [options.attributeSemantic] The attribute semantic, e.g. POSITION or NORMAL.
- * @param {number} [options.accessorId] The accessor id.
  * @param {string} [options.cacheKey] The cache key of the resource.
  * @param {boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  * @param {boolean} [options.loadBuffer=false] Load vertex buffer as a GPU vertex buffer.
  * @param {boolean} [options.loadTypedArray=false] Load vertex buffer as a typed array.
- *
- * @exception {DeveloperError} One of options.bufferViewId and options.draco must be defined.
- * @exception {DeveloperError} When options.draco is defined options.attributeSemantic must also be defined.
- * @exception {DeveloperError} When options.draco is defined options.accessorId must also be defined.
  *
  * @private
  */
@@ -47,10 +36,6 @@ function GltfVertexBufferLoader(options) {
   const gltf = options.gltf;
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
-  const bufferViewId = options.bufferViewId;
-  const draco = options.draco;
-  const attributeSemantic = options.attributeSemantic;
-  const accessorId = options.accessorId;
   const cacheKey = options.cacheKey;
   const asynchronous = defaultValue(options.asynchronous, true);
   const loadBuffer = defaultValue(options.loadBuffer, false);
@@ -66,54 +51,21 @@ function GltfVertexBufferLoader(options) {
       "At least one of loadBuffer and loadTypedArray must be true.",
     );
   }
-
-  const hasBufferViewId = defined(bufferViewId);
-  const hasDraco = GltfUtil.hasDracoCompression(draco, attributeSemantic);
-  const hasAttributeSemantic = defined(attributeSemantic);
-  const hasAccessorId = defined(accessorId);
-
-  if (hasBufferViewId === hasDraco) {
-    throw new DeveloperError(
-      "One of options.bufferViewId and options.draco must be defined.",
-    );
-  }
-
-  if (hasDraco && !hasAttributeSemantic) {
-    throw new DeveloperError(
-      "When options.draco is defined options.attributeSemantic must also be defined.",
-    );
-  }
-
-  if (hasDraco && !hasAccessorId) {
-    throw new DeveloperError(
-      "When options.draco is defined options.accessorId must also be defined.",
-    );
-  }
-
-  if (hasDraco) {
-    Check.typeOf.object("options.draco", draco);
-    Check.typeOf.string("options.attributeSemantic", attributeSemantic);
-    Check.typeOf.number("options.accessorId", accessorId);
-  }
   //>>includeEnd('debug');
 
   this._resourceCache = resourceCache;
   this._gltfResource = gltfResource;
   this._baseResource = baseResource;
   this._gltf = gltf;
-  this._bufferViewId = bufferViewId;
-  this._draco = draco;
-  this._attributeSemantic = attributeSemantic;
-  this._accessorId = accessorId;
   this._cacheKey = cacheKey;
   this._asynchronous = asynchronous;
+
   this._loadBuffer = loadBuffer;
   this._loadTypedArray = loadTypedArray;
-  this._bufferViewLoader = undefined;
-  this._dracoLoader = undefined;
-  this._quantization = undefined;
+
   this._typedArray = undefined;
   this._buffer = undefined;
+
   this._state = ResourceLoaderState.UNLOADED;
   this._promise = undefined;
 }
@@ -166,20 +118,6 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
       return this._typedArray;
     },
   },
-  /**
-   * Information about the quantized vertex attribute after Draco decode.
-   *
-   * @memberof GltfVertexBufferLoader.prototype
-   *
-   * @type {ModelComponents.Quantization}
-   * @readonly
-   * @private
-   */
-  quantization: {
-    get: function () {
-      return this._quantization;
-    },
-  },
 });
 
 /**
@@ -192,159 +130,22 @@ GltfVertexBufferLoader.prototype.load = async function () {
     return this._promise;
   }
 
-  if (GltfUtil.hasDracoCompression(this._draco, this._attributeSemantic)) {
-    this._promise = loadFromDraco(this);
-    return this._promise;
-  }
-
-  this._promise = loadFromBufferView(this);
+  this._promise = this.loadInternal();
   return this._promise;
 };
 
-function getQuantizationInformation(
-  dracoQuantization,
-  componentDatatype,
-  componentCount,
-  type,
-) {
-  const quantizationBits = dracoQuantization.quantizationBits;
-  const normalizationRange = (1 << quantizationBits) - 1;
-  const normalizationDivisor = 1.0 / normalizationRange;
+GltfVertexBufferLoader.prototype.loadInternal = async function () {
+  DeveloperError.throwInstantiationError();
+};
 
-  const quantization = new ModelComponents.Quantization();
-  quantization.componentDatatype = componentDatatype;
-  quantization.octEncoded = dracoQuantization.octEncoded;
-  quantization.octEncodedZXY = true;
-  quantization.type = type;
+GltfVertexBufferLoader.prototype.processInternal = async function () {
+  DeveloperError.throwInstantiationError();
+};
 
-  if (quantization.octEncoded) {
-    quantization.type = AttributeType.VEC2;
-    quantization.normalizationRange = normalizationRange;
-  } else {
-    const MathType = AttributeType.getMathType(type);
-    if (MathType === Number) {
-      const dimensions = dracoQuantization.range;
-      quantization.quantizedVolumeOffset = dracoQuantization.minValues[0];
-      quantization.quantizedVolumeDimensions = dimensions;
-      quantization.normalizationRange = normalizationRange;
-      quantization.quantizedVolumeStepSize = dimensions * normalizationDivisor;
-    } else {
-      quantization.quantizedVolumeOffset = MathType.unpack(
-        dracoQuantization.minValues,
-      );
-      quantization.normalizationRange = MathType.unpack(
-        new Array(componentCount).fill(normalizationRange),
-      );
-      const packedDimensions = new Array(componentCount).fill(
-        dracoQuantization.range,
-      );
-      quantization.quantizedVolumeDimensions =
-        MathType.unpack(packedDimensions);
+GltfVertexBufferLoader.prototype.unloadInternal = async function () {
+  DeveloperError.throwInstantiationError();
+};
 
-      // Computing the step size
-      const packedSteps = packedDimensions.map(function (dimension) {
-        return dimension * normalizationDivisor;
-      });
-      quantization.quantizedVolumeStepSize = MathType.unpack(packedSteps);
-    }
-  }
-
-  return quantization;
-}
-
-async function loadFromDraco(vertexBufferLoader) {
-  vertexBufferLoader._state = ResourceLoaderState.LOADING;
-  const resourceCache = vertexBufferLoader._resourceCache;
-  try {
-    const dracoLoader = resourceCache.getDracoLoader({
-      gltf: vertexBufferLoader._gltf,
-      draco: vertexBufferLoader._draco,
-      gltfResource: vertexBufferLoader._gltfResource,
-      baseResource: vertexBufferLoader._baseResource,
-    });
-    vertexBufferLoader._dracoLoader = dracoLoader;
-    await dracoLoader.load();
-
-    if (vertexBufferLoader.isDestroyed()) {
-      return;
-    }
-
-    // Now wait for process() to run to finish loading
-    vertexBufferLoader._state = ResourceLoaderState.LOADED;
-    return vertexBufferLoader;
-  } catch {
-    if (vertexBufferLoader.isDestroyed()) {
-      return;
-    }
-
-    handleError(vertexBufferLoader);
-  }
-}
-
-function processDraco(vertexBufferLoader) {
-  vertexBufferLoader._state = ResourceLoaderState.PROCESSING;
-  const dracoLoader = vertexBufferLoader._dracoLoader;
-
-  // Get the typed array and quantization information
-  const decodedVertexAttributes = dracoLoader.decodedData.vertexAttributes;
-  const attributeSemantic = vertexBufferLoader._attributeSemantic;
-  const dracoAttribute = decodedVertexAttributes[attributeSemantic];
-  const accessorId = vertexBufferLoader._accessorId;
-  const accessor = vertexBufferLoader._gltf.accessors[accessorId];
-  const type = accessor.type;
-  const typedArray = dracoAttribute.array;
-  const dracoQuantization = dracoAttribute.data.quantization;
-  if (defined(dracoQuantization)) {
-    vertexBufferLoader._quantization = getQuantizationInformation(
-      dracoQuantization,
-      dracoAttribute.data.componentDatatype,
-      dracoAttribute.data.componentsPerAttribute,
-      type,
-    );
-  }
-
-  vertexBufferLoader._typedArray = new Uint8Array(
-    typedArray.buffer,
-    typedArray.byteOffset,
-    typedArray.byteLength,
-  );
-}
-
-async function loadFromBufferView(vertexBufferLoader) {
-  vertexBufferLoader._state = ResourceLoaderState.LOADING;
-  const resourceCache = vertexBufferLoader._resourceCache;
-  try {
-    const bufferViewLoader = resourceCache.getBufferViewLoader({
-      gltf: vertexBufferLoader._gltf,
-      bufferViewId: vertexBufferLoader._bufferViewId,
-      gltfResource: vertexBufferLoader._gltfResource,
-      baseResource: vertexBufferLoader._baseResource,
-    });
-    vertexBufferLoader._bufferViewLoader = bufferViewLoader;
-    await bufferViewLoader.load();
-
-    if (vertexBufferLoader.isDestroyed()) {
-      return;
-    }
-
-    vertexBufferLoader._typedArray = bufferViewLoader.typedArray;
-    vertexBufferLoader._state = ResourceLoaderState.PROCESSING;
-    return vertexBufferLoader;
-  } catch (error) {
-    if (vertexBufferLoader.isDestroyed()) {
-      return;
-    }
-
-    handleError(vertexBufferLoader, error);
-  }
-}
-
-function handleError(vertexBufferLoader, error) {
-  vertexBufferLoader.unload();
-  vertexBufferLoader._state = ResourceLoaderState.FAILED;
-  const errorMessage = "Failed to load vertex buffer";
-  throw vertexBufferLoader.getError(errorMessage, error);
-}
 function CreateVertexBufferJob() {
   this.typedArray = undefined;
   this.context = undefined;
@@ -394,17 +195,9 @@ GltfVertexBufferLoader.prototype.process = function (frameState) {
     return false;
   }
 
-  if (defined(this._dracoLoader)) {
-    try {
-      const ready = this._dracoLoader.process(frameState);
-      if (!ready) {
-        return false;
-      }
-    } catch (error) {
-      handleError(this, error);
-    }
-
-    processDraco(this);
+  if (this._state === ResourceLoader.LOADED) {
+    this.processInternal(frameState);
+    return true;
   }
 
   let buffer;
@@ -441,21 +234,8 @@ GltfVertexBufferLoader.prototype.unload = function () {
     this._buffer.destroy();
   }
 
-  const resourceCache = this._resourceCache;
+  this.unloadInternal();
 
-  if (
-    defined(this._bufferViewLoader) &&
-    !this._bufferViewLoader.isDestroyed()
-  ) {
-    resourceCache.unload(this._bufferViewLoader);
-  }
-
-  if (defined(this._dracoLoader)) {
-    resourceCache.unload(this._dracoLoader);
-  }
-
-  this._bufferViewLoader = undefined;
-  this._dracoLoader = undefined;
   this._typedArray = undefined;
   this._buffer = undefined;
   this._gltf = undefined;

--- a/packages/engine/Source/Scene/GltfVertexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfVertexBufferLoader.js
@@ -1,15 +1,11 @@
 import Check from "../Core/Check.js";
-import ComponentDatatype from "../Core/ComponentDatatype.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Buffer from "../Renderer/Buffer.js";
 import BufferUsage from "../Renderer/BufferUsage.js";
 import AttributeType from "./AttributeType.js";
-import getComponentWriter from "./getComponentWriter.js";
-import GltfIndexBufferLoader from "./GltfIndexBufferLoader.js";
-import GltfLoader from "./GltfLoader.js";
-import numberOfComponentsForType from "./GltfPipeline/numberOfComponentsForType.js";
+import GltfUtil from "./GltfUtil.js";
 import JobType from "./JobType.js";
 import ModelComponents from "./ModelComponents.js";
 import ResourceLoader from "./ResourceLoader.js";
@@ -72,7 +68,7 @@ function GltfVertexBufferLoader(options) {
   }
 
   const hasBufferViewId = defined(bufferViewId);
-  const hasDraco = hasDracoCompression(draco, attributeSemantic);
+  const hasDraco = GltfUtil.hasDracoCompression(draco, attributeSemantic);
   const hasAttributeSemantic = defined(attributeSemantic);
   const hasAccessorId = defined(accessorId);
 
@@ -186,14 +182,6 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
   },
 });
 
-function hasDracoCompression(draco, semantic) {
-  return (
-    defined(draco) &&
-    defined(draco.attributes) &&
-    defined(draco.attributes[semantic])
-  );
-}
-
 /**
  * Loads the resource.
  * @returns {Promise<GltfVertexBufferLoader>} A promise which resolves to the loader when the resource loading is completed.
@@ -204,7 +192,7 @@ GltfVertexBufferLoader.prototype.load = async function () {
     return this._promise;
   }
 
-  if (hasDracoCompression(this._draco, this._attributeSemantic)) {
+  if (GltfUtil.hasDracoCompression(this._draco, this._attributeSemantic)) {
     this._promise = loadFromDraco(this);
     return this._promise;
   }
@@ -340,15 +328,6 @@ async function loadFromBufferView(vertexBufferLoader) {
     }
 
     vertexBufferLoader._typedArray = bufferViewLoader.typedArray;
-
-    if (defined(vertexBufferLoader._accessorId)) {
-      const accessor =
-        vertexBufferLoader._gltf.accessors[vertexBufferLoader._accessorId];
-      if (defined(accessor.sparse)) {
-        await handleSparseAccessor(vertexBufferLoader, accessor);
-      }
-    }
-
     vertexBufferLoader._state = ResourceLoaderState.PROCESSING;
     return vertexBufferLoader;
   } catch (error) {
@@ -360,114 +339,12 @@ async function loadFromBufferView(vertexBufferLoader) {
   }
 }
 
-async function handleSparseAccessor(vertexBufferLoader, accessor) {
-  const sparse = accessor.sparse;
-
-  console.log("There, there, sparse!", sparse);
-  const count = sparse.count;
-
-  const indices = sparse.indices;
-  const indicesBufferViewId = indices.bufferView;
-  const indicesBufferViewTypedArray = await loadDependencyBufferViewTypedArray(
-    vertexBufferLoader,
-    indicesBufferViewId,
-  );
-
-  const indicesByteOffset = indices.byteOffset;
-  const indicesComponentType = indices.componentType;
-  const indicesTypedArray =
-    GltfIndexBufferLoader.createIndicesTypedArrayFromBufferViewTypedArray(
-      indicesBufferViewTypedArray,
-      indicesByteOffset,
-      indicesComponentType,
-      count,
-    );
-  console.log("indices typed array ", indicesTypedArray);
-
-  const values = sparse.values;
-  const valuesBufferViewId = values.bufferView;
-  const valuesBufferViewTypedArray = await loadDependencyBufferViewTypedArray(
-    vertexBufferLoader,
-    valuesBufferViewId,
-  );
-
-  const valuesByteOffset = values.byteOffset;
-  const valuesComponentType = accessor.componentType;
-  const componentByteLength =
-    ComponentDatatype.getSizeInBytes(valuesComponentType);
-  const type = accessor.type;
-  const componentCount = numberOfComponentsForType(type);
-  const byteStride = componentByteLength * componentCount;
-  const valuesTypedArray =
-    GltfLoader.getPackedTypedArrayFromBufferViewTypedArray(
-      valuesBufferViewTypedArray,
-      valuesByteOffset,
-      type,
-      valuesComponentType,
-      byteStride,
-      count,
-    );
-  console.log("values typed array ", valuesTypedArray);
-
-  const targetTypedArray = vertexBufferLoader._typedArray;
-  const targetDataView = new DataView(
-    targetTypedArray.buffer,
-    targetTypedArray.byteOffset,
-    targetTypedArray.byteLength,
-  );
-  const componentWriter = getComponentWriter(valuesComponentType);
-
-  console.log("target typed array     ", targetTypedArray);
-  const n = indicesTypedArray.length;
-  for (let i = 0; i < n; i++) {
-    const index = indicesTypedArray[i];
-    for (let c = 0; c < componentCount; c++) {
-      const value = valuesTypedArray[i * componentCount + c];
-      console.log(
-        `setting ${value} at component ${c} of index ${index} of ${targetTypedArray}`,
-      );
-      componentWriter(targetDataView, index * componentCount + c, value);
-    }
-  }
-  console.log("target typed array now ", targetTypedArray);
-}
-
 function handleError(vertexBufferLoader, error) {
   vertexBufferLoader.unload();
   vertexBufferLoader._state = ResourceLoaderState.FAILED;
   const errorMessage = "Failed to load vertex buffer";
   throw vertexBufferLoader.getError(errorMessage, error);
 }
-
-async function loadDependencyBufferViewTypedArray(
-  vertexBufferLoader,
-  bufferViewId,
-) {
-  vertexBufferLoader._state = ResourceLoaderState.LOADING;
-  const resourceCache = vertexBufferLoader._resourceCache;
-  try {
-    const bufferViewLoader = resourceCache.getBufferViewLoader({
-      gltf: vertexBufferLoader._gltf,
-      bufferViewId: bufferViewId,
-      gltfResource: vertexBufferLoader._gltfResource,
-      baseResource: vertexBufferLoader._baseResource,
-    });
-    vertexBufferLoader._bufferViewLoader = bufferViewLoader;
-    await bufferViewLoader.load();
-
-    if (vertexBufferLoader.isDestroyed()) {
-      return;
-    }
-    return bufferViewLoader.typedArray;
-  } catch (error) {
-    if (vertexBufferLoader.isDestroyed()) {
-      return;
-    }
-
-    handleError(vertexBufferLoader, error);
-  }
-}
-
 function CreateVertexBufferJob() {
   this.typedArray = undefined;
   this.context = undefined;

--- a/packages/engine/Source/Scene/Model/MorphTargetsPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/MorphTargetsPipelineStage.js
@@ -4,6 +4,7 @@ import defined from "../../Core/defined.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 import MorphTargetsStageVS from "../../Shaders/Model/MorphTargetsStageVS.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
+import oneTimeWarning from "../../Core/oneTimeWarning.js";
 
 /**
  * The morph targets pipeline stage processes the morph targets and weights of a primitive.
@@ -68,6 +69,11 @@ MorphTargetsPipelineStage.process = function (renderResources, primitive) {
         semantic !== VertexAttributeSemantic.NORMAL &&
         semantic !== VertexAttributeSemantic.TANGENT
       ) {
+        oneTimeWarning(
+          "morph-target-unsupported-semantic",
+          `Cesium does not support ${semantic} morph targets`,
+        );
+
         continue;
       }
 

--- a/packages/engine/Source/Scene/ResourceCache.js
+++ b/packages/engine/Source/Scene/ResourceCache.js
@@ -9,6 +9,7 @@ import GltfImageLoader from "./GltfImageLoader.js";
 import GltfIndexBufferLoader from "./GltfIndexBufferLoader.js";
 import GltfJsonLoader from "./GltfJsonLoader.js";
 import GltfTextureLoader from "./GltfTextureLoader.js";
+import GltfUtil from "./GltfUtil.js";
 import GltfVertexBufferLoader from "./GltfVertexBufferLoader.js";
 import MetadataSchemaLoader from "./MetadataSchemaLoader.js";
 import ResourceCacheKey from "./ResourceCacheKey.js";
@@ -439,7 +440,7 @@ ResourceCache.getVertexBufferLoader = function (options) {
   }
 
   const hasBufferViewId = defined(bufferViewId);
-  const hasDraco = hasDracoCompression(draco, attributeSemantic);
+  const hasDraco = GltfUtil.hasDracoCompression(draco, attributeSemantic);
   const hasAttributeSemantic = defined(attributeSemantic);
   const hasAccessorId = defined(accessorId);
 
@@ -504,14 +505,6 @@ ResourceCache.getVertexBufferLoader = function (options) {
 
   return ResourceCache.add(vertexBufferLoader);
 };
-
-function hasDracoCompression(draco, semantic) {
-  return (
-    defined(draco) &&
-    defined(draco.attributes) &&
-    defined(draco.attributes[semantic])
-  );
-}
 
 /**
  * Gets an existing glTF index buffer from the cache, or creates a new loader if one does not already exist.

--- a/packages/engine/Source/Scene/ResourceCacheKey.js
+++ b/packages/engine/Source/Scene/ResourceCacheKey.js
@@ -4,6 +4,7 @@ import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import getAbsoluteUri from "../Core/getAbsoluteUri.js";
 import GltfLoaderUtil from "./GltfLoaderUtil.js";
+import GltfUtil from "./GltfUtil.js";
 import hasExtension from "./hasExtension.js";
 
 /**
@@ -314,7 +315,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
   Check.typeOf.object("options.frameState", frameState);
 
   const hasBufferViewId = defined(bufferViewId);
-  const hasDraco = hasDracoCompression(draco, attributeSemantic);
+  const hasDraco = GltfUtil.hasDracoCompression(draco, attributeSemantic);
   const hasAttributeSemantic = defined(attributeSemantic);
 
   if (hasBufferViewId === hasDraco) {
@@ -380,14 +381,6 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
 
   return `vertex-buffer:${bufferCacheKey}-range-${bufferViewCacheKey}${cacheKeySuffix}`;
 };
-
-function hasDracoCompression(draco, semantic) {
-  return (
-    defined(draco) &&
-    defined(draco.attributes) &&
-    defined(draco.attributes[semantic])
-  );
-}
 
 /**
  * Gets the index buffer cache key.

--- a/packages/engine/Source/Scene/getComponentWriter.js
+++ b/packages/engine/Source/Scene/getComponentWriter.js
@@ -1,0 +1,59 @@
+import ComponentDatatype from "../Core/ComponentDatatype.js";
+
+/**
+ * Returns a function to write data into a DataView
+ *
+ * @param {number} componentType Type to convert the data to.
+ * @returns {ComponentWriter} Function that writes.
+ *
+ * @private
+ */
+function getComponentWriter(componentType) {
+  switch (componentType) {
+    case ComponentDatatype.BYTE:
+      return function (dataView, index, input) {
+        dataView.setInt8(index, input);
+      };
+    case ComponentDatatype.UNSIGNED_BYTE:
+      return function (dataView, index, input) {
+        dataView.setUint8(index, input);
+      };
+    case ComponentDatatype.SHORT:
+      return function (dataView, index, input) {
+        dataView.setInt16(index * 2, input, true);
+      };
+    case ComponentDatatype.UNSIGNED_SHORT:
+      return function (dataView, index, input) {
+        dataView.setUint16(index * 2, input, true);
+      };
+    case ComponentDatatype.INT:
+      return function (dataView, index, input) {
+        dataView.setInt32(index * 4, input, true);
+      };
+    case ComponentDatatype.UNSIGNED_INT:
+      return function (dataView, index, input) {
+        dataView.setUint32(index * 4, input, true);
+      };
+    case ComponentDatatype.FLOAT:
+      return function (dataView, index, input) {
+        dataView.setFloat32(index * 4, input, true);
+      };
+    case ComponentDatatype.DOUBLE:
+      return function (dataView, index, input) {
+        dataView.setFloat64(index * 8, input, true);
+      };
+  }
+}
+
+/**
+ * A function to write components into a data view
+ * @callback ComponentWriter
+ *
+ * @param {DataView} dataView The data view to write to.
+ * @param {number} index The index of the component.
+ * @param {number} input The value to write at the given index.
+ *
+ * @private
+ */
+
+export default getComponentWriter;


### PR DESCRIPTION
Opening this as a draft for addressing https://github.com/CesiumGS/cesium/issues/10284 


# Description

The [cx20 `gltf-test`](https://github.com/cx20/gltf-test) repo is an invaluable resource for checking the compatibility of glTF viewers with the glTF specification. CesiumJS is among the ones with the larger number of ✅'s. But there is still that `SimpleSparseAccessor` example, which uses a pretty fundamental glTF concept - namely, sparse accessors - that shows a ❌...

This PR is a **DRAFT**, and the state is kinda messy, but it already loads that sample:

![Cesium Sparse 0001](https://github.com/user-attachments/assets/3c57a83f-dc08-4c18-9315-8b4e2055cc39)


A summary:

A sparse accessor is an accessor that has a `sparse` property. The `sparse` object contains two objects, namely `indices` and `values`. These are actually "small accessors": They refer to a `bufferView` and have a `byteOffset`, one has a `componentType`. The type is taken from the _containing_ accessor.

The `loadFromBufferView` function of `GltfVertexBufferLoader` checks whether the accessor whose data is supposed to be loaded has the `sparse` property. If it does, then it calls `handleSparseAccessor`, which does the main work:

- The function calls a new function `loadDependencyBufferViewTypedArray` which loads the required buffer views for the indices and values
- These buffer views are used for creating typed arrays of the indices and values. (This is a bit quirky - see notes below...)
- The `handleSparseAccessor` finally performs the sparse substitution. It just writes the substituted values into the typed array of the _original_ accessor data. The pseudocode for that is just `accessorData[indices[i]] = values[i]`.

TODO:

The functionality for creating typed arrays from buffer views (based on "accessor information") is required elsewhere - namely, for _standard_ index- and attribute accessors After all, the `indices` and  `values` from the `sparse` object basically _are_ just "accessors". For now, I just added some helper functions like `GltfIndexBufferLoader.createIndicesTypedArrayFromBufferViewTypedArray` for that 🤪 It's not clear what could be the best place for offering these. They could be standalone functions, or maybe 'static' functions in `GltfLoader` ...?

Beyond that: Tests, tests, tests, comments, comments, comments, ....



## Issue number and link

https://github.com/CesiumGS/cesium/issues/10284 

## Testing plan

Load the `SimpleSparseAccessor` model (and other models with sparse accessors), and check that they are displayed properly.


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
