### PR TITLE
Pin prettier version

### DIFF
--- a/Documentation/Contributors/ReleaseGuide/README.md
+++ b/Documentation/Contributors/ReleaseGuide/README.md
@@ -8,6 +8,7 @@ There is no release manager; instead, our community shares the responsibility. A
 
 1. Check for any outdated dependencies with `npm outdated`.
 2. If one or more dependencies are outdated, checkout a new branch and run `npm install <packagename>@latest` for each package to increment the version.
+   - If `prettier` needs updated you _should_ still update it but keep the version pinned. If you run `npm install prettier@latest` you must remove the `^` in `package.json`. If the number of changes when running `npm run prettier` is large it may be worth opening a separate PR for only those.
 3. Verify each update. If an update can be resolved, open a PR with your changes. If an update is incompatible, open an issue. Check the [`dependencies` label](https://github.com/CesiumGS/cesium/issues?q=is%3Aissue+is%3Aopen+label%3Adependencies) for any open issues pinning versions.
 4. Check the [`priority - next release` issues and PRs](https://github.com/CesiumGS/cesium/labels/priority%20-%20next%20release). If there are any outstanding items, post a message to the `#cesiumjs` channel in Slack to figure out what needs to be addressed before we can release.
 5. Ensure you've generated valid [end to end testing snapshots](../TestingGuide/README.md) against a previous release tag with `npm run test-e2e-update`.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "mkdirp": "^3.0.1",
     "node-fetch": "^3.2.10",
     "open": "^10.0.2",
-    "prettier": "^3.3.3",
+    "prettier": "3.5.1",
     "prismjs": "^1.28.0",
     "request": "^2.79.0",
     "rimraf": "^5.0.0",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Every version bump in `prettier` has a chance to change the desired output and thus break our linting. This PR changes it back to a specific pinned version instead of letting npm and semver take over.

Specifically a [recent change](https://github.com/prettier/prettier/pull/16907) in 3.5.0 was a ["breaking" change](https://github.com/prettier/prettier/issues/17094) for us and changed the desired format of a css file we haven't touched in a a while. It looks like @jjhembd addressed this in https://github.com/CesiumGS/cesium/commit/1c892c87bd3f6eae234379bcf13344f5d0db6e59 so merging main will work but branches may be "outdated" and break in CI.

We _should_ keep the prettier version updated so we don't have to do as many big refactors like #12206 but it should be intentional instead of randomly when people run `npm install` or when CI installs a different version than people have locally. I did check and pinning the version still has it show up in `npm outdated` so the release process should still catch it.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

no issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- `rm -rf node_modules`
- `npm install`
- `npm run prettier-check` should pass

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
