### PR TITLE
Update husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The deprecation warning was finally annoying me enough to fix it.

- Remove unneeded lines in `husky/pre-commit` based on migration guide in the [9.0.1 release notes](https://github.com/typicode/husky/releases/tag/v9.0.1)
    - I didn't dig into the motivation behind this change but I did confirm things still work as expected

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12180

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Run these commands to create a test branch and prove that `lint-staged` is still being run on the `pre-commit` hook. Probably worth also doing this after `rm -rf node_modules` and a fresh `npm install`

```sh
git checkout -b testing-husky
touch test.js
git add .
git commit -m 'testing'
# Check that lint-staged was run on the js file
# see deprecation warning here if you're in main

# to cleanup your local git:
git checkout -
git branch -D testing-husky
```

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
