### PR TITLE
fix QuadtreePrimitive updateHeights callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 #### Fixes :wrench:
 
-- `QuadtreePrimitive.updateHeights` now converts positions to Cartographic before invoking the callback, ensuring compatibility with change introduced by [commit 53889cb](https://github.com/CesiumGS/cesium/commit/53889cb) and preventing unnecessary computation. [#12555](https://github.com/CesiumGS/cesium/pull/12555)
+- `QuadtreePrimitive.updateHeights` now converts position to Cartographic before invoking the callback, ensuring compatibility with change introduced by [commit 53889cb](https://github.com/CesiumGS/cesium/commit/53889cb) and preventing unnecessary computation. [#12555](https://github.com/CesiumGS/cesium/pull/12555)
 
 ## 1.128 - 2025-04-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.129 - 2025-05-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- `QuadtreePrimitive.updateHeights` now converts positions to Cartographic before invoking the callback, ensuring compatibility with change introduced by [commit 53889cb](https://github.com/CesiumGS/cesium/commit/53889cb) and preventing unnecessary computation. [#12555](https://github.com/CesiumGS/cesium/pull/12555)
+
 ## 1.128 - 2025-04-01
 
 ### @cesium/engine

--- a/packages/engine/Source/Scene/QuadtreePrimitive.js
+++ b/packages/engine/Source/Scene/QuadtreePrimitive.js
@@ -1526,7 +1526,11 @@ function updateHeights(primitive, frameState) {
         }
         if (defined(position)) {
           if (defined(data.callback)) {
-            data.callback(position);
+            const positionCarto = ellipsoid.cartesianToCartographic(
+              position,
+              scratchCartographic,
+            );
+            data.callback(positionCarto);
           }
           data.level = tile.level;
         }

--- a/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -937,6 +937,7 @@ describe("Scene/QuadtreePrimitive", function () {
         const updatedPositionCarto = Cartographic.fromDegrees(-72.0, 40.0, 100);
         const position = Cartographic.toCartesian(positionCarto);
         const updatedPosition = Cartographic.toCartesian(updatedPositionCarto);
+        // variables for results
         const positionRes = new Cartographic();
         const updatedPositionRes = new Cartographic();
         let currentPosition = position;
@@ -1052,15 +1053,15 @@ describe("Scene/QuadtreePrimitive", function () {
         );
 
         // Variables to store results from the callbacks
-        const position1 = new Cartesian3();
-        const position2 = new Cartesian3();
+        const position1 = new Cartographic();
+        const position2 = new Cartographic();
 
         // Install two height update callbacks with near-identical positions.
         quadtree.updateHeight(carto1, function (p) {
-          Cartographic.toCartesian(p, undefined, position1);
+          Cartographic.clone(p, position1);
         });
         quadtree.updateHeight(carto2, function (p) {
-          Cartographic.toCartesian(p, undefined, position2);
+          Cartographic.clone(p, position2);
         });
 
         // Process a few render cycles to trigger height updates and cache usage.


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This is a trivial fix for changes introduced by commit [53889cb](https://github.com/CesiumGS/cesium/commit/53889cbed2a91d38e0fae4b6f2dcf6783632fc92). 


<!-- Describe your changes in detail -->
After that commit, the callback defined in `Scene.updateHeight` expects a cartographic position.
This updates ensures that positions retrieved during `QuadtreePrivitive.updateHeights` iteration are properly converted to cartographic coordinates before being passed to the callback.
This avoids unneeded computation, which is important because updateHeights is time-constraned. Reducing overhead ensures that entity position updates remain performant and consistent.

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have performed a self-review of my code
