### PR TITLE
Fixes event bug with changes to listeners during callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.135 - 2025-11-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixes an event bug following recent changes, where adding a new listener during an event callback caused an infinite loop. [#12955](https://github.com/CesiumGS/cesium/pull/12955)
+
 ## 1.134 - 2025-10-01
 
 - [Sandcastle](https://sandcastle.cesium.com/) has been updated at `https://sandcastle.cesium.com`! The [legacy Sandcastle app](https://cesium.com/downloads/cesiumjs/releases/1.134/Apps/Sandcastle/index.html) will remain available through November 3, 2025.

--- a/packages/engine/Specs/Core/EventSpec.js
+++ b/packages/engine/Specs/Core/EventSpec.js
@@ -91,6 +91,37 @@ describe("Core/Event", function () {
     expect(event.numberOfListeners).toEqual(5);
   });
 
+  it("can add a listener from within a callback", function () {
+    const doNothing = function (evt) {};
+
+    const addEventCb = function (evt) {
+      event.addEventListener(doNothing);
+    };
+
+    event.addEventListener(addEventCb);
+    event.raiseEvent();
+    expect(event.numberOfListeners).toEqual(2);
+
+    event.removeEventListener(doNothing);
+    event.removeEventListener(addEventCb);
+    expect(event.numberOfListeners).toEqual(0);
+  });
+
+  it("can add multiple listeners within a callback", function () {
+    const addEvent0 = function () {
+      event.addEventListener(function () {});
+    };
+    const addEvent1 = function () {
+      event.addEventListener(function () {});
+    };
+
+    event.addEventListener(addEvent0);
+    event.addEventListener(addEvent1);
+    expect(event.numberOfListeners).toEqual(2);
+    event.raiseEvent();
+    expect(event.numberOfListeners).toEqual(4);
+  });
+
   it("addEventListener and removeEventListener works with same function of different scopes", function () {
     const Scope = function () {
       this.timesCalled = 0;


### PR DESCRIPTION
# Description

Originally discovered in https://github.com/CesiumGS/cesium-analytics/issues/1077, but since that's a private repo, here's the gist from my comment on that issue:

>  The issue here occurs when a caller adds a new event listener from inside an event callback. In #12896, Event switched from an array to a map - the iteration over the map uses an iterator, rather than a length-based loop. This means we're now modifying a collection that we're iterating over - that's a no no.

This can lead to an infinite loop if an event callback removes and re-adds a listener to that event (that new listener gets iterated over immediately and adds and removes a listener, which gets iterated over immediately... and so on).

The solution is to defer addition of new listeners until after the event has fired - like how we defer removal of listeners. It wasn't previously necessary to defer additions, when we were using an array. Now it is.

I also took the liberty of refactoring the `toRemove` array into a map, which is both consistent with the rest of the class now (and simplifies the code), and also reduces memory (no need to store duplicate listeners for unique scopes).

## Issue number and link

Fixes the above issue in the cesium analytics repo.

Testing:
- Run `Event` unit tests
- Run `ClippingPlanesEditor` unit tests in cesium-analytics
- Confirm you can switch from "3D Tiles" to "Model" in the [ClippingPlanesEditor sandcastle.](http://localhost:8080/Apps/Sandcastle/index.html?src=Clipping%20Planes%20Editor.html). (Prior to this fix, it would hang or crash).
- Try your favorite sandcastle that uses events (I just searched for "event" in the gallery).

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
