### PR TITLE
Fix zoom location in orthographic 3D mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Exposed `CustomShader.prototype.destroy` as a public method. [#12444](https://github.com/CesiumGS/cesium/issues/12444)
 - Fixed error when there are duplicated points in polygon/polyline geometries with `ArcType.RHUMB` [#12460](https://github.com/CesiumGS/cesium/pull/12460)
+- Fixed zoom in 3D orthographic mode [#12483](https://github.com/CesiumGS/cesium/pull/12483)
 
 ## 1.126 - 2025-02-03
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -423,3 +423,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Nick Crews](https://github.com/NickCrews)
 - [胡文康](https://github.com/XiaoHu1994)
 - [Parth Petkar](https://github.com/parthpetkar)
+- [Andrew Dassonville](https://github.com/andrewda)

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -623,14 +623,6 @@ function handleZoom(
   orientation.pitch = camera.pitch;
   orientation.roll = camera.roll;
 
-  if (camera.frustum instanceof OrthographicFrustum) {
-    if (Math.abs(distance) > 0.0) {
-      camera.zoomIn(distance);
-      camera._adjustOrthographicFrustum(true);
-    }
-    return;
-  }
-
   const sameStartPosition = defaultValue(
     movement.inertiaEnabled,
     Cartesian2.equals(startPosition, object._zoomMouseStart),

--- a/packages/engine/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/packages/engine/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -1425,6 +1425,60 @@ describe("Scene/ScreenSpaceCameraController", function () {
     expect(frustumWidth).toBeLessThan(camera.frustum.width);
   });
 
+  it("zoom in 3D with orthographic projection with wheel", function () {
+    setUp3D();
+
+    const frustum = new OrthographicFrustum();
+    frustum.aspectRatio = 1.0;
+    frustum.width = 20.0;
+    camera.frustum = frustum;
+
+    expect(frustum.projectionMatrix).toBeDefined();
+
+    camera.setView({ destination: Camera.DEFAULT_VIEW_RECTANGLE });
+
+    const position = Cartesian3.clone(camera.position);
+    const heading = camera.heading;
+    const pitch = camera.pitch;
+    const roll = camera.roll;
+
+    simulateMouseWheel(120);
+    updateController();
+    expect(Cartesian3.magnitude(position)).toBeGreaterThan(
+      Cartesian3.magnitude(camera.position),
+    );
+    expect(camera.heading).toBeCloseTo(heading, 3);
+    expect(camera.pitch).toBeCloseTo(pitch, 3);
+    expect(camera.roll).toBeCloseTo(roll, 3);
+  });
+
+  it("zoom out in 3D with orthographic projection with wheel", function () {
+    setUp3D();
+
+    const frustum = new OrthographicFrustum();
+    frustum.aspectRatio = 1.0;
+    frustum.width = 20.0;
+    camera.frustum = frustum;
+
+    expect(frustum.projectionMatrix).toBeDefined();
+
+    camera.setView({ destination: Camera.DEFAULT_VIEW_RECTANGLE });
+
+    const position = Cartesian3.clone(camera.position);
+    const heading = camera.heading;
+    const pitch = camera.pitch;
+    const roll = camera.roll;
+
+    simulateMouseWheel(-120);
+    updateController();
+    expect(Cartesian3.magnitude(position)).toBeLessThan(
+      Cartesian3.magnitude(camera.position),
+    );
+    expect(camera.heading).toBeCloseTo(heading, 3);
+    expect(camera.pitch).toBeCloseTo(pitch, 3);
+    expect(camera.roll).toBeCloseTo(roll, 3);
+  });
+
   it("zoom in 3D when camera is underground", function () {
     setUp3DUnderground();
 


### PR DESCRIPTION
# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

Currently, zooming with the mouse wheel in 3D orthographic mode will move the camera towards the center of the screen, irrespective of mouse position. This behavior differs from the zoom behavior of 3D perspective mode and 2D orthographic mode. See the following video:

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/5597f68c-4f08-460e-85ca-407511778385
</details>

This change makes the zoom behavior of 3D orthographic mode consistent with 2D and perspective modes. See the following video:

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/67a79f8f-c429-455c-a118-1177e487a9d1
</details>

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

https://github.com/CesiumGS/cesium/issues/9558

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

Added unit tests for orthographic zoom with mouse wheel. Manual testing with:

```ts
const viewer = new Cesium.Viewer("cesiumContainer");

// Disable showGroundAtmosphere as it causes issues with Orthographic 3D mode
viewer.scene.globe.showGroundAtmosphere = false;

viewer.scene.camera.switchToOrthographicFrustum();
```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
