### PR TITLE
Extend recommended deprecation window

### DIFF
--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -923,7 +923,7 @@ An `@experimental` API is subject to breaking changes in future Cesium releases 
 
 A public identifier (class, function, property) should be deprecated before being removed. To do so:
 
-- Decide on which future version the deprecated API should be removed. This is on a case-by-case basis depending on how badly it impacts users and Cesium development. Most deprecated APIs will removed in 1-3 releases. This can be discussed in the pull request if needed.
+- Decide on which future version the deprecated API should be removed. This is on a case-by-case basis depending on how badly it impacts users and Cesium development. Most deprecated APIs will removed in 3-6 releases. This can be discussed in the pull request if needed.
 - Use [`deprecationWarning`](https://github.com/CesiumGS/cesium/blob/main/Source/Core/deprecationWarning.js) to warn users that the API is deprecated and what proactive changes they can take, e.g.,
 
 ```javascript

--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -4,7 +4,6 @@ import ComponentDatatype from "../Core/ComponentDatatype.js";
 import createGuid from "../Core/createGuid.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Geometry from "../Core/Geometry.js";
@@ -1670,8 +1669,5 @@ Context.prototype.destroy = function () {
 
   return destroyObject(this);
 };
-
-// Used for specs.
-Context._deprecationWarning = deprecationWarning;
 
 export default Context;

--- a/packages/engine/Specs/Renderer/ContextSpec.js
+++ b/packages/engine/Specs/Renderer/ContextSpec.js
@@ -17,7 +17,6 @@ describe(
 
     beforeAll(function () {
       context = createContext();
-      spyOn(Context, "_deprecationWarning");
     });
 
     afterAll(function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

We've recently had a few separate instances of feedback around perceived instability of CesiumJS regarding the way we introduce breaking changes, especially when people jump multiple versions. We already have a pretty good [deprecation process](https://github.com/CesiumGS/cesium/tree/main/Documentation/Contributors/CodingGuide#deprecation-and-breaking-changes) but we feel the current suggestion of `1-3 releases` may be a little too short. This PR increases that to `3-6 releases` or functionally 3-6 months.

I've also created enough of our "remove in X" labels on github to cover 6 releases out. The release guide already has steps to rotate this and increment by 1 during a release.

I also found one instance of a call to `deprecationWarning` that is no longer used so I just pulled that out too.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Read the updated guide and make sure it looks good still. It's just a 1 line change

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
