### PR TITLE
Fix intermittent z-fighting issue in DepthPlaneVS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed JulianDate to always generate valid ISO strings for fractional milliseconds [#12345](https://github.com/CesiumGS/cesium/pull/12345)
+- Fixed intermittent z-fighting issue. [#12337](https://github.com/CesiumGS/cesium/issues/12337)
 
 ### 1.124 - 2024-12-02
 

--- a/packages/engine/Source/Shaders/DepthPlaneVS.glsl
+++ b/packages/engine/Source/Shaders/DepthPlaneVS.glsl
@@ -5,7 +5,7 @@ out vec4 positionEC;
 void main()
 {
     positionEC = czm_modelView * position;
-    gl_Position = czm_modelViewProjection * position;
+    gl_Position = czm_projection * positionEC;
 
     czm_vertexLogDepth();
 }


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

#12188 included a change to `DepthPlaneVS`, to use a pre-composed `modelViewProjection` matrix for the vertex position. This was a misguided attempt to improve precision.

When multiplying by a vector by two matrices, we will usually get better precision (and performance) if we pre-multiply the matrices on the CPU. However, the projection matrix is a notable exception to this rule, as noted in https://github.com/CesiumGS/cesium/issues/4250#issue-173857054 based on a [paper by Upchurch and Desbrun](http://www.geometry.caltech.edu/pubs/UD12.pdf). For the view and projection matrices, sequential multiplication on the GPU side actually cancels some of the precision errors.

This PR reverts the change, to again use sequential multiplication of the `modelView` and `projection` matrices.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12337

## Testing plan

Testing is somewhat challenging due to the intermittent nature of the bug.
1. Load [this local Sandcastle](http://localhost:8080/CesiumGS/cesium/Apps/Sandcastle/index.html#c=bZJhT9swEIb/SpRPRSpO0q6osIJWUuhSkUSQwFYUaTKOm5o6TrGdlnTaf9+5LaNoRIlk+9577t6cfapYXaKgEiinM1xzPSSEKpVWCyqscyuzaTOZP40Ji9kkuN8EXsQCFYi7HvGDk2Cx/PngT04RiF7y8cKI+PS58OJ02I2Y64WjonOT3s3DH7d6mhbrKHHdMC16YTopo+fhJhot2I0/WT4CLE5JN9wQFZR8nsM+TKdelIav0YZ0ou8u6ifN6/A2Ybj4Mn6R42kRR5cymYeLeEWaWf3w61X3n+OXejQdZvbXTGSCVEJpa8XomkrwIuja8nd+H7Znrcwm271fCY2ZoDKz29bvTFiWmlc1z4eClVjTM0vLmrYz8efogJtjjZOqloQCG68xeyuF3iMK4TxvGeC+sL8p+ehfGPEKQ9hGyIE3weWSUxN1FDNLRECd2UdQeVd4zye8IgtEaimp0CkrTQN7/qTmDAtgUDSTVRmoqn/ielCi43qdY7d77PVSzz3rnJx1+o+APvADLKYbQL23j7ZnDGwUVF82gek1ATbnTFNnTCvaUG9H+dBaCfeILTnb/nYPojs2MqJraOvjMHwsNayw6LaOu67btjrm67kG6zj7VC0xWTBR3NEZBduEXkt8aDz9NI6G92k8ukqv/PS9xy2K5ldvfncVIG637YHSDacXZmLm+QZzqKS2aslbMCFNYSzgXzlPNSA0IkqZLo104BymDnK2slh+/skNswjHSkFkVnOesA3N7IuBA/r/Us3tAEvxikqOGyObexc3u0OE0MCB7eeZuqr4E5YH5J3iLw) in the current `main` branch, and allow the animation to play for a few seconds until paths that should be behind the globe momentarily flash into view.
2. Repeat the test in this branch, verify the z-fighting is fixed.
3. Load the Sandcastle from https://github.com/CesiumGS/cesium/issues/12371 and verify no z-fighting. (I was not able to reproduce that issue on Windows.)


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
