### PR TITLE
Update npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "esbuild": "^0.25.0",
     "eslint": "^9.1.1",
     "eslint-plugin-html": "^8.1.1",
-    "express": "^4.17.1",
+    "express": "^5.1.0",
     "globals": "^16.0.0",
     "globby": "^14.0.0",
     "glsl-strip-comments": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -98,31 +98,35 @@ async function generateDevelopmentBuild() {
     contexts = await generateDevelopmentBuild();
   }
 
-  // eventually this mime type configuration will need to change
-  // https://github.com/visionmedia/send/commit/d2cb54658ce65948b0ed6e5fb5de69d022bef941
-  // *NOTE* Any changes you make here must be mirrored in web.config.
-  const mime = express.static.mime;
-  mime.define(
-    {
-      "application/json": ["czml", "json", "geojson", "topojson"],
-      "application/wasm": ["wasm"],
-      "image/ktx2": ["ktx2"],
-      "model/gltf+json": ["gltf"],
-      "model/gltf-binary": ["bgltf", "glb"],
-      "application/octet-stream": [
-        "b3dm",
-        "pnts",
-        "i3dm",
-        "cmpt",
-        "geom",
-        "vctr",
-      ],
-      "text/plain": ["glsl"],
-    },
-    true,
-  );
-
   const app = express();
+
+  app.use(function (req, res, next) {
+    // *NOTE* Any changes you make here must be mirrored in web.config.
+    const extensionToMimeType = {
+      ".czml": "application/json",
+      ".json": "application/json",
+      ".geojson": "application/json",
+      ".topojson": "application/json",
+      ".wasm": "application/wasm",
+      ".ktx2": "image/ktx2",
+      ".gltf": "model/gltf+json",
+      ".bgltf": "model/gltf-binary",
+      ".glb": "model/gltf-binary",
+      ".b3dm": "application/octet-stream",
+      ".pnts": "application/octet-stream",
+      ".i3dm": "application/octet-stream",
+      ".cmpt": "application/octet-stream",
+      ".geom": "application/octet-stream",
+      ".vctr": "application/octet-stream",
+      ".glsl": "text/plain",
+    };
+    const extension = path.extname(req.url);
+    if (extensionToMimeType[extension]) {
+      res.contentType(extensionToMimeType[extension]);
+    }
+    next();
+  });
+
   app.use(compression());
   //eslint-disable-next-line no-unused-vars
   app.use(function (req, res, next) {
@@ -170,20 +174,20 @@ async function generateDevelopmentBuild() {
     const iifeCache = createRoute(
       app,
       "Cesium.js",
-      "/Build/CesiumUnminified/Cesium.js*",
+      /\/Build\/CesiumUnminified\/Cesium.js.*/,
       contexts.iife,
       [iifeWorkersCache],
     );
     const esmCache = createRoute(
       app,
       "index.js",
-      "/Build/CesiumUnminified/index.js*",
+      /\/Build\/CesiumUnminified\/index.js.*/,
       contexts.esm,
     );
     const workersCache = createRoute(
       app,
       "Workers/*",
-      "/Build/CesiumUnminified/Workers/*.js",
+      /\/Build\/CesiumUnminified\/Workers\/.*\.js/,
       contexts.workers,
     );
 
@@ -236,7 +240,7 @@ async function generateDevelopmentBuild() {
     const testWorkersCache = createRoute(
       app,
       "TestWorkers/*",
-      "/Build/Specs/TestWorkers/*",
+      /\/Build\/Specs\/TestWorkers\/.*/,
       contexts.testWorkers,
     );
     chokidar
@@ -246,7 +250,7 @@ async function generateDevelopmentBuild() {
     const specsCache = createRoute(
       app,
       "Specs/*",
-      "/Build/Specs/*",
+      /\/Build\/Specs\/.*/,
       contexts.specs,
     );
     const specWatcher = chokidar.watch(
@@ -301,7 +305,7 @@ async function generateDevelopmentBuild() {
   app.use(express.static(path.resolve(".")));
 
   function getRemoteUrlFromParam(req) {
-    let remoteUrl = req.params[0];
+    let remoteUrl = req.params.remote?.join("/");
     if (remoteUrl) {
       // add http:// to the URL if no protocol is present
       if (!/^https?:\/\//.test(remoteUrl)) {
@@ -339,7 +343,7 @@ async function generateDevelopmentBuild() {
   }
 
   //eslint-disable-next-line no-unused-vars
-  app.get("/proxy/*", function (req, res, next) {
+  app.get("/proxy/{*remote}", function (req, res, next) {
     // look for request like http://localhost:8080/proxy/http://example.com/file?query=1
     let remoteUrl = getRemoteUrlFromParam(req);
     if (!remoteUrl) {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
`npm outdated`:
```
Package  Current  Wanted  Latest  Location              Depended by
express   4.21.2  4.21.2   5.1.0  node_modules/express  cesium
jsdoc     3.6.11  3.6.11   4.0.4  node_modules/jsdoc    cesium
lerc       2.0.0   2.0.0   4.0.4  node_modules/lerc     engine@npm:@cesium/engine@16.0.0
rbush      3.0.1   3.0.1   4.0.1  node_modules/rbush    engine@npm:@cesium/engine@16.0.0
```

- express - Updated, see below
- jsdoc - held back https://github.com/CesiumGS/cesium/issues/10455
- lerc - held back https://github.com/CesiumGS/cesium/issues/11034
- rbush - held back https://github.com/CesiumGS/cesium/issues/12203

Express [switched the `@latest` version to v5](https://expressjs.com/2025/03/31/v5-1-latest-release.html). This came with the major changes from v4 -> v5, [migration guide](https://expressjs.com/en/guide/migrating-5). Our server is fairly minimal so it didn't need that many changes. I believe I got them all.

- [`express.static.mime`](https://expressjs.com/en/guide/migrating-5#express.static.mime) no longer exists. They say to switch to [`mime-types`](https://github.com/jshttp/mime-types) but that does _not_ have the `.define()` we were using.
    - Switched to a custom middleware function instead
- wildcards in paths must now be named per the [new path matching syntax](https://expressjs.com/en/guide/migrating-5#path-syntax)
    - Switched some routes to regular expressions instead where the wildcard param was not used
    - Switched the proxy wildcard to a named param and updated handlers 

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue, part of release prep

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm start` and make sure that everything on the local dev server works as expected.
- You can use the script below to test routes with specific extensions for the correct mime type
- Check the proxy routes still work
   - http://localhost:8080/proxy/http://example.com/file?query=1
   - http://localhost:8080/proxy/?http%3A%2F%2Fexample.com%2Ffile%3Fquery%3D1

<details><summary>mime type test script</summary>
<p>

```js
async function checkContentType(route) {
  const request = await fetch(route);
  return request.headers.get("Content-Type");
}

const testUrls = {
  "http://localhost:8080/Apps/SampleData/simple.czml": "application/json",
  "http://localhost:8080/Apps/SampleData/population909500.json":
    "application/json",
  "http://localhost:8080/Apps/SampleData/simplestyles.geojson":
    "application/json",
  "http://localhost:8080/Apps/SampleData/ne_10m_us_states.topojson":
    "application/json",
  "http://localhost:8080/Build/CesiumUnminified/ThirdParty/basis_transcoder.wasm":
    "application/wasm",
  "http://localhost:8080/Apps/Sandcastle/images/Cesium_Logo_ETC1S.ktx2":
    "image/ktx2",
  "http://localhost:8080/Apps/SampleData/models/BoxUnlit/BoxUnlit.gltf":
    "model/gltf+json",
  // "bgltf": 'unknown', // unknown
  "http://localhost:8080/Apps/SampleData/models/Pawns/Pawns.glb":
    "model/gltf-binary",
  "http://localhost:8080/Apps/SampleData/Cesium3DTiles/Tilesets/Tileset/ll.b3dm":
    "application/octet-stream",
  "http://localhost:8080/Apps/SampleData/Cesium3DTiles/PointCloud/PointCloudTimeDynamic/0.pnts":
    "application/octet-stream",
  "http://localhost:8080/Apps/SampleData/Cesium3DTiles/Instanced/InstancedOrientation/instancedOrientation.i3dm":
    "application/octet-stream",
  "http://localhost:8080/Apps/SampleData/Cesium3DTiles/Composite/Composite/composite.cmpt":
    "application/octet-stream",
  "http://localhost:8080/Apps/SampleData/Cesium3DTiles/Classification/PointCloud/content.geom":
    "application/octet-stream",
  "http://localhost:8080/Specs/Data/Cesium3DTiles/Vector/VectorTilePoints/parent.vctr":
    "application/octet-stream",
  "http://localhost:8080/packages/engine/Source/Shaders/Builtin/Functions/clipPolygons.glsl":
    "text/plain",
};

async function main() {
  for (const [url, expected] of Object.entries(testUrls)) {
    const type = await checkContentType(url);
    const matches = type?.startsWith(expected);
    console.log(matches, url);
    if (!matches) {
      console.log(`Expected: ${expected}, got: ${type}`);
    }
  }
}

main().catch((error) => {
  console.error("Something went wrong");
  console.error(error.message);
});
```

</p>
</details> 

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
