### PR TITLE
Fixes titles of Mars and Moon sandcastles

### DIFF
--- a/packages/sandcastle/gallery/mars/sandcastle.yaml
+++ b/packages/sandcastle/gallery/mars/sandcastle.yaml
@@ -1,5 +1,5 @@
 legacyId: Mars.html
-title: Mars Terrain
+title: Mars
 description: Mars terrain visualized using 3D Tiles, tiled and hosted by Cesium ion, with atmospheric effects, points of interest, and rover paths of NASA's Curiosity and Perseverance. Combine a 3D dataset with CZML/GeoJSON to create an interactive Mars exploration app.
 labels:
   - Showcases

--- a/packages/sandcastle/gallery/moon/sandcastle.yaml
+++ b/packages/sandcastle/gallery/moon/sandcastle.yaml
@@ -1,5 +1,5 @@
 legacyId: Moon.html
-title: Moon Terrain
+title: Moon
 description: High-resolution lunar terrain using 3D Tiles from Cesium ion, with Apollo landing sites, craters, mare boundaries, and potential Artemis landing regions. Combining 3D data with GeoJSON overlays and interactive camera flights to create an immersive Moon app.
 labels:
   - Showcases


### PR DESCRIPTION
# Description

Removes "terrain" from Mars and Moon sandcastles (only shows on new sandcastle site). 

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
