### PR TITLE
Fix Terrain Classification Sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -38,7 +38,7 @@
         });
 
         const geocoder = viewer.geocoder.viewModel;
-        geocoder.searchText = "Vienna";
+        geocoder.searchText = "Vienna, Austria";
         geocoder.flightDuration = 0.0;
         geocoder.search();
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

I noticed during release testing that this Sandcastle often searched for `Vienna, VA` instead of `Vienna, Austria` which made the data "not show up". Very small change but should make the Sandcastle more consistent

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

I believe this Fixes https://github.com/CesiumGS/cesium/issues/12677
@javagl please confirm.

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Load the [Terrain Classification Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%20Terrain%20Classification.html) locally and make sure it's always centered on the data. reload a few times and make sure it's always there.

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
