### PR TITLE
types: mark `options` param of ImageryLayer.fromProviderAsync as optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Fixes :wrench:
 
 - Fixed error when resetting `Cesium3DTileset.modelMatrix` to its initial value. [#12409](https://github.com/CesiumGS/cesium/pull/12409)
+- Fixed type of `ImageryLayer.fromProviderAsync`, to correctly show that the param `options` is optional. [#12400](https://github.com/CesiumGS/cesium/pull/12400)
 
 ### 1.125 - 2025-01-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -419,4 +419,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Kirn Kim](https://github.com/squrki)
 - [Emanuele Mastaglia](https://github.com/Masty88)
 - [Connor Manning](https://github.com/connormanning)
-- [NickCrews](https://github.com/NickCrews)
+- [Nick Crews](https://github.com/NickCrews)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -419,3 +419,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Kirn Kim](https://github.com/squrki)
 - [Emanuele Mastaglia](https://github.com/Masty88)
 - [Connor Manning](https://github.com/connormanning)
+- [NickCrews](https://github.com/NickCrews)

--- a/packages/engine/Source/Scene/ImageryLayer.js
+++ b/packages/engine/Source/Scene/ImageryLayer.js
@@ -511,7 +511,7 @@ ImageryLayer.DEFAULT_APPLY_COLOR_TO_ALPHA_THRESHOLD = 0.004;
  * Create a new imagery layer from an asynchronous imagery provider. The layer will handle any asynchronous loads or errors, and begin rendering the imagery layer once ready.
  *
  * @param {Promise<ImageryProvider>} imageryProviderPromise A promise which resolves to a imagery provider
- * @param {ImageryLayer.ConstructorOptions} options An object describing initialization options
+ * @param {ImageryLayer.ConstructorOptions|undefined} options An object describing initialization options
  * @returns {ImageryLayer} The created imagery layer.
  *
  * @example

--- a/packages/engine/Source/Scene/ImageryLayer.js
+++ b/packages/engine/Source/Scene/ImageryLayer.js
@@ -511,7 +511,7 @@ ImageryLayer.DEFAULT_APPLY_COLOR_TO_ALPHA_THRESHOLD = 0.004;
  * Create a new imagery layer from an asynchronous imagery provider. The layer will handle any asynchronous loads or errors, and begin rendering the imagery layer once ready.
  *
  * @param {Promise<ImageryProvider>} imageryProviderPromise A promise which resolves to a imagery provider
- * @param {ImageryLayer.ConstructorOptions|undefined} options An object describing initialization options
+ * @param {ImageryLayer.ConstructorOptions} [options] An object describing initialization options
  * @returns {ImageryLayer} The created imagery layer.
  *
  * @example


### PR DESCRIPTION
As the examples show, it is perfectly fine to not pass in the options object. However, in my typescript project, if I don't pass in the options, I get a type error. This is intended to fix that error.

This was brought up in https://community.cesium.com/t/error-when-initialize-imagerylayer-fromproviderasync-without-options/31665

I'm not used to typescript/jsdoc at all, so this might not actually be the right way to do this. If you tell me how to do this,
let me know and I can update it.

<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->
