### PR TITLE
Change `DataSourceDisplay` ready state behavior for bounding sphere calculations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 #### @cesium/engine
 
+##### Breaking Changes :mega:
+
+- Changed behavior of `DataSourceDisplay.ready` to always stay `true` once it is initially set to `true`.
+
 ##### Fixes :wrench:
 
 - Fixed error when resetting `Cesium3DTileset.modelMatrix` to its initial value. [#12409](https://github.com/CesiumGS/cesium/pull/12409)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 ##### Breaking Changes :mega:
 
-- Changed behavior of `DataSourceDisplay.ready` to always stay `true` once it is initially set to `true`.
+- Changed behavior of `DataSourceDisplay.ready` to always stay `true` once it is initially set to `true`. [#12429](https://github.com/CesiumGS/cesium/pull/12429)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Fixed the parameter types of the `ClippingPolygon.equals` function, and fixed cases where parameters to `equals` functions had erroneously not been marked as 'optional'. [#12394](https://github.com/CesiumGS/cesium/pull/12394)
 - Fixed type of `ImageryLayer.fromProviderAsync`, to correctly show that the param `options` is optional. [#12400](https://github.com/CesiumGS/cesium/pull/12400)
 - Fixed Draco decoding for vertex colors that are normalized `UNSIGNED_BYTE` or `UNSIGNED_SHORT`. [#12417](https://github.com/CesiumGS/cesium/pull/12417)
+- Fixed type error when setting `Viewer.selectedEntity` [#12303](https://github.com/CesiumGS/cesium/issues/12303)
 
 ### 1.125 - 2025-01-02
 

--- a/packages/engine/Source/DataSources/BoundingSphereState.js
+++ b/packages/engine/Source/DataSources/BoundingSphereState.js
@@ -3,7 +3,7 @@
  * @enum {number}
  * @private
  */
-const BoundingSphereState = {
+const BoundingSphereState = Object.freeze({
   /**
    * The BoundingSphere has been computed.
    * @type BoundingSphereState
@@ -22,5 +22,5 @@ const BoundingSphereState = {
    * @constant
    */
   FAILED: 2,
-};
-export default Object.freeze(BoundingSphereState);
+});
+export default BoundingSphereState;

--- a/packages/engine/Source/DataSources/DataSourceDisplay.js
+++ b/packages/engine/Source/DataSources/DataSourceDisplay.js
@@ -330,7 +330,10 @@ DataSourceDisplay.prototype.update = function (time) {
   if (!this._ready && result) {
     this._scene.requestRender();
   }
-  this._ready = result;
+
+  // once the DataSourceDisplay is ready it should stay ready to prevent
+  // entities from breaking updates when they become "un-ready"
+  this._ready = this._ready || result;
 
   return result;
 };
@@ -386,7 +389,7 @@ DataSourceDisplay.prototype.getBoundingSphere = function (
   Check.defined("result", result);
   //>>includeEnd('debug');
 
-  if (!this._ready && !allowPartial) {
+  if (!this._ready) {
     return BoundingSphereState.PENDING;
   }
 

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -1134,8 +1134,6 @@ CesiumWidget.prototype._updateCanAnimate = function (isUpdated) {
   this._clock.canAnimate = isUpdated;
 };
 
-const boundingSphereScratch = new BoundingSphere();
-
 /**
  * @private
  */
@@ -1152,11 +1150,11 @@ CesiumWidget.prototype._onTick = function (clock) {
     const trackedEntity = this._trackedEntity;
     const trackedState = this._dataSourceDisplay.getBoundingSphere(
       trackedEntity,
-      true,
-      boundingSphereScratch,
+      false,
+      entityView.boundingSphere,
     );
     if (trackedState === BoundingSphereState.DONE) {
-      entityView.update(time, boundingSphereScratch);
+      entityView.update(time, entityView.boundingSphere);
     }
   }
 };
@@ -1414,6 +1412,8 @@ CesiumWidget.prototype._postRender = function () {
   updateTrackedEntity(this);
 };
 
+const zoomTargetBoundingSphereScratch = new BoundingSphere();
+
 function updateZoomTarget(widget) {
   const target = widget._zoomTarget;
   if (!defined(target) || widget.scene.mode === SceneMode.MORPHING) {
@@ -1511,13 +1511,15 @@ function updateZoomTarget(widget) {
     const state = widget._dataSourceDisplay.getBoundingSphere(
       entities[i],
       false,
-      boundingSphereScratch,
+      zoomTargetBoundingSphereScratch,
     );
 
     if (state === BoundingSphereState.PENDING) {
       return;
     } else if (state !== BoundingSphereState.FAILED) {
-      boundingSpheres.push(BoundingSphere.clone(boundingSphereScratch));
+      boundingSpheres.push(
+        BoundingSphere.clone(zoomTargetBoundingSphereScratch),
+      );
     }
   }
 
@@ -1552,6 +1554,8 @@ function updateZoomTarget(widget) {
   }
 }
 
+const trackedEntityBoundingSphereScratch2 = new BoundingSphere();
+
 function updateTrackedEntity(widget) {
   if (!widget._needTrackedEntityUpdate) {
     return;
@@ -1577,7 +1581,7 @@ function updateTrackedEntity(widget) {
   const state = widget._dataSourceDisplay.getBoundingSphere(
     trackedEntity,
     false,
-    boundingSphereScratch,
+    trackedEntityBoundingSphereScratch2,
   );
   if (state === BoundingSphereState.PENDING) {
     return;
@@ -1599,7 +1603,9 @@ function updateTrackedEntity(widget) {
   }
 
   const bs =
-    state !== BoundingSphereState.FAILED ? boundingSphereScratch : undefined;
+    state !== BoundingSphereState.FAILED
+      ? trackedEntityBoundingSphereScratch2
+      : undefined;
   widget._entityView = new EntityView(trackedEntity, scene, scene.ellipsoid);
   widget._entityView.update(currentTime, bs);
   widget._needTrackedEntityUpdate = false;

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -1146,7 +1146,7 @@ CesiumWidget.prototype._onTick = function (clock) {
   }
 
   const entityView = this._entityView;
-  if (defined(entityView)) {
+  if (defined(entityView) && defined(entityView.boundingSphere)) {
     const trackedEntity = this._trackedEntity;
     const trackedState = this._dataSourceDisplay.getBoundingSphere(
       trackedEntity,

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -1554,7 +1554,7 @@ function updateZoomTarget(widget) {
   }
 }
 
-const trackedEntityBoundingSphereScratch2 = new BoundingSphere();
+const trackedEntityBoundingSphereScratch = new BoundingSphere();
 
 function updateTrackedEntity(widget) {
   if (!widget._needTrackedEntityUpdate) {
@@ -1581,7 +1581,7 @@ function updateTrackedEntity(widget) {
   const state = widget._dataSourceDisplay.getBoundingSphere(
     trackedEntity,
     false,
-    trackedEntityBoundingSphereScratch2,
+    trackedEntityBoundingSphereScratch,
   );
   if (state === BoundingSphereState.PENDING) {
     return;
@@ -1604,7 +1604,7 @@ function updateTrackedEntity(widget) {
 
   const bs =
     state !== BoundingSphereState.FAILED
-      ? trackedEntityBoundingSphereScratch2
+      ? trackedEntityBoundingSphereScratch
       : undefined;
   widget._entityView = new EntityView(trackedEntity, scene, scene.ellipsoid);
   widget._entityView.update(currentTime, bs);

--- a/packages/engine/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/packages/engine/Specs/DataSources/DataSourceDisplaySpec.js
@@ -363,7 +363,7 @@ describe(
       });
     });
 
-    it("ready is true when datasources are ready", function () {
+    it("ready is true once datasources are ready and stays true", async function () {
       const source1 = new MockDataSource();
       const source2 = new MockDataSource();
 
@@ -372,19 +372,19 @@ describe(
         dataSourceCollection: dataSourceCollection,
         visualizersCallback: visualizersCallback,
       });
-      expect(display.ready).toBe(false);
+      expect(display.ready).withContext("before adding sources").toBe(false);
 
-      return Promise.all([
+      await Promise.all([
         dataSourceCollection.add(source1),
         dataSourceCollection.add(source2),
-      ]).then(function () {
-        display.update(Iso8601.MINIMUM_VALUE);
-        expect(display.ready).toBe(true);
+      ]);
 
-        spyOn(MockVisualizer.prototype, "update").and.returnValue(false);
-        display.update(Iso8601.MINIMUM_VALUE);
-        expect(display.ready).toBe(false);
-      });
+      display.update(Iso8601.MINIMUM_VALUE);
+      expect(display.ready).withContext("after adding sources").toBe(true);
+
+      spyOn(MockVisualizer.prototype, "update").and.returnValue(false);
+      display.update(Iso8601.MINIMUM_VALUE);
+      expect(display.ready).withContext("after updating again").toBe(true);
     });
 
     it("triggers a rendering when the data source becomes ready", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Slightly reverting the change in https://github.com/CesiumGS/cesium/pull/12230 and replacing PR https://github.com/CesiumGS/cesium/pull/12322 in favor of changing the `ready` value to fix both https://github.com/CesiumGS/cesium/issues/4647 and the newer issue https://github.com/CesiumGS/cesium/issues/12303.

The core of this change is to make the `DataSourceDisplay._ready` boolean to remain `true` once it's set to `true` even if the internal datasources become "un-ready" due to transformations or loading.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Alternative fix for https://github.com/CesiumGS/cesium/issues/4647
Fixes https://github.com/CesiumGS/cesium/issues/12303

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Test [this sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVHda8IwEP9Xjj5VcKnDSZ2rMub2JuxB2FNA0uTswtKkJKnihv/70sbCPnwIubvc/T4u3Gjn4SDxiBaWoPEIa3SyrclbX0tpwvt8bbRnUqOlyeiBaqr3reZeGg1MiCepVGmYFekIvqgG2DItOHNeIRHIFbOY/myLCAC8Z0ftpT8F9iiD9LlER8JI2sMBNMbJjm0xyFsz60PE9JTsramfsbKILr3JZ2R2n+f5GO4mZDKdz6ejcYQoB/YFXEABZM0qXABNCMn62GURf7cxldmZA1rFTqTRFU0uMOf+PncWALpzUe1QIfcoXgY30VZoO3dmf28pVJNxUjh/UrgaxDzKujHWQ2tVGvR4rBvFgsmsbPkHesKdi6wARfZztBDyAFIsr/wVhOU7F172rVJb+Yk0WRVZ6P83qgwTUlev0XLX9n672sQiIaTIQnp90hujSmb/IH8D) which demonstrates the error when setting the `viewer.selectedEntity`
- Test [this sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=pVcLT+s2FP4rVqeJdKRpuWXTXSlo47HpSuiCVLqrjaLJJG5rzbEj22nprvjvO7YTxykZMK1CNDn2Of7Od15uKrjSaEPJlkh0ijjZoguiaJknv1lZtOil9v1CcI0pJ3LR658s+IIPh+iSLEGC9JqgQrAdg5cDBY+Kagp2UUQ5+vLr7OMxSoWQGeVYE9VPFjy1pzYbT9H9w0kt5mV+KyjXRjwejUZ+gQk+01hqkA8+tsRXPANhKMO63jr+MZS6ncdHXoaZprrMCEiPRiN33IIvhUQRIxpRkI9O4Gva4ILXw8M++rrgCD4eBOz0CA9B28EaeGEffQeMoCGKGg8H6Khv6AwMYQPa4zeGHOqBF75lyPOaFKVaR1U8L0ATnjAfJ0sp8kuykoQoAzM2lmPPhLXzXIX45yzzsUVa2FirlHASRLFaPa3SKCEcDFGiEpxl0dcak9s1qWlrAZ00j3GzvKWZXk/Q94EohwySFLNJnaUXggmZ/H51fX3zxW0D5M8+Qy8kAQ2E0fgS5SIjDFlwO/ADeN5SxkC8gQ1Aw6qVyN4/q3bltN5w0bkQOHM/eqjAWyst50tJJ+ggSYbwN8N5wcgl1nhoN6qhc+9SCk7C52TFHg9CPiinOSQBfSJsRv8Gen84btH1ZJZnKWaw9GE0itFrJCkCLofx7iJpS/XaMuX4xKBAnjSBryOUEwgPKogs4J2mJcMy4HFD+eoa7L6PzNfz5b7FcYtxeAWnXPl4sArnJrZQKy/ya/x2fp1fz6/2iavAa4nTv0jmfQrSxW4zTSQtpQQnP/GMPNl+UhH/S8lTg9oUFoTI8GXj0CLQofbk4i3eIVPA1q3Kcu3Zsjbord2GpmyviGqu9joYhyjeVksAsmE0asE/hEaDvg16DCN8pdcPVe8JLWZUkrQy97IJqfLRcKej8OAmknE4ixq1yHe5lxa5kDlmUAWRPzluQPRbCE3ai7woO/jewH5o/zC7DMMEKz0Ay3o9KAsUXX2e94F+yKbQU1jpcnH++dPdn3+02nv7qC6lVAqlQg/K4n9x0ToxbgNw+v+K72a5VER3osxLmBYF253vTHPBcv+Y8ZuY3X9JdCl5xwGmFzS50AHr1QOeOyqsLDJTXr51BVcV28Vs92+Fp5oDvqqcBVdFTfW0i/td1dJKiUqhs/ZCYw+2bfhh4npMUjRqe4b89o7IWh+Myit9Ys9c39sDXr/xH1NGuWlBotRAIVWovios6RNaMgrdUaLHchXomE/tSXsoJH78ti6He1DiDmcegqjPFTR8AqxBw9xgZsDYAdZMreomY1pPkwRkQ+SuGoIQ9sBCFEQ+tvdEx8YM8iaFBsGIydc7Idgjluel1oLDxfnOjAaUmbm96MXIp1GdO++aIM/vOWnOrZH/ckoJKWVu75k7oxf3pkrvGDmrh+FPNC+g7cE9hUVwRdEErijm/j58LMGQTlKl6lKeDkPVaUY3iGanHb8cUMqwUrCyLJm9ryx6Z9Mh7H+hygSG3wurGwgJwzuzbX10du2ESZJMh/DarakdN3uW/wE) to test the original issue of a "flickering" entity when it moves (it should _not_ flicker)
- Test some other sandcastles that pertain to entities and selections to make sure selection and tracking still works as expected

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
