### PR TITLE
Fix voxel rendering with orthographic camera

### DIFF
--- a/Apps/Sandcastle/gallery/Voxels.html
+++ b/Apps/Sandcastle/gallery/Voxels.html
@@ -42,6 +42,8 @@
           geocoder: false,
           animation: false,
           timeline: false,
+          projectionPicker: true,
+          sceneModePicker: false,
         });
 
         viewer.extend(Cesium.viewerVoxelInspectorMixin);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 - Support Texture3D and add Volume Cloud SandBox Sample. [#12550](https://github.com/CesiumGS/cesium/issues/12550)
 
+#### Fixes :wrench:
+
+- Fixed voxel rendering with orthographic cameras. [#12629](https://github.com/CesiumGS/cesium/pull/12629)
+
 ## 1.129 - 2025-05-01
 
 ### @cesium/engine

--- a/Specs/e2e/voxel-cameras.spec.js
+++ b/Specs/e2e/voxel-cameras.spec.js
@@ -1,0 +1,252 @@
+import { test, expect } from "./test.js";
+
+test("renders procedural voxel in perspective camera", async ({
+  cesiumPage,
+}) => {
+  await cesiumPage.goto();
+
+  await cesiumPage.page.evaluate(() => {
+    const viewer = new Cesium.Viewer("cesiumContainer", {
+      baseLayer: Cesium.ImageryLayer.fromProviderAsync(
+        Cesium.TileMapServiceImageryProvider.fromUrl(
+          Cesium.buildModuleUrl("Assets/Textures/NaturalEarthII"),
+        ),
+      ),
+      baseLayerPicker: false,
+      geocoder: false,
+      animation: false,
+      timeline: false,
+      sceneModePicker: false,
+      homeButton: false,
+      navigationHelpButton: false,
+    });
+
+    const { scene, camera } = viewer;
+    camera.setView({
+      destination: new Cesium.Cartesian3(
+        20463166.456674013,
+        24169216.80790143,
+        15536221.507601531,
+      ),
+      orientation: new Cesium.HeadingPitchRoll(
+        6.283185307179586,
+        -1.5680902263173198,
+        0,
+      ),
+    });
+
+    const globalTransform = Cesium.Matrix4.fromScale(
+      Cesium.Cartesian3.fromElements(
+        Cesium.Ellipsoid.WGS84.maximumRadius,
+        Cesium.Ellipsoid.WGS84.maximumRadius,
+        Cesium.Ellipsoid.WGS84.maximumRadius,
+      ),
+    );
+
+    function ProceduralSingleTileVoxelProvider(shape) {
+      this.shape = shape;
+      this.minBounds = Cesium.VoxelShapeType.getMinBounds(shape).clone();
+      this.maxBounds = Cesium.VoxelShapeType.getMaxBounds(shape).clone();
+      this.dimensions = new Cesium.Cartesian3(8, 8, 8);
+      this.names = ["color"];
+      this.types = [Cesium.MetadataType.VEC4];
+      this.componentTypes = [Cesium.MetadataComponentType.FLOAT32];
+      this.globalTransform = globalTransform;
+    }
+
+    const scratchColor = new Cesium.Color();
+
+    ProceduralSingleTileVoxelProvider.prototype.requestData = function (
+      options,
+    ) {
+      if (options.tileLevel >= 1) {
+        return Promise.reject(`No tiles available beyond level 0`);
+      }
+
+      const dimensions = this.dimensions;
+      const voxelCount = dimensions.x * dimensions.y * dimensions.z;
+      const type = this.types[0];
+      const channelCount = Cesium.MetadataType.getComponentCount(type);
+      const dataColor = new Float32Array(voxelCount * channelCount);
+
+      const randomSeed = dimensions.y * dimensions.x + dimensions.x;
+      Cesium.Math.setRandomNumberSeed(randomSeed);
+      const hue = Cesium.Math.nextRandomNumber();
+
+      for (let z = 0; z < dimensions.z; z++) {
+        for (let y = 0; y < dimensions.y; y++) {
+          const indexZY = z * dimensions.y * dimensions.x + y * dimensions.x;
+          for (let x = 0; x < dimensions.x; x++) {
+            const lerperX = x / (dimensions.x - 1);
+            const lerperY = y / (dimensions.y - 1);
+            const lerperZ = z / (dimensions.z - 1);
+
+            const h = hue + lerperX * 0.5 - lerperY * 0.3 + lerperZ * 0.2;
+            const s = 1.0 - lerperY * 0.2;
+            const v = 0.5 + 2.0 * (lerperZ - 0.5) * 0.2;
+            const color = Cesium.Color.fromHsl(h, s, v, 1.0, scratchColor);
+
+            const index = (indexZY + x) * channelCount;
+            dataColor[index + 0] = color.red;
+            dataColor[index + 1] = color.green;
+            dataColor[index + 2] = color.blue;
+            dataColor[index + 3] = 0.75;
+          }
+        }
+      }
+
+      const content = Cesium.VoxelContent.fromMetadataArray([dataColor]);
+      return Promise.resolve(content);
+    };
+
+    const provider = new ProceduralSingleTileVoxelProvider(
+      Cesium.VoxelShapeType.BOX,
+    );
+
+    const customShader = new Cesium.CustomShader({
+      fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+  {
+      material.diffuse = fsInput.metadata.color.rgb;
+      float transparency = 1.0 - fsInput.metadata.color.a;
+
+      // To mimic light scattering, use exponential decay
+      float thickness = fsInput.voxel.travelDistance * 16.0;
+      material.alpha = 1.0 - pow(transparency, thickness);
+  }`,
+    });
+
+    scene.primitives.add(new Cesium.VoxelPrimitive({ provider, customShader }));
+  });
+  await cesiumPage.page.clock.pauseAt(new Date("2023-12-25T14:00:00"));
+  await cesiumPage.page.waitForLoadState("networkidle");
+
+  await cesiumPage.page.clock.runFor(1000);
+
+  await expect(cesiumPage.page).toHaveScreenshot();
+});
+
+test("renders procedural voxel in orthographic camera", async ({
+  cesiumPage,
+}) => {
+  await cesiumPage.goto();
+
+  await cesiumPage.page.evaluate(() => {
+    const viewer = new Cesium.Viewer("cesiumContainer", {
+      baseLayer: Cesium.ImageryLayer.fromProviderAsync(
+        Cesium.TileMapServiceImageryProvider.fromUrl(
+          Cesium.buildModuleUrl("Assets/Textures/NaturalEarthII"),
+        ),
+      ),
+      baseLayerPicker: false,
+      geocoder: false,
+      animation: false,
+      timeline: false,
+      sceneModePicker: false,
+      homeButton: false,
+      navigationHelpButton: false,
+    });
+
+    const { scene, camera } = viewer;
+    camera.setView({
+      destination: new Cesium.Cartesian3(
+        20463166.456674013,
+        24169216.80790143,
+        15536221.507601531,
+      ),
+      orientation: new Cesium.HeadingPitchRoll(
+        6.283185307179586,
+        -1.5680902263173198,
+        0,
+      ),
+    });
+    camera.switchToOrthographicFrustum();
+
+    const globalTransform = Cesium.Matrix4.fromScale(
+      Cesium.Cartesian3.fromElements(
+        Cesium.Ellipsoid.WGS84.maximumRadius,
+        Cesium.Ellipsoid.WGS84.maximumRadius,
+        Cesium.Ellipsoid.WGS84.maximumRadius,
+      ),
+    );
+
+    function ProceduralSingleTileVoxelProvider(shape) {
+      this.shape = shape;
+      this.minBounds = Cesium.VoxelShapeType.getMinBounds(shape).clone();
+      this.maxBounds = Cesium.VoxelShapeType.getMaxBounds(shape).clone();
+      this.dimensions = new Cesium.Cartesian3(8, 8, 8);
+      this.names = ["color"];
+      this.types = [Cesium.MetadataType.VEC4];
+      this.componentTypes = [Cesium.MetadataComponentType.FLOAT32];
+      this.globalTransform = globalTransform;
+    }
+
+    const scratchColor = new Cesium.Color();
+
+    ProceduralSingleTileVoxelProvider.prototype.requestData = function (
+      options,
+    ) {
+      if (options.tileLevel >= 1) {
+        return Promise.reject(`No tiles available beyond level 0`);
+      }
+
+      const dimensions = this.dimensions;
+      const voxelCount = dimensions.x * dimensions.y * dimensions.z;
+      const type = this.types[0];
+      const channelCount = Cesium.MetadataType.getComponentCount(type);
+      const dataColor = new Float32Array(voxelCount * channelCount);
+
+      const randomSeed = dimensions.y * dimensions.x + dimensions.x;
+      Cesium.Math.setRandomNumberSeed(randomSeed);
+      const hue = Cesium.Math.nextRandomNumber();
+
+      for (let z = 0; z < dimensions.z; z++) {
+        for (let y = 0; y < dimensions.y; y++) {
+          const indexZY = z * dimensions.y * dimensions.x + y * dimensions.x;
+          for (let x = 0; x < dimensions.x; x++) {
+            const lerperX = x / (dimensions.x - 1);
+            const lerperY = y / (dimensions.y - 1);
+            const lerperZ = z / (dimensions.z - 1);
+
+            const h = hue + lerperX * 0.5 - lerperY * 0.3 + lerperZ * 0.2;
+            const s = 1.0 - lerperY * 0.2;
+            const v = 0.5 + 2.0 * (lerperZ - 0.5) * 0.2;
+            const color = Cesium.Color.fromHsl(h, s, v, 1.0, scratchColor);
+
+            const index = (indexZY + x) * channelCount;
+            dataColor[index + 0] = color.red;
+            dataColor[index + 1] = color.green;
+            dataColor[index + 2] = color.blue;
+            dataColor[index + 3] = 0.75;
+          }
+        }
+      }
+
+      const content = Cesium.VoxelContent.fromMetadataArray([dataColor]);
+      return Promise.resolve(content);
+    };
+
+    const provider = new ProceduralSingleTileVoxelProvider(
+      Cesium.VoxelShapeType.BOX,
+    );
+
+    const customShader = new Cesium.CustomShader({
+      fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+  {
+      material.diffuse = fsInput.metadata.color.rgb;
+      float transparency = 1.0 - fsInput.metadata.color.a;
+
+      // To mimic light scattering, use exponential decay
+      float thickness = fsInput.voxel.travelDistance * 16.0;
+      material.alpha = 1.0 - pow(transparency, thickness);
+  }`,
+    });
+
+    scene.primitives.add(new Cesium.VoxelPrimitive({ provider, customShader }));
+  });
+  await cesiumPage.page.clock.pauseAt(new Date("2023-12-25T14:00:00"));
+  await cesiumPage.page.waitForLoadState("networkidle");
+
+  await cesiumPage.page.clock.runFor(1000);
+
+  await expect(cesiumPage.page).toHaveScreenshot();
+});

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -1327,6 +1327,10 @@ VoxelPrimitive.prototype.update = function (frameState) {
     frameState.camera.directionWC,
     uniforms.cameraDirectionUv,
   );
+  uniforms.cameraDirectionUv = Cartesian3.normalize(
+    uniforms.cameraDirectionUv,
+    uniforms.cameraDirectionUv,
+  );
   uniforms.stepSize = this._stepSizeMultiplier;
 
   // Render the primitive

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -339,6 +339,12 @@ function VoxelPrimitive(options) {
   this._transformPositionWorldToUv = new Matrix4();
 
   /**
+   * @type {Matrix3}
+   * @private
+   */
+  this._transformDirectionWorldToUv = new Matrix3();
+
+  /**
    * @type {Matrix4}
    * @private
    */
@@ -444,6 +450,7 @@ function VoxelPrimitive(options) {
     transformDirectionViewToLocal: new Matrix3(),
     transformNormalLocalToWorld: new Matrix3(),
     cameraPositionUv: new Cartesian3(),
+    cameraDirectionUv: new Cartesian3(),
     ndcSpaceAxisAlignedBoundingBox: new Cartesian4(),
     clippingPlanesTexture: undefined,
     clippingPlanesMatrix: new Matrix4(),
@@ -1310,11 +1317,15 @@ VoxelPrimitive.prototype.update = function (frameState) {
     this._transformNormalLocalToWorld,
     uniforms.transformNormalLocalToWorld,
   );
-  const cameraPositionWorld = frameState.camera.positionWC;
   uniforms.cameraPositionUv = Matrix4.multiplyByPoint(
     this._transformPositionWorldToUv,
-    cameraPositionWorld,
+    frameState.camera.positionWC,
     uniforms.cameraPositionUv,
+  );
+  uniforms.cameraDirectionUv = Matrix3.multiplyByVector(
+    this._transformDirectionWorldToUv,
+    frameState.camera.directionWC,
+    uniforms.cameraDirectionUv,
   );
   uniforms.stepSize = this._stepSizeMultiplier;
 
@@ -1629,6 +1640,10 @@ function updateShapeAndTransforms(primitive, shape, provider) {
     transformPositionLocalToUv,
     transformPositionWorldToLocal,
     primitive._transformPositionWorldToUv,
+  );
+  primitive._transformDirectionWorldToUv = Matrix4.getMatrix3(
+    primitive._transformPositionWorldToUv,
+    primitive._transformDirectionWorldToUv,
   );
   primitive._transformPositionUvToWorld = Matrix4.multiplyTransformation(
     transformPositionLocalToWorld,

--- a/packages/engine/Source/Scene/processVoxelProperties.js
+++ b/packages/engine/Source/Scene/processVoxelProperties.js
@@ -145,7 +145,6 @@ function processVoxelProperties(renderResources, primitive) {
   shaderBuilder.addStructField(voxelStructId, "vec3", "positionShapeUv");
   shaderBuilder.addStructField(voxelStructId, "vec3", "positionUvLocal");
   shaderBuilder.addStructField(voxelStructId, "vec3", "viewDirUv");
-  shaderBuilder.addStructField(voxelStructId, "vec3", "viewDirWorld");
   shaderBuilder.addStructField(voxelStructId, "vec3", "surfaceNormal");
   shaderBuilder.addStructField(voxelStructId, "float", "travelDistance");
   shaderBuilder.addStructField(voxelStructId, "int", "stepCount");

--- a/packages/engine/Source/Shaders/Builtin/Functions/windowToEyeCoordinates.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/windowToEyeCoordinates.glsl
@@ -76,7 +76,6 @@ vec4 czm_screenToEyeCoordinates(vec2 screenCoordinateXY, float depthOrLogDepth)
     vec4 screenCoord = vec4(screenCoordinateXY, far * (1.0 - near / depthFromCamera) / (far - near), 1.0);
     vec4 eyeCoordinate = czm_screenToEyeCoordinates(screenCoord);
     eyeCoordinate.w = 1.0 / depthFromCamera; // Better precision
-    return eyeCoordinate;
 #else
     vec4 screenCoord = vec4(screenCoordinateXY, depthOrLogDepth, 1.0);
     vec4 eyeCoordinate = czm_screenToEyeCoordinates(screenCoord);

--- a/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
+++ b/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
@@ -118,9 +118,9 @@ Ray getViewRayUv() {
     vec3 viewDirUv;
     vec3 viewPosUv;
     if (czm_orthographicIn3D == 1.0) {
-        eyeCoordinates.z = -czm_currentFrustum.x;
-        viewPosUv = u_cameraPositionUv + (u_transformPositionViewToUv * eyeCoordinates).xyz;
-        viewDirUv = u_cameraDirectionUv;
+        eyeCoordinates.z = 0.0;
+        viewPosUv = (u_transformPositionViewToUv * eyeCoordinates).xyz;
+        viewDirUv = normalize(u_cameraDirectionUv);
     } else {
         viewPosUv = u_cameraPositionUv;
         viewDirUv = normalize(u_transformDirectionViewToLocal * eyeCoordinates.xyz);

--- a/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
+++ b/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
@@ -112,9 +112,11 @@ int getSampleIndex(in SampleData sampleData) {
     return sampleIndex.x + u_inputDimensions.x * (sampleIndex.y + u_inputDimensions.y * sampleIndex.z);
 }
 
+/**
+ * Compute the view ray at the current fragment, in the local UV coordinates of the shape.
+ */
 Ray getViewRayUv() {
     vec4 eyeCoordinates = czm_windowToEyeCoordinates(gl_FragCoord);
-    // TODO: use orthographicIn3D define to avoid branching
     vec3 viewDirUv;
     vec3 viewPosUv;
     if (czm_orthographicIn3D == 1.0) {

--- a/packages/engine/Specs/Scene/processVoxelPropertiesSpec.js
+++ b/packages/engine/Specs/Scene/processVoxelPropertiesSpec.js
@@ -90,7 +90,6 @@ describe("Scene/processVoxelProperties", function () {
       "    vec3 positionUvLocal;",
       "    vec3 surfaceNormal;",
       "    vec3 viewDirUv;",
-      "    vec3 viewDirWorld;",
       "    float travelDistance;",
       "    int stepCount;",
       "    int sampleIndex;",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR corrects the calculation of the starting view ray in `VoxelFS.glsl` to account for orthographic cameras.

In the usual perspective camera, the view rays all originate from the camera position and emanate in a direction that depends on the screen pixel. The camera in this case is perhaps best understood as an eye, with the screen pixels corresponding to different angular directions from a focal point.

In an orthographic camera, all view rays are exactly parallel, with the different pixels corresponding to different ray origins.

Along with the new logic in VoxelFS, code changes include:
- New uniform `cameraDirectionUv` in `VoxelPrimitive`.
- Removed the (unused, undocumented) `viewDirWorld` property from the `fsInput.voxel` struct, to facilitate pulling the ray calculation out into a helper function.

## Issue number and link

Resolves https://github.com/CesiumGS/cesium/issues/11013

## Testing plan

Load the "Voxels" Sandcastle, and use the projection picker to switch between perspective and orthographic cameras. The voxel should render correctly in both projections, with the globe partially visible through the semi-transparent voxels. The orthographic effect may be most obvious with the "Box" examples.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
