### PR TITLE
Fix requestRender condition in DataSourceDIsplay.update

### DIFF
--- a/packages/engine/Source/DataSources/DataSourceDisplay.js
+++ b/packages/engine/Source/DataSources/DataSourceDisplay.js
@@ -322,9 +322,7 @@ DataSourceDisplay.prototype.update = function (time) {
     result = visualizers[x].update(time) && result;
   }
 
-  // Request a rendering of the scene when the data source
-  // becomes 'ready' for the first time
-  if (!this._ready && result) {
+  if (!result) {
     this._scene.requestRender();
   }
 


### PR DESCRIPTION
# Description

Attempt to fix the requestRenderMode issue which stems from #12429.

## Issue number and link

Fixes #12543

## Testing plan

Opened the sandbox and added the following code:
```js
const widget = new Cesium.CesiumWidget("cesiumContainer", { 
  requestRenderMode: true,
  targetFrameRate: 30,
});

widget.scene.debugShowFramesPerSecond = true;
const entity = widget.entities.add({
  polyline: {
    positions: Cesium.Cartesian3.fromDegreesArray([-77, 35, -77.1, 35]),
    width: 5,
    material: Cesium.Color.RED,
  },
});
widget.zoomTo(entity);
setTimeout(() => {
  entity.polyline.material = Cesium.Color.WHITE;
}, 10_000);
setTimeout(() => {
  entity.polyline.material = Cesium.Color.BLUE;
}, 20_000);
```
I've noticed the bug is more likely with a large viewport and zooming out a bit on the entity.

The setTimeouts are so that the scene is definitely **NOT** requesting any render when updating the polyline material (all the tiles should already be loaded in).

With the above test the bug is easily reproducible, and is fixed with my branch.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
