### PR TITLE
fix issues 12474

### DIFF
--- a/Source/DataSources/DynamicGeometryUpdater.js
+++ b/Source/DataSources/DynamicGeometryUpdater.js
@@ -81,12 +81,12 @@ define([
 
         var primitives = this._primitives;
         var orderedGroundPrimitives = this._orderedGroundPrimitives;
-        if (onTerrain) {
+        if(orderedGroundPrimitives.contains(this._primitive)){
             orderedGroundPrimitives.remove(this._primitive);
-        } else {
+        } else if(primitives.contains(this._primitive)){
             primitives.removeAndDestroy(this._primitive);
             primitives.removeAndDestroy(this._outlinePrimitive);
-            this._outlinePrimitive = undefined;
+            this._outlinePrimitive = void 0;
         }
         this._primitive = undefined;
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
probrem: After CallbackProperty is used in the hierarchy value of polygon, two polygons will be rendered if the hightreference attribute value of Polygon is modified again.

change:
in DynamicGeometryUpdater.js , DynamicGeometryUpdater.prototype.update

old code:
  if (onTerrain) {
      orderedGroundPrimitives.remove(this._primitive);
  } else {
      primitives.removeAndDestroy(this._primitive);
      primitives.removeAndDestroy(this._outlinePrimitive);
      this._outlinePrimitive = undefined;
  }

Judging which container to remove the primitive from based on the variable onTerrain is inaccurate, because the external environment can change the value of onTerrain by modifying parameters.

new code:
    if(orderedGroundPrimitives.contains(this._primitive)){
      orderedGroundPrimitives.remove(this._primitive);
    } else if(primitives.contains(this._primitive)){
      primitives.removeAndDestroy(this._primitive);
      primitives.removeAndDestroy(this._outlinePrimitive);
      this._outlinePrimitive = void 0;
    }

## Issue number and link
issues 12474，https://github.com/CesiumGS/cesium/issues/12474

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
