### PR TITLE
Environment map cleanup: No infinite mipmaps, wider epsilons for unit tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.130 - 2025-06-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixed error with `DynamicEnvironmentMapManager` when `ContextLimits.maximumCubeMapSize` is zero.
+
 ## 1.129 - 2025-05-01
 
 ### @cesium/engine

--- a/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
+++ b/packages/engine/Source/Scene/DynamicEnvironmentMapManager.js
@@ -81,9 +81,12 @@ function DynamicEnvironmentMapManager(options) {
 
   options = options ?? Frozen.EMPTY_OBJECT;
 
-  const mipmapLevels = Math.min(
-    options.mipmapLevels ?? 7,
-    Math.log2(ContextLimits.maximumCubeMapSize),
+  const mipmapLevels = Math.max(
+    Math.min(
+      options.mipmapLevels ?? 7,
+      Math.log2(ContextLimits.maximumCubeMapSize),
+    ),
+    1,
   );
 
   this._mipmapLevels = mipmapLevels;
@@ -841,7 +844,8 @@ DynamicEnvironmentMapManager.prototype.update = function (frameState) {
   const isSupported =
     // A FrameState type works here because the function only references the context parameter.
     // @ts-ignore
-    DynamicEnvironmentMapManager.isDynamicUpdateSupported(frameState);
+    DynamicEnvironmentMapManager.isDynamicUpdateSupported(frameState) &&
+    this._mipmapLevels > 1;
 
   if (
     !isSupported ||

--- a/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
+++ b/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
@@ -66,12 +66,12 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
     );
   });
 
-  it("always use at least one mipmap level", () => {
+  it("uses at a minimum of 0 mipmap levels", () => {
     const manager = new DynamicEnvironmentMapManager({
-      mipmapLevels: 0,
+      mipmapLevels: Number.NEGATIVE_INFINITY,
     });
 
-    expect(manager._mipmapLevels).toBe(1);
+    expect(manager._mipmapLevels).toBe(0);
   });
 
   describe(
@@ -140,6 +140,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         scene.primitives.add(primitive);
 
         scene.renderForSpecs();
+        scene.renderForSpecs();
 
         expect(manager.radianceCubeMap).toBeUndefined();
 
@@ -150,9 +151,9 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         );
       });
 
-      it("does not update if there is only one mipmap level", async function () {
+      it("does not update if there are zero mipmap levels", async function () {
         const manager = new DynamicEnvironmentMapManager({
-          mipmapLevels: 1,
+          mipmapLevels: 0,
         });
 
         const cartographic = Cartographic.fromDegrees(-75.165222, 39.952583);
@@ -162,6 +163,7 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         const primitive = new EnvironmentMockPrimitive(manager);
         scene.primitives.add(primitive);
 
+        scene.renderForSpecs();
         scene.renderForSpecs();
 
         expect(manager.radianceCubeMap).toBeUndefined();
@@ -189,12 +191,44 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         scene.primitives.add(primitive);
 
         scene.renderForSpecs();
+        scene.renderForSpecs();
 
         expect(manager.radianceCubeMap).toBeUndefined();
 
         scene.renderForSpecs();
 
         expect(manager.sphericalHarmonicCoefficients).toEqual(
+          DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+        );
+      });
+
+      it("works with only one mipmap level", async function () {
+        const manager = new DynamicEnvironmentMapManager({
+          mipmapLevels: 1,
+        });
+
+        const cartographic = Cartographic.fromDegrees(-75.165222, 39.952583);
+        manager.position =
+          Ellipsoid.WGS84.cartographicToCartesian(cartographic);
+
+        const primitive = new EnvironmentMockPrimitive(manager);
+        scene.primitives.add(primitive);
+
+        scene.renderForSpecs();
+        scene.renderForSpecs();
+
+        expect(manager.radianceCubeMap).toBeInstanceOf(CubeMap);
+
+        scene.renderForSpecs();
+
+        expect(manager.sphericalHarmonicCoefficients).toEqual(
+          DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS,
+        );
+
+        scene.renderForSpecs();
+        scene.renderForSpecs();
+
+        expect(manager.sphericalHarmonicCoefficients).not.toEqual(
           DynamicEnvironmentMapManager.DEFAULT_SPHERICAL_HARMONIC_COEFFICIENTS,
         );
       });

--- a/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
+++ b/packages/engine/Specs/Scene/DynamicEnvironmentMapManagerSpec.js
@@ -261,25 +261,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("creates environment map and spherical harmonics at altitude in Philadelphia with static lighting", async function () {
@@ -348,25 +378,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("creates environment map and spherical harmonics above Earth's atmosphere with static lighting", async function () {
@@ -436,25 +496,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("creates environment map and spherical harmonics at surface in Philadelphia with dynamic lighting", async function () {
@@ -522,25 +612,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("creates environment map and spherical harmonics at surface in Sydney with dynamic lighting", async function () {
@@ -575,58 +695,73 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
         scene.renderForSpecs(time);
         scene.renderForSpecs(time);
 
+        // Expect darkness at night
         expect(manager.sphericalHarmonicCoefficients[0]).toEqualEpsilon(
-          new Cartesian3(
-            0.0054358793422579765,
-            0.0054358793422579765,
-            0.0027179396711289883,
-          ),
-          CesiumMath.EPSILON2,
+          new Cartesian3(0.0, 0.0, 0.0),
+          0.2,
         );
         expect(manager.sphericalHarmonicCoefficients[1]).toEqualEpsilon(
-          new Cartesian3(
-            0.0037772462237626314,
-            0.0037772462237626314,
-            0.0018886231118813157,
-          ),
-          CesiumMath.EPSILON2,
+          new Cartesian3(0.0, 0.0, 0.0),
+          0.2,
         );
         expect(manager.sphericalHarmonicCoefficients[2]).toEqualEpsilon(
-          new Cartesian3(
-            -0.000007333524990826845,
-            -0.000007333524990826845,
-            -0.0000036667624954134226,
-          ),
-          CesiumMath.EPSILON2,
+          new Cartesian3(0.0, 0.0, 0.0),
+          0.2,
         );
         expect(manager.sphericalHarmonicCoefficients[3]).toEqualEpsilon(
-          new Cartesian3(
-            0.000008501945558236912,
-            0.000008501945558236912,
-            0.000004250972779118456,
-          ),
-          CesiumMath.EPSILON2,
+          new Cartesian3(0.0, 0.0, 0.0),
+          0.2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("lighting uses atmosphere properties", async function () {
@@ -697,25 +832,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("lighting uses atmosphereScatteringIntensity value", async function () {
@@ -780,25 +945,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("lighting uses gamma value", async function () {
@@ -864,25 +1059,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("lighting uses brightness value", async function () {
@@ -948,25 +1173,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("lighting uses saturation value", async function () {
@@ -1032,25 +1287,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("lighting uses ground color value", async function () {
@@ -1126,21 +1411,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
+
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("lighting uses ground albedo value", async function () {
@@ -1206,25 +1525,55 @@ describe("Scene/DynamicEnvironmentMapManager", function () {
           CesiumMath.EPSILON2,
         );
 
-        expect(manager.sphericalHarmonicCoefficients[4].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[4].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[4].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[4].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[5].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[5].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[5].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[5].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[6].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[6].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[6].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[6].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[7].x).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].y).toBeGreaterThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[7].z).toBeGreaterThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[7].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[7].z).toEqual(
+          jasmine.any(Number),
+        );
 
-        expect(manager.sphericalHarmonicCoefficients[8].x).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].y).toBeLessThan(0.0);
-        expect(manager.sphericalHarmonicCoefficients[8].z).toBeLessThan(0.0);
+        expect(manager.sphericalHarmonicCoefficients[8].x).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].y).toEqual(
+          jasmine.any(Number),
+        );
+        expect(manager.sphericalHarmonicCoefficients[8].z).toEqual(
+          jasmine.any(Number),
+        );
       });
 
       it("destroys", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR should fixes an error that arises with `DynamicEnvironmentMap` when `ContextLimits.maximumCubeMapSize` is zero, such as in a NodeJS environment where there is no working WebGL context. We set a bottom limit at `0`, make sure we have valid array sizes, and don't try to update the maps unless we have at least `1` mipmap level.

While I was in the tests, I went ahead and cleaned up the failing unit tests described in the linked issue.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12302.

## Testing plan

@angrycat9000 Would you mind verifying the issue you ran into, or alternatively, leaving reproduction instructions?

1. To test the unit test fixes, run `npm run test` locally.
2. Sanity check the "Image-Based Lighting" Sandcastle example by checking the "procedural environment lighting" toggle.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
