### PR TITLE
Fix contentAvailability structure in Implicit3DTileContentSpec #12596

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## 1.131 - 2025-06-10
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- This PR fixes issue #12596 by updating the Voxel spec data to use the array format for contentAvailability as required by the latest 3D Tiles 1.1 specification. 
+
+
+```glsl
+// Replace this:
+// "contentAvailability": {
+//  "constant": 1
+// }
+// with this:
+"contentAvailability": [{
+  "constant": 1,
+}]
+```
+
 ## 1.130 - 2025-06-02
 
 ### @cesium/engine

--- a/packages/engine/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/Implicit3DTileContentSpec.js
@@ -73,9 +73,11 @@ describe(
       tileAvailability: {
         constant: 1,
       },
-      contentAvailability: {
-        constant: 1,
-      },
+      contentAvailability: [
+        {
+          constant: 1,
+        },
+      ],
       childSubtreeAvailability: {
         constant: 0,
       },


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->
This PR fixes issue #12596 by updating the Voxel spec data to use the array format for contentAvailability as required by the latest 3D Tiles 1.1 specification. 

The change make sure that test files follow the current specification while maintaining backward compatibility with the existing code that handles both formats.

I verified the changes by running the affected tests, which all passed successfully.

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

<img width="975" alt="Screenshot 2025-06-10 at 1 18 53 PM" src="https://github.com/user-attachments/assets/b8aa9720-cb32-4c5f-99c1-2bcf9a419ccb" />

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->
#12596

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
