### PR TITLE
Gaussian Splat content destroy fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,15 +21,6 @@
             "type": "chrome",
             "url": "http://localhost:8080",
             "webRoot": "${workspaceFolder}"
-        },
-         {
-      "name": "Attach to Chrome for Karma",
-      "type": "chrome",
-      "request": "attach",
-      "port": 9333,
-      "webRoot": "${workspaceFolder}",
-      "sourceMaps": true,
-      "timeout": 5000
-    }
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,15 @@
             "type": "chrome",
             "url": "http://localhost:8080",
             "webRoot": "${workspaceFolder}"
-        }
+        },
+         {
+      "name": "Attach to Chrome for Karma",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9333,
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true,
+      "timeout": 5000
+    }
     ]
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Updates use of deprecated options on createImageBitmap. [#12664](https://github.com/CesiumGS/cesium/pull/12664)
 - Fixed raymarching step size for cylindrical voxels. [#12681](https://github.com/CesiumGS/cesium/pull/12681)
 - Fixes handling of tileset `modelMatrix` changes for translations and rotations in `GaussianSplatPrimitive`. [#12706](https://github.com/CesiumGS/cesium/pull/12706)
+- Fixes an exception when removing a Gaussian splat asset from the scene primitives when it has more than one tile.
 
 #### Additions :tada:
 
@@ -4073,8 +4074,10 @@ _This is an npm-only release to fix a publishing issue_.
 ## 1.0 - 2014-08-01
 
 - Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209))
+
   - All `Matrix2`, `Matrix3`, `Matrix4` and `Quaternion` functions that take a `result` parameter now require the parameter, except functions starting with `from`.
   - Removed `Billboard.imageIndex` and `BillboardCollection.textureAtlas`. Instead, use `Billboard.image`.
+
     - Code that looked like:
 
             var billboards = new Cesium.BillboardCollection();
@@ -4211,6 +4214,7 @@ _This is an npm-only release to fix a publishing issue_.
 ## b30 - 2014-07-01
 
 - Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209))
+
   - CZML property references now use a `#` symbol to separate identifier from property path. `objectId.position` should now be `objectId#position`.
   - All `Cartesian2`, `Cartesian3`, `Cartesian4`, `TimeInterval`, and `JulianDate` functions that take a `result` parameter now require the parameter (except for functions starting with `from`).
   - Modified `Transforms.pointToWindowCoordinates` and `SceneTransforms.wgs84ToWindowCoordinates` to return window coordinates with origin at the top left corner.
@@ -4259,6 +4263,7 @@ _This is an npm-only release to fix a publishing issue_.
     - `date.greaterThan(right)` -> `JulianDate.greaterThan(left, right)`
     - `date.greaterThanOrEquals(right)` -> `JulianDate.greaterThanOrEquals(left, right)`
   - Refactored `TimeInterval` to be in line with other Core types.
+
     - The constructor no longer requires parameters and now takes a single options parameter. Code that looked like:
 
             new TimeInterval(startTime, stopTime, true, true, data);
@@ -4272,6 +4277,7 @@ _This is an npm-only release to fix a publishing issue_.
                 isStopIncluded : true,
                 data : data
             });
+
     - `TimeInterval.fromIso8601` now takes a single options parameter. Code that looked like:
 
             TimeInterval.fromIso8601(intervalString, true, true, data);
@@ -4284,6 +4290,7 @@ _This is an npm-only release to fix a publishing issue_.
                 isStopIncluded : true,
                 data : data
             });
+
     - `interval.intersect(otherInterval)` -> `TimeInterval.intersect(interval, otherInterval)`
     - `interval.contains(date)` -> `TimeInterval.contains(interval, date)`
 
@@ -4340,6 +4347,7 @@ _This is an npm-only release to fix a publishing issue_.
 ## b29 - 2014-06-02
 
 - Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209))
+
   - Replaced `Scene.createTextureAtlas` with `new TextureAtlas`.
   - Removed `CameraFlightPath.createAnimationCartographic`. Code that looked like:
 
@@ -4457,6 +4465,7 @@ _This is an npm-only release to fix a publishing issue_.
 ## b27 - 2014-04-01
 
 - Breaking changes:
+
   - All `CameraController` functions have been moved up to the `Camera`. Removed `CameraController`. For example, code that looked like:
 
            scene.camera.controller.viewExtent(extent);
@@ -4766,6 +4775,7 @@ _This is an npm-only release to fix a publishing issue_.
 ## b24 - 2014-01-06
 
 - Breaking changes:
+
   - Added `allowTextureFilterAnisotropic` (default: `true`) and `failIfMajorPerformanceCaveat` (default: `true`) properties to the `contextOptions` property passed to `Viewer`, `CesiumWidget`, and `Scene` constructors and moved the existing properties to a new `webgl` sub-property. For example, code that looked like:
 
            var viewer = new Viewer('cesiumContainer', {
@@ -4813,6 +4823,7 @@ _This is an npm-only release to fix a publishing issue_.
 ## b23 - 2013-12-02
 
 - Breaking changes:
+
   - Changed the `CatmullRomSpline` and `HermiteSpline` constructors from taking an array of structures to a structure of arrays. For example, code that looked like:
 
            var controlPoints = [
@@ -4926,6 +4937,7 @@ _This is an npm-only release to fix a publishing issue_.
 ## b21 - 2013-10-01
 
 - Breaking changes:
+
   - Cesium now prints a reminder to the console if your application uses Bing Maps imagery and you do not supply a Bing Maps key for your application. This is a reminder that you should create a Bing Maps key for your application as soon as possible and prior to deployment. You can generate a Bing Maps key by visiting [https://www.bingmapsportal.com/](https://www.bingmapsportal.com/). Set the `BingMapsApi.defaultKey` property to the value of your application's key before constructing the `CesiumWidget` or any other types that use the Bing Maps API.
 
            BingMapsApi.defaultKey = 'my-key-generated-with-bingmapsportal.com';
@@ -4947,6 +4959,7 @@ _This is an npm-only release to fix a publishing issue_.
   - Removed `getViewMatrix`, `getInverseViewMatrix`, `getInverseTransform`, `getPositionWC`, `getDirectionWC`, `getUpWC` and `getRightWC` from `Camera`. Instead, use the `viewMatrix`, `inverseViewMatrix`, `inverseTransform`, `positionWC`, `directionWC`, `upWC`, and `rightWC` properties.
   - Removed `getProjectionMatrix` and `getInfiniteProjectionMatrix` from `PerspectiveFrustum`, `PerspectiveOffCenterFrustum` and `OrthographicFrustum`. Instead, use the `projectionMatrix` and `infiniteProjectionMatrix` properties.
   - The following prototype functions were removed:
+
     - From `Quaternion`: `conjugate`, `magnitudeSquared`, `magnitude`, `normalize`, `inverse`, `add`, `subtract`, `negate`, `dot`, `multiply`, `multiplyByScalar`, `divideByScalar`, `getAxis`, `getAngle`, `lerp`, `slerp`, `equals`, `equalsEpsilon`
     - From `Cartesian2`, `Cartesian3`, and `Cartesian4`: `getMaximumComponent`, `getMinimumComponent`, `magnitudeSquared`, `magnitude`, `normalize`, `dot`, `multiplyComponents`, `add`, `subtract`, `multiplyByScalar`, `divideByScalar`, `negate`, `abs`, `lerp`, `angleBetween`, `mostOrthogonalAxis`, `equals`, and `equalsEpsilon`.
     - From `Cartesian3`: `cross`
@@ -5001,6 +5014,7 @@ _This is an npm-only release to fix a publishing issue_.
 _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https://github.com/CesiumGS/cesium/issues/1002) and [#1047](https://github.com/CesiumGS/cesium/issues/1047))._
 
 - Breaking changes:
+
   - The `CameraFlightPath` functions `createAnimation`, `createAnimationCartographic`, and `createAnimationExtent` now take `scene` as their first parameter instead of `frameState`.
   - Completely refactored the `DynamicScene` property system to vastly improve the API. See [#1080](https://github.com/CesiumGS/cesium/pull/1080) for complete details.
     - Removed `CzmlBoolean`, `CzmlCartesian2`, `CzmlCartesian3`, `CzmlColor`, `CzmlDefaults`, `CzmlDirection`, `CzmlHorizontalOrigin`, `CzmlImage`, `CzmlLabelStyle`, `CzmlNumber`, `CzmlPosition`, `CzmlString`, `CzmlUnitCartesian3`, `CzmlUnitQuaternion`, `CzmlUnitSpherical`, and `CzmlVerticalOrigin` since they are no longer needed.
@@ -5178,6 +5192,7 @@ _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https
 ## b16 - 2013-05-01
 
 - Breaking changes:
+
   - Removed the color, outline color, and outline width properties of polylines. Instead, use materials for polyline color and outline properties. Code that looked like:
 
            var polyline = polylineCollection.add({
@@ -5295,6 +5310,7 @@ _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https
 ## b12a - 2013-01-18
 
 - Breaking changes:
+
   - Renamed the `server` property to `url` when constructing a `BingMapsImageryProvider`. Likewise, renamed `BingMapsImageryProvider.getServer` to `BingMapsImageryProvider.getUrl`. Code that looked like
 
            var bing = new BingMapsImageryProvider({
@@ -5422,6 +5438,7 @@ _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https
 ## b8 - 2012-09-05
 
 - Breaking changes:
+
   - Materials are now created through a centralized Material class using a JSON schema called [Fabric](https://github.com/CesiumGS/cesium/wiki/Fabric). For example, change:
 
           polygon.material = new BlobMaterial({repeat : 10.0});
@@ -5487,6 +5504,7 @@ _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https
 ## b7 - 2012-08-01
 
 - Breaking changes:
+
   - Removed keyboard input handling from `EventHandler`.
   - `TextureAtlas` takes an object literal in its constructor instead of separate parameters. Code that previously looked like:
 
@@ -5597,6 +5615,7 @@ _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https
 ## b5 - 2012-05-15
 
 - Breaking changes:
+
   - Renamed Geoscope to Cesium. To update your code, change all `Geoscope.*` references to `Cesium.*`, and reference Cesium.js instead of Geoscope.js.
   - `CompositePrimitive.addGround` was removed; use `CompositePrimitive.add` instead. For example, change
 
@@ -5676,6 +5695,7 @@ _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https
 ## b4 - 2012-03-01
 
 - Breaking changes:
+
   - Replaced `Geoscope.SkyFromSpace` object with `CentralBody.showSkyAtmosphere` property.
   - For mouse click and double click events, replaced `event.x` and `event.y` with `event.position`.
   - For mouse move events, replaced `movement.startX` and `startY` with `movement.startPosition`. Replaced `movement.endX` and `movement.endY` with `movement.endPosition`.
@@ -5736,11 +5756,13 @@ _This releases fixes 2D and other issues with Chrome 29.0.1547.57 ([#1002](https
 - Added CameraFlightController to zoom smoothly from one point to another. See the new camera examples in the Sandbox.
 - Added row and column assessors to Matrix2, Matrix3, and Matrix4.
 - Added Scene, which reduces the amount of code required to use Geoscope. See the Skeleton. We recommend using this instead of explicitly calling update() and render() for individual or composite primitives. Existing code will need minor changes:
+
   - Calls to Context.pick() should be replaced with Scene.pick().
   - Primitive constructors no longer require a context argument.
   - Primitive update() and render() functions now require a context argument. However, when using the new Scene object, these functions do not need to be called directly.
   - TextureAtlas should no longer be created directly; instead, call Scene.getContext().createTextureAtlas().
   - Other breaking changes:
+
     - Camera get/set functions, e.g., getPosition/setPosition were replaced with properties, e.g., position.
     - Replaced CompositePrimitive, Polygon, and Polyline getShow/setShow functions with a show property.
     - Replaced Polyline, Polygon, BillboardCollection, and LabelCollection getBufferUsage/setBufferUsage functions with a bufferUsage property.

--- a/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
+++ b/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
@@ -513,10 +513,9 @@ GaussianSplat3DTileContent.prototype.isDestroyed = function () {
  */
 GaussianSplat3DTileContent.prototype.destroy = function () {
   this.splatPrimitive = undefined;
-  if (defined(this._tileset.gaussianSplatPrimitive)) {
+  if (this._tileset.gaussianSplatPrimitive.isDestroyed() === false) {
     this._tileset.gaussianSplatPrimitive.destroy();
   }
-  this._tileset.gaussianSplatPrimitive = undefined;
   this._tile = undefined;
   this._tileset = undefined;
   this._resource = undefined;

--- a/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
+++ b/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
@@ -513,7 +513,9 @@ GaussianSplat3DTileContent.prototype.isDestroyed = function () {
  */
 GaussianSplat3DTileContent.prototype.destroy = function () {
   this.splatPrimitive = undefined;
-  this._tileset.gaussianSplatPrimitive.destroy();
+  if (defined(this._tileset.gaussianSplatPrimitive)) {
+    this._tileset.gaussianSplatPrimitive.destroy();
+  }
   this._tileset.gaussianSplatPrimitive = undefined;
   this._tile = undefined;
   this._tileset = undefined;

--- a/packages/engine/Specs/Scene/GaussianSplat3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/GaussianSplat3DTileContentSpec.js
@@ -96,6 +96,25 @@ describe(
         },
       );
     });
+    // it("Create and destroy GaussianSplat3DTileContent", function () {
+    //     return Cesium3DTilesTester.loadTileset(scene, tilesetUrl, options).then(
+    //       function (tileset) {
+    //         scene.camera.lookAt(
+    //           tileset.boundingSphere.center,
+    //           new HeadingPitchRange(0.0, -1.57, tileset.boundingSphere.radius),
+    //         );
+
+    //         return Cesium3DTilesTester.waitForTileContentReady(
+    //           scene,
+    //           tileset.root,
+    //         ).then(function (tile) {
+    //           tileset.destroy();
+    //         //  expect(tile.content.isDestroyed()).toBe(true);
+    //         //  expect(tile.content.splatPrimitive).toBeUndefined();
+    //         });
+    //       },
+    //     );
+    //   });
   },
   "WebGL",
 );

--- a/packages/engine/Specs/Scene/GaussianSplat3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/GaussianSplat3DTileContentSpec.js
@@ -96,25 +96,26 @@ describe(
         },
       );
     });
-    // it("Create and destroy GaussianSplat3DTileContent", function () {
-    //     return Cesium3DTilesTester.loadTileset(scene, tilesetUrl, options).then(
-    //       function (tileset) {
-    //         scene.camera.lookAt(
-    //           tileset.boundingSphere.center,
-    //           new HeadingPitchRange(0.0, -1.57, tileset.boundingSphere.radius),
-    //         );
+    it("Create and destroy GaussianSplat3DTileContent", function () {
+      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl, options).then(
+        function (tileset) {
+          scene.camera.lookAt(
+            tileset.boundingSphere.center,
+            new HeadingPitchRange(0.0, -1.57, tileset.boundingSphere.radius),
+          );
 
-    //         return Cesium3DTilesTester.waitForTileContentReady(
-    //           scene,
-    //           tileset.root,
-    //         ).then(function (tile) {
-    //           tileset.destroy();
-    //         //  expect(tile.content.isDestroyed()).toBe(true);
-    //         //  expect(tile.content.splatPrimitive).toBeUndefined();
-    //         });
-    //       },
-    //     );
-    //   });
+          return Cesium3DTilesTester.waitForTileContentReady(
+            scene,
+            tileset.root,
+          ).then(function (tile) {
+            scene.primitives.remove(tileset);
+            expect(tileset.isDestroyed()).toBe(true);
+            expect(tile.isDestroyed()).toBe(true);
+            expect(tile.content).toBeUndefined();
+          });
+        },
+      );
+    });
   },
   "WebGL",
 );


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This fixes an issue where the tileset would attempt to free the already freed primitive when being removed from the scene primitives. Additional unit test has also been added to explicitly check the clean up.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
* Load a Gaussian Splat asset and add it to the scene primitives. Asset must have more than 1 tile.
* After it has fully loaded, attempt to remove it from the scene primitives.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
