### PR TITLE
Fix Sandcastle urls with `code` search param

### DIFF
--- a/packages/sandcastle/src/Gallery/loadFromUrl.ts
+++ b/packages/sandcastle/src/Gallery/loadFromUrl.ts
@@ -43,6 +43,20 @@ export function loadFromUrl(
 ) {
   const searchParams = new URLSearchParams(window.location.search);
 
+  const codeParam = searchParams.get("code");
+  if (codeParam) {
+    // This is a legacy support type url that was used by ion.
+    // Ideally we use the #c= param as that results in shorter urls
+    // The code query parameter is a Base64 encoded JSON string with `code` and `html` properties.
+    const json = JSON.parse(window.atob(codeParam.replaceAll(" ", "+")));
+
+    return {
+      title: "New Sandcastle",
+      code: json.code,
+      html: json.html,
+    };
+  }
+
   if (window.location.hash.indexOf("#c=") === 0) {
     const base64String = window.location.hash.substr(3);
     const { code, html } = decodeBase64Data(base64String);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The code examples that open from ion use a `code` parameter to encode the sandcastle code instead of the `#c=` like our share urls. I missed accounting for this previously so they're all broken now that sandcastle is fully live.

This PR updates the loading logic for these urls. I think we may want to update the urls directly in ion still but there's a chance people have them saved so we should leave the logic in sandcastle as well.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes #12946 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- log into ion and click on any asset in the list
- Copy the link for the "Open complete code example" link on the right to open sandcastle
    - Most browsers should let you right click it and pick "Copy link address" or similar. Clicking it will redirect you so the url disappears
- Replace the `sandcastle.cesium.com` with the local url for sandcastle if running locally or `https://ci-builds.cesium.com/cesium/fix-sandcastle-code-url/Apps/Sandcastle2/index.html` to load it in CI for this branch
- Ensure the code and viewer loads showing the asset you picked

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
