### PR TITLE
Build sandcastle to relative paths

### DIFF
--- a/packages/sandcastle/vite.config.app.ts
+++ b/packages/sandcastle/vite.config.app.ts
@@ -1,7 +1,10 @@
 import { defineConfig, UserConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
-
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import baseConfig, { cesiumPathReplace } from "./vite.config.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(() => {
   const cesiumBaseUrl = "/Build/CesiumUnminified";
@@ -13,7 +16,7 @@ export default defineConfig(() => {
 
   config.build = {
     ...config.build,
-    outDir: "../../Apps/Sandcastle2",
+    outDir: join(__dirname, "../../Apps/Sandcastle2"),
   };
 
   config.define = {

--- a/packages/sandcastle/vite.config.ci.ts
+++ b/packages/sandcastle/vite.config.ci.ts
@@ -1,8 +1,11 @@
 import { defineConfig, UserConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { env } from "process";
-
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import baseConfig, { cesiumPathReplace } from "./vite.config.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(() => {
   const cesiumBaseUrl = `${process.env.BASE_URL}Build/CesiumUnminified`;
@@ -16,7 +19,7 @@ export default defineConfig(() => {
 
   config.build = {
     ...config.build,
-    outDir: "../../Apps/Sandcastle2",
+    outDir: join(__dirname, "../../Apps/Sandcastle2"),
   };
 
   config.define = {

--- a/packages/sandcastle/vite.config.prod.ts
+++ b/packages/sandcastle/vite.config.prod.ts
@@ -1,8 +1,11 @@
 import { defineConfig, UserConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { env } from "process";
-
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 import baseConfig, { cesiumPathReplace } from "./vite.config.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(() => {
   const cesiumSource = "../../Build/CesiumUnminified";
@@ -17,7 +20,7 @@ export default defineConfig(() => {
 
   config.build = {
     ...config.build,
-    outDir: "../../Build/Sandcastle2",
+    outDir: join(__dirname, "../../Build/Sandcastle2"),
   };
 
   config.define = {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Annoyingly it sees that running an `npm` command on a workspace doesn't change the working directory. On top of that `vite` doesn't guarantee paths like the `outDir` are relative to the config file itself. Together these points mean that running `npm run build-sandcastle` can try and create files outside the repo directory which is a big no-no.

This PR updates the output paths for all vite configs that needed it to always be relative to the config file itself. This should mean they're always put where we expect them to be in the repo itself.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12867

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm run build-sandcastle` and make sure files show up in `Apps/Sandcastle2` and _not_ outside the project directory

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
