### PR TITLE
Fix removePragmas command line argument and honour removePragmas in the bundleWorker flow

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -431,3 +431,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Easy Mahaffey](https://github.com/easymaahffey)
 - [Pamela Augustine](https://github.com/pamelaAugustine)
 - [宋时旺](https://github.com/BlockCnFuture)
+- [Marco Zhan](https://github.com/marcoYxz)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,7 +123,7 @@ function handleBuildWarnings(result) {
 export async function build() {
   // Configure build options from command line arguments.
   const minify = argv.minify ?? false;
-  const removePragmas = argv.pragmas ?? false;
+  const removePragmas = argv.removePragmas ?? false;
   const sourcemap = argv.sourcemap ?? true;
   const node = argv.node ?? true;
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -387,6 +387,9 @@ export async function bundleWorkers(options) {
     workerConfig.logOverride = {
       "empty-import-meta": "silent",
     };
+    workerConfig.plugins = options.removePragmas
+      ? [stripPragmaPlugin]
+      : undefined;
   } else {
     workerConfig.format = "esm";
     workerConfig.splitting = true;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

According to Documentation/Contributors/BuildGuide/README.md, the arg to remove pragmas should be --removePragmas, e.g. `npm run build -- --removePragmas`. However, in gulpfile's build function, it is taking argsv.pragmas instead.

Also, the `removePragmas` options is missed when building the inlineWorkers.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
