### PR TITLE
Mousemove fires outside canvas

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -423,3 +423,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Nick Crews](https://github.com/NickCrews)
 - [胡文康](https://github.com/XiaoHu1994)
 - [Parth Petkar](https://github.com/parthpetkar)
+- [Riley Howley](https://github.com/Riley-Howley)

--- a/packages/engine/Source/Core/ScreenSpaceEventHandler.js
+++ b/packages/engine/Source/Core/ScreenSpaceEventHandler.js
@@ -352,6 +352,18 @@ function handleMouseMove(screenSpaceEventHandler, event) {
     return;
   }
 
+  const canvas = screenSpaceEventHandler._element;
+  const rect = canvas.getBoundingClientRect();
+
+  if (
+    event.clientX < rect.left ||
+    event.clientX > rect.right ||
+    event.clientY < rect.top ||
+    event.clientY > rect.bottom
+  ) {
+    return;
+  }
+
   const modifier = getModifier(event);
 
   const position = getPosition(

--- a/packages/engine/Specs/Core/ScreenSpaceEventHandlerSpec.js
+++ b/packages/engine/Specs/Core/ScreenSpaceEventHandlerSpec.js
@@ -542,6 +542,13 @@ describe("Core/ScreenSpaceEventHandler", function () {
       const action = createCloningSpy("action");
       handler.setInputAction(action, eventType, modifier);
 
+      spyOn(element, "getBoundingClientRect").and.returnValue({
+        left: 0,
+        right: 100,
+        top: 0,
+        bottom: 100,
+      });
+
       expect(handler.getInputAction(eventType, modifier)).toEqual(action);
 
       function simulateInput() {
@@ -595,6 +602,56 @@ describe("Core/ScreenSpaceEventHandler", function () {
     const possibleEventTypes = [ScreenSpaceEventType.MOUSE_MOVE];
     createAllMouseSpecCombinations(
       testMouseMoveEvent,
+      possibleButtons,
+      possibleModifiers,
+      possibleEventTypes,
+    );
+  });
+
+  describe("handles out of bounds mouse move", function () {
+    function testOutOfBoundsMouseMoveEvent(eventType, modifier, eventOptions) {
+      const action = createCloningSpy("action");
+      handler.setInputAction(action, eventType, modifier);
+
+      expect(handler.getInputAction(eventType, modifier)).toEqual(action);
+
+      function simulateInput() {
+        simulateMouseMove(
+          element,
+          combine(
+            {
+              clientX: 1,
+              clientY: 2,
+            },
+            eventOptions,
+          ),
+        );
+      }
+
+      simulateInput();
+
+      expect(action.calls.count()).toEqual(0);
+
+      // should not be fired after removal
+      action.calls.reset();
+
+      handler.removeInputAction(eventType, modifier);
+
+      simulateInput();
+
+      expect(action).not.toHaveBeenCalled();
+    }
+
+    const possibleButtons = [undefined];
+    const possibleModifiers = [
+      undefined,
+      KeyboardEventModifier.SHIFT,
+      KeyboardEventModifier.CTRL,
+      KeyboardEventModifier.ALT,
+    ];
+    const possibleEventTypes = [ScreenSpaceEventType.MOUSE_MOVE];
+    createAllMouseSpecCombinations(
+      testOutOfBoundsMouseMoveEvent,
       possibleButtons,
       possibleModifiers,
       possibleEventTypes,


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->
Fixes Issue: #12373 
This PR addresses adding a bounds check on the `ScreenSpaceEventHandler` `handleMouseMove` this issue was only reproducible in Firefox. Checking to make sure the client is inside the bounds of the canvas solves this issue

<!-- Consider: Why is this change required? What problem does it solve? -->
When integration Cesium in existing application, if menus are overlayed on the canvas then in firefox the event is triggered even though its not in the canvas

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->
https://github.com/CesiumGS/cesium/issues/12373

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
Using the given example in the Issue, after my change I tested in Firefox, and Chrome. Note: I did this on a Mac.

Automated tests were updated to have a valid `boundingClientRect` so that it passes the new check. Also added a new test to ensure the event is not fired when in the bounds of the canvas

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
