### PR TITLE
Add resizing panels to Sandcastle

### DIFF
--- a/packages/sandcastle/package.json
+++ b/packages/sandcastle/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@itwin/itwinui-react": "^5.0.0-alpha.14",
     "@monaco-editor/react": "^4.7.0",
+    "allotment": "^1.20.4",
     "monaco-editor": "^0.52.2",
     "pako": "^2.1.0",
     "prettier": "^3.5.3",

--- a/packages/sandcastle/src/App.css
+++ b/packages/sandcastle/src/App.css
@@ -3,15 +3,16 @@
   height: 100vh;
   display: grid;
   grid-template:
-    "toolbar toolbar"
-    "code viewer"
-    "gallery gallery";
-  grid-template-columns: 50% 50%;
-  /* Monaco needs a defined height for dynamic resizing to work */
-  --toolbar-height: 2.5rem;
-  grid-template-rows:
-    var(--toolbar-height) calc(100% - var(--toolbar-height) - 150px)
-    150px;
+    "toolbar"
+    "center"
+    "gallery";
+  grid-template-rows: max-content auto 150px;
+}
+
+.split-view {
+  /* These control the styling of the Allotment dividers */
+  --focus-border: var(--ids-color-border-accent-base);
+  --separator-border: var(--ids-color-border-neutral-base);
 }
 
 .toolbar {
@@ -31,22 +32,18 @@
 }
 
 .editor-container {
-  grid-area: code;
   display: flex;
   flex-direction: column;
+  height: 100%;
 
   section {
-    border-top: 1px solid grey;
+    border-top: 1px solid var(--ids-color-border-neutral-base);
     flex-shrink: 1;
-    /* Monaco needs a defined height for dynamic resizing to work */
-    --tabs-height: 1.5rem;
-    height: calc(100% - var(--tabs-height)) !important;
   }
 }
 
 .viewer-bucket {
-  grid-area: viewer;
-  width: 50vw;
+  height: 100%;
   background-color: white;
   background-image: var(--_rings), var(--_gradient);
   --_rings: repeating-radial-gradient(
@@ -70,6 +67,6 @@
 
 .gallery {
   grid-area: gallery;
-  border-top: 1px solid grey;
+  border-top: 1px solid var(--ids-color-border-neutral-base);
   background: var(--ids-color-bg-page-depth);
 }

--- a/packages/sandcastle/src/App.tsx
+++ b/packages/sandcastle/src/App.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { Allotment } from "allotment";
+import "allotment/dist/style.css";
 import "./App.css";
 
 import { Button, Root } from "@itwin/itwinui-react/bricks";
@@ -316,27 +318,33 @@ Sandcastle.addToolbarMenu(${variableName});`,
         <div className="spacer"></div>
         <Button onClick={() => setDarkTheme(!darkTheme)}>Swap Theme</Button>
       </div>
-      <SandcastleEditor
-        ref={editorRef}
-        darkTheme={darkTheme}
-        onJsChange={(value: string = "") =>
-          dispatch({ type: "setCode", code: value })
-        }
-        onHtmlChange={(value: string = "") =>
-          dispatch({ type: "setHtml", html: value })
-        }
-        onRun={() => dispatch({ type: "runSandcastle" })}
-        js={codeState.code}
-        html={codeState.html}
-      />
-      <div className="viewer-bucket">
-        <Bucket
-          code={codeState.committedCode}
-          html={codeState.committedHtml}
-          runNumber={codeState.runNumber}
-          highlightLine={(lineNumber) => highlightLine(lineNumber)}
-        />
-      </div>
+      <Allotment>
+        <Allotment.Pane minSize={400}>
+          <SandcastleEditor
+            ref={editorRef}
+            darkTheme={darkTheme}
+            onJsChange={(value: string = "") =>
+              dispatch({ type: "setCode", code: value })
+            }
+            onHtmlChange={(value: string = "") =>
+              dispatch({ type: "setHtml", html: value })
+            }
+            onRun={() => dispatch({ type: "runSandcastle" })}
+            js={codeState.code}
+            html={codeState.html}
+          />
+        </Allotment.Pane>
+        <Allotment.Pane minSize={400}>
+          <div className="viewer-bucket">
+            <Bucket
+              code={codeState.committedCode}
+              html={codeState.committedHtml}
+              runNumber={codeState.runNumber}
+              highlightLine={(lineNumber) => highlightLine(lineNumber)}
+            />
+          </div>
+        </Allotment.Pane>
+      </Allotment>
       <div className="gallery">
         <Gallery
           demos={galleryItems}


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Small and simple change thanks to a really easy-to-use library [`allotment`](https://github.com/johnwalley/allotment/). I also updated the colors to pull from stratakit to match.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Part of #12566 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run the app however you want
- Try dragging the center vertical line sideways
    - Make sure the style looks good in light and dark and when hovered
    - Make sure both sides, editor and viewer, resize nicely
    - Make sure changing the size of the window itself still behaves nicely

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
