### PR TITLE
remove label filter on first search

### DIFF
--- a/packages/sandcastle/src/Gallery/GalleryItemStore.ts
+++ b/packages/sandcastle/src/Gallery/GalleryItemStore.ts
@@ -194,6 +194,21 @@ export function useGalleryItemStore() {
     return isGalleryLoaded ? () => loadFromUrl(items, legacyIds) : null;
   }, [items, legacyIds]);
 
+  const [isFirstSearch, setFirstSearch] = useState(true);
+  const setSearchTermWrapper = useCallback(
+    (newSearchTerm: string | null) => {
+      // the default label filter for Showcases can be confusing when it doesn't
+      // search everything after page load. Remove the filter on the first search only
+      // to ensure we search everything
+      if (isFirstSearch) {
+        setSearchFilter(null);
+        setFirstSearch(false);
+      }
+      setSearchTerm(newSearchTerm);
+    },
+    [setSearchTerm, isFirstSearch, setSearchFilter],
+  );
+
   return {
     items,
     galleryLoaded,
@@ -203,7 +218,7 @@ export function useGalleryItemStore() {
     searchFilter,
     searchTerm,
     isSearchPending,
-    setSearchTerm,
+    setSearchTerm: setSearchTermWrapper,
     setSearchFilter,
     searchResults: memoizedSearchResults,
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

On initial page load the gallery is filtered to the Showcases label. When searching the gallery it's restricted to the currently selected label. This can cause confusion for why there are so "few" search results because it's limited to showcases.

On the first search this PR removes the label filter to enable searching the whole gallery. After the first search I'm assuming users specifically picked a label they want to filter by and it should not be removed.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm run dev` from the sandcastle package or `npm run build-sandcastle` and `npm start` from the project root
- Load sandcastle and perform a search in the gallery
- Make sure it shows more than the showcases
- Add a label filter back and continue searching
- make sure the filter is not reset again

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
