### PR TITLE
Adds configuration for breakpoint debugging Karma tests in IDE

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,13 @@
             "type": "chrome",
             "url": "http://localhost:8080",
             "webRoot": "${workspaceFolder}"
+        },
+        {
+            "request": "attach",
+            "name": "Attach to Karma",
+            "type": "chrome",
+            "port": 9333, // This is the remote debugging port specified in karma.conf.cjs
+            "webRoot": "${workspaceFolder}"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,26 @@
             "name": "Attach to Karma",
             "type": "chrome",
             "port": 9333, // This is the remote debugging port specified in karma.conf.cjs
-            "webRoot": "${workspaceFolder}"
+            "webRoot": "${workspaceFolder}",
+            "timeout": 60000
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Test Suite",
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "test", "--", "--includeName", "${fileDirnameBasename}${/}${fileBasenameNoExtension}", "--debug"],
+            "console": "integratedTerminal"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Launch Test Suite and Debug in VSCode",
+            "configurations": [
+                "Launch Test Suite",
+                "Attach to Karma"
+            ]
         }
     ]
 }

--- a/Documentation/Contributors/TestingGuide/README.md
+++ b/Documentation/Contributors/TestingGuide/README.md
@@ -16,7 +16,7 @@ All new code should have 100% code coverage and should pass all tests. Always ru
       - [Run Only Non-WebGL Tests](#run-only-non-webgl-tests)
       - [Run All Tests Against the Minified Release Version of CesiumJS](#run-all-tests-against-the-minified-release-version-of-cesiumjs)
       - [Run a Single Test or Suite](#run-a-single-test-or-suite)
-      - [Using Browser Debugging Tools](#using-browser-debugging-tools)
+      - [Debugging Tests in the Browser or IDE](#debugging-tests-in-the-browser-or-ide)
     - [Running the Tests in the Browser](#running-the-tests-in-the-browser)
       - [Run All Tests](#run-all-tests)
       - [Run with WebGL validation](#run-with-webgl-validation)
@@ -122,13 +122,13 @@ Alternatively, test suites can be run from the command line with the `includeNam
 
 `npm run test -- --includeName Cartesian2`
 
-#### Using Browser Debugging Tools
+#### Debugging Tests in the Browser or IDE
 
-If it is helpful to step through a unit test in a browser debugger, run the tests with the `debug` flag:
+If it is helpful to step through a unit test in a browser debugger or your IDE, run the tests with the `debug` flag:
 
 `npm run test -- --debug`
 
-The `--debug` flag will prevent the Karma browser from closing after running the tests, and clicking the "Debug" button will open a new tab that can be used for placing breakpoints and stepping through the code.
+The `--debug` flag will prevent the Karma browser from closing after running the tests, and clicking the "Debug" button will open a new tab that can be used for placing breakpoints and stepping through the code. Alternatively, after Chrome launches, run the "Attach to Karma" launch configuration in VS Code to be able to set breakpoints directly in your IDE, and then click "Debug" in Chrome to run the tests. The same may be possible in other IDEs by attaching to port 9333 (Karma's configured remote debugging port).
 
 ![Karma](8.jpg)
 

--- a/Documentation/Contributors/TestingGuide/README.md
+++ b/Documentation/Contributors/TestingGuide/README.md
@@ -128,7 +128,7 @@ If it is helpful to step through a unit test in a browser debugger or your IDE, 
 
 `npm run test -- --debug`
 
-The `--debug` flag will prevent the Karma browser from closing after running the tests, and clicking the "Debug" button will open a new tab that can be used for placing breakpoints and stepping through the code. Alternatively, after Chrome launches, run the "Attach to Karma" launch configuration in VS Code to be able to set breakpoints directly in your IDE, and then click "Debug" in Chrome to run the tests. The same may be possible in other IDEs by attaching to port 9333 (Karma's configured remote debugging port).
+The `--debug` flag will prevent the Karma browser from closing after running the tests, and clicking the "Debug" button will open a new tab that can be used for placing breakpoints and stepping through the code. Alternatively, run the "Launch Test Suite and Debug in VSCode" launch configuration (which opens chrome, attaches VSCode, and prepares the test suite of the current file), set breakpoints directly in the Spec file, and then click "Debug" in Chrome to run the tests. Similar behavior may be possible in other IDEs by attaching to port 9333 (Karma's configured remote debugging port) after running the npm test command above.
 
 ![Karma](8.jpg)
 

--- a/Documentation/Contributors/VSCodeGuide/README.md
+++ b/Documentation/Contributors/VSCodeGuide/README.md
@@ -77,3 +77,5 @@ you quit VSCode, so should be restarted manually on next launch.
 ## Debugging CesiumJS
 
 To debug CesiumJS using the VSCode Chrome debugger, run the `"Launch Server"` configuration. If the server was already started in the terminal using `npm start`, use the `"Launch in Chrome"` configuration.
+
+To debug a specific unit test suite, run the "Launch Test Suite and Debug in VSCode" configuration. This will start the server, launch chrome, and prepare to run the tests in the currently open file. Set one or more breakpoints in VSCode and then click "Debug" in the browser. If the server is already started, use the "Attach to Karma" configuration and then continue setting breakpoints.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -999,7 +999,7 @@ export async function test() {
   const release = argv.release ? argv.release : false;
   const failTaskOnError = argv.failTaskOnError ? argv.failTaskOnError : false;
   const suppressPassed = argv.suppressPassed ? argv.suppressPassed : false;
-  const debug = argv.debug ? false : true;
+  const debug = argv.debug ? true : false;
   const debugCanvasWidth = argv.debugCanvasWidth;
   const debugCanvasHeight = argv.debugCanvasHeight;
   const includeName = argv.includeName ? argv.includeName : "";
@@ -1017,7 +1017,7 @@ export async function test() {
     });
   }
 
-  let browsers = ["Chrome"];
+  let browsers = debug ? ["ChromeDebugging"] : ["Chrome"];
   if (argv.browsers) {
     browsers = argv.browsers.split(",");
   }
@@ -1087,7 +1087,7 @@ export async function test() {
     karmaConfigFile,
     {
       port: 9876,
-      singleRun: debug,
+      singleRun: !debug,
       browsers: browsers,
       specReporter: {
         suppressErrorSummary: false,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1002,8 +1002,10 @@ export async function test() {
   const debug = argv.debug ? true : false;
   const debugCanvasWidth = argv.debugCanvasWidth;
   const debugCanvasHeight = argv.debugCanvasHeight;
-  const includeName = argv.includeName ? argv.includeName : "";
   const isProduction = argv.production;
+  const includeName = argv.includeName
+    ? argv.includeName.replace(/Spec$/, "")
+    : "";
 
   let workspace = argv.workspace;
   if (workspace) {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Added VSCode launch config for attaching to Karma test runner to breakpoint debug tests from IDE.

Minor changes to Gulpfile to support this.

## Issue number and link

No issue

## Testing plan

1. Run a test with the debug flag (single suite for simplicity): `npm run test-suite DataSources/StaticGroundGeometryPerMaterialBatch --debug` 
2. Run the `Attach to Karma` debug launch configuration from VSCode
3. Place a breakpoint in one of the Spec's tests
4. Click `Debug` in Chrome and observe it stop on breakpoint

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
