### PR TITLE
Fix editor fonts in firefox

### DIFF
--- a/packages/sandcastle/src/SandcastleEditor.tsx
+++ b/packages/sandcastle/src/SandcastleEditor.tsx
@@ -86,7 +86,7 @@ function SandcastleEditor({
   const documentRef = useRef(document);
   useEffect(() => {
     const cssName = availableFonts[fontFamily]?.cssValue ?? "Droid Sans Mono";
-    const fontFace = [...documentRef.current.fonts.values()].find(
+    const fontFace = [...documentRef.current.fonts].find(
       (font) => font.family === cssName && font.weight === "400",
     );
     if (fontFace?.status !== "loaded") {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Firefox apparently has an annoying bug where `document.fonts.values()` is not iterable even though it should be which was causing page load to fail.

- https://bugzilla.mozilla.org/show_bug.cgi?id=1780657
- https://bugzilla.mozilla.org/show_bug.cgi?id=1311198

This PR switches to iterate directly on `document.fonts` which I have tested works in chromium browsers _and_ firefox.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes #12953

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run `npm run dev` from the sandcastle package or `npm run build-sandcastle` and `npm start` from the project root
- Load sandcastle and open the editor
- Make sure things load and it's not a white screen
- Try changing the font in settings and make sure it works
- Refresh the page and make sure the new font is shown to confirm switching works after page load

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
