### PR TITLE
Add support for loading GH Gist urls

### DIFF
--- a/packages/sandcastle/src/App.tsx
+++ b/packages/sandcastle/src/App.tsx
@@ -251,15 +251,18 @@ function App() {
   const [galleryLoaded, setGalleryLoaded] = useState(false);
 
   const [consoleMessages, setConsoleMessages] = useState<ConsoleMessage[]>([]);
-  function appendConsole(type: ConsoleMessageType, message: string) {
-    setConsoleMessages((prevConsoleMessages) => [
-      ...prevConsoleMessages,
-      { type, message, id: crypto.randomUUID() },
-    ]);
-    if (!consoleExpanded && type !== "log") {
-      rightSideRef.current?.toggleExpanded();
-    }
-  }
+  const appendConsole = useCallback(
+    function appendConsole(type: ConsoleMessageType, message: string) {
+      setConsoleMessages((prevConsoleMessages) => [
+        ...prevConsoleMessages,
+        { type, message, id: crypto.randomUUID() },
+      ]);
+      if (!consoleExpanded && type !== "log") {
+        rightSideRef.current?.toggleExpanded();
+      }
+    },
+    [consoleExpanded],
+  );
 
   function resetConsole() {
     // the console should only be cleared by the Bucket when the viewer page
@@ -383,6 +386,7 @@ function App() {
               const html =
                 files["Cesium-Sandcastle.html"]?.content ?? defaultHtmlCode;
               dispatch({ type: "setAndRun", code: code, html: html });
+              setTitle("Gist Import");
               setReadyForViewer(true);
             })
             .catch(function (error) {
@@ -419,7 +423,7 @@ function App() {
         }
       }
     },
-    [galleryLoaded, legacyIdMap, loadGalleryItem],
+    [galleryLoaded, legacyIdMap, loadGalleryItem, appendConsole],
   );
 
   useEffect(() => loadFromUrl(), [galleryLoaded, galleryItems, loadFromUrl]);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

In the past it was possible to save sandcastles to Github Gists and load them back. Gist changed to no longer allow anonymous Gists so we no longer support that but there _are_ old links still out there that utilize gist ids to load. This PR adds support back for loading those sandcastles based on the code in current sandcastle.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Part of #12566 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm run dev` from the sandcastle package or `npm run build-sandcastle` and `npm start` from the project root
- Load these urls and make sure they work. I found these digging through some old github issues, I'm sure you could find others
    - http://localhost:5173/?gist=879789aed4f39e674732819d7b7380da (this one has broken code but make sure it still loads)
    - http://localhost:5173/?src=Hello%20World.html&label=Showcases&gist=879789aed4f39e674732819d7b7380da
    - http://localhost:5173/?gist=13311b55ffaaff8ed890a4c203641c89 (this one should work)
    - http://localhost:5173/?src=Hello%20World.html&label=Showcases&gist=13311b55ffaaff8ed890a4c203641c89

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
