### PR TITLE
Fix picks on clipped regions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 - Removes the minimum tile threshold of four for WMTS. [#4372](https://github.com/CesiumGS/cesium/issues/4372)
 - Fixed a crash that could happen when loading PNTS (point cloud) data that contained a batch table without a binary part [#11166](https://github.com/CesiumGS/cesium/issues/11166)
+- Fixed an error picking an area hidden by a `ClippingPolygon`. [#12725](https://github.com/CesiumGS/cesium/issues/12725)
 
 #### Additions :tada:
 

--- a/packages/engine/Source/Scene/Model/ModelClippingPolygonsPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/ModelClippingPolygonsPipelineStage.js
@@ -79,10 +79,14 @@ ModelClippingPolygonsPipelineStage.process = function (
 
   const uniformMap = {
     model_clippingDistance: function () {
-      return clippingPolygons.clippingTexture;
+      return (
+        clippingPolygons.clippingTexture ?? frameState.context.defaultTexture
+      );
     },
     model_clippingExtents: function () {
-      return clippingPolygons.extentsTexture;
+      return (
+        clippingPolygons.extentsTexture ?? frameState.context.defaultTexture
+      );
     },
   };
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR fixes a uniform error which can arise when picking 3D Tilesets that have a region clipped by `ClippingPolygonCollection`.

As @javagl helpfully pointed out, the `ClippingPolygonCollection._extentsTexture` property is [set during the collection update](https://github.com/CesiumGS/cesium/blob/a9480d31fdd85217c385b3bfc1659ae83c8d975c/packages/engine/Source/Scene/ClippingPolygonCollection.js#L627) (the webgl context, required to create the Texture, is not available until then). The error can manifest during picking, particularly `clampToHeight `, which attempts to render sooner than expected in the process. This leads to an uniform error.

Instead, this PR simply defaults to the default empty texture in the case where the texture has not yet had the chance to initialize.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12725

## Testing plan

**You will need to open the developer tools in order to replicate the bug.**
- [`main`, with error when you drag and move the polygon](https://sandcastle.cesium.com/#c=rVZZcyI3EP4rCk9DFRFzH74qhHXKrrJjyuDdB+PaEjMClBXSlEbgYl3897TmwGNsr7NJeADU6uPr7q97pt8fSSY0GnK5ztBsi0ZKzjEaUU0VGnBORQ8NJV+vZoygO8E2VBVMb9GtnEnN0gJdkRlG45QIwcTCOBhw+hcRmZJoomSaSs4QHNE10ZShIZMpUZxRPBWpFIVGG0YfIdQpEvQRDWnB1iv8uZRZ005anodSaMIEVdNODz1NBUIAToHkqDGYVGc8V3L1RSqe1QKr25uKXfd4KqaiCoSLlAqKU7KiiuCCahPLKp1mtNBMEM0kOG6hGRKl4R8RnmXUEPJ924l8H4e+7/iB5/i9Su66gR042HfsKE4cxw7c+sIPksB3bexFfhT7vucZcbe8lIpRyO5V0AtKMijoiOl0eSs5r0MHEDSMPC+2A9tLoiCqI/xqYzcKQztyAi/2kjgO64sQu7EDWOIo8G3bjoMmdF2Vqgm5hKYChAL6cG807k2OYexiL7CjJHDdpFemZ/vY8xI/8hKI4/aqzMIQe3YQe2Hgxg+9vXkEyknsBVHg2I4x95MI4JiPE0QGe2Xuh9gByIGb+G1rFwrsOW5ie55bBw8xfEWhDZW1w9raDXASeXGYeIFnzB/wiuSWlXfR6dnrDpYMGQA3tqDRroBmnAIbIH/ySJjeW5Y/3qdJdV2aX0oxKOBwmVlO6LuOcfOCXLliKyjnhhaYZJlVuzZq9V+ccpbnpr2SbxdV2duEe3kL48dpatpT8ZQJM4T0CGm1pmXB8trNEbp/34311GrzrvvwzAFOdeNi1CJCWaYyY2tvWJE2U2SxMON+iuaEFxUIRVNFYchBaIC1Zw4YDuZ1OZ5aiI+qcUZoyWAcVbrcHkwe5zOSfoOdlFOlt/UQIGSV3W1p1jleNG6sw3y6vca2RFwdGuEKYCtG+H6fQMmlwrfnn/Aj08sBz5fEsnFQ6e8Op2cJ+40f7rAxVIOKcU5Ser6BAlxUSlZdEliYG1IYL7W12UWXIl/rQdVqixqrMs+q63Nk/dIUvtvUTVG9VuK4hGW+KkAAo0kcQL3kJoNy1ndVCOhO1ki6x/tQLR8fREs5WeU0O4xUiifygrLFUlttd89BatN3A7zBynuM8Z6OvSb4w95nQ8O9z/9l5szn9dyZz0/P3tHrrKppNN52VXF2iAJJP8oAK7qSGwpPaasy+4GqmbwG8n/AWc9N06Fd7z26T7Y5xdc3d+Pzr9c3n89/RPRnjrf2Sr1C0EtOFc9RhuUT3LwaKNMrs2TIjNPSc9EspuMPIV6d/zH5+unmy58/jbAJ8O8h1jn+E4R3o2rhjAFhSgrNqenoRC4WnP6+1hpQGiTTzm2zhd8lNLxEtdd1eZivRXmHrHRJ028vJnK/1eurpvcGUKfXOSn0ltOzhlu/sVUulUZrxS2M+5qucg7mRX+2BmMgZlE0XD3pt01PMrZBLDt946XPDHlRwM18zfmYfafTztlJH/RfmXJZvjXdwKBysjVqS+fsqhLC3jjpw/FtSy0lPGrUgee/AQ)
- [this branch, no errors when you drag and move the polygon](https://ci-builds.cesium.com/cesium/fix-12725/Apps/Sandcastle/index.html#c=rVZZcyI3EP4rCk9DFRFzH74qhHXKrrJjyuDdB+PaEjMClBXSlEbgYl3897TmwGNsr7NJeADU6uPr7q97pt8fSSY0GnK5ztBsi0ZKzjEaUU0VGnBORQ8NJV+vZoygO8E2VBVMb9GtnEnN0gJdkRlG45QIwcTCOBhw+hcRmZJoomSaSs4QHNE10ZShIZMpUZxRPBWpFIVGG0YfIdQpEvQRDWnB1iv8uZRZ005anodSaMIEVdNODz1NBUIAToHkqDGYVGc8V3L1RSqe1QKr25uKXfd4KqaiCoSLlAqKU7KiiuCCahPLKp1mtNBMEM0kOG6hGRKl4R8RnmXUEPJ924l8H4e+7/iB5/i9Su66gR042HfsKE4cxw7c+sIPksB3bexFfhT7vucZcbe8lIpRyO5V0AtKMijoiOl0eSs5r0MHEDSMPC+2A9tLoiCqI/xqYzcKQztyAi/2kjgO64sQu7EDWOIo8G3bjoMmdF2Vqgm5hKYChAL6cG807k2OYexiL7CjJHDdpFemZ/vY8xI/8hKI4/aqzMIQe3YQe2Hgxg+9vXkEyknsBVHg2I4x95MI4JiPE0QGe2Xuh9gByIGb+G1rFwrsOW5ie55bBw8xfEWhDZW1w9raDXASeXGYeIFnzB/wiuSWlXfR6dnrDpYMGQA3tqDRroBmnAIbIH/ySJjeW5Y/3qdJdV2aX0oxKOBwmVlO6LuOcfOCXLliKyjnhhaYZJlVuzZq9V+ccpbnpr2SbxdV2duEe3kL48dpatpT8ZQJM4T0CGm1pmXB8trNEbp/34311GrzrvvwzAFOdeNi1CJCWaYyY2tvWJE2U2SxMON+iuaEFxUIRVNFYchBaIC1Zw4YDuZ1OZ5aiI+qcUZoyWAcVbrcHkwe5zOSfoOdlFOlt/UQIGSV3W1p1jleNG6sw3y6vca2RFwdGuEKYCtG+H6fQMmlwrfnn/Aj08sBz5fEsnFQ6e8Op2cJ+40f7rAxVIOKcU5Ser6BAlxUSlZdEliYG1IYL7W12UWXIl/rQdVqixqrMs+q63Nk/dIUvtvUTVG9VuK4hGW+KkAAo0kcQL3kJoNy1ndVCOhO1ki6x/tQLR8fREs5WeU0O4xUiifygrLFUlttd89BatN3A7zBynuM8Z6OvSb4w95nQ8O9z/9l5szn9dyZz0/P3tHrrKppNN52VXF2iAJJP8oAK7qSGwpPaasy+4GqmbwG8n/AWc9N06Fd7z26T7Y5xdc3d+Pzr9c3n89/RPRnjrf2Sr1C0EtOFc9RhuUT3LwaKNMrs2TIjNPSc9EspuMPIV6d/zH5+unmy58/jbAJ8O8h1jn+E4R3o2rhjAFhSgrNqenoRC4WnP6+1hpQGiTTzm2zhd8lNLxEtdd1eZivRXmHrHRJ028vJnK/1eurpvcGUKfXOSn0ltOzhlu/sVUulUZrxS2M+5qucg7mRX+2BmMgZlE0XD3pt01PMrZBLDt946XPDHlRwM18zfmYfafTztlJH/RfmXJZvjXdwKBysjVqS+fsqhLC3jjpw/FtSy0lPGrUgee/AQ)

I did not add a unit test since this is an edge case that is difficult to construct a sensible test for.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code
