### PR TITLE
Fix Performance Issue in updateHeights with High-Resolution Custom Terrain Providers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Fixed camera zooming in 3D orthographic mode when pixelRatio is not 1. [#12487](https://github.com/CesiumGS/cesium/pull/12487)
 - Fixed VaryingType.MAT3: "mat2" significant typo. [#12524](https://github.com/CesiumGS/cesium/issues/12524)
 - Fixed shape bounds and transforms for cylinder-shaped voxels. [#12522](https://github.com/CesiumGS/cesium/pull/12522)
+- Fixed an issue where clamped entities' height updates could stall when using high-resolution terrain due to a growing queue of tiles in `updateHeights` in `QuadtreePrimitive`. [#12476](https://github.com/CesiumGS/cesium/issues/12476)
 
 ## 1.127 - 2025-03-03
 

--- a/packages/engine/Source/Scene/QuadtreePrimitive.js
+++ b/packages/engine/Source/Scene/QuadtreePrimitive.js
@@ -1414,6 +1414,8 @@ function updateHeights(primitive, frameState) {
       ) {
         tryNextFrame.push(tile);
       }
+      // Ensure stale position cache is cleared
+      tile.clearPositionCache();
       tilesToUpdateHeights.shift();
       primitive._lastTileIndex = 0;
       continue;
@@ -1431,77 +1433,92 @@ function updateHeights(primitive, frameState) {
         defined(terrainData) && terrainData.wasCreatedByUpsampling();
 
       if (tile.level > data.level && !upsampledGeometryFromParent) {
-        if (!defined(data.positionOnEllipsoidSurface)) {
-          // cartesian has to be on the ellipsoid surface for `ellipsoid.geodeticSurfaceNormal`
-          data.positionOnEllipsoidSurface = Cartesian3.fromRadians(
-            data.positionCartographic.longitude,
-            data.positionCartographic.latitude,
-            0.0,
-            ellipsoid,
-          );
-        }
-
-        if (mode === SceneMode.SCENE3D) {
-          const surfaceNormal = ellipsoid.geodeticSurfaceNormal(
-            data.positionOnEllipsoidSurface,
-            scratchRay.direction,
-          );
-
-          // compute origin point
-
-          // Try to find the intersection point between the surface normal and z-axis.
-          // minimum height (-11500.0) for the terrain set, need to get this information from the terrain provider
-          const rayOrigin = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
-            data.positionOnEllipsoidSurface,
-            11500.0,
-            scratchRay.origin,
-          );
-
-          // Theoretically, not with Earth datums, the intersection point can be outside the ellipsoid
-          if (!defined(rayOrigin)) {
-            // intersection point is outside the ellipsoid, try other value
-            // minimum height (-11500.0) for the terrain set, need to get this information from the terrain provider
-            let minimumHeight = 0.0;
-            if (defined(tile.data.tileBoundingRegion)) {
-              minimumHeight = tile.data.tileBoundingRegion.minimumHeight;
-            }
-            const magnitude = Math.min(minimumHeight, -11500.0);
-
-            // multiply by the *positive* value of the magnitude
-            const vectorToMinimumPoint = Cartesian3.multiplyByScalar(
-              surfaceNormal,
-              Math.abs(magnitude) + 1,
-              scratchPosition,
-            );
-            Cartesian3.subtract(
-              data.positionOnEllipsoidSurface,
-              vectorToMinimumPoint,
-              scratchRay.origin,
+        let position;
+        // find cached entry
+        const cachedData = tile.getPositionCacheEntry(
+          data.positionCartographic,
+        );
+        if (defined(cachedData)) {
+          // cache hit
+          position = cachedData;
+        } else {
+          if (!defined(data.positionOnEllipsoidSurface)) {
+            // cartesian has to be on the ellipsoid surface for `ellipsoid.geodeticSurfaceNormal`
+            data.positionOnEllipsoidSurface = Cartesian3.fromRadians(
+              data.positionCartographic.longitude,
+              data.positionCartographic.latitude,
+              0.0,
+              ellipsoid,
             );
           }
-        } else {
-          Cartographic.clone(data.positionCartographic, scratchCartographic);
 
-          // minimum height for the terrain set, need to get this information from the terrain provider
-          scratchCartographic.height = -11500.0;
-          projection.project(scratchCartographic, scratchPosition);
-          Cartesian3.fromElements(
-            scratchPosition.z,
-            scratchPosition.x,
-            scratchPosition.y,
+          if (mode === SceneMode.SCENE3D) {
+            const surfaceNormal = ellipsoid.geodeticSurfaceNormal(
+              data.positionOnEllipsoidSurface,
+              scratchRay.direction,
+            );
+
+            // compute origin point
+
+            // Try to find the intersection point between the surface normal and z-axis.
+            // minimum height (-11500.0) for the terrain set, need to get this information from the terrain provider
+            const rayOrigin = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
+              data.positionOnEllipsoidSurface,
+              11500.0,
+              scratchRay.origin,
+            );
+
+            // Theoretically, not with Earth datums, the intersection point can be outside the ellipsoid
+            if (!defined(rayOrigin)) {
+              // intersection point is outside the ellipsoid, try other value
+              // minimum height (-11500.0) for the terrain set, need to get this information from the terrain provider
+              let minimumHeight = 0.0;
+              if (defined(tile.data.tileBoundingRegion)) {
+                minimumHeight = tile.data.tileBoundingRegion.minimumHeight;
+              }
+              const magnitude = Math.min(minimumHeight, -11500.0);
+
+              // multiply by the *positive* value of the magnitude
+              const vectorToMinimumPoint = Cartesian3.multiplyByScalar(
+                surfaceNormal,
+                Math.abs(magnitude) + 1,
+                scratchPosition,
+              );
+              Cartesian3.subtract(
+                data.positionOnEllipsoidSurface,
+                vectorToMinimumPoint,
+                scratchRay.origin,
+              );
+            }
+          } else {
+            Cartographic.clone(data.positionCartographic, scratchCartographic);
+
+            // minimum height for the terrain set, need to get this information from the terrain provider
+            scratchCartographic.height = -11500.0;
+            projection.project(scratchCartographic, scratchPosition);
+            Cartesian3.fromElements(
+              scratchPosition.z,
+              scratchPosition.x,
+              scratchPosition.y,
+              scratchPosition,
+            );
+            Cartesian3.clone(scratchPosition, scratchRay.origin);
+            Cartesian3.clone(Cartesian3.UNIT_X, scratchRay.direction);
+          }
+
+          position = tile.data.pick(
+            scratchRay,
+            mode,
+            projection,
+            false,
             scratchPosition,
           );
-          Cartesian3.clone(scratchPosition, scratchRay.origin);
-          Cartesian3.clone(Cartesian3.UNIT_X, scratchRay.direction);
-        }
 
-        const position = tile.data.pick(
-          scratchRay,
-          mode,
-          projection,
-          false,
-          scratchPosition,
-        );
+          if (defined(position)) {
+            // Store the computed position in the cache for future reuse
+            tile.setPositionCacheEntry(data.positionCartographic, position);
+          }
+        }
         if (defined(position)) {
           if (defined(data.callback)) {
             data.callback(position);

--- a/packages/engine/Source/Scene/QuadtreePrimitive.js
+++ b/packages/engine/Source/Scene/QuadtreePrimitive.js
@@ -1437,6 +1437,7 @@ function updateHeights(primitive, frameState) {
         // find cached entry
         const cachedData = tile.getPositionCacheEntry(
           data.positionCartographic,
+          primitive.maximumScreenSpaceError,
         );
         if (defined(cachedData)) {
           // cache hit
@@ -1516,7 +1517,11 @@ function updateHeights(primitive, frameState) {
 
           if (defined(position)) {
             // Store the computed position in the cache for future reuse
-            tile.setPositionCacheEntry(data.positionCartographic, position);
+            tile.setPositionCacheEntry(
+              data.positionCartographic,
+              primitive.maximumScreenSpaceError,
+              position,
+            );
           }
         }
         if (defined(position)) {

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3885,6 +3885,7 @@ Scene.prototype.getHeight = function (cartographic, heightReference) {
 };
 
 const updateHeightScratchCartographic = new Cartographic();
+const updateClampedScratchCartographic = new Cartographic();
 /**
  * Calls the callback when a new tile is rendered that contains the given cartographic. The only parameter
  * is the cartesian position on the tile.
@@ -3905,10 +3906,23 @@ Scene.prototype.updateHeight = function (
   Check.typeOf.func("callback", callback);
   //>>includeEnd('debug');
 
-  const callbackWrapper = () => {
+  const ellipsoid = this._ellipsoid;
+  const callbackWrapper = (clampedPosition) => {
     Cartographic.clone(cartographic, updateHeightScratchCartographic);
 
-    const height = this.getHeight(cartographic, heightReference);
+    let height;
+    if (defined(clampedPosition)) {
+      const updatedClampedPosition = ellipsoid.cartesianToCartographic(
+        clampedPosition,
+        updateClampedScratchCartographic,
+      );
+      if (defined(updatedClampedPosition)) {
+        height = updatedClampedPosition.height;
+      }
+    }
+    if (!defined(height)) {
+      height = this.getHeight(cartographic, heightReference);
+    }
     if (defined(height)) {
       updateHeightScratchCartographic.height = height;
       callback(updateHeightScratchCartographic);
@@ -3932,7 +3946,6 @@ Scene.prototype.updateHeight = function (
   }
 
   let tilesetRemoveCallbacks = {};
-  const ellipsoid = this._ellipsoid;
   const createPrimitiveEventListener = (primitive) => {
     if (
       ignore3dTiles ||

--- a/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -971,6 +971,87 @@ describe("Scene/QuadtreePrimitive", function () {
         expect(position).toEqual(updatedPosition);
       });
 
+      it("uses tiles position caching in update heights", function () {
+        const tileProvider = createSpyTileProvider();
+        tileProvider.getReady.and.returnValue(true);
+        tileProvider.computeTileVisibility.and.returnValue(Visibility.FULL);
+        tileProvider.computeDistanceToTile.and.returnValue(1e-15);
+
+        tileProvider.terrainProvider = {
+          getTileDataAvailable: function () {
+            return true;
+          },
+        };
+
+        // Dummy positions
+        const computedPosition = new Cartesian3(1000, 2000, 3000);
+        const currentPosition = computedPosition;
+
+        // Create a Map to count how many times the tile's pick function is called for each tile level.
+        const pickCounters = new Map();
+
+        // Load the root tiles.
+        tileProvider.loadTile.and.callFake(function (frameState, tile) {
+          tile.state = QuadtreeTileLoadState.DONE;
+          tile.renderable = true;
+          tile.data = {
+            // The pick function simulates computing a clamped position.
+            // Each call increments the counter.
+            pick: function () {
+              // Initialize the counter for this tile's level if not already set.
+              if (!pickCounters.has(tile.level)) {
+                pickCounters.set(tile.level, 0);
+              }
+              const count = pickCounters.get(tile.level);
+              const pickPosition = currentPosition;
+              pickCounters.set(tile.level, count + 1);
+              return pickPosition;
+            },
+            mesh: {},
+          };
+        });
+
+        const quadtree = new QuadtreePrimitive({
+          tileProvider: tileProvider,
+        });
+
+        // Create two nearly identical cartographic positions (in degrees)
+        const carto1 = Cartographic.fromDegrees(-72.0, 40.0);
+        // Slightly offset cartographic coordinates (within the rounding tolerance)
+        const carto2 = Cartographic.fromDegrees(
+          -72.0 + 0.000001,
+          40.0 + 0.000001,
+        );
+
+        // Variables to store results from the callbacks
+        const position1 = new Cartesian3();
+        const position2 = new Cartesian3();
+
+        // Install two height update callbacks with near-identical positions.
+        quadtree.updateHeight(carto1, function (p) {
+          Cartesian3.clone(p, position1);
+        });
+        quadtree.updateHeight(carto2, function (p) {
+          Cartesian3.clone(p, position2);
+        });
+
+        // Process a few render cycles to trigger height updates and cache usage.
+        for (let i = 0; i < 3; ++i) {
+          quadtree.update(scene.frameState);
+          quadtree.beginFrame(scene.frameState);
+          quadtree.render(scene.frameState);
+          quadtree.endFrame(scene.frameState);
+        }
+
+        // Verify that for each tile level recorded in pickCounters, the pick function was called only once.
+        pickCounters.forEach((count, level) => {
+          expect(count).toEqual(1);
+        });
+
+        // Verify that both callbacks produced the same computed position (indicating a cache hit).
+        expect(position1).toEqual(position2);
+      });
+
       it("gives correct priority to tile loads", function () {
         const tileProvider = createSpyTileProvider();
         tileProvider.getReady.and.returnValue(true);

--- a/packages/engine/Specs/Scene/QuadtreeTileSpec.js
+++ b/packages/engine/Specs/Scene/QuadtreeTileSpec.js
@@ -1,4 +1,6 @@
 import {
+  Cartesian3,
+  Cartographic,
   GeographicTilingScheme,
   Rectangle,
   Math as CesiumMath,
@@ -376,6 +378,68 @@ describe("Scene/QuadtreeTile", function () {
       expect(northwest.rectangle.south).toBeGreaterThan(
         southwest.rectangle.south,
       );
+    });
+  });
+
+  describe("QuadtreeTile Position Cache", function () {
+    it("store and retrieve a cached position correctly", function () {
+      // Create a dummy Cartographic position
+      const longitude = CesiumMath.toRadians(45);
+      const latitude = CesiumMath.toRadians(30);
+      const cartographic = new Cartographic(longitude, latitude, 0);
+
+      // Create a dummy Cartesian3 position (the computed clamped position)
+      const dummyPosition = new Cartesian3(1000, 2000, 3000);
+
+      // Create a dummy QuadtreeTile instance.
+      const tile = new QuadtreeTile({
+        level: 3,
+        x: 0,
+        y: 0,
+        tilingScheme: new GeographicTilingScheme(),
+        parent: undefined,
+      });
+
+      // Ensure the tile's cache is cleared before the test.
+      tile.clearPositionCache();
+
+      // Set a cache entry for the given cartographic position.
+      tile.setPositionCacheEntry(cartographic, dummyPosition);
+
+      // Retrieve the cache entry.
+      const cachedData = tile.getPositionCacheEntry(cartographic);
+      expect(cachedData).toBeDefined();
+      expect(cachedData).toEqual(dummyPosition);
+
+      // Also check that the cache size is 1.
+      expect(tile._positionCache.cache.size).toEqual(1);
+    });
+
+    it("generate consistent cache keys for equivalent cartographic values", function () {
+      // Two separate Cartographic instances with the same longitude/latitude
+      const lon = CesiumMath.toRadians(45);
+      const lat = CesiumMath.toRadians(30);
+      const carto1 = new Cartographic(lon, lat, 0);
+      const carto2 = new Cartographic(lon, lat, 0);
+
+      // Create a dummy tile at level 3.
+      const tile = new QuadtreeTile({
+        level: 3,
+        x: 0,
+        y: 0,
+        tilingScheme: new GeographicTilingScheme(),
+        parent: undefined,
+      });
+      tile.clearPositionCache();
+
+      // Set a cache entry using the first cartographic object.
+      const dummyPosition = new Cartesian3(1000, 2000, 3000);
+      tile.setPositionCacheEntry(carto1, dummyPosition);
+
+      // Retrieve the cache entry using the second (equal) cartographic instance.
+      const cachedData = tile.getPositionCacheEntry(carto2);
+      expect(cachedData).toBeDefined();
+      expect(cachedData).toEqual(dummyPosition);
     });
   });
 });

--- a/packages/engine/Specs/Scene/QuadtreeTileSpec.js
+++ b/packages/engine/Specs/Scene/QuadtreeTileSpec.js
@@ -387,6 +387,7 @@ describe("Scene/QuadtreeTile", function () {
       const longitude = CesiumMath.toRadians(45);
       const latitude = CesiumMath.toRadians(30);
       const cartographic = new Cartographic(longitude, latitude, 0);
+      const maximumScreenSpaceError = 2;
 
       // Create a dummy Cartesian3 position (the computed clamped position)
       const dummyPosition = new Cartesian3(1000, 2000, 3000);
@@ -404,10 +405,17 @@ describe("Scene/QuadtreeTile", function () {
       tile.clearPositionCache();
 
       // Set a cache entry for the given cartographic position.
-      tile.setPositionCacheEntry(cartographic, dummyPosition);
+      tile.setPositionCacheEntry(
+        cartographic,
+        maximumScreenSpaceError,
+        dummyPosition,
+      );
 
       // Retrieve the cache entry.
-      const cachedData = tile.getPositionCacheEntry(cartographic);
+      const cachedData = tile.getPositionCacheEntry(
+        cartographic,
+        maximumScreenSpaceError,
+      );
       expect(cachedData).toBeDefined();
       expect(cachedData).toEqual(dummyPosition);
 
@@ -421,6 +429,7 @@ describe("Scene/QuadtreeTile", function () {
       const lat = CesiumMath.toRadians(30);
       const carto1 = new Cartographic(lon, lat, 0);
       const carto2 = new Cartographic(lon, lat, 0);
+      const maximumScreenSpaceError = 2;
 
       // Create a dummy tile at level 3.
       const tile = new QuadtreeTile({
@@ -434,10 +443,17 @@ describe("Scene/QuadtreeTile", function () {
 
       // Set a cache entry using the first cartographic object.
       const dummyPosition = new Cartesian3(1000, 2000, 3000);
-      tile.setPositionCacheEntry(carto1, dummyPosition);
+      tile.setPositionCacheEntry(
+        carto1,
+        maximumScreenSpaceError,
+        dummyPosition,
+      );
 
       // Retrieve the cache entry using the second (equal) cartographic instance.
-      const cachedData = tile.getPositionCacheEntry(carto2);
+      const cachedData = tile.getPositionCacheEntry(
+        carto2,
+        maximumScreenSpaceError,
+      );
       expect(cachedData).toBeDefined();
       expect(cachedData).toEqual(dummyPosition);
     });


### PR DESCRIPTION
# Description

This fix addresses a performance issue with `QuadtreePrimitive.updateHeights` when using high-resolution custom terrain (e.g., ArcGIS WorldElevation 3D) or running on  low-performance machines. The height update process struggles to keep up, causing terrain intersection calculations to exceed the 2ms time limit, leading to:
- Entity positioning  delays and inconsistencies
- Performance degradation due to an ever-growing height update queu

<!-- Describe your changes in detail -->

## Proposed Fixes

- **Added an LRU (Least Recently Used) cache** to `QuadtreeTile` to store already computed clamped positions, avoiding redundant calculations.
- **Each time a new clamped position is computed** in `QuadtreePrimitive.updateHeights`, it is stored in the cache for future lookups.
- **Modified** `Scene.updateHeight` to ensure the callback reuses the clamped position passed by `QuadtreePrimitive.updateHeights` as input, preventing unnecessary recalculations.

**Cache Implementation details**
- Each `QuadtreeTile` now has an **LRU cache** that stores computed height positions.
- **Cache limit: 1000 entries per tile**. 
- **Memory usage estimate**:
-- Each entry is a Cartesian position (3 floats, approximately max 24KB per tile).
-- For 100 active tiles, this results in max ~2.4MB of memory usage, which is acceptable for most machines.

<!-- Consider: Why is this change required? What problem does it solve? -->

The 2ms time limit for `QuadtreePrimitive.updateHeights` is too restrictive, expecially for high-resolution terrain or low-performance machine. This fix allows to avoid the `tilesToUpdateHeights` queue grows indefinitely preventing possible entity positioning issues and performance degradation.

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->
Fixes issue [#12476](https://github.com/CesiumGS/cesium/issues/12476)

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
Tested on high-resolution terrain (e.g. ArcGIS WorldElevation3D) and low-performance machines
The fix was validated using the provided Sandcastle example, which successfully demonstrated a reduced queue size in tilesToUpdateHeights and better height updates after few rendering cycles.

[Sandcastle example](https://sandcastle.cesium.com/#c=rVTbbhs3EP2VgdCHla2Qko00vihGDTtNAsSxYSntQ7ZwaO5oRZRLCuSsFNXwv2f2JkuN+5CgxALkkjNnzpwZUnsXCZYGVxjgNThcwQVGUxbij3ovSXu6/r/wjpRxGNJe/zR1qZN7qaOwhofUQQsgokaHgjAENr0JfmmyCrayAFArZahD1wEV4Z8+2GzamJ/HtdNJhf0IWpGeQ8IHPvSbCCvjMr8SymKg5MvvyljMgDxYr3huIAT88lD7PH5pcFK3JyuuP8/zPOi37yfTKtobi0tFxrvprp+YBV98CjZp3AHS3pxoEU+kxM7lMBMq6NxEoX0hm6UMGElGDEvDEstai02Mw0vZhuHV+0LlOGHDSv1BE+b/Fip1O9rk1t+jyHBB8ynTPM/ZK1JLiRuFQol1G8xKpyvCkCPdKg5dXM9mESlp6QSkMjhIrhTNRagN+OgFDMXLPuzxNKzH6BSkhEmhrIXGCnyNw+yqMLruU2QFmM2FCuTzoBZzo5lLW6rt3boml5gHxJgc/SqOD14O4OCVOD46Gg1g2K+jvWnQIJZFYWgriiNDBiNDf/6Lk5z5AIlFAsM7w1OexjCq5v39NsnGz3qXGyozfOJUZ02+Y/IMf/Hktf+9hlV1NvDcGD+O3jn9B/gTfJ31msHbPuhUECrLkoem6RY+mqrYJ9ua80q5wx3FNzkNNqwHcMxl7rfdW/gM7Qk8dFemGmUwJ3x3hJD8TVSxsHipSMnaNsom4pVy7eqOl9ym95sb0Yw5mnxOtzhjLZzGDdN3u/vi4sP51c3d9Pru7e31p4+XOxiFcaYoixvzFe3E/MMgo4OjXQv1tbKYaL5mfDocbp0+1uvHTt2NjosyzpNG5frSbd05Ckr/zS9MV4LO5/Ow6r/eoDeOtLZ41gX5zRQLH4glswmLRchi8XMa5X3JOCR0jE3nAIzltus4M0sw2etnXnXQVsXIJ7PS1lmnvbOxZPvvXKuXxLj8mtvNqnVlNh+dfWg2hRBjyb/Pe5L39l6FfyF/Aw)

#### **Observations & Debugging**

To analyze the issue, I added logging inside `QuadtreePrimitive.updateHeights` as follows:

replaced

```
if (getTimestamp() >= endTime) {
   timeSliceMax = true;
   break;
}
```

with

```
const currentTime = getTimestamp();
const deltaTime = currentTime - startTime; // Calculate elapsed time
if (currentTime >= endTime) {
    console.log(`Time slice exceeded: Δt = ${deltaTime} ms (limit: ${timeSlice} ms)`);
    console.log(`Queue size: tilesToUpdateHeights.length = ${tilesToUpdateHeights.length}`);
    console.log(`Last processed tile index: ${primitive._lastTileIndex}`);
    timeSliceMax = true;
    break;
}
```
Before the fix, this is the log after all tiles have been loaded


```
Time slice exceeded: Δt = 53.59999990463257 ms (limit: 2 ms)
Queue size: tilesToUpdateHeights.length = 56
Last processed tile index: 1
Time slice exceeded: Δt = 86.2999997138977 ms (limit: 2 ms)
Queue size: tilesToUpdateHeights.length = 56
Last processed tile index: 1
...
```

After the fix nothing is printed after few rendering cycles, meaning that the queue has been cleared and the time limit is not hit anymore.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x]  I have added or updated unit tests to ensure consistent code coverage
- [x] I have performed a self-review of my code
