### PR TITLE
Remove deprecated createGooglePhotorealistic3DTileset key option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Breaking Changes :mega:
 
 - Changed behavior of `DataSourceDisplay.ready` to always stay `true` once it is initially set to `true`. [#12429](https://github.com/CesiumGS/cesium/pull/12429)
+- `createGooglePhotorealistic3DTileset(key)` has been removed. Use `createGooglePhotorealistic3DTileset({key})` instead.
 
 #### Additions :tada:
 

--- a/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
+++ b/packages/engine/Source/Scene/createGooglePhotorealistic3DTileset.js
@@ -1,11 +1,11 @@
 import Cesium3DTileset from "./Cesium3DTileset.js";
+import Check from "../Core/Check.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import IonResource from "../Core/IonResource.js";
 import GoogleMaps from "../Core/GoogleMaps.js";
 import Resource from "../Core/Resource.js";
 import oneTimeWarning from "../Core/oneTimeWarning.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 
 /**
  * Creates a {@link Cesium3DTileset} instance for the Google Photorealistic 3D
@@ -73,13 +73,10 @@ async function createGooglePhotorealistic3DTileset(apiOptions, tilesetOptions) {
   );
 
   apiOptions = defaultValue(apiOptions, defaultValue.EMPTY_OBJECT);
-  if (typeof apiOptions === "string") {
-    deprecationWarning(
-      "createGooglePhotorealistic3DTileset(key)",
-      "createGooglePhotorealistic3DTileset(key) has been deprecated.   It is replaced by createGooglePhotorealistic3DTileset({key}).  It will be removed in Cesium 1.126.",
-    );
-    apiOptions = { key: apiOptions };
-  }
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("apiOptions", apiOptions);
+  //>>includeEnd('debug');
+
   if (!apiOptions.onlyUsingWithGoogleGeocoder) {
     oneTimeWarning(
       "google-tiles-with-google-geocoder",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Removes the deprecated `createGooglePhotorealistic3DTileset` `key` option.

## Issue number and link

Resolves https://github.com/CesiumGS/cesium/issues/12328

## Testing plan

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
