### PR TITLE
GaussianSplatPrimitive Multiple Instances Fix

### DIFF
--- a/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
+++ b/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
@@ -31,15 +31,14 @@ function GaussianSplat3DTileContent(loader, tileset, tile, resource) {
   }
 
   /**
-   * Original position, scale and rotation values for splats. Used to maintain
-   * consistency when multiple transforms may occur. Downstream consumers otherwise may not know
-   * the underlying data was modified.
+   * Local copies of attribute buffers with transformed values. Originals are kept in the gltf loader.
+   * These are the buffers that are used for rendering.
    * @type {undefined|Float32Array}
    * @private
    */
-  this._originalPositions = undefined;
-  this._originalRotations = undefined;
-  this._originalScales = undefined;
+  this._positions = undefined;
+  this._rotations = undefined;
+  this._scales = undefined;
 
   /**
    * glTF primitive data that contains the Gaussian splat data needed for rendering.
@@ -309,6 +308,24 @@ Object.defineProperties(GaussianSplat3DTileContent.prototype, {
       this._group = value;
     },
   },
+
+  positions: {
+    get: function () {
+      return this._positions;
+    },
+  },
+
+  rotations: {
+    get: function () {
+      return this._rotations;
+    },
+  },
+
+  scales: {
+    get: function () {
+      return this._scales;
+    },
+  },
 });
 
 /**
@@ -391,21 +408,21 @@ GaussianSplat3DTileContent.prototype.update = function (primitive, frameState) {
     this.worldTransform = loader.components.scene.nodes[0].matrix;
     this._ready = true;
 
-    this._originalPositions = new Float32Array(
+    this._positions = new Float32Array(
       ModelUtility.getAttributeBySemantic(
         this.splatPrimitive,
         VertexAttributeSemantic.POSITION,
       ).typedArray,
     );
 
-    this._originalRotations = new Float32Array(
+    this._rotations = new Float32Array(
       ModelUtility.getAttributeBySemantic(
         this.splatPrimitive,
         VertexAttributeSemantic.ROTATION,
       ).typedArray,
     );
 
-    this._originalScales = new Float32Array(
+    this._scales = new Float32Array(
       ModelUtility.getAttributeBySemantic(
         this.splatPrimitive,
         VertexAttributeSemantic.SCALE,

--- a/packages/engine/Source/Scene/GaussianSplatPrimitive.js
+++ b/packages/engine/Source/Scene/GaussianSplatPrimitive.js
@@ -421,9 +421,9 @@ GaussianSplatPrimitive.transformTile = function (tile) {
     computedModelMatrix,
     scratchMatrix4A,
   );
-  const positions = tile.content._originalPositions;
-  const rotations = tile.content._originalRotations;
-  const scales = tile.content._originalScales;
+  const positions = tile.content.positions;
+  const rotations = tile.content.rotations;
+  const scales = tile.content.scales;
   const attributePositions = ModelUtility.getAttributeBySemantic(
     splatPrimitive,
     VertexAttributeSemantic.POSITION,
@@ -442,19 +442,19 @@ GaussianSplatPrimitive.transformTile = function (tile) {
   const position = new Cartesian3();
   const rotation = new Quaternion();
   const scale = new Cartesian3();
-  for (let i = 0; i < positions.length / 3; ++i) {
-    position.x = positions[i * 3];
-    position.y = positions[i * 3 + 1];
-    position.z = positions[i * 3 + 2];
+  for (let i = 0; i < attributePositions.length / 3; ++i) {
+    position.x = attributePositions[i * 3];
+    position.y = attributePositions[i * 3 + 1];
+    position.z = attributePositions[i * 3 + 2];
 
-    rotation.x = rotations[i * 4];
-    rotation.y = rotations[i * 4 + 1];
-    rotation.z = rotations[i * 4 + 2];
-    rotation.w = rotations[i * 4 + 3];
+    rotation.x = attributeRotations[i * 4];
+    rotation.y = attributeRotations[i * 4 + 1];
+    rotation.z = attributeRotations[i * 4 + 2];
+    rotation.w = attributeRotations[i * 4 + 3];
 
-    scale.x = scales[i * 3];
-    scale.y = scales[i * 3 + 1];
-    scale.z = scales[i * 3 + 2];
+    scale.x = attributeScales[i * 3];
+    scale.y = attributeScales[i * 3 + 1];
+    scale.z = attributeScales[i * 3 + 2];
 
     Matrix4.fromTranslationQuaternionRotationScale(
       position,
@@ -469,18 +469,18 @@ GaussianSplatPrimitive.transformTile = function (tile) {
     Matrix4.getRotation(scratchMatrix4C, rotation);
     Matrix4.getScale(scratchMatrix4C, scale);
 
-    attributePositions[i * 3] = position.x;
-    attributePositions[i * 3 + 1] = position.y;
-    attributePositions[i * 3 + 2] = position.z;
+    positions[i * 3] = position.x;
+    positions[i * 3 + 1] = position.y;
+    positions[i * 3 + 2] = position.z;
 
-    attributeRotations[i * 4] = rotation.x;
-    attributeRotations[i * 4 + 1] = rotation.y;
-    attributeRotations[i * 4 + 2] = rotation.z;
-    attributeRotations[i * 4 + 3] = rotation.w;
+    rotations[i * 4] = rotation.x;
+    rotations[i * 4 + 1] = rotation.y;
+    rotations[i * 4 + 2] = rotation.z;
+    rotations[i * 4 + 3] = rotation.w;
 
-    attributeScales[i * 3] = scale.x;
-    attributeScales[i * 3 + 1] = scale.y;
-    attributeScales[i * 3 + 2] = scale.z;
+    scales[i * 3] = scale.x;
+    scales[i * 3 + 1] = scale.y;
+    scales[i * 3 + 2] = scale.z;
   }
 };
 
@@ -767,57 +767,54 @@ GaussianSplatPrimitive.prototype.update = function (frameState) {
       const aggregateAttributeValues = (
         componentDatatype,
         getAttributeCallback,
+        numberOfComponents,
       ) => {
         let aggregate;
         let offset = 0;
         for (const tile of tiles) {
-          const primitive = tile.content.splatPrimitive;
-          const attribute = getAttributeCallback(primitive);
+          const content = tile.content;
+          const attribute = getAttributeCallback(content);
+          const componentsPerAttribute = defined(numberOfComponents)
+            ? numberOfComponents
+            : AttributeType.getNumberOfComponents(attribute.type);
+          const buffer = defined(attribute.typedArray)
+            ? attribute.typedArray
+            : attribute;
           if (!defined(aggregate)) {
             aggregate = ComponentDatatype.createTypedArray(
               componentDatatype,
-              totalElements *
-                AttributeType.getNumberOfComponents(attribute.type),
+              totalElements * componentsPerAttribute,
             );
           }
-          aggregate.set(attribute.typedArray, offset);
-          offset += attribute.typedArray.length;
+          aggregate.set(buffer, offset);
+          offset += buffer.length;
         }
         return aggregate;
       };
 
       this._positions = aggregateAttributeValues(
         ComponentDatatype.FLOAT,
-        (splatPrimitive) =>
-          ModelUtility.getAttributeBySemantic(
-            splatPrimitive,
-            VertexAttributeSemantic.POSITION,
-          ),
+        (content) => content.positions,
+        3,
       );
 
       this._scales = aggregateAttributeValues(
         ComponentDatatype.FLOAT,
-        (splatPrimitive) =>
-          ModelUtility.getAttributeBySemantic(
-            splatPrimitive,
-            VertexAttributeSemantic.SCALE,
-          ),
+        (content) => content.scales,
+        3,
       );
 
       this._rotations = aggregateAttributeValues(
         ComponentDatatype.FLOAT,
-        (splatPrimitive) =>
-          ModelUtility.getAttributeBySemantic(
-            splatPrimitive,
-            VertexAttributeSemantic.ROTATION,
-          ),
+        (content) => content.rotations,
+        4,
       );
 
       this._colors = aggregateAttributeValues(
         ComponentDatatype.UNSIGNED_BYTE,
-        (splatPrimitive) =>
+        (content) =>
           ModelUtility.getAttributeBySemantic(
-            splatPrimitive,
+            content.splatPrimitive,
             VertexAttributeSemantic.COLOR,
           ),
       );


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

When loaded multiple instances of the same Gaussian Splat model, any subsequent loaded instances would have their tiles transformed incorrectly. The primitive was transforming and modifying the underlying glTF attribute buffers. Any new instances loaded would not know those buffers were modified in any way and proceed to perform their own transforms on them.

<!-- Describe your changes in detail -->

This simply makes copies of those buffers into the GaussianSplat3DTileContent class, so they can be transformed and modified locally in the GaussianSplatPrimitive class without affecting other instances. When transforming child tiles into root tile space and when gathering tile data for rendering we read from the local copies rather than from the glTF attributes directly.

<!-- Consider: Why is this change required? What problem does it solve? -->



<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->
Fixes #12795 

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Load this Sandcastle. It's essentially a race condition whether or not both tileset instances load correctly. Most of the time one will have tiles incorrectly rendered.

[Broken Split Pane Sandcastle](https://sandcastle.cesium.com/#c=tVZtT9swEP4rXrdJ6VbcMrYPCwWNQTeQgCLajS+RwDiXxpprR7bTUlD/+/yStCnsBU1aK7X2+e55zs9drqVSaINmDOag0B4SMEeHoFk5xd+9LUpa1O8PpTCECVBJq4MeEoGQAaWsJa4DxmGPMyWnV1LxtDJE7U4ilu3dRCTCqEUIpp6XQ2YsK5kTZmqY8LVzNGYcNBgPdyLFgbabkzTaef9+5+O7noNDVd5YUxCAC8WmzLAZaEzSNHLYwcutsC44M0dMATVMCkta0Y027Ph08GXsM12B30s5HcvIWQJUJywbUh0DSZmYXDBD80siJlB5o9rhjJgcG3lp3YjQ0daHXrvzF5d3DZftXg/3ql2wtqscg4yKTfL/pqMHD25++VwlL0++Hjspl4gSqwuKbDdI1V6XX3LAXE6im4E7QFx6EZEJ+cbo1YOPWN448qW7b7eLRgtBkckBFVIzzy8zv9ecpbaF58zkYe+yWXklIihVee2hVNJyCsLgCZgBB7f8vLCyJK3gkrQc64YuHvGipt2rsLDMMpvuqevkbm0riLKAFW7lccVSk/uyhVRyIlL++KEbUQUgRgWhMJjZ2OPgFAXcUHUOBk3lDA6oK5KNzwjX4I+yUoSiuPPIfbgEKs1ZhqIX68DKaqsKplTCF3i50VXAiXMc+vQtT42HQaS1Dvhudx3xSKEAHz3V6e0j7PbzlEO1kzYL1ztheNy8evDPB3qzyb98ffO0t5/UsLmv26yqDHYPiihKc+A1jVbiRpV0G0UwqnQ1WHZ+V8rxogA/Xq6PhlfnrpT/kefi5Pzw+Ho0Prgch6b5DZeD/jPS2fDbaHB9Nvw++EPKf4cJCdUw/3j3utGfI/K3i3+W+Jk04UqD8yNH1Oq0+r4t9+uh/YlNC6kMKhWPMO4amBa250F3b0v6w85jqnU9xd3rZTWaHmoDWg2vGJFbOy1LA7vrQ9f9MfrQe92wGVnEqFfcNUy3hP6YKFmKdItKLlWMXqY77t3wmbvny2JtBObghn3sfnuaFPdbTKRwF6OP9rWyL5/cI86tohu3oaXSjh/mW8qqeg/NaPfV7zYF7Kdshli694v/H4hyorU9yUrORxYpaa1UX4fVc3y/37W2GrW5XrlWPz1DmzEnCxeSb++fBiPGuN+1219HGin5LXnM8hM)


Same demo but on this branch using local buffers for each instance. Each gets transformed correctly.

[Fixed Splt Pane Sandcastle](https://ci-builds.cesium.com/cesium/gsplat-buffer-fix/Apps/Sandcastle/index.html#c=tVZtT9swEP4rXrdJ6VbcMrYPCwWNQTeQgCLajS+RwDiXxpprR7bTUlD/+/yStCnsBU1aK7X2+e55zs9drqVSaINmDOag0B4SMEeHoFk5xd+9LUpa1O8PpTCECVBJq4MeEoGQAaWsJa4DxmGPMyWnV1LxtDJE7U4ilu3dRCTCqEUIpp6XQ2YsK5kTZmqY8LVzNGYcNBgPdyLFgbabkzTaef9+5+O7noNDVd5YUxCAC8WmzLAZaEzSNHLYwcutsC44M0dMATVMCkta0Y027Ph08GXsM12B30s5HcvIWQJUJywbUh0DSZmYXDBD80siJlB5o9rhjJgcG3lp3YjQ0daHXrvzF5d3DZftXg/3ql2wtqscg4yKTfL/pqMHD25++VwlL0++Hjspl4gSqwuKbDdI1V6XX3LAXE6im4E7QFx6EZEJ+cbo1YOPWN448qW7b7eLRgtBkckBFVIzzy8zv9ecpbaF58zkYe+yWXklIihVee2hVNJyCsLgCZgBB7f8vLCyJK3gkrQc64YuHvGipt2rsLDMMpvuqevkbm0riLKAFW7lccVSk/uyhVRyIlL++KEbUQUgRgWhMJjZ2OPgFAXcUHUOBk3lDA6oK5KNzwjX4I+yUoSiuPPIfbgEKs1ZhqIX68DKaqsKplTCF3i50VXAiXMc+vQtT42HQaS1Dvhudx3xSKEAHz3V6e0j7PbzlEO1kzYL1ztheNy8evDPB3qzyb98ffO0t5/UsLmv26yqDHYPiihKc+A1jVbiRpV0G0UwqnQ1WHZ+V8rxogA/Xq6PhlfnrpT/kefi5Pzw+Ho0Prgch6b5DZeD/jPS2fDbaHB9Nvw++EPKf4cJCdUw/3j3utGfI/K3i3+W+Jk04UqD8yNH1Oq0+r4t9+uh/YlNC6kMKhWPMO4amBa250F3b0v6w85jqnU9xd3rZTWaHmoDWg2vGJFbOy1LA7vrQ9f9MfrQe92wGVnEqFfcNUy3hP6YKFmKdItKLlWMXqY77t3wmbvny2JtBObghn3sfnuaFPdbTKRwF6OP9rWyL5/cI86tohu3oaXSjh/mW8qqeg/NaPfV7zYF7Kdshli694v/H4hyorU9yUrORxYpaa1UX4fVc3y/37W2GrW5XrlWPz1DmzEnCxeSb++fBiPGuN+1219HGin5LXnMEj5/Ag)
<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
