### PR TITLE
Update draped imagery visibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@
 
 ### Fixes :wrench:
 
-- Fixes material flashing when changing properties [#1640](https://github.com/CesiumGS/cesium/issues/1640), [12716](https://github.com/CesiumGS/cesium/issues/12716)
+- Fixes material flashing when changing properties [#1640](https://github.com/CesiumGS/cesium/issues/1640), [#12716](https://github.com/CesiumGS/cesium/issues/12716)
+- Fixed an issue where draped imagery on tilesets was not updated based on the visibility of the imagery layer [#12742](https://github.com/CesiumGS/cesium/issues/12742)
 
 #### Additions :tada:
 

--- a/Specs/loadTilesetWithImagery.js
+++ b/Specs/loadTilesetWithImagery.js
@@ -1,0 +1,73 @@
+import {
+  Cartesian3,
+  HeadingPitchRoll,
+  ImageryLayer,
+  TileCoordinatesImageryProvider,
+  Transforms,
+  WebMercatorTilingScheme,
+} from "@cesium/engine";
+
+import pollToPromise from "./pollToPromise";
+import Cesium3DTilesTester from "./Cesium3DTilesTester";
+
+// A currently hard-wired tileset to be loaded for imagery draping tests
+const tileset_unitSquare_fourPrimitives_plain_url =
+  "./Data/Models/glTF-2.0/unitSquare/tileset_unitSquare_fourPrimitives_plain.json";
+
+/**
+ * Wait until the root tile of the given tileset is loaded
+ *
+ * @param {Cesium3DTileset} tileset The tileset
+ * @param {Scene} scene The scene
+ */
+async function waitForRootLoaded(tileset, scene) {
+  scene.renderForSpecs();
+  const root = tileset.root;
+  await pollToPromise(() => {
+    scene.renderForSpecs();
+    return root.contentFailed || root.contentReady;
+  });
+}
+
+/**
+ * Load and return a test tileset that defines an imagery layer,
+ * waiting until the root of that tileset is loaded.
+ *
+ * This means that the resulting <code>tileset.root.content._model._modelImagery</code>
+ * (including the <code>ModelPrimitiveImagery</code> instances) will be defined and ready.
+ *
+ * @param {Scene} scene The scene
+ * @returns {Cesium3DTileset} The tileset
+ */
+async function loadTilesetWithImagery(scene) {
+  const url = tileset_unitSquare_fourPrimitives_plain_url;
+  const tileset = await Cesium3DTilesTester.loadTileset(scene, url);
+
+  // Create a non-trivial transform for the tileset
+  const transform = Transforms.eastNorthUpToFixedFrame(
+    Cartesian3.fromDegrees(-120.0, 40.0, 1.0),
+  );
+  tileset.modelMatrix = transform;
+
+  // Set a view that fully shows the tile content
+  // (a unit square at the position given above)
+  scene.camera.setView({
+    destination: new Cartesian3(
+      -2446354.452726738,
+      -4237211.248955036,
+      4077988.0921552004,
+    ),
+    orientation: new HeadingPitchRoll(Math.PI * 2, -Math.PI / 2, 0),
+  });
+
+  const imageryProvider = new TileCoordinatesImageryProvider({
+    tilingScheme: new WebMercatorTilingScheme(),
+  });
+  const imageryLayer = new ImageryLayer(imageryProvider);
+  tileset.imageryLayers.add(imageryLayer);
+
+  await waitForRootLoaded(tileset, scene);
+  return tileset;
+}
+
+export default loadTilesetWithImagery;

--- a/packages/engine/Source/Scene/Model/ImageryConfiguration.js
+++ b/packages/engine/Source/Scene/Model/ImageryConfiguration.js
@@ -12,6 +12,7 @@
  */
 class ImageryConfiguration {
   constructor(imageryLayer) {
+    this.show = imageryLayer.show;
     this.alpha = imageryLayer.alpha;
     this.brightness = imageryLayer.brightness;
     this.contrast = imageryLayer.contrast;

--- a/packages/engine/Source/Scene/Model/ImageryPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/ImageryPipelineStage.js
@@ -109,7 +109,9 @@ class ImageryPipelineStage {
     );
 
     // This can happen when none of the imagery textures could
-    // be obtained, because they had all been INVALID/FAILED.
+    // be obtained, because they had all been INVALID/FAILED,
+    // or when none of the imagery layers is actually visible
+    // according to `show==true`
     // Bail out in this case
     if (imageryInputs.length === 0) {
       return;
@@ -758,7 +760,8 @@ class ImageryPipelineStage {
    * pipeline stage for draping the given imagery layers over the primitive
    * that is described by the given model primitive imagery.
    *
-   * This will obtain the <code>ImageryCoverage</code> objects that are provided by
+   * For each imagery layer that is currently visible (as of `show==true`), this
+   * will obtain the <code>ImageryCoverage</code> objects that are provided by
    * the given model primitive imagery (and that describe the imagery tiles
    * that are covered by the primitive), and create one <code>ImageryInput</code> for
    * each of them.
@@ -791,6 +794,9 @@ class ImageryPipelineStage {
 
     for (let i = 0; i < imageryLayers.length; i++) {
       const imageryLayer = imageryLayers.get(i);
+      if (!imageryLayer.show) {
+        continue;
+      }
       const imageryTexCoordAttributeSetIndex =
         imageryTexCoordAttributeSetIndices[i];
       const mappedPositions =

--- a/packages/engine/Source/Scene/Model/ModelImagery.js
+++ b/packages/engine/Source/Scene/Model/ModelImagery.js
@@ -335,6 +335,9 @@ class ModelImagery {
       const imageryLayer = imageryLayers.get(i);
       const imageryConfiguration = imageryConfigurations[i];
 
+      if (imageryLayer.show !== imageryConfiguration.show) {
+        return true;
+      }
       if (imageryLayer.alpha !== imageryConfiguration.alpha) {
         return true;
       }

--- a/packages/engine/Specs/Scene/Model/ImageryPipelineStageSpec.js
+++ b/packages/engine/Specs/Scene/Model/ImageryPipelineStageSpec.js
@@ -1,0 +1,100 @@
+import {
+  defined,
+  ResourceCache,
+  ShaderBuilder,
+  ImageryPipelineStage,
+} from "../../../index.js";
+import createScene from "../../../../../Specs/createScene.js";
+import loadTilesetWithImagery from "../../../../../Specs/loadTilesetWithImagery.js";
+
+describe("Scene/Model/ImageryPipelineStage", function () {
+  let scene;
+
+  beforeAll(function () {
+    scene = createScene();
+  });
+
+  afterAll(function () {
+    scene.destroyForSpecs();
+  });
+
+  afterEach(function () {
+    scene.primitives.removeAll();
+    ResourceCache.clearForSpecs();
+  });
+
+  // A mock `FrameState` object, extracted from other specs, for
+  // the ImageryPipelineStage.process call
+  const mockFrameState = {
+    context: {
+      defaultTexture: {},
+      defaultNormalTexture: {},
+      defaultEmissiveTexture: {},
+    },
+  };
+
+  // Create a mock `PrimitiveRenderResources` object, extracted from
+  // other specs, for the ImageryPipelineStage.process call
+  function mockRenderResources(model, primitive) {
+    const count = defined(primitive.indices)
+      ? primitive.indices.count
+      : primitive.attributes[0].count;
+
+    return {
+      attributes: [],
+      shaderBuilder: new ShaderBuilder(),
+      attributeIndex: 1,
+      count: count,
+      model: model,
+      runtimeNode: {
+        node: {},
+      },
+      uniformMap: {},
+      runtimePrimitive: {},
+    };
+  }
+
+  it("does not create imagery inputs for imagery layers that are not shown", async function () {
+    // Part of a "regression test" test against https://github.com/CesiumGS/cesium/issues/12742
+    const tileset = await loadTilesetWithImagery(scene);
+
+    // Drill a hole through the loaded structures and create some
+    // mock data for the ImageryPipelineStage.process call
+    const imageryLayers = tileset.imageryLayers;
+    const root = tileset.root;
+    const content = root.content;
+    const model = content._model;
+    const modelImagery = model._modelImagery;
+    const modelPrimitiveImagery = modelImagery._modelPrimitiveImageries[0];
+    const primitive = model.sceneGraph.components.nodes[0].primitives[0];
+    const primitiveRenderResources = mockRenderResources(model, primitive);
+    const imageryTexCoordAttributeSetIndices = [0];
+    const frameState = mockFrameState;
+    ImageryPipelineStage.process(
+      primitiveRenderResources,
+      primitive,
+      frameState,
+    );
+
+    // Initially, the imagery layers are visible, as of show===true,
+    // and there should be at least one ImageryInput be generated
+    // to be sent to the shader
+    const imageryInputsA = ImageryPipelineStage._createImageryInputs(
+      imageryLayers,
+      modelPrimitiveImagery,
+      imageryTexCoordAttributeSetIndices,
+    );
+    expect(imageryInputsA.length).not.toBe(0);
+
+    // For specs: Hide the imagery layer by setting show = false
+    imageryLayers.get(0).show = false;
+
+    // No more ImageryInput objects should be generated now
+    const imageryInputsB = ImageryPipelineStage._createImageryInputs(
+      imageryLayers,
+      modelPrimitiveImagery,
+      imageryTexCoordAttributeSetIndices,
+    );
+    expect(imageryInputsB.length).toBe(0);
+  });
+});

--- a/packages/engine/Specs/Scene/Model/ImageryPipelineStageSpec.js
+++ b/packages/engine/Specs/Scene/Model/ImageryPipelineStageSpec.js
@@ -55,6 +55,14 @@ describe("Scene/Model/ImageryPipelineStage", function () {
   }
 
   it("does not create imagery inputs for imagery layers that are not shown", async function () {
+    // The prerequisites for computing the imagery inputs are not
+    // met without a GL context: The "mappedPositions" cannot be
+    // computed without fetching the primitive POSITION data from
+    // the GPU
+    if (!scene.context.webgl2) {
+      return;
+    }
+
     // Part of a "regression test" test against https://github.com/CesiumGS/cesium/issues/12742
     const tileset = await loadTilesetWithImagery(scene);
 

--- a/packages/engine/Specs/Scene/Model/ImageryPipelineStageSpec.js
+++ b/packages/engine/Specs/Scene/Model/ImageryPipelineStageSpec.js
@@ -5,7 +5,7 @@ import {
   ImageryPipelineStage,
 } from "../../../index.js";
 import createScene from "../../../../../Specs/createScene.js";
-import loadTilesetWithImagery from "../../../../../Specs/loadTilesetWithImagery.js";
+import loadTilesetWithImagery from "./loadTilesetWithImagery.js";
 
 describe("Scene/Model/ImageryPipelineStage", function () {
   let scene;

--- a/packages/engine/Specs/Scene/Model/ModelImagerySpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelImagerySpec.js
@@ -1,7 +1,7 @@
 import { ResourceCache, ModelImagery } from "../../../index.js";
 
 import createScene from "../../../../../Specs/createScene.js";
-import loadTilesetWithImagery from "../../../../../Specs/loadTilesetWithImagery.js";
+import loadTilesetWithImagery from "./loadTilesetWithImagery.js";
 
 describe("Scene/Model/ModelImagery", function () {
   let scene;
@@ -109,7 +109,7 @@ describe("Scene/Model/ModelImagery", function () {
     expect(modelImagery._imageryConfigurationsModified()).toBeFalse();
 
     // For spec: Modify imagery configuration
-    imageryLayer.show = 0.5;
+    imageryLayer.show = false;
 
     // Now, _imageryConfigurationsModified is true
     expect(modelImagery._imageryConfigurationsModified()).toBeTrue();

--- a/packages/engine/Specs/Scene/Model/loadTilesetWithImagery.js
+++ b/packages/engine/Specs/Scene/Model/loadTilesetWithImagery.js
@@ -5,10 +5,9 @@ import {
   TileCoordinatesImageryProvider,
   Transforms,
   WebMercatorTilingScheme,
-} from "@cesium/engine";
-
-import pollToPromise from "./pollToPromise";
-import Cesium3DTilesTester from "./Cesium3DTilesTester";
+} from "../../../index.js";
+import pollToPromise from "../../../../../Specs/pollToPromise";
+import Cesium3DTilesTester from "../../../../../Specs/Cesium3DTilesTester.js";
 
 // A currently hard-wired tileset to be loaded for imagery draping tests
 const tileset_unitSquare_fourPrimitives_plain_url =


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/12742

# Description

The visibility of imagery that was draped over a tileset was not updated under certain conditions when the `show` flag was toggled. This is fixed here with two small changes:

- The `ModelImagery` stores an `ImageryConfiguration` object, to track changes of the "state" of the imagery. When this configuration changes, then the draw commands of the model are reset, causing the pipelines to be re-run. Unitl now, this configuration covered the `alpha`, `brightness`, etc. properties. Now it also covers the `show` property.
- The `ImageryPipelineStage` object creates `ImageryInput` objects that are sent to the shader, and contain information about the imagery that is draped over the model. Until now, this created these `ImageryInput` objects regardless of the `show` value of the respective imagery layer. Now, when there is an `imageryLayer.show === false`, then it will _not_ create these objects for that layer

Considerations:

There are structures (like the whole `ModelPrimitiveImagery`, storing the texture and texture coordinate information for the draping) that **could**, in theory, be discarded when setting `show=false`. But then they would need to be rebuilt from scratch when setting `show=true` later. I consider this `show` flag as a pure, quick, "rendering-time" toggle. So when setting `show=false` now, then these structures are kept. Only when the imagery layer is actually _removed_ from the `ImageryLayerCollection`, the associated structures are discarded.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12742

## Testing plan

Open the sandcastle from the issue and toggle the visibility of the tile coordinate imagery. Ensure that the visibiltiy of the tile coordinate imagery (grid and numbers) on the tileset matches the state of the toggle value.


# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [X] I have updated the inline documentation, and included code examples where relevant
- [X] I have performed a self-review of my code
