### PR TITLE
Fix availability check in VoxelTraversal for procedural tilesets

### DIFF
--- a/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
@@ -98,6 +98,7 @@ Object.defineProperties(Cesium3DTilesVoxelProvider.prototype, {
   /**
    * The number of levels of detail containing available tiles in the tileset.
    *
+   * @memberof VoxelPrimitive.prototype
    * @type {number|undefined}
    * @readonly
    */

--- a/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
@@ -89,12 +89,24 @@ function Cesium3DTilesVoxelProvider(options) {
   /** @inheritdoc */
   this.maximumTileCount = undefined;
 
-  /** @inheritdoc */
-  this.availableLevels = undefined;
-
+  this._availableLevels = undefined;
   this._implicitTileset = undefined;
   this._subtreeCache = new ImplicitSubtreeCache();
 }
+
+Object.defineProperties(Cesium3DTilesVoxelProvider.prototype, {
+  /**
+   * The number of levels of detail containing available tiles in the tileset.
+   *
+   * @type {number|undefined}
+   * @readonly
+   */
+  availableLevels: {
+    get: function () {
+      return this._availableLevels;
+    },
+  },
+});
 
 /**
  * Creates a {@link VoxelProvider} that fetches voxel data from a 3D Tiles tileset.
@@ -151,7 +163,6 @@ Cesium3DTilesVoxelProvider.fromUrl = async function (url) {
   provider.shapeTransform = shapeTransform;
   provider.globalTransform = globalTransform;
   provider.maximumTileCount = getTileCount(metadata);
-  provider.availableLevels = implicitTileset.availableLevels;
 
   let paddingBefore;
   let paddingAfter;
@@ -165,6 +176,7 @@ Cesium3DTilesVoxelProvider.fromUrl = async function (url) {
   provider.paddingAfter = paddingAfter;
 
   provider._implicitTileset = implicitTileset;
+  provider._availableLevels = implicitTileset.availableLevels;
 
   ResourceCache.unload(schemaLoader);
 

--- a/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
@@ -89,6 +89,9 @@ function Cesium3DTilesVoxelProvider(options) {
   /** @inheritdoc */
   this.maximumTileCount = undefined;
 
+  /** @inheritdoc */
+  this.availableLevels = undefined;
+
   this._implicitTileset = undefined;
   this._subtreeCache = new ImplicitSubtreeCache();
 }
@@ -148,6 +151,7 @@ Cesium3DTilesVoxelProvider.fromUrl = async function (url) {
   provider.shapeTransform = shapeTransform;
   provider.globalTransform = globalTransform;
   provider.maximumTileCount = getTileCount(metadata);
+  provider.availableLevels = implicitTileset.availableLevels;
 
   let paddingBefore;
   let paddingAfter;

--- a/packages/engine/Source/Scene/VoxelProvider.js
+++ b/packages/engine/Source/Scene/VoxelProvider.js
@@ -187,6 +187,16 @@ Object.defineProperties(VoxelProvider.prototype, {
   },
 
   /**
+   * The number of levels of detail containing available tiles in the tileset.
+   *
+   * @type {number|undefined}
+   * @readonly
+   */
+  availableLevels: {
+    get: DeveloperError.throwInstantiationError,
+  },
+
+  /**
    * Gets the number of keyframes in the dataset.
    * This should not be called before {@link VoxelProvider#ready} returns true.
    *

--- a/packages/engine/Source/Scene/VoxelTraversal.js
+++ b/packages/engine/Source/Scene/VoxelTraversal.js
@@ -429,7 +429,10 @@ function requestData(that, keyframeNode) {
 
   const provider = that._primitive._provider;
   const { keyframe, spatialNode } = keyframeNode;
-  if (spatialNode.level >= provider._implicitTileset.availableLevels) {
+  if (
+    defined(provider.availableLevels) &&
+    spatialNode.level >= provider.availableLevels
+  ) {
     return;
   }
 

--- a/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
@@ -58,6 +58,18 @@ describe(
       expect(primitive.maximumValues).toBe(provider.maximumValues);
     });
 
+    it("loads tiles from a minimal procedural provider", async function () {
+      const spyUpdate = jasmine.createSpy("listener");
+      const primitive = new VoxelPrimitive();
+      primitive.initialTilesLoaded.addEventListener(spyUpdate);
+      scene.primitives.add(primitive);
+      await pollToPromise(() => {
+        scene.renderForSpecs();
+        return primitive._traversal._initialTilesLoaded;
+      });
+      expect(spyUpdate.calls.count()).toEqual(1);
+    });
+
     it("initial tiles loaded and all tiles loaded events are raised", async function () {
       const spyUpdate1 = jasmine.createSpy("listener");
       const spyUpdate2 = jasmine.createSpy("listener");


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR fixes a small bug introduced in https://github.com/CesiumGS/cesium/pull/12430 affecting procedural tilesets.

The `requestData` helper function in `VoxelTraversal` included a check of `provider._implicitTileset.availableLevels` to avoid generating spurious `tileFailed` events. However, custom procedural providers (as used in some of our sandcastle examples) do not have an `._implicitTileset`.

This PR adds a public `availableLevels` property to `VoxelProvider`, which is allowed to be undefined. `VoxelTraversal` now verifies the property is defined before checking its value.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Load the "Voxels" Sandcastle and verify that all datasets render without errors.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- ~[ ] I have updated `CHANGES.md` with a short summary of my change~ Fixes a bug not present in the previous release
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
