### PR TITLE
Removes the proxy endpoint from the server.js file

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,14 +30,6 @@ const argv = yargs(process.argv)
       type: "boolean",
       description: "Run a public server that listens on all interfaces.",
     },
-    "upstream-proxy": {
-      description:
-        'A standard proxy server that will be used to retrieve data.  Specify a URL including port, e.g. "http://proxy:8000".',
-    },
-    "bypass-upstream-proxy-hosts": {
-      description:
-        'A comma separated list of hosts that will bypass the specified upstream_proxy, e.g. "lanhost1,lanhost2"',
-    },
     production: {
       type: "boolean",
       description: "If true, skip build step and serve existing built files.",
@@ -302,28 +294,6 @@ async function generateDevelopmentBuild() {
   }
 
   app.use(express.static(path.resolve(".")));
-
-  const dontProxyHeaderRegex =
-    /^(?:Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade)$/i;
-
-  //eslint-disable-next-line no-unused-vars
-  function filterHeaders(req, headers) {
-    const result = {};
-    // filter out headers that are listed in the regex above
-    Object.keys(headers).forEach(function (name) {
-      if (!dontProxyHeaderRegex.test(name)) {
-        result[name] = headers[name];
-      }
-    });
-    return result;
-  }
-
-  const bypassUpstreamProxyHosts = {};
-  if (argv["bypass-upstream-proxy-hosts"]) {
-    argv["bypass-upstream-proxy-hosts"].split(",").forEach(function (host) {
-      bypassUpstreamProxyHosts[host.toLowerCase()] = true;
-    });
-  }
 
   const server = app.listen(
     argv.port,

--- a/server.js
+++ b/server.js
@@ -325,25 +325,6 @@ async function generateDevelopmentBuild() {
     });
   }
 
-  //eslint-disable-next-line no-unused-vars
-  app.param("remote", function (req, res, next, remote) {
-    if (remote) {
-      // Handles request like http://localhost:8080/proxy/http://example.com/file?query=1
-      let remoteUrl = remote.join("/");
-      // add http:// to the URL if no protocol is present
-      if (!/^https?:\/\//.test(remoteUrl)) {
-        remoteUrl = `http://${remoteUrl}`;
-      }
-      remoteUrl = new URL(remoteUrl);
-      // copy query string
-      const baseURL = `${req.protocol}://${req.headers.host}/`;
-      remoteUrl.search = new URL(req.url, baseURL).search;
-
-      req.remote = remoteUrl;
-    }
-    next();
-  });
-
   const server = app.listen(
     argv.port,
     argv.public ? undefined : "localhost",


### PR DESCRIPTION
# Description

It's generally unused and it's the only code that depends on the request package which is deprecated. Now we can remove the "request" pacakge a la https://github.com/CesiumGS/cesium/pull/12686

## Issue number and link

Original issue - https://github.com/CesiumGS/cesium/issues/11095

## Testing plan

Started up the local server to make sure everything else generally still works.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
