### PR TITLE
Add hack to avoid Firefox styling bug

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -618,7 +618,10 @@ require({
 
     // Apply user HTML to bucket.
     const htmlElement = bucketDoc.createElement("div");
-    htmlElement.innerHTML = htmlEditor.getValue();
+    // Stylesheet imports are weirdly broken in Firefox 140. This is a hacky workaround
+    // https://github.com/CesiumGS/cesium/issues/12700
+    const htmlCode = htmlEditor.getValue().replace(/@import/, "@import ");
+    htmlElement.innerHTML = htmlCode;
     bucketDoc.body.appendChild(htmlElement);
 
     const onScriptTagError = function () {
@@ -1176,7 +1179,9 @@ require({
     baseHref = `${baseHref.substring(0, pos)}/gallery/`;
 
     const code = jsEditor.getValue();
-    const html = htmlEditor.getValue();
+    // Stylesheet imports are weirdly broken in Firefox 140. This is a hacky workaround
+    // https://github.com/CesiumGS/cesium/issues/12700
+    const html = htmlEditor.getValue().replace(/@import/, "@import ");
     const data = makeCompressedBase64String([code, html, baseHref]);
 
     let url = getBaseUrl();


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This is, by all means, not an ideal solution. _Something_, that I am unable to determine, is causing Firefox v140 to fail to load the imported `bucket.css` stylesheet. The network request _just doesn't happen_ after constructing the stylesheet.

Adding a random space (` `) character somewhere in the style tag seems to make it work for whatever reason. I chose to automate this and add it after the `@import` rule we can expect to exist.

More details and discussion about investigation and attempts to reproduce is in #12700.

So far this does not seem to be an issue in the new version of Sandcastle (#12566) so this "hack" should only have to exist until that's done.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Hack for #12700 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm start`
- Load [Sandcastle locally](http://localhost:8080/Apps/Sandcastle/index.html) in Firefox v140 and make sure it works
- Make sure clicking "Open in new window" opens the standalone page and it still works
- Verify Chrome and other browsers still work as well

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
