### PR TITLE
Fix z-fighting and performance issues in 2D infinite scroll mode

### DIFF
--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3310,8 +3310,9 @@ function execute2DViewportCommands(scene, passState) {
   }
 
   camera._setTransform(transform);
-  Cartesian3.clone(position, camera.position);
-  camera.frustum = frustum.clone();
+  camera.position.x = position.x;
+  camera.position.y = position.y;
+  camera.frustum = frustum;
   passState.viewport = originalViewport;
 }
 


### PR DESCRIPTION
# Description

This pull request addresses both performance issues and zIndex issues in 2D infinite scroll mode.

Currently, the `execute2DViewportCommands` function [clones `camera.position`](https://github.com/CesiumGS/cesium/blob/31670c1b4a346353f7dffba98d4e8daade04d030/packages/engine/Source/Scene/Scene.js#L3169-L3172) so that the camera's x and y positions can be modified to enable infinite scrolling (i.e., rendering another copy of the map to the side). At the end of `execute2DViewportCommands`, the camera's position is reset to the copy that was created earlier, because the camera modifications made were solely for rendering -- the camera is not actually intended to move. However, it appears that copying the previous camera z position (which is not modified in `execute2DViewportCommands` for infinite scroll rendering) resets changes made in `executeCommands` to avoid z-fighting:

https://github.com/CesiumGS/cesium/blob/47b5d295facaca795381bf607b78cc60c643fd85/packages/engine/Source/Scene/Scene.js#L2614-L2617

This pull request fixes this issue by only resetting the x and y values of the camera, rather than the entire position object. This fixes z-fighting reported in https://github.com/CesiumGS/cesium/issues/8302 ([zIndex Sandcastle](https://sandcastle.cesium.com/#c=tVZbb9owFP4rHi8JUjAkDA0YrbbSCE3qTZTtYWOq3MSk3hw7sh0orfjvs3OBQKnaatQPSPa55Hzn+3zwHAkwJ3iBBTgCDC/AEEuSxvBHdmZbQbYdcqYQYVhYDngEMsAMn/MQ90vv6/IEXg/9C987Bav65ymbsjw1xEwRRbCEKAztxykDepEQ9IE1xiEQOFCIRRQ74OEbC/E9cC0nd1qbtG8RZ1bAuQgJQwpLsC5iXPrCmeDxKY4ExtJuuG4LthzgZb8Nt9WCHQe09a7ubBLGOpUgiG6yDTnlAo7904pXXl0fuPnRaspeC3OC71Uq9mL1DorVy7B2CqxehrXzLFYLwiaJUYRlM098c8YjfpNj/5NE1h7w3pvBn9AU7wHePjzJbbdK8kf3dSSfnH339wBtH5LlQ4Lt9Qy6QtC9HHjroBy/HfpIl8beWd29TxnuXNzdboa78zqKR2Pfv3hPMbsH57fQcs7vf0r5ycAiM2B/KCJ9g3UJZZokXCh5xemS6lkvL9kEC6HHvl00JZv79XoJa0FYyBcQUSyUba3DAGdA5YEACQwYV6DIrW+GMd4RCRKK1IyL2AE/GyTr4IJQCm4xIBHj+g5ZptDVC7WeF22QOpVfUPa2stdXtuzoVv2JBhVxJg8D5EVtlT18enuSwrItqoRLncnUt5EB0tVJgli7qqmvGs7S/rWJNKvh5iPEM/8ZO6bu2rIx/K4KcEFCdac/292Krciy8pYoYY0oX5SMXQmeaAKW9uP2lyPtc8XNc6QPWtDbqSswIt+n+Y3bqr5H/41qooCiOJnwkeApM21XIsXPjIEHzuMJt3eIMy41pzaQaknxcZn4C4mNNEAqqK1HrsKxkYaeurdp8BcrGMgs0LgOmtXQQUjmWgBH09rOY2taM7VKqS2zlNJr8oCnteNBU/s/CaUc6fESXc6xoGhp3O7c47P8EEI4aOrt/kjFOb1FYifzPw)): 

|Before|After|
|------|-----|
|![CleanShot 2025-02-19 at 12 32 09](https://github.com/user-attachments/assets/9c1972ae-3a62-483a-9711-91c581ac37b9)|![CleanShot 2025-02-19 at 12 32 25](https://github.com/user-attachments/assets/1b2c2af1-874e-432e-a1e3-2773d1aa4d9f)|

Additionally, this pull request removes an extraneous `clone()` operation on the frustum. The `frustum` variable is cloned from the camera on initialization, and thus does not need to be recloned later:

https://github.com/CesiumGS/cesium/blob/31670c1b4a346353f7dffba98d4e8daade04d030/packages/engine/Source/Scene/Scene.js#L3177

These two changes also resolve some performance issues in 2D infinite scroll mode, for reasons that are not entirely clear to me. See the following screen recordings. In the Before recording, the FPS while panning drops from a steady ~100fps to around ~75fps. In the After recording, the FPS starts substantially higher, around ~140fps, and drops to only ~130fps.

<details>
<summary>Before Change</summary>

https://github.com/user-attachments/assets/a8a05ca5-7bbb-497b-b8cf-bbfb6a733a92
</details>


<details>
<summary>After Change</summary>

https://github.com/user-attachments/assets/3e658333-d674-4e2d-87d2-72572ff6297b
</details>

I am not clear on exactly where this performance hit is coming from, but the improvements appear to be even more noticeable on a lower-spec machine (where panning performance goes from ~30fps before the change to a steady ~90fps after the change).

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

zIndex Issue: https://github.com/CesiumGS/cesium/issues/8302

Likely related performance issue: https://github.com/CesiumGS/cesium/issues/5026

## Testing plan

I have tested that this fixes both the zIndex and performance issues on a variety of machines using this [zIndex Sandcastle](https://sandcastle.cesium.com/#c=tVZbb9owFP4rHi8JUjAkDA0YrbbSCE3qTZTtYWOq3MSk3hw7sh0orfjvs3OBQKnaatQPSPa55Hzn+3zwHAkwJ3iBBTgCDC/AEEuSxvBHdmZbQbYdcqYQYVhYDngEMsAMn/MQ90vv6/IEXg/9C987Bav65ymbsjw1xEwRRbCEKAztxykDepEQ9IE1xiEQOFCIRRQ74OEbC/E9cC0nd1qbtG8RZ1bAuQgJQwpLsC5iXPrCmeDxKY4ExtJuuG4LthzgZb8Nt9WCHQe09a7ubBLGOpUgiG6yDTnlAo7904pXXl0fuPnRaspeC3OC71Uq9mL1DorVy7B2CqxehrXzLFYLwiaJUYRlM098c8YjfpNj/5NE1h7w3pvBn9AU7wHePjzJbbdK8kf3dSSfnH339wBtH5LlQ4Lt9Qy6QtC9HHjroBy/HfpIl8beWd29TxnuXNzdboa78zqKR2Pfv3hPMbsH57fQcs7vf0r5ycAiM2B/KCJ9g3UJZZokXCh5xemS6lkvL9kEC6HHvl00JZv79XoJa0FYyBcQUSyUba3DAGdA5YEACQwYV6DIrW+GMd4RCRKK1IyL2AE/GyTr4IJQCm4xIBHj+g5ZptDVC7WeF22QOpVfUPa2stdXtuzoVv2JBhVxJg8D5EVtlT18enuSwrItqoRLncnUt5EB0tVJgli7qqmvGs7S/rWJNKvh5iPEM/8ZO6bu2rIx/K4KcEFCdac/292Krciy8pYoYY0oX5SMXQmeaAKW9uP2lyPtc8XNc6QPWtDbqSswIt+n+Y3bqr5H/41qooCiOJnwkeApM21XIsXPjIEHzuMJt3eIMy41pzaQaknxcZn4C4mNNEAqqK1HrsKxkYaeurdp8BcrGMgs0LgOmtXQQUjmWgBH09rOY2taM7VKqS2zlNJr8oCnteNBU/s/CaUc6fESXc6xoGhp3O7c47P8EEI4aOrt/kjFOb1FYifzPw).

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
