### PR TITLE
Use proper URLs for import statements

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -664,7 +664,7 @@ const externalResolvePlugin = {
 export async function getSandcastleConfig() {
   const configPath = "packages/sandcastle/sandcastle.config.js";
   const configImportPath = path.join(projectRoot, configPath);
-  const config = await import(pathToFileURL(configImportPath));
+  const config = await import(pathToFileURL(configImportPath).href);
   const options = config.default;
   return {
     ...options,
@@ -699,7 +699,7 @@ export async function buildSandcastleGallery(includeDevelopment) {
     "../packages/sandcastle/scripts/buildGallery.js",
   );
   const { buildGalleryList } = await import(
-    pathToFileURL(buildGalleryScriptPath)
+    pathToFileURL(buildGalleryScriptPath).href
   );
 
   await buildGalleryList({


### PR DESCRIPTION
This was intended to become a fix for https://github.com/CesiumGS/cesium/issues/12910 , but to avoid merge conflicts given the larger restructuring that seems to be in progress at https://github.com/CesiumGS/cesium/pull/12904, this is now a PR into that state.

This only changes two `import` calls to make sure that they don't receive a **path**, but an actual **url**. 

Ping @jjspace 
