### PR TITLE
Add billboard subregion condition

### DIFF
--- a/packages/engine/Source/DataSources/BillboardVisualizer.js
+++ b/packages/engine/Source/DataSources/BillboardVisualizer.js
@@ -232,8 +232,12 @@ BillboardVisualizer.prototype.update = function (time) {
       time,
       boundingRectangleScratch,
     );
-    if (defined(subRegion)) {
+    if (
+      defined(subRegion) &&
+      !BoundingRectangle.equals(subRegion, item.subRegion)
+    ) {
       billboard.setImageSubRegion(billboard.image, subRegion);
+      item.subRegion = BoundingRectangle.clone(subRegion, item.subRegion);
     }
   }
   return true;

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -189,8 +189,6 @@ function Billboard(options, billboardCollection) {
   this._batchIndex = undefined; // Used only by Vector3DTilePoints and BillboardCollection
 
   this._imageTexture = new BillboardTexture(billboardCollection);
-  this._imageWidth = undefined;
-  this._imageHeight = undefined;
 
   this._labelDimensions = undefined;
   this._labelHorizontalOrigin = undefined;


### PR DESCRIPTION
# Description

As per #12585, image subregions currently do not work since 1.127. The cause was a conditionless `addImageSubregion` call on the `BillboardVisualizer` every frame prior to rendering, which resulted in a large promise queue but also made sure that `image.state` was `LOADING` for every render.

This PR adds a comparison against the previous loading subRegion, which skips adding a new subregion if not needed, letting the first call resolve properly and set the state to `LOADED`.

## Issue number and link

#12585

## Testing plan

Sandboxes from #12585

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
