### PR TITLE
Update Stamen Maps in Imagery Layers Manipulation Sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
@@ -169,12 +169,14 @@
           );
           addBaseLayerOption("OpenStreetMaps", new Cesium.OpenStreetMapImageryProvider());
           addBaseLayerOption(
-            "Stamen Maps",
+            "Stadia x Stamen Watercolor",
             new Cesium.OpenStreetMapImageryProvider({
-              url: "https://stamen-tiles.a.ssl.fastly.net/watercolor/",
+              url: "https://tiles.stadiamaps.com/tiles/stamen_watercolor/",
               fileExtension: "jpg",
-              credit:
-                "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under CC BY SA.",
+              credit: `&copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a>
+               &copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>
+               &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>
+               &copy; <a href="https://www.openstreetmap.org/about/" target="_blank">OpenStreetMap contributors</a>`,
             }),
           );
           addBaseLayerOption(


### PR DESCRIPTION

# Description

Fixes the "Stamen Maps" in the "Imagery Layers Maniuplation" sandcastle.

As of right now (1.128), selecting "Stamen Maps" from the dropdown in the "Imagery Layers Maniuplation" sandcastle at https://sandcastle.cesium.com/index.html?src=Imagery%20Layers%20Manipulation.html causes a bunch of errors, because "Stamen Maps" was renamed. This was already fixed via https://github.com/CesiumGS/cesium/pull/11485 , but the Sandcastle has not been updated yet.

This PR adds the information (updated name, URL, and copyright) that is used in the sandcastle, based on the changes at https://github.com/CesiumGS/cesium/pull/11485/files#diff-ae8ad05e27b46d010c5d7ffb28e84093c4545d61059eb1c4bd501dbd39fb5541R164 from this PR.

## Testing plan

Open https://sandcastle.cesium.com/index.html?src=Imagery%20Layers%20Manipulation.html and select "Stamen Maps" from the dropdown: It does not display the imagery.

Do the same on this branch: It _does_ display the imagery


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] (**N/A?**) I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
