### PR TITLE
Add wildcards back to routes in local server

### DIFF
--- a/server.js
+++ b/server.js
@@ -187,7 +187,7 @@ async function generateDevelopmentBuild() {
     const workersCache = createRoute(
       app,
       "Workers/*",
-      "/Build/CesiumUnminified/Workers",
+      "/Build/CesiumUnminified/Workers/*file.js",
       contexts.workers,
     );
 
@@ -240,7 +240,7 @@ async function generateDevelopmentBuild() {
     const testWorkersCache = createRoute(
       app,
       "TestWorkers/*",
-      "/Build/Specs/TestWorkers",
+      "/Build/Specs/TestWorkers/*file",
       contexts.testWorkers,
     );
     chokidar
@@ -250,7 +250,7 @@ async function generateDevelopmentBuild() {
     const specsCache = createRoute(
       app,
       "Specs/*",
-      "/Build/Specs",
+      "/Build/Specs/*file",
       contexts.specs,
     );
     const specWatcher = chokidar.watch(
@@ -347,7 +347,7 @@ async function generateDevelopmentBuild() {
   });
 
   //eslint-disable-next-line no-unused-vars
-  app.get("/proxy{/:remote}", function (req, res, next) {
+  app.get("/proxy{/*remote}", function (req, res, next) {
     let remoteUrl = req.remote;
     if (!remoteUrl) {
       // look for request like http://localhost:8080/proxy/?http%3A%2F%2Fexample.com%2Ffile%3Fquery%3D1


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

As part of https://github.com/CesiumGS/cesium/pull/12591 @ggetz removed some of the wildcards from routes. On the surface this seemed fine, especially with the [path examples docs](https://expressjs.com/en/5x/api.html#path-examples) saying "This will match paths starting with...". However that's not how it actually works and the wildcards are actually necessary.

I also think the problem was masked by the fact that some of the routes that use the wildcards are also routes that exist on disk if you've run certain commands so they're served statically making it _seem_ like they're working. For example anything under `Build/Specs` exists on disk and will load as static files if the wildcard doesn't pick up that it may need to rebuild from the context cache.

This PR just adds them back. I opened a PR for secondary validation in case I'm missing something since express sometimes confuses me and their docs aren't always as exhaustive as I'd like.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue, follow up to https://github.com/CesiumGS/cesium/pull/12591

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Check _both_ of the proxy methods still work
   - http://localhost:8080/proxy/http://example.com/file?query=1
   - http://localhost:8080/proxy/?http%3A%2F%2Fexample.com%2Ffile%3Fquery%3D1
- Recommend running a `git clean` to make sure there are no unnecessary build files to confuse
- Check some other urls that fall under the wildcard routes.
    - NOTE: you should also see a log statement from the server for each of these like `Built Specs/* in 0.3 seconds.` if the handler is set up correctly
    - http://localhost:8080/Build/CesiumUnminified/Workers/decodeI3S.js
    - http://localhost:8080/Build/Specs/karma-main.js
    - http://localhost:8080/Build/Specs/TestWorkers/createBadGeometry.js

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
