### PR TITLE
Sandcastle gallery build path fix

### DIFF
--- a/packages/sandcastle/sandcastle.config.js
+++ b/packages/sandcastle/sandcastle.config.js
@@ -3,7 +3,7 @@ const config = {
   sourceUrl: "https://github.com/CesiumGS/cesium/blob/main/packages/sandcastle",
   publicDir: "./public",
   gallery: {
-    files: ["gallery/**/*"],
+    files: ["gallery"],
     searchOptions: {
       excerptLength: 10,
       ranking: {

--- a/packages/sandcastle/scripts/buildGallery.js
+++ b/packages/sandcastle/scripts/buildGallery.js
@@ -15,7 +15,7 @@ import createGalleryRecord from "./createGalleryRecord.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultRootDirectory = join(__dirname, "..");
 const defaultPublicDirectory = "./public";
-const defaultGalleryFiles = ["gallery/**/*"];
+const defaultGalleryFiles = ["gallery"];
 const defaultThumbnailPath = "images/placeholder-thumbnail.jpg";
 const requiredMetadataKeys = ["title", "description"];
 const galleryItemConfig = /sandcastle\.(yml|yaml)/;
@@ -118,7 +118,7 @@ export async function buildGalleryList(options = {}) {
   };
 
   const galleryFiles = await globby(
-    galleryFilesPattern.map((pattern) => join(rootDirectory, pattern)),
+    galleryFilesPattern.map((pattern) => join(rootDirectory, pattern, "**/*")),
   );
   const yamlFiles = galleryFiles.filter((path) =>
     basename(path).match(galleryItemConfig),
@@ -261,7 +261,7 @@ export async function buildGalleryList(options = {}) {
   // regardless of if titles match the directory names
   output.entries.sort((a, b) => a.title.localeCompare(b.title));
 
-  const outputDirectory = join(publicDirectory, "gallery");
+  const outputDirectory = join(rootDirectory, publicDirectory, "gallery");
   await rimraf(outputDirectory);
   await mkdir(outputDirectory, { recursive: true });
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Cleans up some rough edges that I overlooked in https://github.com/CesiumGS/cesium/pull/12854.

- Fixes build paths so that output is put in the right place for both root cesium development as well as sandcastle development.
- Fixes the `gallery` file watcher and rebuild which is part of `npm start`.
- Does a bit of cleanup to `build.js` while I was in there: I noticed that it was running some async functions as a side effect. That means they were running even when importing a totally unrelated function.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12867

## Testing plan

1. From a clean repository state, run `npm install` and `npm run build`. The gallery files should be built to `Apps/Sandcastle2`, not a parent directory as in the original bug report.
2. Run `npm start`. Update a gallery file in `packages/sandcastle/gallery` and be sure the updates are rebuilt and reflected in `http://localhost:8080/Apps/Sandcastle2/index.html`.
3. Change your working directory to `packages/sandcastle`. Ensure that running `npm run dev` build the gallery files to the `packages/sandcastle/public` directory, and that the app loads examples as expected.

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
