### PR TITLE
Toggle GaussianSplatPrimitive visibility based on Tileset show flag

### DIFF
--- a/packages/engine/Source/Scene/GaussianSplatPrimitive.js
+++ b/packages/engine/Source/Scene/GaussianSplatPrimitive.js
@@ -720,7 +720,7 @@ GaussianSplatPrimitive.prototype.update = function (frameState) {
     this._rootTransform = tileset.root.computedTransform;
   }
 
-  if (this._drawCommand) {
+  if (this._drawCommand && tileset.show) {
     frameState.commandList.push(this._drawCommand);
   }
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->
# Description

A small fix so that the GaussianSplatPrimitive takes the tileset show flag into account when updating, and not rendering if it's false.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Run the following sandcastle demo and use button to toggle show property on the tileset.

[Toggle Show Test](https://ci-builds.cesium.com/cesium/gsplat-show-flag/Apps/Sandcastle/index.html#c=bVHBTsMwDP0VU3HopCkFtgusm4BxQULisAouPRBSb4tI7SlJN8HEv5M2G1RApCp69nvPzqtich62GndoYQqEO5ij000tnrpaWiaqw3MmLzWhLZMh7EuC7+PR2tC5OgqLiMXScv3M1lSHQjoY/sg+B5OSSsoymFuUHsGvw6cNOvSgqYNxq5JUt+OxOQWQO6n9cVy8RndF7Hdj75luXAD3VToaj0eXF2ftuOgnnEJCsbG61l5v0QlZVenBvUf7YK4L7jdKWkiqlHTeYCsqmM2rtLeN90whqIJXK4OwWPOuDWnZkPKaCdJBDOxgJVwghGec9PGkJbQP5eBteJW+dCzt4HTf532+tJt06SXDJHf+3eDsGOu1rjdsPTTWpEJkHuuNCdm67LVRb8FAOTeYRHKe9aV5pbegq+k/PxuUkc6FzrIxZqE/sExmeRb4f6SGZaVp9bhFa+R7S1ufzx5iUQiRZwH+r/QxyF/OXw)
<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
