### PR TITLE
upgrade packages - March 2025 release

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import globals from "globals";
 import html from "eslint-plugin-html";
-import configCesium from "eslint-config-cesium";
+import configCesium from "@cesium/eslint-config";
 
 export default [
   {

--- a/package.json
+++ b/package.json
@@ -55,16 +55,16 @@
     "@cesium/widgets": "^10.2.0"
   },
   "devDependencies": {
+    "@cesium/eslint-config": "^12.0.0",
     "@playwright/test": "^1.41.1",
     "chokidar": "^4.0.1",
     "cloc": "^2.4.0-cloc",
     "compression": "^1.7.4",
     "esbuild": "^0.25.0",
     "eslint": "^9.1.1",
-    "eslint-config-cesium": "^11.0.1",
     "eslint-plugin-html": "^8.1.1",
     "express": "^4.17.1",
-    "globals": "^15.1.0",
+    "globals": "^16.0.0",
     "globby": "^14.0.0",
     "glsl-strip-comments": "^1.0.0",
     "gulp": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@playwright/test": "^1.41.1",
     "chokidar": "^4.0.1",
-    "cloc": "^2.2.0-cloc",
+    "cloc": "^2.4.0-cloc",
     "compression": "^1.7.4",
-    "esbuild": "^0.24.0",
+    "esbuild": "^0.25.0",
     "eslint": "^9.1.1",
     "eslint-config-cesium": "^11.0.1",
     "eslint-plugin-html": "^8.1.1",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -42,7 +42,7 @@
     "grapheme-splitter": "^1.0.4",
     "jsep": "^1.3.8",
     "kdbush": "^4.0.1",
-    "ktx-parse": "^0.7.0",
+    "ktx-parse": "^1.0.0",
     "lerc": "^2.0.0",
     "mersenne-twister": "^1.1.0",
     "meshoptimizer": "^0.22.0",


### PR DESCRIPTION
# Description
`npm outdated -->`
```
Package   Current   Wanted      Latest  Location               Depended by
cloc       2.11.0   2.11.0  2.4.0-cloc  node_modules/cloc      cesium
esbuild    0.24.2   0.24.2      0.25.0  node_modules/esbuild   cesium
globals   15.15.0  15.15.0      16.0.0  node_modules/globals   cesium
jsdoc      3.6.11   3.6.11       4.0.4  node_modules/jsdoc     cesium
ktx-parse    0.7.1   0.7.1   1.0.0  node_modules/ktx-parse  engine@npm:@cesium/engine@14.0.0
lerc        2.0.0    2.0.0       4.0.4  node_modules/lerc      engine@npm:@cesium/engine@14.0.0
prettier    3.5.1    3.5.1       3.5.2  node_modules/prettier  cesium
rbush       3.0.1    3.0.1       4.0.1  node_modules/rbush     engine@npm:@cesium/engine@14.0.0
rimraf     5.0.10   5.0.10       6.0.1  node_modules/rimraf    cesium
```


- jsdoc - held back https://github.com/CesiumGS/cesium/issues/10455
- lerc - held back https://github.com/CesiumGS/cesium/issues/11034
- markdownlint-cli - updated
- rbush - held back https://github.com/CesiumGS/cesium/issues/12203
- rimraf - held back https://github.com/CesiumGS/cesium/issues/12171
- globals - updated https://github.com/CesiumGS/cesium/issues/12496

## Issue number and link

No issue, prepping for release

## Testing plan

 - Run git clean -dxf
 - Run npm install

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
