### PR TITLE
Removed JSONP for bing in favor of normal JSON loading over CORS

### DIFF
--- a/packages/engine/Source/Core/IonResource.js
+++ b/packages/engine/Source/Core/IonResource.js
@@ -199,15 +199,8 @@ IonResource.prototype._makeRequest = function (options) {
     return Resource.prototype._makeRequest.call(this, options);
   }
 
-  if (!defined(options.headers)) {
-    options.headers = {};
-  }
+  addClientHeaders(options);
   options.headers.Authorization = `Bearer ${this._ionEndpoint.accessToken}`;
-  options.headers["X-Cesium-Client"] = "CesiumJS";
-  /* global CESIUM_VERSION */
-  if (typeof CESIUM_VERSION !== "undefined") {
-    options.headers["X-Cesium-Client-Version"] = CESIUM_VERSION;
-  }
 
   return Resource.prototype._makeRequest.call(this, options);
 };
@@ -233,8 +226,21 @@ IonResource._createEndpointResource = function (assetId, options) {
     resourceOptions.queryParameters = { access_token: accessToken };
   }
 
+  addClientHeaders(resourceOptions);
+
   return server.getDerivedResource(resourceOptions);
 };
+
+function addClientHeaders(options) {
+  if (!defined(options.headers)) {
+    options.headers = {};
+  }
+  options.headers["X-Cesium-Client"] = "CesiumJS";
+  /* global CESIUM_VERSION */
+  if (typeof CESIUM_VERSION !== "undefined") {
+    options.headers["X-Cesium-Client-Version"] = CESIUM_VERSION;
+  }
+}
 
 function retryCallback(that, error) {
   const ionRoot = that._ionRoot ?? that;

--- a/packages/engine/Source/Scene/BingMapsImageryProvider.js
+++ b/packages/engine/Source/Scene/BingMapsImageryProvider.js
@@ -160,7 +160,7 @@ async function requestMetadata(
   const cacheKey = metadataResource.url;
   let promise = BingMapsImageryProvider._metadataCache[cacheKey];
   if (!defined(promise)) {
-    promise = metadataResource.fetchJsonp("jsonp");
+    promise = metadataResource.fetchJson();
     BingMapsImageryProvider._metadataCache[cacheKey] = promise;
   }
 

--- a/packages/engine/Specs/Scene/ImageryLayerSpec.js
+++ b/packages/engine/Specs/Scene/ImageryLayerSpec.js
@@ -43,8 +43,6 @@ describe(
     });
 
     afterEach(function () {
-      Resource._Implementations.loadAndExecuteScript =
-        Resource._DefaultImplementations.loadAndExecuteScript;
       Resource._Implementations.createImage =
         Resource._DefaultImplementations.createImage;
       Resource._Implementations.loadWithXhr =
@@ -172,44 +170,6 @@ describe(
     });
 
     async function createWebMercatorProvider() {
-      Resource._Implementations.loadAndExecuteScript = function (
-        url,
-        functionName,
-      ) {
-        window[functionName]({
-          authenticationResultCode: "ValidCredentials",
-          brandLogoUri:
-            "http://dev.virtualearth.net/Branding/logo_powered_by.png",
-          copyright:
-            "Copyright © 2012 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.",
-          resourceSets: [
-            {
-              estimatedTotal: 1,
-              resources: [
-                {
-                  __type:
-                    "ImageryMetadata:http://schemas.microsoft.com/search/local/ws/rest/v1",
-                  imageHeight: 256,
-                  imageUrl:
-                    "http://invalid.{subdomain}.invalid/tiles/r{quadkey}?g=1062&lbl=l1&productSet=mmCB",
-                  imageUrlSubdomains: ["t0"],
-                  imageWidth: 256,
-                  imageryProviders: null,
-                  vintageEnd: null,
-                  vintageStart: null,
-                  zoomMax: 21,
-                  zoomMin: 1,
-                },
-              ],
-            },
-          ],
-          statusCode: 200,
-          statusDescription: "OK",
-          traceId:
-            "c9cf8c74a8b24644974288c92e448972|EWRM003311|02.00.171.2600|",
-        });
-      };
-
       Resource._Implementations.createImage = function (
         request,
         crossOrigin,
@@ -231,6 +191,42 @@ describe(
         deferred,
         overrideMimeType,
       ) {
+        if (url.includes("REST/v1/Imagery/Metadata")) {
+          deferred.resolve(
+            JSON.stringify({
+              authenticationResultCode: "ValidCredentials",
+              brandLogoUri:
+                "http://dev.virtualearth.net/Branding/logo_powered_by.png",
+              copyright:
+                "Copyright © 2012 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.",
+              resourceSets: [
+                {
+                  estimatedTotal: 1,
+                  resources: [
+                    {
+                      __type:
+                        "ImageryMetadata:http://schemas.microsoft.com/search/local/ws/rest/v1",
+                      imageHeight: 256,
+                      imageUrl:
+                        "http://invalid.{subdomain}.invalid/tiles/r{quadkey}?g=1062&lbl=l1&productSet=mmCB",
+                      imageUrlSubdomains: ["t0"],
+                      imageWidth: 256,
+                      imageryProviders: null,
+                      vintageEnd: null,
+                      vintageStart: null,
+                      zoomMax: 21,
+                      zoomMin: 1,
+                    },
+                  ],
+                },
+              ],
+              statusCode: 200,
+              statusDescription: "OK",
+              traceId:
+                "c9cf8c74a8b24644974288c92e448972|EWRM003311|02.00.171.2600|",
+            }),
+          );
+        }
         Resource._DefaultImplementations.loadWithXhr(
           "Data/Images/Red16x16.png",
           responseType,

--- a/packages/engine/Specs/Scene/IonImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/IonImageryProviderSpec.js
@@ -231,15 +231,27 @@ describe("Scene/IonImageryProvider", function () {
   });
 
   it("createImageryProvider works with BING", function () {
-    spyOn(Resource._Implementations, "loadAndExecuteScript").and.callFake(
-      function (url, name, deffered) {
-        deffered.resolve({
-          resourceSets: [
-            {
-              resources: [{ imageUrl: "", imageUrlSubdomains: [], zoomMax: 0 }],
-            },
-          ],
-        });
+    spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
+      function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType,
+      ) {
+        deferred.resolve(
+          JSON.stringify({
+            resourceSets: [
+              {
+                resources: [
+                  { imageUrl: "", imageUrlSubdomains: [], zoomMax: 0 },
+                ],
+              },
+            ],
+          }),
+        );
       },
     );
     return testExternalImagery(

--- a/packages/engine/Specs/Scene/createWorldImageryAsyncSpec.js
+++ b/packages/engine/Specs/Scene/createWorldImageryAsyncSpec.js
@@ -9,8 +9,36 @@ import createFakeBingMapsMetadataResponse from "../createFakeBingMapsMetadataRes
 
 describe("Core/createWorldImageryAsync", function () {
   it("resolves to IonImageryProvider instance with default parameters", async function () {
-    spyOn(Resource.prototype, "fetchJsonp").and.callFake(() =>
-      Promise.resolve(createFakeBingMapsMetadataResponse(BingMapsStyle.AERIAL)),
+    const originalLoadWithXhr = Resource._Implementations.loadWithXhr;
+    spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
+      function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType,
+      ) {
+        if (url.includes("REST/v1/Imagery/Metadata")) {
+          deferred.resolve(
+            JSON.stringify(
+              createFakeBingMapsMetadataResponse(BingMapsStyle.AERIAL),
+            ),
+          );
+          return;
+        }
+
+        return originalLoadWithXhr(
+          url,
+          responseType,
+          method,
+          data,
+          headers,
+          deferred,
+          overrideMimeType,
+        );
+      },
     );
 
     const provider = await createWorldImageryAsync();


### PR DESCRIPTION
# Description

For Bing maps, we can load the metadata files via a normal CORS request to get the JSON. Previously we used JSONP which  requires headers in the application to allow execution of scripts from other domains.

## Issue number and link

Fixes #12622

## Testing plan

Load bing maps sandcastle examples and verify they all load.

# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [X] I have updated `CHANGES.md` with a short summary of my change
- [X] I have added or updated unit tests to ensure consistent code coverage
- [X] I have updated the inline documentation, and included code examples where relevant
- [X] I have performed a self-review of my code
