### PR TITLE
Expose CustomShader.prototype.destroy as a public method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.127 - 2025-03-03
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Exposed `CustomShader.prototype.destroy` as a public method. [#12444](https://github.com/CesiumGS/cesium/issues/12444)
+
 ## 1.126 - 2025-02-03
 
 ### @cesium/engine

--- a/packages/engine/Source/Scene/Model/CustomShader.js
+++ b/packages/engine/Source/Scene/Model/CustomShader.js
@@ -443,7 +443,6 @@ CustomShader.prototype.update = function (frameState) {
  * @returns {boolean} True if this object was destroyed; otherwise, false.
  *
  * @see CustomShader#destroy
- * @private
  */
 CustomShader.prototype.isDestroyed = function () {
   return false;
@@ -463,7 +462,6 @@ CustomShader.prototype.isDestroyed = function () {
  * customShader = customShader && customShader.destroy();
  *
  * @see CustomShader#isDestroyed
- * @private
  */
 CustomShader.prototype.destroy = function () {
   this._textureManager = this._textureManager && this._textureManager.destroy();


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR deletes the `@private` tag from `CustomShader.prototype.isDestroyed` and `CustomShader.prototype.destroy`. As pointed out by @anne-gropler: these methods are recommended in public API docs, therefore they should be public methods.

## Issue number and link

Resolves https://github.com/CesiumGS/cesium/issues/12444.

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
