### PR TITLE
docs: update WMTS examples to use https for basemap.nationalmap.gov

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fixed type of `ImageryLayer.fromProviderAsync`, to correctly show that the param `options` is optional. [#12400](https://github.com/CesiumGS/cesium/pull/12400)
 - Fixed Draco decoding for vertex colors that are normalized `UNSIGNED_BYTE` or `UNSIGNED_SHORT`. [#12417](https://github.com/CesiumGS/cesium/pull/12417)
 - Fixed type error when setting `Viewer.selectedEntity` [#12303](https://github.com/CesiumGS/cesium/issues/12303)
+- Fixed urls with https in the documentation `basemap.nationalmap.gov` [#12375](https://github.com/CesiumGS/cesium/issues/12375)
 
 ## 1.125 - 2025-01-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -422,3 +422,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Isaac Young](https://github.com/ibreathebsb)
 - [Nick Crews](https://github.com/NickCrews)
 - [胡文康](https://github.com/XiaoHu1994)
+- [Parth Petkar](https://github.com/parthpetkar)

--- a/packages/engine/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/packages/engine/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -57,7 +57,7 @@ const defaultParameters = Object.freeze({
  * @example
  * // Example 1. USGS shaded relief tiles (KVP)
  * const shadedRelief1 = new Cesium.WebMapTileServiceImageryProvider({
- *     url : 'http://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer/WMTS',
+ *     url : 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer/WMTS',
  *     layer : 'USGSShadedReliefOnly',
  *     style : 'default',
  *     format : 'image/jpeg',
@@ -71,7 +71,7 @@ const defaultParameters = Object.freeze({
  * @example
  * // Example 2. USGS shaded relief tiles (RESTful)
  * const shadedRelief2 = new Cesium.WebMapTileServiceImageryProvider({
- *     url : 'http://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer/WMTS/tile/1.0.0/USGSShadedReliefOnly/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg',
+ *     url : 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer/WMTS/tile/1.0.0/USGSShadedReliefOnly/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg',
  *     layer : 'USGSShadedReliefOnly',
  *     style : 'default',
  *     format : 'image/jpeg',


### PR DESCRIPTION
**Description**
I have fixed the issue of #12375 by updating the file packages/engine/Source/Scene/WebMapTileServiceImageryProvider.js. The changes were made at:

**Line 60**: Changed http to https
**Line 74**: Changed http to https
After building the code, it is working as expected. Attached is a screenshot demonstrating the successful fix.

![image](https://github.com/user-attachments/assets/f8a5de73-a563-46ac-8da8-5eec8776f438)

**Issue Number and Link**
Fixes [#12375](https://github.com/CesiumGS/cesium/issues/12375).

**Testing Plan**
Reproduced the issue by running the original code.
Made the updates to replace http with https.
Built and tested the updated code to verify that the issue is resolved.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
