### PR TITLE
Sandcastle gallery list—Default to Showcases label 

### DIFF
--- a/packages/sandcastle/src/Gallery.tsx
+++ b/packages/sandcastle/src/Gallery.tsx
@@ -168,14 +168,18 @@ export function GallerySearch({
             setCurrentTag(e.target.value);
             setTag(e.target.value);
           }}
-          value={defaultTag}
         >
+          <option value={defaultTag} selected>
+            {defaultTag}
+          </option>
           <option value={"All"}>All</option>
-          {Object.keys(availableFilters.tags).map((label) => (
-            <option value={label} key={label}>
-              {label}
-            </option>
-          ))}
+          {Object.keys(availableFilters.tags)
+            .filter((label) => label !== defaultTag)
+            .map((label) => (
+              <option value={label} key={label}>
+                {label}
+              </option>
+            ))}
         </Select.HtmlSelect>
       </Select.Root>
     </>


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This is a quick implementation of setting the default search filter for the gallery list panel. We discussed offline setting this to "Showcases", like the old version of Sandcastle, to make the default list view more manageable. 

<img width="717" height="74" alt="image" src="https://github.com/user-attachments/assets/8f75f526-bfa5-475b-9575-9a5f4685deb1" />

There are certainly other improvements we can make, but this should be one small step towards guiding users to useful information as opposed to giving them an avalanche of content.

The next step is to purge the metadata for the gallery examples themselves to make better use of labels—In particular, pare down the "Showcases" tag to only a handful of recent and high-value items.

## Issue number and link

N/A

## Testing plan

1. Open the gallery panel and ensure only items tagged with "Showcases" are shown
2. Play with the tag filter to ensure "All" and other filters still work as before 

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
