### PR TITLE
Fix missing properties on `ClippingPolygonCollection`

### DIFF
--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -66,7 +66,6 @@ function ClippingPolygonCollection(options) {
   /**
    * If true, clipping will be enabled.
    *
-   * @memberof ClippingPolygonCollection.prototype
    * @type {boolean}
    * @default true
    */
@@ -77,7 +76,6 @@ function ClippingPolygonCollection(options) {
    * collection. Otherwise, a region will only be clipped if it is
    * inside of any polygon.
    *
-   * @memberof ClippingPolygonCollection.prototype
    * @type {boolean}
    * @default false
    */


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

When properties are defined in the constructor itself they don't need the extra `@memberof` tag that they need when using `defineProperties`. Removing this makes them show up in docs and the typescript types properly.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12697

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm run build-docs`
- Run `npm run build-ts`
- Run `npm start` and open the [local docs](http://localhost:8080/Build/Documentation/ClippingPolygonCollection.html)
- Verify that the `enabled` and `inverse` properties are on that page
- Open `Source/Cesium.d.ts` and search for `ClippingPolygonCollection` and verify the `enabled` and `inverse` properties are in the class

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
