### PR TITLE
Fix ground atmosphere shaders in 3D orthographic mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Exposed `CustomShader.prototype.destroy` as a public method. [#12444](https://github.com/CesiumGS/cesium/issues/12444)
 - Fixed error when there are duplicated points in polygon/polyline geometries with `ArcType.RHUMB` [#12460](https://github.com/CesiumGS/cesium/pull/12460)
+- Fixed ground atmosphere shaders in 3D orthographic mode [#12484](https://github.com/CesiumGS/cesium/pull/12484)
 
 ## 1.126 - 2025-02-03
 

--- a/packages/engine/Source/Shaders/GlobeFS.glsl
+++ b/packages/engine/Source/Shaders/GlobeFS.glsl
@@ -285,7 +285,16 @@ vec3 computeEllipsoidPosition()
     vec2 xy = gl_FragCoord.xy / czm_viewport.zw * 2.0 - vec2(1.0);
     xy *= czm_viewport.zw * mpp * 0.5;
 
-    vec3 direction = normalize(vec3(xy, -czm_currentFrustum.x));
+    vec3 direction;
+    if (czm_orthographicIn3D == 1.0)
+    {
+        direction = vec3(0.0, 0.0, -1.0);
+    }
+    else
+    {
+        direction = normalize(vec3(xy, -czm_currentFrustum.x));
+    }
+
     czm_ray ray = czm_ray(vec3(0.0), direction);
 
     vec3 ellipsoid_center = czm_view[3].xyz;


### PR DESCRIPTION
# Description

3D orthographic mode is currently broken with the default globe options (i.e., `showGroundAtmosphere = true` -- see the [Projection sandcastle](https://sandcastle.cesium.com/?src=Projection.html)). The behavior can be fixed by setting `showGroundAtmosphere = false`. See the attached videos:

<details>
<summary>Before (showGroundAtmosphere = true)</summary>

https://github.com/user-attachments/assets/7587a393-ef64-476b-8e69-6b72940d2687
</details>

<details>
<summary>Before (showGroundAtmosphere = false)</summary>

https://github.com/user-attachments/assets/6e2f9ed5-3364-467e-8795-fffb105c36fd
</details>

This pull request fixes the ground atmosphere shaders so that 3D orthographic mode works by default. See the attached video of this fix, with `showGroundAtmosphere = true`:

https://github.com/user-attachments/assets/d0a764b3-f174-489c-a905-d473440caf6e


## Issue number and link

https://github.com/CesiumGS/cesium/issues/11955

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

Manual testing with the [Projection sandcastle](https://sandcastle.cesium.com/?src=Projection.html), or with the following code:

```ts
const viewer = new Cesium.Viewer("cesiumContainer");

// Setting `showGroundAtmosphere = false` is required for orthographic 3D mode prior to this change
//viewer.scene.globe.showGroundAtmosphere = false;

viewer.scene.camera.switchToOrthographicFrustum();
```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
