### PR TITLE
Allow overriding the geometry processing stage

### DIFF
--- a/packages/engine/Source/Shaders/Model/GeometryStageVS.glsl
+++ b/packages/engine/Source/Shaders/Model/GeometryStageVS.glsl
@@ -1,3 +1,4 @@
+#ifndef CUSTOM_GEOMETRY_STAGE
 vec4 geometryStage(inout ProcessedAttributes attributes, mat4 modelView, mat3 normal)
 {
     vec4 computedPosition;
@@ -40,3 +41,4 @@ vec4 geometryStage(inout ProcessedAttributes attributes, mat4 modelView, mat3 no
 
     return computedPosition;
 }
+#endif


### PR DESCRIPTION
**Motivation**
When customizing vertex shaders in CesiumJS, there's a key architectural difference from standard GLSL practices. Instead of directly setting gl_Position, developers need to modify vsOutput.positionMC, which is then used by the engine's geometryStage.

This pull request (PR) aims to improve the developer experience by providing an optional and non-intrusive way to bypass the default geometryStage. This gives developers more direct control over the final vertex position, aligning more closely with standard GLSL practices when advanced customization is needed.

**Proposed Change**
I've introduced a preprocessor guard, #ifndef CUSTOM_GEOMETRY_STAGE, around the entire geometryStage function definition in the vertex shader.

This change is backward-compatible and has no impact on existing projects. However, it empowers developers to override the default geometry processing by simply defining the CUSTOM_GEOMETRY_STAGE preprocessor directive before the shader is compiled.