### PR TITLE
Remove unused sourceUri parameter from GeoJsonDataSource

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -424,3 +424,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Cody Butler](https://github.com/CodyBu)
 - [Hiwen](https://github.com/Hiwen)
 - [Matt Schwartz](https://github.com/mzschwartz5)
+- [Khalisah Khan](https://github.com/khalisahkhan)

--- a/packages/engine/Source/DataSources/GeoJsonDataSource.js
+++ b/packages/engine/Source/DataSources/GeoJsonDataSource.js
@@ -7,7 +7,6 @@ import Frozen from "../Core/Frozen.js";
 import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Event from "../Core/Event.js";
-import getFilenameFromUri from "../Core/getFilenameFromUri.js";
 import PinBuilder from "../Core/PinBuilder.js";
 import PolygonHierarchy from "../Core/PolygonHierarchy.js";
 import Resource from "../Core/Resource.js";
@@ -554,7 +553,6 @@ function processTopology(dataSource, geoJson, geometry, crsFunction, options) {
  *
  * Initialization options for the <code>load</code> method.
  *
- * @property {string} [sourceUri] Overrides the url to use for resolving relative links.
  * @property {GeoJsonDataSource.describe} [describe=GeoJsonDataSource.defaultDescribeProperty] A function which returns a Property object (or just a string).
  * @property {number} [markerSize=GeoJsonDataSource.markerSize] The default size of the map pin created for each point, in pixels.
  * @property {string} [markerSymbol=GeoJsonDataSource.markerSymbol] The default symbol of the map pin created for each point.
@@ -924,11 +922,9 @@ function preload(that, data, options, clear) {
   that._credit = credit;
 
   let promise = data;
-  let sourceUri = options.sourceUri;
   if (typeof data === "string" || data instanceof Resource) {
     data = Resource.createIfNeeded(data);
     promise = data.fetchJson();
-    sourceUri = sourceUri ?? data.getUrlComponent();
 
     // Add resource credits to our list of credits to display
     const resourceCredits = that._resourceCredits;
@@ -960,7 +956,7 @@ function preload(that, data, options, clear) {
 
   return Promise.resolve(promise)
     .then(function (geoJson) {
-      return load(that, geoJson, options, sourceUri, clear);
+      return load(that, geoJson, options, clear);
     })
     .catch(function (error) {
       DataSource.setLoading(that, false);
@@ -982,10 +978,10 @@ GeoJsonDataSource.prototype.update = function (time) {
   return true;
 };
 
-function load(that, geoJson, options, sourceUri, clear) {
+function load(that, geoJson, options, clear) {
   let name;
-  if (defined(sourceUri)) {
-    name = getFilenameFromUri(sourceUri);
+  if (defined(geoJson.name)) {
+    name = geoJson.name;
   }
 
   if (defined(name) && that._name !== name) {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->
Removed the `sourceUri` parameter from the method signature and internal function calls in `GeoJsonDataSource.load()`.

- Cleaned up unused imports (e.g., `getFilenameFromUri`).
- Updated inline documentation to reflect the change.

The `sourceUri` parameter was no longer used in the logic and acted as a no-op. Removing it improves code clarity and reduces potential confusion for contributors and users of the API.


## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->
[Issue #6108](https://github.com/CesiumGS/cesium/issues/6108) by removing the unused sourceUri parameter from the GeoJsonDataSource.load() method.

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

Verified that:
- The app builds successfully using `npm start`
- `GeoJsonDataSource.load()` continues to work without the `sourceUri` parameter
- No regressions occur in runtime behavior

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
