### PR TITLE
Better Check.typeOf.object.  Fixes #12572

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - `QuadtreePrimitive.updateHeights` now converts position to Cartographic before invoking the callback, ensuring compatibility with change introduced by [commit 53889cb](https://github.com/CesiumGS/cesium/commit/53889cb) and preventing unnecessary computation. [#12555](https://github.com/CesiumGS/cesium/pull/12555)
+- `Check.typeOf.object` now asserts `Record<string|number|symbol, any>` intead of `object` to allow property checks after assertion. [#12572](https://github.com/CesiumGS/cesium/issues/12572)
 
 ## 1.128 - 2025-04-01
 

--- a/packages/engine/Source/Core/Check.d.ts
+++ b/packages/engine/Source/Core/Check.d.ts
@@ -38,7 +38,7 @@ const Check: {
      * @param {*} test The value to test
      * @exception {DeveloperError} test must be typeof 'object'
      */
-    object(name: string, test: any): asserts test is object;
+    object(name: string, test: any): asserts test is Record<string|number|symbol, any>;
     /**
      * Throws if test is not typeof 'boolean'
      *

--- a/packages/engine/Source/Core/Check.d.ts
+++ b/packages/engine/Source/Core/Check.d.ts
@@ -38,7 +38,10 @@ const Check: {
      * @param {*} test The value to test
      * @exception {DeveloperError} test must be typeof 'object'
      */
-    object(name: string, test: any): asserts test is Record<string|number|symbol, any>;
+    object(
+      name: string,
+      test: any,
+    ): asserts test is Record<string | number | symbol, any>;
     /**
      * Throws if test is not typeof 'boolean'
      *


### PR DESCRIPTION

# Description

Better typing for `Check.typeOf.object`.   Allows test object properties to be checked after asserting that the test value is an object.

## Issue number and link

https://github.com/CesiumGS/cesium/issues/12572

## Testing plan

Run `npm build-ts` and make sure the new definition for `Check.typeOf` is published

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [NA] I have added or updated unit tests to ensure consistent code coverage
- [NA] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
