### PR TITLE
GeoJsonDataSource: Allow setter for defaultCrsFunction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@
 
 - `defaultValue` function and `defaultValue.EMPTY_OBJECT` have been deprecated, and will be removed in 1.134. Use respectively the nullish coalescing operator [??](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and `Frozen.EMPTY_OBJECT` instead. A new `Frozen.EMPTY_ARRAY` frozen value has been added for the same purpose as `Frozen.EMPTY_OBJECT`. See [Coding Guide](https://github.com/CesiumGS/cesium/tree/main/Documentation/Contributors/CodingGuide#default-parameter-values).
 
+#### Additions :tada:
+
+- Implemented ablity to set custom `GeoJsonDataSource.defaultCrsFunction` [#12525](https://github.com/CesiumGS/cesium/pull/12525)
+
 #### Fixes :wrench:
 
 - Fixed broken Entity Tracking [sandcastle](https://sandcastle.cesium.com/?src=Entity%20tracking.html). [#12467](https://github.com/CesiumGS/cesium/pull/12467)

--- a/packages/engine/Source/DataSources/GeoJsonDataSource.js
+++ b/packages/engine/Source/DataSources/GeoJsonDataSource.js
@@ -26,14 +26,19 @@ import EntityCollection from "./EntityCollection.js";
 import PolygonGraphics from "./PolygonGraphics.js";
 import PolylineGraphics from "./PolylineGraphics.js";
 
-function defaultCrsFunction(coordinates) {
+// Keep the original defaultCrsFunction for WGS84
+function wgs84CrsFunction(coordinates) {
   return Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]);
 }
 
+// Create a new modifiable default for other CRS types
+let defaultCrsFunction = wgs84CrsFunction;
+
 const crsNames = {
-  "urn:ogc:def:crs:OGC:1.3:CRS84": defaultCrsFunction,
-  "EPSG:4326": defaultCrsFunction,
-  "urn:ogc:def:crs:EPSG::4326": defaultCrsFunction,
+  // Standard WGS84 mappings should always use wgs84CrsFunction, unless explicitly overridden
+  "urn:ogc:def:crs:OGC:1.3:CRS84": wgs84CrsFunction,
+  "EPSG:4326": wgs84CrsFunction,
+  "urn:ogc:def:crs:EPSG::4326": wgs84CrsFunction,
 };
 
 const crsLinkHrefs = {};
@@ -757,6 +762,27 @@ Object.defineProperties(GeoJsonDataSource, {
   crsLinkTypes: {
     get: function () {
       return crsLinkTypes;
+    },
+  },
+
+  /**
+   * Gets or sets the default CRS function used to convert GeoJSON coordinates with no CRS-specified to Cartesian3 positions.
+   * The function takes an array of coordinates [longitude, latitude, height] and returns a Cartesian3.
+   * Note: This does not affect the standard WGS84 CRS mappings.
+   * @memberof GeoJsonDataSource
+   * @type {Function}
+   */
+  defaultCrsFunction: {
+    get: function () {
+      return defaultCrsFunction;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      if (typeof value !== "function") {
+        throw new DeveloperError("value must be a function");
+      }
+      //>>includeEnd('debug');
+      defaultCrsFunction = value;
     },
   },
 });


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Adds ability to set the defaultCrsFunction used by GeoJsonDataSource.

My specific use-case is trying to load GeoJSON to display on a lunar ellipsoid, so need the ability to specify a custom defaultCrsFunction that calls Cartesian3.fromDegrees() with Ellipsoid.default.


## Testing plan

Tests were added to GeoJsonDataSourceSpec.js

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
