### PR TITLE
Draping across antimeridian

### DIFF
--- a/packages/engine/Source/Core/Rectangle.js
+++ b/packages/engine/Source/Core/Rectangle.js
@@ -87,6 +87,42 @@ Object.defineProperties(Rectangle.prototype, {
 Rectangle.packedLength = 4;
 
 /**
+ * XXX_DRAPING
+ *
+ * Print the message and the rectangle for debugging, assuming that it stores values
+ * that are given in radians, and converting them to degrees for printing.
+ *
+ * Note that a rectangle may contain arbitrary values in arbitrary units (degrees, meters,
+ * furlongs, who knows). If the printed values do not make sense, try debugPrintDirectly.
+ *
+ * @param {string} message The message
+ * @param {Rectangle} rectangle The rectangle
+ */
+Rectangle.debugPrintRadiansAsDegrees = function (message, rectangle) {
+  console.log(message, " (converted from radians to degrees)");
+  console.log("  E ", CesiumMath.toDegrees(rectangle.east));
+  console.log("  S ", CesiumMath.toDegrees(rectangle.south));
+  console.log("  W ", CesiumMath.toDegrees(rectangle.west));
+  console.log("  N ", CesiumMath.toDegrees(rectangle.north));
+};
+/**
+ * XXX_DRAPING
+ *
+ * Print the message and the rectangle for debugging, directly, without assuming
+ * that the input is actually storing values in radians.
+ *
+ * @param {string} message The message
+ * @param {Rectangle} rectangle The rectangle
+ */
+Rectangle.debugPrintDirectly = function (message, rectangle) {
+  console.log(message, " (printed directly)");
+  console.log("  W ", rectangle.west);
+  console.log("  S ", rectangle.south);
+  console.log("  E ", rectangle.east);
+  console.log("  N ", rectangle.north);
+};
+
+/**
  * Stores the provided instance into the provided array.
  *
  * @param {Rectangle} value The value to pack.

--- a/packages/engine/Source/Scene/Model/ImageryPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/ImageryPipelineStage.js
@@ -924,6 +924,9 @@ class ImageryPipelineStage {
   }
 
   /**
+   * XXX_DRAPING: This should essentially do the same as _localizeCartographicRectanglesToCartesianRectangle,
+   * but whether or not this should (or has to) operate on the so-called "native" rectangles has to be checked.
+   *
    * Compute the translation and scale that has to be applied to
    * the texture coordinates for mapping the given imagery to
    * the geometry.

--- a/packages/engine/Source/Scene/Model/ModelPrimitiveImagery.js
+++ b/packages/engine/Source/Scene/Model/ModelPrimitiveImagery.js
@@ -707,10 +707,16 @@ class ModelPrimitiveImagery {
     );
 
     // Clamp the level to a valid range, and an integer value
-    const imageryLevel = ImageryCoverage._clampImageryLevel(
+    let imageryLevel = ImageryCoverage._clampImageryLevel(
       imageryProvider,
       desiredLevel,
     );
+    // XXX_DRAPING Using fixed imagery level for debugging
+    imageryLevel = -1; // Comment this out to use the fixed level
+    if (imageryLevel < 0) {
+      imageryLevel = 12;
+      console.log(`XXX_DRAPING: Using fixed imagery level ${imageryLevel}`);
+    }
     return imageryLevel;
   }
 

--- a/packages/engine/Specs/Scene/Model/ImageryCoverageSpec.js
+++ b/packages/engine/Specs/Scene/Model/ImageryCoverageSpec.js
@@ -1,0 +1,128 @@
+import {
+  Rectangle,
+  ImageryCoverage,
+  CartesianRectangle,
+  Math as CesiumMath,
+} from "../../../index.js";
+
+describe("Scene/Model/ImageryCoverage", function () {
+  it("_localizeCartographicRectanglesToCartesianRectangle returns unit rectangle for equal inputs", async function () {
+    const ra = Rectangle.fromDegrees(10, 10, 20, 20);
+    const rb = Rectangle.fromDegrees(10, 10, 20, 20);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(0, 0, 1, 1);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle computes offset for overlapping inputs", async function () {
+    const ra = Rectangle.fromDegrees(15, 15, 25, 25);
+    const rb = Rectangle.fromDegrees(10, 10, 20, 20);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(0.5, 0.5, 1.5, 1.5);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle computes offset for non-overlapping inputs", async function () {
+    const ra = Rectangle.fromDegrees(30, 30, 50, 50);
+    const rb = Rectangle.fromDegrees(10, 10, 20, 20);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(2, 2, 4, 4);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle works when inner rectangle is left of antimeridian", async function () {
+    const ra = Rectangle.fromDegrees(160, 10, 170, 50);
+    const rb = Rectangle.fromDegrees(155, 10, -155, 50);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(0.1, 0, 0.3, 1);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle works when inner rectangle is right of antimeridian", async function () {
+    const ra = Rectangle.fromDegrees(-175, 10, -165, 50);
+    const rb = Rectangle.fromDegrees(155, 10, -155, 50);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(0.6, 0, 0.8, 1);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle works when inner rectangle crosses antimeridian", async function () {
+    const ra = Rectangle.fromDegrees(175, 10, -175, 50);
+    const rb = Rectangle.fromDegrees(155, 10, -155, 50);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(0.4, 0, 0.6, 1);
+
+    console.log(actual);
+
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle works when inner is left and outer is right of antimeridian", async function () {
+    const ra = Rectangle.fromDegrees(-175, 10, -165, 50);
+    const rb = Rectangle.fromDegrees(165, 10, 175, 50);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(2, 0, 3, 1);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle works when inner is right and outer is left or antimeridian", async function () {
+    const ra = Rectangle.fromDegrees(165, 10, 175, 50);
+    const rb = Rectangle.fromDegrees(-175, 10, -165, 50);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(-2, 0, -1, 1);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+
+  it("_localizeCartographicRectanglesToCartesianRectangle works when inner is left or meridian and outer is right of meridian", async function () {
+    const ra = Rectangle.fromDegrees(-20, 10, -10, 20);
+    const rb = Rectangle.fromDegrees(10, 10, 20, 20);
+    const actual = new CartesianRectangle();
+    const expected = new CartesianRectangle(-3, 0, -2, 1);
+    ImageryCoverage._localizeCartographicRectanglesToCartesianRectangle(
+      ra,
+      rb,
+      actual,
+    );
+    expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON8);
+  });
+});


### PR DESCRIPTION

# Description

As described in https://github.com/CesiumGS/cesium/issues/12769 , draping imagery on 3D Tiles does currently not work for tiles that cross the antimeridian. There are several factors that contribute to this vague concept of "not working". Some of them have been mentioned in https://github.com/CesiumGS/cesium/issues/12769#issuecomment-3128046585 . 

This **DRAFT** PR contains a few commits that _address_ these points, but there are many follow-up changes that are not integrated here yet.

- The computation of the bounding rectangle of the tile has to take into account that the tile might cross the antimeridian. For the _cartographic_ version of the bounding rectangle, this is handled with https://github.com/CesiumGS/cesium/commit/78d24406002a4c298b0ad883472708532ee28fbd
  - The `BoundingRectangle.fromRectangle` function does not work for this case. So as a follow-up-fix, there is a new function to compute the bounding rectangle from a rectangle, added in https://github.com/CesiumGS/cesium/commit/22cadc1af1d6cd5ad6d134bef9f9d9c33cce17f5 
  - When computing the cartographic positions (later, when computing texture coordinates), the "wrapping" that may have occurred earlier has to be taken into account.  As a follow-up fix, the cartographic positions are wrapped into the range that actually is described with that new bounding rectangle, via https://github.com/CesiumGS/cesium/commit/e4958a0ea1dbe7182c15ad0ecbde79f8e18e6931 
- The range of imagery tiles that are covered by the geometry (the "imagery range") has to anticipate the wrapping at the antimeridian. When `minX = 999, maxX = 1` for this range, then this will be turned into `minX = 999, maxX = 1001` and the receiver has to wrap this, to receive the actual imagery tile coordinates 999, 0, 1. This is done in https://github.com/CesiumGS/cesium/commit/267fe47dc7dbbe19f4b1fe8a2245eb65ec7eda59 
- Texture coordinates have to be computed for the geometry, based in the imagery tiles. The information here is summarized in `ImageryCoverage` objects. But the rectangles that are involved here are converted into their "native" representation. And the `Rectangle.computeWidth` function is broken for this case. An attempt to provide a function to compute the necessary texture coordinates is drafted in https://github.com/CesiumGS/cesium/commit/ee5dcdd85d1ff17d376ca1da4c863418230d812c . This operates on "non-native" rectangles (i.e. on real `Rectangle` objects that actually _do_ follow the constraints that are described in the `Rectangle` class). This part even involves a few unit tests, because ... why not? Whether or not the computation of the texture coordinates _can_ or _should_ happen based on the "non-native" rectangles, or whether it _must_ happen based on the non-native rectangles is not yet clear to me. Given that all this aims at _relative_ coordinates, I think that it _should_ be possible to implement that based on "any" rectangle. But maybe there are some sorts of distortions from the projection that wouldn't be taken into account based on "real" rectangles...? In any case, certain inlined clipping, clamping, and conversion steps that have been taken from the terrain imagery implementation will have to be reviewed for this.

The current state contains several logs and places that are marked with comments saying that they may require further review or follow-up fixes.

## Issue number and link

Addresses https://github.com/CesiumGS/cesium/issues/12769

## Testing plan

None yet

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
