### PR TITLE
Defers batch destruction until next update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 ### Fixes :wrench:
 
-- Fixes material flashing when changing properties [#12722](https://github.com/CesiumGS/cesium/pull/12722)
+- Fixes material flashing when changing properties [#1640](https://github.com/CesiumGS/cesium/issues/1640), [12716](https://github.com/CesiumGS/cesium/issues/12716)
 
 #### Additions :tada:
 

--- a/packages/engine/Source/DataSources/StaticGroundGeometryPerMaterialBatch.js
+++ b/packages/engine/Source/DataSources/StaticGroundGeometryPerMaterialBatch.js
@@ -66,6 +66,7 @@ Batch.prototype.isMaterial = function (updater) {
  * @param {JulianDate} time
  * @param {GeometryUpdater} updater
  * @param {GeometryInstance} geometryInstance
+ * @private
  */
 Batch.prototype.add = function (time, updater, geometryInstance) {
   const id = updater.id;
@@ -101,6 +102,7 @@ Batch.prototype.add = function (time, updater, geometryInstance) {
  * on the next update.
  * @param {GeometryUpdater} updater
  * @returns true if the updater was removed, false if it was not found.
+ * @private
  */
 Batch.prototype.remove = function (updater) {
   const id = updater.id;
@@ -127,6 +129,7 @@ Batch.prototype.remove = function (updater) {
  * A new primitive is created whenever an updater is added to or removed from a Batch.
  * @param {JulianDate} time
  * @returns a boolean indicating whether the Batch was updated.
+ * @private
  */
 Batch.prototype.update = function (time) {
   let isUpdated = true;
@@ -305,6 +308,7 @@ Batch.prototype.getBoundingSphere = function (updater, result) {
 
 /**
  * Removes a Batch's primitive (and oldPrimitive, if it exists).
+ * @private
  */
 Batch.prototype.destroy = function () {
   const primitive = this.primitive;
@@ -340,7 +344,7 @@ function StaticGroundGeometryPerMaterialBatch(
  *
  * @param {JulianDate} time
  * @param {GeometryUpdater} updater A GeometryUpdater that manages the visual representation of a primitive.
- * @returns {void}
+ * @private
  */
 StaticGroundGeometryPerMaterialBatch.prototype.add = function (time, updater) {
   const items = this._items;
@@ -384,6 +388,7 @@ StaticGroundGeometryPerMaterialBatch.prototype.add = function (time, updater) {
 /**
  * Removes an updater from a Batch. Defers potential deletion until the next update.
  * @param {GeometryUpdater} updater A GeometryUpdater that manages the visual representation of a primitive.
+ * @private
  */
 StaticGroundGeometryPerMaterialBatch.prototype.remove = function (updater) {
   const items = this._items;
@@ -402,6 +407,7 @@ StaticGroundGeometryPerMaterialBatch.prototype.remove = function (updater) {
  * Updates all the items (Batches) in the collection, and deletes any that are empty.
  * @param {JulianDate} time
  * @returns a boolean indicating whether any of the items (Batches) were updated.
+ * @private
  */
 StaticGroundGeometryPerMaterialBatch.prototype.update = function (time) {
   let i;


### PR DESCRIPTION
# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

Previously, materials would flash (both transparent, then white) when changing a simple property (for example, the `cellAlpha` in a `GridMaterial` or the image in an `ImageMaterial`). This doesn't look good and was especially problematic for users doing animations.

The root cause is discussed in much more detail in the issue linked below, but is summarized in [this comment](https://github.com/CesiumGS/cesium/issues/1640#issuecomment-3029064087). In one line: Material batches get destroyed prematurely, causing the recreation of materials and primitives and circumventing the logic that ensures a seamless swap out.

There are a [couple ways one might fix this](https://github.com/CesiumGS/cesium/issues/1640#issuecomment-3029064437), but I believe the most effective is to simply defer Batch destruction until `Update`, rather than doing it immediately (this means that, if a material gets re-added to a Batch in the same frame, as happens when a material property changes, the Batch sticks around and so does the Material).

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->
Originally discovered here: #1640
Also fixes: #12716

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Use the following sandcastles. For image-type materials, go to Chrome devtools and disable caching (and optionally turn throttling to Slow4G). Previously, the white default texture would show between every image change. Now, it seamlessly switches from the previous image once the new one is loaded.

Also (harder to observe / independent of caching), previously between every image change, a transparent frame would show. If you toggle quickly on the canvas example below, you can see the terrain flashing through for a frame each time.

[Simple image material](https://sandcastle.cesium.com/#c=fVPLjtMwFP0V01UqtXbSdEJpOoWhIIQEYqSp2BCE3OQ2MePYke20kxl1z5Yv4Bf5BJzXTAsVO5/7OPY59zqWQhu0Y7AHhS6RgD1agWZljj83MScaxA1eSWEoE6CiwQg9RAIhncmSJ1eC5dTAHBlVwigSh2EYiUjEDa9NpeBZ3miQGVPoOSFlwSVN8J7dshwSRrFUKalRUSMSyzy3rcRkZb4hAQmAvJM8Ad+fTn38vUhJMHWLu/FpMBqEJ1dOTq6ME4ELdkc3tMKWnxSZNJJMXG9K3IC4PvFeEH9GNpKqZOwH3oUXfPMmM/eRORIcDCo1vO/11GKPdBaSV6kUb4VhprLp1k8MNWagMU0Sp/GsK5y3DiKUMVBUxVk1721fUWXsiQofb5XM30CqAPSVUrRyvrRNCI2fX+BghKYudqejM0H/JHgx+1+0J/g67A71OBWjfH68DY3yj13mWskClKmch56wcX3ezbvjObSEh6el6Gy5lzJfS+fEtGGICEG/f/38geq0RkYik0FvWN19Q0USU2041H6upeQbql6Xxkhht3Qt05QDum7rUfPeelW3pYgNsxFn2Jp+PMZnjyA8mk77Itwh3PuBG3W264nhZb/hnfRJ2GkdjAYLbSoOy96hVywvpLJbpLiDMTGQF9wSa7Ip41swONZ6GLbFC3LcukjYDrHk8sxHRDGnWtvMtuT8ht1bwcsFsfX/tNZ/jon00w4Up1VdlnnLD20QY7wgFp7vNK3PfzH/AQ)

[Canvas image](https://sandcastle.cesium.com/#c=bVTbbtswDP0VLi92AFdpsnYrctuwrA8DNmxogz3lRbVpR5gsGZKcS4v8+yjLbp22QOCA1Dnk0SHtVCvrYCdwjwYWoHAPK7SiLtnfJhdvBmkTr7RyXCg0m8FwtlEbNRrByiB3CG6vIeVqxy1a2Au3hUzkORpUDlIttcEMKu4cGmU3Kq9V6oRWkDbsVUOMG1wCDg9uCE8bBcT0ykJdUpbptC6pIgu0W4k+iqMAiLwmaNFsLzISsYDJ9ad+eoui2Lp+PrRwB8q1mAKdvynJiKNJ1pV1B5YLKe/dUaLHerFnJ3eYuvgyAfr1NSTnrd+vFu23wmH0ckb9ffrqpjqA5cpeWDQij87Ia6/Qy0xgQk3HV5ehuEFXG9W2pczJj6pv5djr7zsf0XiiBKIQwri5c58xecN4kDX2KJMobIREB7VtUb6PMzXOXgQYMomrQuKtcsIdCRD2jqGPBVrGsyx+CtdoodOwDH5W2mRCkQo77Vb0rkOx3OjyOxYG0cYXN5eMLPl47Z8Xn5u/K0oNk1CppBpGcDntb/uPkhf4qz35Y3SFxh3jtjeA8MfTzsKkSxusyJezQituSKLgahKPaS7DZ6wzNMqK+7diCjmXFtujU8Cc6HkKRra2PGpdrnX8yrYAuecqS7l1dHcyba21fODmW+2cVnG01gXBIQyCBhUPYbEMRp7N58NLNDtzPXRizzHrPGONEUTt1fnyvFmdQZNZe5VBMphbv+bLzoWvoqy0oT0xMmZs5LCspJ/p6KFO/yG93daGRQaYj/rUeSZ2ILLFO98jSCW3lk7ymt4q8YibwXI+IvwbqtScdqj4vUMj+dHDtuPlz5BkjM1HFL7PdMHhV5X/Aw)

[Grid type material, two entities go from being in 1 batch to being split into 2](https://sandcastle.cesium.com/#c=3VTdbtMwFH6VQ69SqXPSbJOg7QajDIS0aYhGIES48JLTxsyxK9tZ6dAkHoIn5Ek4cZKu3cYd4oKbJOfnOz+fvzjTyjq4FrhCA0egcAVTtKIq2QfvC9Je5u2pVo4LhSbt9cepSpVEB3YlXFZgTsg5lxZ9IPMlS+7QCC6Hu1XfGJGft6F3Ri/RuHXwPVUAmZbajLq8aW2xT6dnZxcfGXUpTuSy4MGQRf2Bz0YpvWsE5PMuSdNNdaXcaLvhlBtHX1zFwcEADvqb1KQQ2ZVCa/+UHlNdiJuGt83OYQgzXiJwu7XfHpwk8Prt+1nCIFlpoMnE0qKFlZASFkTTJW9YcpqsAg3lFahgVT+ygqsFbsrFA4+wuOSGXC3Usvu0xv8TrZ7YU+WEW8Ow2xS9XcunUSfzDkFc8DxvdltqSx6tRg/a7LO50eUrXBhEG+wNo6juehB1e7ZnNAJfB4jvUpzzr9qcfBM0+WEUecRWUKguuL8T7A5kdKcIH7ndUU27XAy/fvwEW3BD8iAlgK3V1AFBKFqHS7ne5SD+Kxw8e/rvKIjvU9COf6N1mejgc3u2g27BLxuiEq3lJTf1r7KQSK/2jtnIgTzcK2vDWi1jyMV8joaS7iScqhlXecatk1jz1ZZ+WTmnFd1rSdNiSvngAaDVnQp7A5hXKquphaDfkLR13T3pvseey2Y41nLKutnYZhiCbNDPIWKH4P+wcctQb9CbWLeWeNxQCvBClEttHFRGBoyFDsulpKo2vKyyK3Qss7Y/bpIn4TZ0kotrEPnRIxc3ZJJbS5F5JeVM3GDaO56ElP8AKjXPhVpcXKORfF2nFcPjs8bJGJuEZD6OdA3L9yr/Bg)

[Billboards should be unaffected by this change](https://sandcastle.cesium.com/#c=bVLLbtswEPwVVicbUEjJ8iuy4z7coihQIIcEOQkoaHItsaFIgaTsukX+vaRkO3abm2a4M9qdXaaVdWgnYA8G3SEFe7QGK9oaP3XcoIhYh9daOSoUmCKK0Z9CIWQr3Ur+UYmaOsiRMy3EhXoZLgpVKNb5+qcSUu9bRJVzjc0JaRupKcd78Sxq4IJibUoSUBMQYbquvZRMyRTIVy05ZNl4nOGfTVlEiyvf0ZUv4wo34hfd0AP2JqSptNNklKRjkkxJkpH0lmRzstHU8Jtsmk7S6Y90NE/OzoWS4FBr4dup6TDRxTAbIWUn/6KccAdf0MeGIWABFlPOB100jbae0So/hbmmxvkvqjK8Nbr+DKUBsIOb2QRPbmezWYzGCU6y+TwbxsHg/K+8zxr1I+fHROOes4xKz6U4ORJ7wV2Vo0lyIioQZeU6JhAvrwt6oIozap2E0Paj1nJDzafWOa38zh91WUpAXRRh4dtWsTAQGgz7hi5zencGi6ve+5zwGeOueS94Fb8/nchxstHi2GAUR0vrDhJW/SAIfRB1o43fkJEDjImDupH+8CzZtOwZHGbWDhd98ZJcSpdc7JDgd29cMmKSWutftq2UD+K3n3W1JL7+P2k4WqHK+x0YSQ+hrEpX33sSY7wkHr6tdH20/zj/BQ)

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
