### PR TITLE
Attempt to fix highlighting issue in monaco

### DIFF
--- a/packages/sandcastle/src/SandcastleEditor.tsx
+++ b/packages/sandcastle/src/SandcastleEditor.tsx
@@ -54,6 +54,15 @@ loader.config({ monaco });
 const TYPES_URL = `${__PAGE_BASE_URL__}Source/Cesium.d.ts`;
 const SANDCASTLE_TYPES_URL = `templates/Sandcastle.d.ts`;
 
+function fontLigaturesValue(fontLigaturesBool: boolean): boolean | string {
+  // Due to what seems like a bug in Monaco on some systems like Windows + Chrome
+  // the text highlighting and selection is offset from the actual values.
+  // This issue thread shows that setting the ligatures to an empty string resolves
+  // the issue. https://github.com/microsoft/monaco-editor/issues/3217#issuecomment-1511978166
+  // Testing has shown that `true` renders fine however.
+  return fontLigaturesBool ? fontLigaturesBool : "";
+}
+
 export type SandcastleEditorRef = {
   formatCode(): void;
 };
@@ -90,7 +99,7 @@ function SandcastleEditor({
   }, [fontFamily]);
   useEffect(() => {
     internalEditorRef.current?.updateOptions({
-      fontLigatures: fontLigatures,
+      fontLigatures: fontLigaturesValue(fontLigatures),
     });
   }, [fontLigatures]);
   useEffect(() => {
@@ -325,7 +334,7 @@ Sandcastle.addToolbarMenu(${variableName});`);
             fontFamily:
               availableFonts[fontFamily]?.cssValue ?? "Droid Sans Mono",
             fontSize: fontSize,
-            fontLigatures: fontLigatures,
+            fontLigatures: fontLigaturesValue(fontLigatures),
           }}
           path={activeTab === "js" ? "script.js" : "index.html"}
           language={activeTab === "js" ? "javascript" : "html"}

--- a/packages/sandcastle/src/SandcastleEditor.tsx
+++ b/packages/sandcastle/src/SandcastleEditor.tsx
@@ -196,6 +196,9 @@ function SandcastleEditor({
 
     setupSandcastleSnippets(monaco);
     setTypes(monaco);
+    // TODO: remove this!
+    // @ts-expect-error just testing
+    window.monaco = monaco;
   }
 
   async function setTypes(monaco: Monaco) {

--- a/packages/sandcastle/src/SandcastleEditor.tsx
+++ b/packages/sandcastle/src/SandcastleEditor.tsx
@@ -205,9 +205,6 @@ function SandcastleEditor({
 
     setupSandcastleSnippets(monaco);
     setTypes(monaco);
-    // TODO: remove this!
-    // @ts-expect-error just testing
-    window.monaco = monaco;
   }
 
   async function setTypes(monaco: Monaco) {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This is an attempt to fix the highlighting issue shown below from the feedback thread [comment](https://github.com/CesiumGS/cesium/issues/12857#issuecomment-3256443143)

![Image](https://github.com/user-attachments/assets/64a45146-7283-4e80-980b-1e63c9f1d502)

I can't reproduce this myself as it seems specific to Windows + Chrome. ~~Some investigation has pointed to potentially the ligature setting affecting this so this PR is to test that.~~ More investigation showed this was a problem with loading fonts after Monaco tried to measure them.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

part of https://github.com/CesiumGS/cesium/issues/12857

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm run dev` from the sandcastle package or `npm run build-sandcastle` and `npm start` from the project root
- Open the editor and do some text selection
- Click single tokens so the highlight shows up for them
- Confirm all highlights and cursors appear where you'd expect
- Test with multiple font and ligature enabled options in the settings

These steps reproduced the issue for me even on Linux:

- Set settings to a larger font size to make it more obvious
- Set font to Droid Sans, Ligatures OFF
- REFRESH
- Click Cesium in the editor to show the highlight in the background
- Switch to Cascadia Code font, observe offset (however small it is)

Same works for me from 
Cascadia -> Fira
Droid -> Cascadia
Jetbrains -> Cascadia

Toggling Ligatures on the selected font also usually fixed it _for me_

Example on Linux:
<img width="250" height="358" alt="2025-09-25_12-37" src="https://github.com/user-attachments/assets/e80b9071-2be6-458d-9759-2983ad6d9a55" />

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
