### PR TITLE
Gsplat fixedframe transform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Improved performance and reduced memory usage of `Event` class. [#12896](https://github.com/CesiumGS/cesium/pull/12896)
 - Fixes vertical misalignment of glyphs in labels with small fonts [#8474](https://github.com/CesiumGS/cesium/issues/8474)
 - Prevent runtime errors for certain forms of invalid PNTS files [#12872](https://github.com/CesiumGS/cesium/issues/12872)
+- Fixes precision issues with Gaussian splat tilesets where tiles have a world transform and the tileset does not [#12925](https://github.com/CesiumGS/cesium/issues/12925)
 
 #### Additions :tada:
 

--- a/packages/engine/Source/Scene/GaussianSplatPrimitive.js
+++ b/packages/engine/Source/Scene/GaussianSplatPrimitive.js
@@ -32,6 +32,7 @@ import Quaternion from "../Core/Quaternion.js";
 import SplitDirection from "./SplitDirection.js";
 import destroyObject from "../Core/destroyObject.js";
 import ContextLimits from "../Renderer/ContextLimits.js";
+import Transforms from "../Core/Transforms.js";
 
 const scratchMatrix4A = new Matrix4();
 const scratchMatrix4B = new Matrix4();
@@ -427,6 +428,13 @@ GaussianSplatPrimitive.transformTile = function (tile) {
   const gltfPrimitive = tile.content.gltfPrimitive;
   const gaussianSplatPrimitive = tile.tileset.gaussianSplatPrimitive;
 
+  if (gaussianSplatPrimitive._rootTransform === undefined) {
+    gaussianSplatPrimitive._rootTransform = Transforms.eastNorthUpToFixedFrame(
+      tile.tileset.boundingSphere.center,
+    );
+  }
+  const rootTransform = gaussianSplatPrimitive._rootTransform;
+
   const computedModelMatrix = Matrix4.multiplyTransformation(
     computedTransform,
     gaussianSplatPrimitive._axisCorrectionMatrix,
@@ -441,7 +449,7 @@ GaussianSplatPrimitive.transformTile = function (tile) {
 
   const toGlobal = Matrix4.multiply(
     tile.tileset.modelMatrix,
-    Matrix4.fromArray(tile.tileset.root.transform),
+    Matrix4.fromArray(rootTransform),
     scratchMatrix4B,
   );
   const toLocal = Matrix4.inverse(toGlobal, scratchMatrix4C);
@@ -765,7 +773,7 @@ GaussianSplatPrimitive.buildGSplatDrawCommand = function (
 
   const modelMatrix = Matrix4.multiply(
     tileset.modelMatrix,
-    Matrix4.fromArray(tileset.root.transform),
+    Matrix4.fromArray(primitive._rootTransform),
     scratchMatrix4B,
   );
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Fixes issue with tilesets that have an identity root transform and child tiles with their own world transform. This uses the tileset bounding sphere center point transformed using `Transforms.eastNorthUpToFixedFrame`.

Previously, because of the identity, it led to tiles transforming themselves into world space prematurely leading to low quality output due to precision loss.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

#12925 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
