### PR TITLE
jsdoc fixup: fix typo in comment and add missing @return

### DIFF
--- a/packages/engine/Source/Core/PolygonGeometry.js
+++ b/packages/engine/Source/Core/PolygonGeometry.js
@@ -876,6 +876,7 @@ const dummyOptions = {
  * @param {number[]} array The packed array.
  * @param {number} [startingIndex=0] The starting index of the element to be unpacked.
  * @param {PolygonGeometry} [result] The object into which to store the result.
+ * @returns {PolygonGeometry} The modified result parameter or a new PolygonGeometry instance if one was not provided.
  */
 PolygonGeometry.unpack = function (array, startingIndex, result) {
   //>>includeStart('debug', pragmas.debug);

--- a/packages/engine/Source/Core/RectangleOutlineGeometry.js
+++ b/packages/engine/Source/Core/RectangleOutlineGeometry.js
@@ -364,7 +364,7 @@ const scratchOptions = {
  * @param {number[]} array The packed array.
  * @param {number} [startingIndex=0] The starting index of the element to be unpacked.
  * @param {RectangleOutlineGeometry} [result] The object into which to store the result.
- * @returns {RectangleOutlineGeometry} The modified result parameter or a new Quaternion instance if one was not provided.
+ * @returns {RectangleOutlineGeometry} The modified result parameter or a new RectangleOutlineGeometry instance if one was not provided.
  */
 RectangleOutlineGeometry.unpack = function (array, startingIndex, result) {
   //>>includeStart('debug', pragmas.debug);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Trivial jsdoc updates to fix a typo and add a missing `@return`

## Issue number and link

n/a

## Testing plan

n/a

# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
