### PR TITLE
Remove code for deprecated argument signatures in `ITwinData`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.133 - 2025-09-02
+
+### @cesium/engine
+
+#### Breaking Changes :mega:
+
+- Removed the argument fallback in `ITwinData.*` functions. Please switch to the new options argument signature [#12778](https://github.com/CesiumGS/cesium/issues/12778)
+
 ## 1.132 - 2025-08-01
 
 ### @cesium/engine

--- a/packages/engine/Source/Scene/ITwinData.js
+++ b/packages/engine/Source/Scene/ITwinData.js
@@ -7,7 +7,6 @@ import Check from "../Core/Check.js";
 import KmlDataSource from "../DataSources/KmlDataSource.js";
 import GeoJsonDataSource from "../DataSources/GeoJsonDataSource.js";
 import DeveloperError from "../Core/DeveloperError.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 
 /**
  * Methods for loading iTwin platform data into CesiumJS
@@ -45,20 +44,11 @@ const ITwinData = {};
  * @throws {RuntimeError} If all exports for the given iModel are Invalid
  * @throws {RuntimeError} If the iTwin API request is not successful
  */
-ITwinData.createTilesetFromIModelId = async function (options) {
-  let internalOptions = options;
-
-  if (typeof options === "string") {
-    // the old signature was (iModelId: string, options?: Cesium3DTileset.ConstructorOptions)
-    // grab the later arguments directly instead of in the params only for this special case
-    internalOptions = { iModelId: options, tilesetOptions: arguments[1] };
-    deprecationWarning(
-      "ITwinData.createTilesetFromIModelId",
-      "The arguments signature for ITwinData functions has changed in 1.132 in favor of a single options object. Please update your code. This fallback will be removed in 1.133",
-    );
-  }
-
-  const { iModelId, changesetId, tilesetOptions } = internalOptions;
+ITwinData.createTilesetFromIModelId = async function ({
+  iModelId,
+  changesetId,
+  tilesetOptions,
+}) {
   const { exports } = await ITwinPlatform.getExports(iModelId, changesetId);
 
   if (
@@ -111,26 +101,12 @@ ITwinData.createTilesetFromIModelId = async function (options) {
  *
  * @throws {RuntimeError} if the type of reality data is not supported by this function
  */
-ITwinData.createTilesetForRealityDataId = async function (options) {
-  let internalOptions = options;
-
-  if (typeof options === "string") {
-    // the old signature was (iTwinId: string, realityDataId: string, type: RealityDataType, rootDocument: string)
-    // grab the later arguments directly instead of in the params only for this special case
-    internalOptions = {
-      iTwinId: options,
-      realityDataId: arguments[1],
-      type: arguments[2],
-      rootDocument: arguments[3],
-    };
-    deprecationWarning(
-      "ITwinData.createTilesetFromIModelId",
-      "The arguments signature for ITwinData functions has changed in 1.132 in favor of a single options object. Please update your code. This fallback will be removed in 1.133",
-    );
-  }
-  const { iTwinId, realityDataId } = internalOptions;
-  let { type, rootDocument } = internalOptions;
-
+ITwinData.createTilesetForRealityDataId = async function ({
+  iTwinId,
+  realityDataId,
+  type,
+  rootDocument,
+}) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("iTwinId", iTwinId);
   Check.typeOf.string("realityDataId", realityDataId);
@@ -189,26 +165,12 @@ ITwinData.createTilesetForRealityDataId = async function (options) {
  *
  * @throws {RuntimeError} if the type of reality data is not supported by this function
  */
-ITwinData.createDataSourceForRealityDataId = async function (options) {
-  let internalOptions = options;
-
-  if (typeof options === "string") {
-    // the old signature was (iTwinId: string, realityDataId: string, type: RealityDataType, rootDocument: string)
-    // grab the later arguments directly instead of in the params only for this special case
-    internalOptions = {
-      iTwinId: options,
-      realityDataId: arguments[1],
-      type: arguments[2],
-      rootDocument: arguments[3],
-    };
-    deprecationWarning(
-      "ITwinData.createTilesetFromIModelId",
-      "The arguments signature for ITwinData functions has changed in 1.132 in favor of a single options object. Please update your code. This fallback will be removed in 1.133",
-    );
-  }
-  const { iTwinId, realityDataId } = internalOptions;
-  let { type, rootDocument } = internalOptions;
-
+ITwinData.createDataSourceForRealityDataId = async function ({
+  iTwinId,
+  realityDataId,
+  type,
+  rootDocument,
+}) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("iTwinId", iTwinId);
   Check.typeOf.string("realityDataId", realityDataId);
@@ -263,25 +225,11 @@ ITwinData.createDataSourceForRealityDataId = async function (options) {
  * @param {number} [options.limit=10000] number of items per page, must be between 1 and 10,000 inclusive
  * @returns {Promise<GeoJsonDataSource>}
  */
-ITwinData.loadGeospatialFeatures = async function (options) {
-  let internalOptions = options;
-
-  if (typeof options === "string") {
-    // the old signature was (iTwinId: string, collectionId: string, limit: number)
-    // grab the later arguments directly instead of in the params only for this special case
-    internalOptions = {
-      iTwinId: options,
-      collectionId: arguments[1],
-      limit: arguments[2],
-    };
-    deprecationWarning(
-      "ITwinData.createTilesetFromIModelId",
-      "The arguments signature for ITwinData functions has changed in 1.132 in favor of a single options object. Please update your code. This fallback will be removed in 1.133",
-    );
-  }
-
-  const { iTwinId, collectionId, limit } = internalOptions;
-
+ITwinData.loadGeospatialFeatures = async function ({
+  iTwinId,
+  collectionId,
+  limit,
+}) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("iTwinId", iTwinId);
   Check.typeOf.string("collectionId", collectionId);

--- a/packages/engine/Specs/Scene/ITwinDataSpec.js
+++ b/packages/engine/Specs/Scene/ITwinDataSpec.js
@@ -126,17 +126,6 @@ describe("ITwinData", () => {
       expect(tilesetSpy).toHaveBeenCalledTimes(1);
       expect(tilesetSpy.calls.mostRecent().args[1]).toEqual(tilesetOptions);
     });
-
-    it("passes tileset options through to the tileset constructor DEPRECATED arguments", async () => {
-      spyOn(ITwinPlatform, "getExports").and.resolveTo({
-        exports: [createMockExport(1, ITwinPlatform.ExportStatus.Complete)],
-      });
-      const tilesetSpy = spyOn(Cesium3DTileset, "fromUrl");
-      const tilesetOptions = { show: false };
-      await ITwinData.createTilesetFromIModelId("imodel-id-1", tilesetOptions);
-      expect(tilesetSpy).toHaveBeenCalledTimes(1);
-      expect(tilesetSpy.calls.mostRecent().args[1]).toEqual(tilesetOptions);
-    });
   });
 
   describe("createTilesetForRealityDataId", () => {
@@ -237,23 +226,6 @@ describe("ITwinData", () => {
         type: ITwinPlatform.RealityDataType.Cesium3DTiles,
         rootDocument: "root/document/path.json",
       });
-
-      expect(tilesetSpy).toHaveBeenCalledOnceWith(tilesetUrl, {
-        maximumScreenSpaceError: 4,
-      });
-    });
-
-    it("creates a tileset from the constructed blob url using DEPRECATED arguments", async () => {
-      const tilesetUrl =
-        "https://example.com/root/document/path.json?auth=token";
-      getUrlSpy.and.resolveTo(tilesetUrl);
-
-      await ITwinData.createTilesetForRealityDataId(
-        "itwin-id-1",
-        "reality-data-id-1",
-        ITwinPlatform.RealityDataType.Cesium3DTiles,
-        "root/document/path.json",
-      );
 
       expect(tilesetSpy).toHaveBeenCalledOnceWith(tilesetUrl, {
         maximumScreenSpaceError: 4,
@@ -367,22 +339,6 @@ describe("ITwinData", () => {
       expect(kmlSpy).not.toHaveBeenCalled();
     });
 
-    it("creates a GeoJsonDataSource from the constructed blob url if the type is GeoJSON using DEPRECATED arguments", async () => {
-      const tilesetUrl =
-        "https://example.com/root/document/path.json?auth=token";
-      getUrlSpy.and.resolveTo(tilesetUrl);
-
-      await ITwinData.createDataSourceForRealityDataId(
-        "itwin-id-1",
-        "reality-data-id-1",
-        ITwinPlatform.RealityDataType.GeoJSON,
-        "root/document/path.json",
-      );
-
-      expect(geojsonSpy).toHaveBeenCalledOnceWith(tilesetUrl);
-      expect(kmlSpy).not.toHaveBeenCalled();
-    });
-
     it("creates a KmlDataSource from the constructed blob url if the type is KML", async () => {
       const tilesetUrl =
         "https://example.com/root/document/path.json?auth=token";
@@ -394,22 +350,6 @@ describe("ITwinData", () => {
         type: ITwinPlatform.RealityDataType.KML,
         rootDocument: "root/document/path.json",
       });
-
-      expect(kmlSpy).toHaveBeenCalledOnceWith(tilesetUrl);
-      expect(geojsonSpy).not.toHaveBeenCalled();
-    });
-
-    it("creates a KmlDataSource from the constructed blob url if the type is KML using DEPRECATED arguments", async () => {
-      const tilesetUrl =
-        "https://example.com/root/document/path.json?auth=token";
-      getUrlSpy.and.resolveTo(tilesetUrl);
-
-      await ITwinData.createDataSourceForRealityDataId(
-        "itwin-id-1",
-        "reality-data-id-1",
-        ITwinPlatform.RealityDataType.KML,
-        "root/document/path.json",
-      );
 
       expect(kmlSpy).toHaveBeenCalledOnceWith(tilesetUrl);
       expect(geojsonSpy).not.toHaveBeenCalled();
@@ -483,15 +423,6 @@ describe("ITwinData", () => {
         iTwinId: "itwin-id-1",
         collectionId: "collection-id-1",
       });
-
-      expect(geojsonSpy).toHaveBeenCalledTimes(1);
-      expect(geojsonSpy.calls.mostRecent().args[0].url).toEqual(
-        "https://api.bentley.com/geospatial-features/itwins/itwin-id-1/ogc/collections/collection-id-1/items?limit=10000&client=CesiumJS",
-      );
-    });
-
-    it("creates a GeoJsonDataSource from the constructed blob url if the type is GeoJSON using DEPRECATED arguments", async () => {
-      await ITwinData.loadGeospatialFeatures("itwin-id-1", "collection-id-1");
 
       expect(geojsonSpy).toHaveBeenCalledTimes(1);
       expect(geojsonSpy.calls.mostRecent().args[0].url).toEqual(


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This removes the fallback code for the old argument structure that I added in https://github.com/CesiumGS/cesium/pull/12778. This feature is still marked as experimental so the 1 release deprecation length is ok. 

**DO NOT MERGE UNTIL MONDAY**. This should go in the _next_ release in September, not this one in August.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue, cleanup from https://github.com/CesiumGS/cesium/issues/12776 / https://github.com/CesiumGS/cesium/issues/12778

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Verify the itwin focused sandcastles still work as expected

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
