### PR TITLE
Rounds image width when writing billboard attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Fixes material flashing when changing properties [#1640](https://github.com/CesiumGS/cesium/issues/1640), [#12716](https://github.com/CesiumGS/cesium/issues/12716)
 - Fixes an exception when removing a Gaussian splat tileset from the scene primitives when it has more than one tile. [#12726](https://github.com/CesiumGS/cesium/pull/12726)
 - Fixes rendering of Gaussian splats when they are scaled by the glTF transform, tileset transform, or model matrix. [#12721](https://github.com/CesiumGS/cesium/issues/12721), [#12718](https://github.com/CesiumGS/cesium/issues/12718)
+- Fixes label background translucency issue [#12673](https://github.com/CesiumGS/cesium/issues/12673)
 
 #### Additions :tada:
 

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -1118,7 +1118,7 @@ function writeCompressedAttrib1(
     }
   }
 
-  const imageWidth = billboard.width ?? 0;
+  const imageWidth = Math.round(billboard.width ?? 0);
   billboardCollection._maxSize = Math.max(
     billboardCollection._maxSize,
     imageWidth,

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -2490,6 +2490,44 @@ describe("Scene/BillboardCollection", function () {
         expect(scene).toPickPrimitive(b);
       });
 
+      it("renders translucency correctly independently of image width", async function () {
+        // This test effectively probes at writeCompressedAttrib1, which packs together imageWidth and translucencyByDistance.
+        // In a previous regression, imageWidth was not being rounded, and was being packed incorrectly as a result of being treated as an incorrect type (float vs int).
+        const narrowBillboard = billboards.add({
+          position: Cartesian3.ZERO,
+          image: whiteImage,
+          width: 230.23,
+          translucencyByDistance: new NearFarScalar(2.0, 1.0, 4.0, 0.0),
+        });
+
+        const wideBillboard = billboards.add({
+          position: Cartesian3.ZERO,
+          image: whiteImage,
+          width: 300.355,
+          translucencyByDistance: new NearFarScalar(2.0, 1.0, 4.0, 0.0),
+        });
+
+        // Position the camera in the middle of the translucency range
+        camera.position = new Cartesian3(3.0, 0.0, 0.0);
+
+        await pollToPromise(() => {
+          scene.renderForSpecs();
+          return narrowBillboard.ready && wideBillboard.ready;
+        });
+
+        wideBillboard.show = false;
+        narrowBillboard.show = true;
+        scene.renderForSpecs();
+        const narrowBillboardColor = scene.context.readPixels();
+
+        wideBillboard.show = true;
+        narrowBillboard.show = false;
+        scene.renderForSpecs();
+        const wideBillboardColor = scene.context.readPixels();
+
+        expect(narrowBillboardColor).toEqual(wideBillboardColor);
+      });
+
       describe("height referenced billboards", function () {
         let billboardsWithHeight;
         beforeEach(function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The [original issue](https://github.com/CesiumGS/cesium/issues/12673?reload=1?reload=1) describes it pretty well - tl;dr, the `translucencyByDistance` property of labels and billboards was broken such that the width of the billboard affected the translucency.

Read [here](https://github.com/CesiumGS/cesium/issues/12673#issuecomment-3085446938) for root cause. 

## Issue number and link

Fixes #12673

## Testing plan

Testing using [sandcastle](https://sandcastle.cesium.com/index.html#c=zVZtb9owEP4rVj4FKTOQtGvHm7ZS9VPXTWKaNC37YJwLWBgb2Q4dnfjvu0CSMYg2WqGxSITE57t7nud8sblW1pGlgEcwpE8UPJIhWJHN6efNmB97fPM+1MoxocDEXqMbKwmOSDYGeS+sAxweMinHjM/QFqs0U9wJrUjKErhZ3eIcpji0/Qb5EStCRkwlnFkngSbAJTPg783Mc5ACFwXlhBNgKUsSfxOAkIW2Ik/RKfEOmXH4xFREU6PntzAxANZ/dRXRNxcBuWjR11eNYOu8Qd4hRShCHHx3HRJ7D0j/izaz2AtKk53qxxvkNTE6U0mHOJNBZXSGKSszDoqvfoHv7Mr4AMzcMTPiDGn6bXoJYUDatJXfLuE6IC3aKmGtN//r03Nv0/BY6pP/gfuJyf+98BjAnZ/4+g+9Ex7dO2Gh4UlFDI8QcYEJhDp6AY0rw8et428SVoBCH7Wrlu+55I+Olj86ffueU3zMf/3PxN8RF1F90hq3FPMeVOZ/zScWpEvKd6h7uyKMGxlI4GipSljWLL8OdqJuadlJOhWTqcSfq9+OKsBBDZpCxxcCCp8HKDweUPgyQNHzAEV7gGL1rdHdK6kBi6eG/mH2/V4xMNdLeCdlgUGkxC9WVwIpHkISv/bs0ajY1JqLaIhtjQ9e4PWsW0kYlDTfivlCG0cyI31Kmw7mC8mwD5rjjM/AUW5tybLX3HXtJWJJRNKvOSsR/ERYi5Y0k3IkniD2Br0mzj9wlZrl5fqwBCPZKp82bQ/ut4OU0l4TX+s93bZP9iL/BA) in original issue write up. Before fix, the labels have different translucencies depending on the content / padding. After, they should all be identical (given the same `translucencyByDistance` values).

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
