### PR TITLE
Preserves subpixel precision on glyph alignment

### DIFF
--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -1020,13 +1020,20 @@ function writeCompressedAttrib0(
     Math.floor(
       CesiumMath.clamp(pixelOffsetY, -UPPER_BOUND, UPPER_BOUND) + UPPER_BOUND,
     ) * LEFT_SHIFT8;
+
+  // We scale `translate` by LEFT_SHIFT2 before encoding it
+  // to preserve some subpixel precision (1 / 4 = 0.25 pixels). This mitigates rounding errors in aligning glyphs.
+  // The cost of increasing this scaling factor is that it decreases the range of representable `translate` values
+  // by the same scaling factor. Value must be kept in sync with the shader.
   let compressed2 =
     Math.floor(
-      CesiumMath.clamp(translateX, -UPPER_BOUND, UPPER_BOUND) + UPPER_BOUND,
+      CesiumMath.clamp(translateX * LEFT_SHIFT2, -UPPER_BOUND, UPPER_BOUND) +
+        UPPER_BOUND,
     ) * LEFT_SHIFT8;
 
   const tempTanslateY =
-    (CesiumMath.clamp(translateY, -UPPER_BOUND, UPPER_BOUND) + UPPER_BOUND) *
+    (CesiumMath.clamp(translateY * LEFT_SHIFT2, -UPPER_BOUND, UPPER_BOUND) +
+      UPPER_BOUND) *
     RIGHT_SHIFT8;
   const upperTranslateY = Math.floor(tempTanslateY);
   const lowerTranslateY = Math.floor(

--- a/packages/engine/Source/Shaders/BillboardCollectionVS.glsl
+++ b/packages/engine/Source/Shaders/BillboardCollectionVS.glsl
@@ -165,9 +165,11 @@ void main()
 
     temp = compressedAttribute0.z * SHIFT_RIGHT8;
     translate.x = floor(temp) - UPPER_BOUND;
+    translate.x *= SHIFT_RIGHT2; // undo translateX scaling (helps preserve subpixel precision, see BillboardCollection.js attribute writer for more info)
 
     translate.y += (temp - floor(temp)) * SHIFT_LEFT8;
     translate.y -= UPPER_BOUND;
+    translate.y *= SHIFT_RIGHT2;
 
     temp = compressedAttribute1.x * SHIFT_RIGHT8;
     float temp2 = floor(compressedAttribute2.w * SHIFT_RIGHT2);


### PR DESCRIPTION
# Description

Currently, labels with small fonts suffer from poor glyph alignment. (At least, it's most noticeable with small fonts). The source of the issue is how we quantize these alignment values and pack them into vertex attributes. In doing so, we lose subpixel precision on alignment. 

To solve the issue, I introduced a scaling factor that's applied before packing (and un-applied after unpacking) to preserve some subpixel precision, at the cost of reducing the range of representable translation values. More detail in the [comment here.](https://github.com/CesiumGS/cesium/issues/8474#issuecomment-3268642867)

## Issue number and link

#8474

## Testing plan

NOTE: this issue is much more apparent on high-DPI screens, and as such should be tested on one.

[Sandcastle linked from issue](https://dev-sandcastle.cesium.com/#c=vVRRT9swEP4rVl6SSsEhbSliTStEAfHAtEmd9pSXa3JtrV3syHYCBfHfsRMQjGlahzbuyb6777vv7iy3oFkr8AY1mzGJN2yBRjQV/975orDorgslLQiJOhxMc5nL1qEIVkgX0gq7c9Ceg6O/CzQcyjK6zyVzVivjfEqyT8/kC9DWnUCO+Fqr6hw3GtFEB8dHPJ2M08nkOGajE35yNPQ2iHuerqAjeaL1ZvHWOk/4dSsISqR6KyCMX+Jrp9vHx4f1LbtCatGKAsI+4SGXD307S5BlAcYSet3flKIV6LPGWiWjMB067KUjCmO2bmThW4kG96809UPg3Zl3JWesh72UnP4u3xRA6ADpdD85w/G75HSw98n5g6Butn8v6M1K/tl8lhUQsaVH/V9Bh3y0p6TPWLpX/zGaJnvv7UxsPkLS096COMiM3RHOPeBUVLXSljWaIs4Ti1VN4L6EZNUUP9DywhjfQ5Y8Q7JStEyUszx48yHlASsIjHGRdUO0FHeYB/Mscfk/wUhBKeTmS4uaYOdTtun8undyzrPEXX9F2X5krxgfAQ).

Before changes (current state) - 12px font:
<img width="178" height="72" alt="image" src="https://github.com/user-attachments/assets/28b61af5-8a50-4c55-ae14-8acd038a714f" />


After changes - also 12px font:
<img width="168" height="52" alt="image" src="https://github.com/user-attachments/assets/9a5d54e0-166c-49d1-a51f-d40dc9d731e7" />

Another note: the original issue complained about the vertical alignment, but the horizontal alignment was also suffering from quantization errors. It was just harder to notice. With the word `Philadelphia`, you may notice above that the `e` and `l` are pretty much overlapping horizontally, in the "before" image. Applying the same scaling treatment solves this issue too.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
