### PR TITLE
Allow passing tileset options to reality data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Breaking Changes :mega:
 
 - Removed the argument fallback in `ITwinData.*` functions. Please switch to the new options argument signature [#12778](https://github.com/CesiumGS/cesium/issues/12778)
+- Allow passing tileset constructor options to the tileset that is created with `ITwinData.createTilesetForRealityDataId` [#12709](https://github.com/CesiumGS/cesium/issues/12709)
 
 ## 1.132 - 2025-08-01
 
@@ -2462,7 +2463,6 @@ _This is an npm-only release to fix a publishing issue_.
     tileset.boundingSphere.center,
   );
   ```
-
   - This also fixes several issues with clipping planes not using the correct transform for tilesets with children.
 
 ### Additions :tada:
@@ -4308,7 +4308,6 @@ _This is an npm-only release to fix a publishing issue_.
                 isStopIncluded : true,
                 data : data
             });
-
     - `TimeInterval.fromIso8601` now takes a single options parameter. Code that looked like:
 
             TimeInterval.fromIso8601(intervalString, true, true, data);
@@ -4321,7 +4320,6 @@ _This is an npm-only release to fix a publishing issue_.
                 isStopIncluded : true,
                 data : data
             });
-
     - `interval.intersect(otherInterval)` -> `TimeInterval.intersect(interval, otherInterval)`
     - `interval.contains(date)` -> `TimeInterval.contains(interval, date)`
 

--- a/packages/engine/Source/Scene/ITwinData.js
+++ b/packages/engine/Source/Scene/ITwinData.js
@@ -90,6 +90,9 @@ ITwinData.createTilesetFromIModelId = async function ({
  * If the <code>type</code> or <code>rootDocument</code> are not provided this function
  * will first request the full metadata for the specified reality data to fill these values.
  *
+ * The <code>maximumScreenSpaceError</code> of the resulting tileset will default to 4,
+ * unless it is explicitly overridden with the given tileset options.
+ *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  *
  * @param {Object} options
@@ -97,6 +100,8 @@ ITwinData.createTilesetFromIModelId = async function ({
  * @param {string} options.realityDataId The id of the reality data to load
  * @param {ITwinPlatform.RealityDataType} [options.type] The type of this reality data
  * @param {string} [options.rootDocument] The path of the root document for this reality data
+ * @param {Cesium3DTileset.ConstructorOptions} [options.tilesetOptions] Object containing
+ * options to pass to the internally created {@link Cesium3DTileset}.
  * @returns {Promise<Cesium3DTileset>}
  *
  * @throws {RuntimeError} if the type of reality data is not supported by this function
@@ -106,6 +111,7 @@ ITwinData.createTilesetForRealityDataId = async function ({
   realityDataId,
   type,
   rootDocument,
+  tilesetOptions,
 }) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("iTwinId", iTwinId);
@@ -144,9 +150,15 @@ ITwinData.createTilesetForRealityDataId = async function ({
     rootDocument,
   );
 
-  return Cesium3DTileset.fromUrl(tilesetAccessUrl, {
+  // The maximum screen space error was defined to default to 4 for
+  // reality data tilesets. This will only be overridden if it was
+  // specified in the tilesetOptions explicitly.
+  const internalTilesetOptions = {
     maximumScreenSpaceError: 4,
-  });
+    ...tilesetOptions,
+  };
+
+  return Cesium3DTileset.fromUrl(tilesetAccessUrl, internalTilesetOptions);
 };
 
 /**

--- a/packages/engine/Specs/Scene/ITwinDataSpec.js
+++ b/packages/engine/Specs/Scene/ITwinDataSpec.js
@@ -231,6 +231,54 @@ describe("ITwinData", () => {
         maximumScreenSpaceError: 4,
       });
     });
+
+    it("creates a tileset with the given tilesetOptions", async () => {
+      const tilesetUrl =
+        "https://example.com/root/document/path.json?auth=token";
+      getUrlSpy.and.resolveTo(tilesetUrl);
+
+      await ITwinData.createTilesetForRealityDataId({
+        iTwinId: "itwin-id-1",
+        realityDataId: "reality-data-id-1",
+        type: ITwinPlatform.RealityDataType.Cesium3DTiles,
+        rootDocument: "root/document/path.json",
+        tilesetOptions: {
+          cacheBytes: 500000000,
+        },
+      });
+
+      // The createTilesetForRealityDataId was defined to use a
+      // maximum screen space error of 4 by default
+      expect(tilesetSpy).toHaveBeenCalledOnceWith(tilesetUrl, {
+        maximumScreenSpaceError: 4,
+        cacheBytes: 500000000,
+      });
+    });
+
+    it("creates a tileset with tilesetOptions overriding the defaults", async () => {
+      const tilesetUrl =
+        "https://example.com/root/document/path.json?auth=token";
+      getUrlSpy.and.resolveTo(tilesetUrl);
+
+      await ITwinData.createTilesetForRealityDataId({
+        iTwinId: "itwin-id-1",
+        realityDataId: "reality-data-id-1",
+        type: ITwinPlatform.RealityDataType.Cesium3DTiles,
+        rootDocument: "root/document/path.json",
+        tilesetOptions: {
+          maximumScreenSpaceError: 32,
+          cacheBytes: 500000000,
+        },
+      });
+
+      // The createTilesetForRealityDataId was defined to use a
+      // maximum screen space error of 4 by default, which should
+      // be overridden with the value from the given options
+      expect(tilesetSpy).toHaveBeenCalledOnceWith(tilesetUrl, {
+        maximumScreenSpaceError: 32,
+        cacheBytes: 500000000,
+      });
+    });
   });
 
   describe("createDataSourceForRealityDataId", () => {


### PR DESCRIPTION

# Description

Allow passing a `tilesetOptions` object to `ITwinData.createTilesetForRealityDataId`. The tileset options will be forwarded to the tileset that is created internally. One caveat is that the `maximumScreenSpaceError` for reality data tilesets was set to 4 by default. This should still be the default, with the option of overriding that default with the given options.

## Issue number and link

https://github.com/CesiumGS/cesium/issues/12709

## Testing plan

Basic specs have been added for passing on the options, including the special handling of the `maximumScreenSpaceError`. 

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
