### PR TITLE
Fix for `ClippingPolygon` `equals` funciton

### DIFF
--- a/packages/engine/Source/Scene/ClippingPolygon.js
+++ b/packages/engine/Source/Scene/ClippingPolygon.js
@@ -117,8 +117,8 @@ ClippingPolygon.clone = function (polygon, result) {
  * Compares the provided ClippingPolygons and returns
  * <code>true</code> if they are equal, <code>false</code> otherwise.
  *
- * @param {Plane} left The first polygon.
- * @param {Plane} right The second polygon.
+ * @param {ClippingPolygon} left The first polygon.
+ * @param {ClippingPolygon} right The second polygon.
  * @returns {boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
  */
 ClippingPolygon.equals = function (left, right) {


### PR DESCRIPTION
# Description

Until now, this **only** fixes the JSDoc parameter type for `ClippingPolygon#equals` from `Plane` to `ClippingPolygon`.

See additional comments in the issue.


## Issue number and link

https://github.com/CesiumGS/cesium/issues/12389

## Testing plan

For now, there's not much to test. With `main`, running `npm run build.ts` generated
```
export class ClippingPolygon {
...
    /**
     * Compares the provided ClippingPolygons and returns
    <code>true</code> if they are equal, <code>false</code> otherwise.
     * @param left - The first polygon.
     * @param right - The second polygon.
     * @returns <code>true</code> if left and right are equal, <code>false</code> otherwise.
     */
    static equals(left: Plane, right: Plane): boolean;
```
and now it generates
```
export class ClippingPolygon {
...
    /**
     * Compares the provided ClippingPolygons and returns
    <code>true</code> if they are equal, <code>false</code> otherwise.
     * @param left - The first polygon.
     * @param right - The second polygon.
     * @returns <code>true</code> if left and right are equal, <code>false</code> otherwise.
     */
    static equals(left: ClippingPolygon, right: ClippingPolygon): boolean;

```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
