### PR TITLE
Add labels to split view sandcastles

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Compare.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Compare.html
@@ -61,8 +61,8 @@
     </style>
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
-      <div class="split-label left">3D Tileset</div>
-      <div class="split-label right">OSM Buildings</div>
+      <div class="split-label left">3D Tiles<br />Mesh</div>
+      <div class="split-label right">3D Tiles<br />OSM buildings</div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>

--- a/Apps/Sandcastle/gallery/3D Tiles Compare.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Compare.html
@@ -39,9 +39,30 @@
       #slider:hover {
         cursor: ew-resize;
       }
+
+      .split-label {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        background: rgba(42, 42, 42, 0.8);
+        padding: 8px;
+        border-radius: 4px;
+        z-index: 9999;
+        font-size: large;
+        font-weight: bold;
+        text-align: center;
+      }
+      .split-label.left {
+        left: 0;
+      }
+      .split-label.right {
+        right: 0;
+      }
     </style>
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
+      <div class="split-label left">3D Tileset</div>
+      <div class="split-label right">OSM Buildings</div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>

--- a/Apps/Sandcastle/gallery/3D Tiles Gaussian Splatting.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Gaussian Splatting.html
@@ -49,6 +49,7 @@
         z-index: 9999;
         font-size: large;
         font-weight: bold;
+        text-align: center;
       }
       .split-label.left {
         left: 0;
@@ -59,8 +60,8 @@
     </style>
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
-      <div class="split-label left">Gaussian Splats</div>
-      <div class="split-label right">3D Tiles Mesh</div>
+      <div class="split-label left">3D Tiles<br />Gaussian splats</div>
+      <div class="split-label right">3D Tiles<br />Mesh</div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>

--- a/Apps/Sandcastle/gallery/3D Tiles Gaussian Splatting.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Gaussian Splatting.html
@@ -39,9 +39,28 @@
       #slider:hover {
         cursor: ew-resize;
       }
+      .split-label {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        background: rgba(42, 42, 42, 0.8);
+        padding: 8px;
+        border-radius: 4px;
+        z-index: 9999;
+        font-size: large;
+        font-weight: bold;
+      }
+      .split-label.left {
+        left: 0;
+      }
+      .split-label.right {
+        right: 0;
+      }
     </style>
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
+      <div class="split-label left">Gaussian Splats</div>
+      <div class="split-label right">3D Tiles Mesh</div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>

--- a/Apps/Sandcastle/gallery/Bing Maps Labels Only.html
+++ b/Apps/Sandcastle/gallery/Bing Maps Labels Only.html
@@ -61,9 +61,12 @@
 
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
-      <div class="split-label left">Bing Maps labeled<br />+<br />Washington Imagery</div>
+      <div class="split-label left">
+        Bing Maps (labeled)<br />+<br />Washington Imagery
+      </div>
       <div class="split-label right">
-        Bing Maps unlabeled<br />+<br />Washington Imagery<br />+<br />Labels only
+        Bing Maps (unlabeled)<br />+<br />Washington Imagery<br />+<br />Bing Maps (labels
+        only)
       </div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
@@ -131,9 +134,9 @@
           const rightLabel = document.querySelector(".split-label.right");
           if (checked) {
             rightLabel.innerHTML =
-              "Bing Maps unlabeled<br>+<br>Washington Imagery<br>+<br>Labels only";
+              "Bing Maps (unlabeled)<br />+<br />Washington Imagery<br />+<br />Bing Maps (labels only)";
           } else {
-            rightLabel.innerHTML = "Bing Maps unlabeled<br>+<br>Washington Imagery";
+            rightLabel.innerHTML = "Bing Maps (unlabeled)<br />+<br />Washington Imagery";
           }
         });
 

--- a/Apps/Sandcastle/gallery/Bing Maps Labels Only.html
+++ b/Apps/Sandcastle/gallery/Bing Maps Labels Only.html
@@ -38,10 +38,33 @@
       #slider:hover {
         cursor: ew-resize;
       }
+
+      .split-label {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        background: rgba(42, 42, 42, 0.8);
+        padding: 8px;
+        border-radius: 4px;
+        z-index: 9999;
+        font-size: large;
+        font-weight: bold;
+        text-align: center;
+      }
+      .split-label.left {
+        left: 0;
+      }
+      .split-label.right {
+        right: 0;
+      }
     </style>
 
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
+      <div class="split-label left">Bing Maps labeled<br />+<br />Washington Imagery</div>
+      <div class="split-label right">
+        Bing Maps unlabeled<br />+<br />Washington Imagery<br />+<br />Labels only
+      </div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
@@ -105,6 +128,13 @@
         // Add a button to toggle the display of the Bing Maps Labels Only layer
         Sandcastle.addToggleButton("Show Bing Maps Labels Only", true, (checked) => {
           bingMapsLabelsOnly.show = checked;
+          const rightLabel = document.querySelector(".split-label.right");
+          if (checked) {
+            rightLabel.innerHTML =
+              "Bing Maps unlabeled<br>+<br>Washington Imagery<br>+<br>Labels only";
+          } else {
+            rightLabel.innerHTML = "Bing Maps unlabeled<br>+<br>Washington Imagery";
+          }
         });
 
         // The remaining code synchronizes the position of the slider with the split position

--- a/Apps/Sandcastle/gallery/Imagery Layers Split.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Split.html
@@ -38,10 +38,31 @@
       #slider:hover {
         cursor: ew-resize;
       }
+
+      .split-label {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        background: rgba(42, 42, 42, 0.8);
+        padding: 8px;
+        border-radius: 4px;
+        z-index: 9999;
+        font-size: large;
+        font-weight: bold;
+        text-align: center;
+      }
+      .split-label.left {
+        left: 0;
+      }
+      .split-label.right {
+        right: 0;
+      }
     </style>
 
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
+      <div class="split-label left">Earth at Night</div>
+      <div class="split-label right">Arc GIS World<br />Street Map</div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>

--- a/Apps/Sandcastle/gallery/Imagery Layers Texture Filters.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Texture Filters.html
@@ -38,10 +38,31 @@
       #slider:hover {
         cursor: ew-resize;
       }
+
+      .split-label {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        background: rgba(42, 42, 42, 0.8);
+        padding: 8px;
+        border-radius: 4px;
+        z-index: 9999;
+        font-size: large;
+        font-weight: bold;
+        text-align: center;
+      }
+      .split-label.left {
+        left: 0;
+      }
+      .split-label.right {
+        right: 0;
+      }
     </style>
 
     <div id="cesiumContainer" class="fullSize">
       <div id="slider"></div>
+      <div class="split-label left">Magnification<br />Linear</div>
+      <div class="split-label right">Magnification<br />Nearest</div>
     </div>
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Add clarity by including labels to sandcastles that use the split view. I'd appreciate a second pass on the wording to make sure all the labels are correct (@ggetz?).

<img width="2263" height="1501" alt="image" src="https://github.com/user-attachments/assets/ee4ce7b3-3619-48ef-b46d-41743e7dbd5d" />


<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12758

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `npm start`
- Open sandcastle locally
- Search for `SplitDirection` (or part of this)
- Test each sandcastle and make sure they're labeled.
    - I specifically did not do the `SplitDirection` sandcastle itself because it'd dynamic and the focus is on the splitter not the content.

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
