### PR TITLE
Update `gltf-pipeline` 4.2.0

### DIFF
--- a/packages/engine/Source/Scene/GltfPipeline/ForEach.js
+++ b/packages/engine/Source/Scene/GltfPipeline/ForEach.js
@@ -80,7 +80,7 @@ ForEach.accessorWithSemantic = function (gltf, semantic, handler) {
               return value;
             }
           }
-        }
+        },
       );
 
       if (defined(valueForEach)) {
@@ -102,7 +102,7 @@ ForEach.accessorWithSemantic = function (gltf, semantic, handler) {
                 return value;
               }
             }
-          }
+          },
         );
       });
     });
@@ -124,7 +124,7 @@ ForEach.accessorContainingVertexAttributeData = function (gltf, handler) {
               return value;
             }
           }
-        }
+        },
       );
 
       if (defined(valueForEach)) {
@@ -143,7 +143,7 @@ ForEach.accessorContainingVertexAttributeData = function (gltf, handler) {
                 return value;
               }
             }
-          }
+          },
         );
       });
     });
@@ -322,7 +322,7 @@ ForEach.program = function (gltf, handler) {
   if (usesExtension(gltf, "KHR_techniques_webgl")) {
     return ForEach.object(
       gltf.extensions.KHR_techniques_webgl.programs,
-      handler
+      handler,
     );
   }
 
@@ -341,7 +341,7 @@ ForEach.shader = function (gltf, handler) {
   if (usesExtension(gltf, "KHR_techniques_webgl")) {
     return ForEach.object(
       gltf.extensions.KHR_techniques_webgl.shaders,
-      handler
+      handler,
     );
   }
 
@@ -410,7 +410,7 @@ ForEach.technique = function (gltf, handler) {
   if (usesExtension(gltf, "KHR_techniques_webgl")) {
     return ForEach.object(
       gltf.extensions.KHR_techniques_webgl.techniques,
-      handler
+      handler,
     );
   }
 

--- a/packages/engine/Source/Scene/GltfPipeline/addDefaults.js
+++ b/packages/engine/Source/Scene/GltfPipeline/addDefaults.js
@@ -1,7 +1,6 @@
 import addToArray from "./addToArray.js";
 import ForEach from "./ForEach.js";
 import getAccessorByteStride from "./getAccessorByteStride.js";
-import Frozen from "../../Core/Frozen.js";
 import defined from "../../Core/defined.js";
 import WebGLConstants from "../../Core/WebGLConstants.js";
 
@@ -62,7 +61,7 @@ function addDefaults(gltf) {
   });
 
   ForEach.material(gltf, function (material) {
-    const extensions = material.extensions ?? Frozen.EMPTY_OBJECT;
+    const extensions = material.extensions ?? {};
     const materialsCommon = extensions.KHR_materials_common;
     if (defined(materialsCommon)) {
       const technique = materialsCommon.technique;

--- a/packages/engine/Source/Scene/GltfPipeline/addToArray.js
+++ b/packages/engine/Source/Scene/GltfPipeline/addToArray.js
@@ -1,3 +1,5 @@
+
+
 /**
  * Adds an element to an array and returns the element's index.
  *

--- a/packages/engine/Source/Scene/GltfPipeline/findAccessorMinMax.js
+++ b/packages/engine/Source/Scene/GltfPipeline/findAccessorMinMax.js
@@ -52,7 +52,7 @@ function findAccessorMinMax(gltf, accessor) {
       byteOffset,
       numberOfComponents,
       componentTypeByteLength,
-      components
+      components,
     );
     for (let j = 0; j < numberOfComponents; j++) {
       const value = components[j];

--- a/packages/engine/Source/Scene/GltfPipeline/forEachTextureInMaterial.js
+++ b/packages/engine/Source/Scene/GltfPipeline/forEachTextureInMaterial.js
@@ -33,11 +33,10 @@ function forEachTextureInMaterial(material, handler) {
     }
   }
 
-  const { extensions } = material;
-  if (defined(extensions)) {
+  if (defined(material.extensions)) {
     // Spec gloss extension
     const pbrSpecularGlossiness =
-      extensions.KHR_materials_pbrSpecularGlossiness;
+      material.extensions.KHR_materials_pbrSpecularGlossiness;
     if (defined(pbrSpecularGlossiness)) {
       if (defined(pbrSpecularGlossiness.diffuseTexture)) {
         const textureInfo = pbrSpecularGlossiness.diffuseTexture;
@@ -55,28 +54,13 @@ function forEachTextureInMaterial(material, handler) {
       }
     }
 
-    // Specular extension
-    const specular = extensions.KHR_materials_specular;
-    if (defined(specular)) {
-      const { specularTexture, specularColorTexture } = specular;
-      if (defined(specularTexture)) {
-        const value = handler(specularTexture.index, specularTexture);
-        if (defined(value)) {
-          return value;
-        }
-      }
-      if (defined(specularColorTexture)) {
-        const value = handler(specularColorTexture.index, specularColorTexture);
-        if (defined(value)) {
-          return value;
-        }
-      }
-    }
-
     // Materials common extension (may be present in models converted from glTF 1.0)
-    const materialsCommon = extensions.KHR_materials_common;
+    const materialsCommon = material.extensions.KHR_materials_common;
     if (defined(materialsCommon) && defined(materialsCommon.values)) {
-      const { diffuse, ambient, emission, specular } = materialsCommon.values;
+      const diffuse = materialsCommon.values.diffuse;
+      const ambient = materialsCommon.values.ambient;
+      const emission = materialsCommon.values.emission;
+      const specular = materialsCommon.values.specular;
       if (defined(diffuse) && defined(diffuse.index)) {
         const value = handler(diffuse.index, diffuse);
         if (defined(value)) {

--- a/packages/engine/Source/Scene/GltfPipeline/getComponentReader.js
+++ b/packages/engine/Source/Scene/GltfPipeline/getComponentReader.js
@@ -16,11 +16,11 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getInt8(
-            byteOffset + i * componentTypeByteLength
+            byteOffset + i * componentTypeByteLength,
           );
         }
       };
@@ -30,11 +30,11 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getUint8(
-            byteOffset + i * componentTypeByteLength
+            byteOffset + i * componentTypeByteLength,
           );
         }
       };
@@ -44,12 +44,12 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getInt16(
             byteOffset + i * componentTypeByteLength,
-            true
+            true,
           );
         }
       };
@@ -59,12 +59,12 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getUint16(
             byteOffset + i * componentTypeByteLength,
-            true
+            true,
           );
         }
       };
@@ -74,12 +74,12 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getInt32(
             byteOffset + i * componentTypeByteLength,
-            true
+            true,
           );
         }
       };
@@ -89,12 +89,12 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getUint32(
             byteOffset + i * componentTypeByteLength,
-            true
+            true,
           );
         }
       };
@@ -104,12 +104,12 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getFloat32(
             byteOffset + i * componentTypeByteLength,
-            true
+            true,
           );
         }
       };
@@ -119,12 +119,12 @@ function getComponentReader(componentType) {
         byteOffset,
         numberOfComponents,
         componentTypeByteLength,
-        result
+        result,
       ) {
         for (let i = 0; i < numberOfComponents; ++i) {
           result[i] = dataView.getFloat64(
             byteOffset + i * componentTypeByteLength,
-            true
+            true,
           );
         }
       };

--- a/packages/engine/Source/Scene/GltfPipeline/moveTechniqueRenderStates.js
+++ b/packages/engine/Source/Scene/GltfPipeline/moveTechniqueRenderStates.js
@@ -87,7 +87,7 @@ function moveTechniqueRenderStates(gltf) {
               blendFunctions.blendEquationSeparate ?? defaultBlendEquation,
             blendFactors: getSupportedBlendFactors(
               blendFunctions.blendFuncSeparate,
-              defaultBlendFactors
+              defaultBlendFactors,
             ),
           };
         }

--- a/packages/engine/Source/Scene/GltfPipeline/moveTechniquesToExtension.js
+++ b/packages/engine/Source/Scene/GltfPipeline/moveTechniquesToExtension.js
@@ -44,7 +44,7 @@ function moveTechniquesToExtension(gltf) {
           technique.attributes[attributeName] = {
             semantic: parameterLegacy.semantic,
           };
-        }
+        },
       );
 
       ForEach.techniqueUniform(
@@ -64,7 +64,7 @@ function moveTechniquesToExtension(gltf) {
             mappedUniforms[techniqueId] = {};
           }
           mappedUniforms[techniqueId][parameterName] = uniformName;
-        }
+        },
       );
 
       if (!defined(seenPrograms[techniqueLegacy.program])) {
@@ -92,7 +92,7 @@ function moveTechniquesToExtension(gltf) {
       // Store the index of the new technique to reference instead.
       updatedTechniqueIndices[techniqueId] = addToArray(
         extension.techniques,
-        technique
+        technique,
       );
     });
 

--- a/packages/engine/Source/Scene/GltfPipeline/parseGlb.js
+++ b/packages/engine/Source/Scene/GltfPipeline/parseGlb.js
@@ -43,7 +43,7 @@ function readHeader(glb, byteOffset, count) {
   for (let i = 0; i < count; ++i) {
     header[i] = dataView.getUint32(
       glb.byteOffset + byteOffset + i * sizeOfUint32,
-      true
+      true,
     );
   }
   return header;

--- a/packages/engine/Source/Scene/GltfPipeline/readAccessorPacked.js
+++ b/packages/engine/Source/Scene/GltfPipeline/readAccessorPacked.js
@@ -16,7 +16,7 @@ import defined from "../../Core/defined.js";
 function readAccessorPacked(gltf, accessor) {
   const byteStride = getAccessorByteStride(gltf, accessor);
   const componentTypeByteLength = ComponentDatatype.getSizeInBytes(
-    accessor.componentType
+    accessor.componentType,
   );
   const numberOfComponents = numberOfComponentsForType(accessor.type);
   const count = accessor.count;
@@ -41,7 +41,7 @@ function readAccessorPacked(gltf, accessor) {
       byteOffset,
       numberOfComponents,
       componentTypeByteLength,
-      components
+      components,
     );
     for (let j = 0; j < numberOfComponents; ++j) {
       values[i * numberOfComponents + j] = components[j];

--- a/packages/engine/Source/Scene/GltfPipeline/removeUnusedElements.js
+++ b/packages/engine/Source/Scene/GltfPipeline/removeUnusedElements.js
@@ -87,7 +87,7 @@ Remove.accessor = function (gltf, accessorId) {
           if (attributeAccessorId > accessorId) {
             primitive.attributes[semantic]--;
           }
-        }
+        },
       );
 
       // Update accessor ids for the targets.
@@ -98,7 +98,7 @@ Remove.accessor = function (gltf, accessorId) {
             if (attributeAccessorId > accessorId) {
               target[semantic]--;
             }
-          }
+          },
         );
       });
       const indices = primitive.indices;
@@ -548,7 +548,7 @@ getListOfElementsIdsInUse.accessor = function (gltf) {
             const attributeAccessorId =
               node.extensions.EXT_mesh_gpu_instancing.attributes[key];
             usedAccessorIds[attributeAccessorId] = true;
-          }
+          },
         );
       }
     });
@@ -587,9 +587,8 @@ getListOfElementsIdsInUse.buffer = function (gltf) {
       defined(bufferView.extensions) &&
       defined(bufferView.extensions.EXT_meshopt_compression)
     ) {
-      usedBufferIds[
-        bufferView.extensions.EXT_meshopt_compression.buffer
-      ] = true;
+      usedBufferIds[bufferView.extensions.EXT_meshopt_compression.buffer] =
+        true;
     }
   });
 

--- a/packages/engine/Source/Scene/GltfPipeline/updateAccessorComponentTypes.js
+++ b/packages/engine/Source/Scene/GltfPipeline/updateAccessorComponentTypes.js
@@ -42,7 +42,7 @@ function updateAccessorComponentTypes(gltf) {
 function convertType(gltf, accessor, updatedComponentType) {
   const typedArray = ComponentDatatype.createTypedArray(
     updatedComponentType,
-    readAccessorPacked(gltf, accessor)
+    readAccessorPacked(gltf, accessor),
   );
   const newBuffer = new Uint8Array(typedArray.buffer);
   accessor.bufferView = addBuffer(gltf, newBuffer);

--- a/packages/engine/Source/Scene/GltfPipeline/updateVersion.js
+++ b/packages/engine/Source/Scene/GltfPipeline/updateVersion.js
@@ -13,7 +13,6 @@ import Cartesian3 from "../../Core/Cartesian3.js";
 import Cartesian4 from "../../Core/Cartesian4.js";
 import clone from "../../Core/clone.js";
 import ComponentDatatype from "../../Core/ComponentDatatype.js";
-import Frozen from "../../Core/Frozen.js";
 import defined from "../../Core/defined.js";
 import Matrix4 from "../../Core/Matrix4.js";
 import Quaternion from "../../Core/Quaternion.js";
@@ -40,11 +39,13 @@ const updateFunctions = {
  * @private
  */
 function updateVersion(gltf, options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+  options = options ?? {};
   const targetVersion = options.targetVersion;
   let version = gltf.version;
 
-  gltf.asset = gltf.asset ?? { version: "1.0" };
+  gltf.asset = gltf.asset ?? {
+    version: "1.0",
+  };
 
   gltf.asset.version = gltf.asset.version ?? "1.0";
   version = (version ?? gltf.asset.version).toString();
@@ -176,7 +177,7 @@ function updateAnimations(gltf) {
               componentType,
               source.buffer,
               byteOffset,
-              length
+              length,
             );
 
             for (let j = 0; j < count; j++) {
@@ -416,7 +417,7 @@ function objectsToArrays(gltf) {
         primitive,
         function (accessorId, semantic) {
           primitive.attributes[semantic] = globalMapping.accessors[accessorId];
-        }
+        },
       );
       if (defined(primitive.material)) {
         primitive.material = globalMapping.materials[primitive.material];
@@ -636,7 +637,7 @@ function requireAttributeSetIndex(gltf) {
           } else if (semantic === "COLOR") {
             primitive.attributes.COLOR_0 = accessorId;
           }
-        }
+        },
       );
       delete primitive.attributes.TEXCOORD;
       delete primitive.attributes.COLOR;
@@ -695,7 +696,7 @@ function underscoreApplicationSpecificSemantics(gltf) {
               mappedSemantics[semantic] = newSemantic;
             }
           }
-        }
+        },
       );
       for (const semantic in mappedSemantics) {
         if (Object.prototype.hasOwnProperty.call(mappedSemantics, semantic)) {
@@ -756,7 +757,7 @@ function requireByteLength(gltf) {
         accessor.byteOffset + accessor.count * accessorByteStride;
       bufferView.byteLength = Math.max(
         bufferView.byteLength ?? 0,
-        accessorByteEnd
+        accessorByteEnd,
       );
     }
   });
@@ -861,7 +862,7 @@ function isNodeEmpty(node) {
       Cartesian3.fromArray(node.scale).equals(new Cartesian3(1.0, 1.0, 1.0))) &&
     (!defined(node.rotation) ||
       Cartesian4.fromArray(node.rotation).equals(
-        new Cartesian4(0.0, 0.0, 0.0, 1.0)
+        new Cartesian4(0.0, 0.0, 0.0, 1.0),
       )) &&
     (!defined(node.matrix) ||
       Matrix4.fromColumnMajorArray(node.matrix).equals(Matrix4.IDENTITY)) &&
@@ -1028,7 +1029,7 @@ function srgbToLinear(srgb) {
       linear[i] = Math.pow(
         // eslint-disable-next-line no-loss-of-precision
         (c + 0.055) * 0.94786729857819905213270142180095,
-        2.4
+        2.4,
       );
     }
   }
@@ -1037,7 +1038,7 @@ function srgbToLinear(srgb) {
 }
 
 function convertTechniquesToPbr(gltf, options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+  options = options ?? {};
   const baseColorTextureNames =
     options.baseColorTextureNames ?? defaultBaseColorTextureNames;
   const baseColorFactorNames =
@@ -1083,8 +1084,7 @@ function assignAsEmissive(material, emissive) {
 function convertMaterialsCommonToPbr(gltf) {
   // Future work: convert KHR_materials_common lights to KHR_lights_punctual
   ForEach.material(gltf, function (material) {
-    const materialsCommon = (material.extensions ?? Frozen.EMPTY_OBJECT)
-      .KHR_materials_common;
+    const materialsCommon = (material.extensions ?? {}).KHR_materials_common;
     if (!defined(materialsCommon)) {
       // Nothing to do
       return;


### PR DESCRIPTION
# Description

Updates the `GltfPipeline` directory contents with the state of [`gltf-pipeline` 4.2.0](https://www.npmjs.com/package/gltf-pipeline/v/4.2.0), as described in the [readme](https://github.com/CesiumGS/gltf-pipeline?tab=readme-ov-file#building-for-cesiumjs-integration).

Several changes seem to be caused by minor `prettier` differences. 

The most important change of that new release is that it [removes the use of `defaultValue`](https://github.com/CesiumGS/gltf-pipeline/pull/672), which is no longer going to be part of CesiumJS in one of the next releases. Most of this has already been done manually _in CesiumJS_ via https://github.com/CesiumGS/cesium/pull/12507 , but now it's coming from the actual `gltf-pipeline` source.

This can still not be merged. Apparently, there was a change in https://github.com/CesiumGS/cesium/commit/59141130b72a7d43f3e30eb56e45ec99255edad3#diff-6a3b6ddf82583b7f0637f12718da327f21acabf8e5dac921f0fb13c0b9150869 that didn't find its way back into `gltf-pipeline`. So we'll have to do one more roundtrip here...

## Issue number and link

n/a

## Testing plan

n/a (Specs should cover it...)

# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [ ] **n/a** I have updated `CHANGES.md` with a short summary of my change
- [ ] **n/a** I have added or updated unit tests to ensure consistent code coverage
- [ ] **n/a** I have updated the inline documentation, and included code examples where relevant
- [X] I have performed a self-review of my code


