### PR TITLE
Force webgl context removal in Context.prototype.destroy

### DIFF
--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -1648,7 +1648,8 @@ Context.prototype.destroy = function () {
       }
     }
   }
-
+  
+  this._gl.getExtension('WEBGL_lose_context')?.loseContext();
   this._shaderCache = this._shaderCache.destroy();
   this._textureCache = this._textureCache.destroy();
   this._defaultTexture = this._defaultTexture && this._defaultTexture.destroy();


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Try to force webgl context loss in Context.prototype.destroy so resources can be cleared when the CesiumWidget/Viewer are destroyed.

## Issue number and link

#11533 (https://github.com/CesiumGS/cesium/issues/11533)

## Testing plan

With this sandcastle link, click "test button" to open a dialog with a cesium viewer inside, and click the "x" button to close it and destroy the viewer. Repeat this process 16 times.

Before, this would have crashed Cesium (specifically on Chrome, I think).

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
