### PR TITLE
Allow resetting model matrix when tiles have regions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.126 - 2025-02-03
+
+#### @cesium/engine
+
+##### Fixes :wrench:
+
+- Fixed error when resetting `Cesium3DTileset.modelMatrix` to its initial value. [#12409](https://github.com/CesiumGS/cesium/pull/12409)
+
 ### 1.125 - 2025-01-02
 
 #### @cesium/engine


### PR DESCRIPTION

# Description

When loading a tileset where the tiles contained bounding regions, changing the `modelMatrix` of the tileset, and then setting the `modelMatrix` back to its initial value, the update caused a

> TypeError: result.computeBoundingVolumes is not a function

A detailed description of what went wrong is in https://github.com/CesiumGS/cesium/issues/12002#issuecomment-2135572779

While creating a (pretty strict, dedicated) spec, I noticed that the [suggested fix](https://github.com/CesiumGS/cesium/issues/12002#issuecomment-2150805368) does not fully cover it. There are basically four cases to consider:

- When the transform **did** change (compared to the initial one)
  - When the `result` **is** a `TileOrientedBoundingBox`, then reuse it
  - When the result is **not** a `TileOrientedBoundingBox`, then create a new one
- When the transform did **not** change (compared to the initial one)
  - When the `result` **is** a `TileBoundingRegion`, then reuse it
  - When the result is **not** a `TileBoundingRegion`, then create a new one

(It's hard to be 100% sure that all cases can happen in practice, but easy to handle them generically)

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12002
Fixes https://github.com/CesiumGS/cesium/issues/12403

## Testing plan

The issue descriptions contain examples that caused the crash (basically the same example, though). 

Also, I added a dedicated spec for this. 

**NOTE**: The whole spec is currently wrapped into a `expect ... not.toThrow`. This is the actual _change_ that is done here. One could consider this as the "baseline", though, and remove this check, and only use the expect's for the respective bounding volume types.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
