### PR TITLE
Matrix performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fix JSDoc for SkyBox.show to correctly declare it as a prototype property for TypeScript compatibility. [#13357](https://github.com/CesiumGS/cesium/pull/13357)
 - Fixed lighting affecting `EquirectangularPanorama`. [#13369](https://github.com/CesiumGS/cesium/pull/13369)
+- Speed up `MatrixN` operations, improving performance when picking terrain and 3D tiles. [#12973](https://github.com/CesiumGS/cesium/pull/12973)
 
 ## 1.140 - 2026-04-01
 

--- a/packages/engine/Source/Core/Matrix2.js
+++ b/packages/engine/Source/Core/Matrix2.js
@@ -1037,7 +1037,7 @@ Matrix2.fromArray = Matrix2.unpack;
  * @type {Matrix2}
  * @constant
  */
-Matrix2.IDENTITY = Object.freeze(new Matrix2(1.0, 0.0, 0.0, 1.0));
+Matrix2.IDENTITY = new Matrix2(1.0, 0.0, 0.0, 1.0);
 
 /**
  * An immutable Matrix2 instance initialized to the zero matrix.
@@ -1045,7 +1045,7 @@ Matrix2.IDENTITY = Object.freeze(new Matrix2(1.0, 0.0, 0.0, 1.0));
  * @type {Matrix2}
  * @constant
  */
-Matrix2.ZERO = Object.freeze(new Matrix2(0.0, 0.0, 0.0, 0.0));
+Matrix2.ZERO = new Matrix2(0.0, 0.0, 0.0, 0.0);
 
 /**
  * The index into Matrix2 for column 0, row 0.

--- a/packages/engine/Source/Core/Matrix3.js
+++ b/packages/engine/Source/Core/Matrix3.js
@@ -35,8 +35,7 @@ import CesiumMath from "./Math.js";
  * @see Matrix2
  * @see Matrix4
  */
-// @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
-class Matrix3 {
+class Matrix3 extends Float64Array {
   /**
    * @param {number} [column0Row0=0.0] The value for column 0, row 0.
    * @param {number} [column1Row0=0.0] The value for column 1, row 0.
@@ -59,6 +58,7 @@ class Matrix3 {
     column1Row2,
     column2Row2,
   ) {
+    super(9);
     this[0] = column0Row0 ?? 0.0;
     this[1] = column0Row1 ?? 0.0;
     this[2] = column0Row2 ?? 0.0;
@@ -736,11 +736,8 @@ class Matrix3 {
 
     const startIndex = index * 3;
 
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const x = matrix[startIndex];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const y = matrix[startIndex + 1];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const z = matrix[startIndex + 2];
 
     result.x = x;
@@ -772,11 +769,8 @@ class Matrix3 {
     result = Matrix3.clone(matrix, result);
     const startIndex = index * 3;
 
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[startIndex] = cartesian.x;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[startIndex + 1] = cartesian.y;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[startIndex + 2] = cartesian.z;
 
     return result;
@@ -800,11 +794,8 @@ class Matrix3 {
     Check.typeOf.object("result", result);
     //>>includeEnd('debug');
 
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const x = matrix[index];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const y = matrix[index + 3];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const z = matrix[index + 6];
 
     result.x = x;
@@ -835,11 +826,8 @@ class Matrix3 {
 
     result = Matrix3.clone(matrix, result);
 
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[index] = cartesian.x;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[index + 3] = cartesian.y;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[index + 6] = cartesian.z;
 
     return result;
@@ -1698,9 +1686,7 @@ Matrix3.fromArray = Matrix3.unpack;
  * @type {Matrix3}
  * @constant
  */
-Matrix3.IDENTITY = Object.freeze(
-  new Matrix3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-);
+Matrix3.IDENTITY = new Matrix3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
 
 /**
  * An immutable Matrix3 instance initialized to the zero matrix.
@@ -1708,9 +1694,7 @@ Matrix3.IDENTITY = Object.freeze(
  * @type {Matrix3}
  * @constant
  */
-Matrix3.ZERO = Object.freeze(
-  new Matrix3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-);
+Matrix3.ZERO = new Matrix3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
 
 /**
  * The index into Matrix3 for column 0, row 0.
@@ -1802,7 +1786,6 @@ const scratchTransposeMatrix = new Matrix3();
 function computeFrobeniusNorm(matrix) {
   let norm = 0.0;
   for (let i = 0; i < 9; ++i) {
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const temp = matrix[i];
     norm += temp * temp;
   }
@@ -1823,7 +1806,6 @@ function offDiagonalFrobeniusNorm(matrix) {
 
   let norm = 0.0;
   for (let i = 0; i < 3; ++i) {
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const temp = matrix[Matrix3.getElementIndex(colVal[i], rowVal[i])];
     norm += 2.0 * temp * temp;
   }
@@ -1852,7 +1834,6 @@ function shurDecomposition(matrix, result) {
   // find pivot (rotAxis) based on max diagonal of matrix
   for (let i = 0; i < 3; ++i) {
     const temp = Math.abs(
-      // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
       matrix[Matrix3.getElementIndex(colVal[i], rowVal[i])],
     );
     if (temp > maxDiagonal) {
@@ -1867,13 +1848,9 @@ function shurDecomposition(matrix, result) {
   const p = rowVal[rotAxis];
   const q = colVal[rotAxis];
 
-  // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
   if (Math.abs(matrix[Matrix3.getElementIndex(q, p)]) > tolerance) {
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const qq = matrix[Matrix3.getElementIndex(q, q)];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const pp = matrix[Matrix3.getElementIndex(p, p)];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const qp = matrix[Matrix3.getElementIndex(q, p)];
 
     const tau = (qq - pp) / 2.0 / qp;
@@ -1891,13 +1868,10 @@ function shurDecomposition(matrix, result) {
 
   result = Matrix3.clone(Matrix3.IDENTITY, result);
 
-  // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
   result[Matrix3.getElementIndex(p, p)] = result[
     Matrix3.getElementIndex(q, q)
   ] = c;
-  // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
   result[Matrix3.getElementIndex(q, p)] = s;
-  // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
   result[Matrix3.getElementIndex(p, q)] = -s;
 
   return result;

--- a/packages/engine/Source/Core/Matrix4.js
+++ b/packages/engine/Source/Core/Matrix4.js
@@ -49,8 +49,7 @@ import RuntimeError from "./RuntimeError.js";
  * @see Matrix3
  * @see Packable
  */
-// @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
-class Matrix4 {
+class Matrix4 extends Float64Array {
   /**
    * @param {number} [column0Row0=0.0] The value for column 0, row 0.
    * @param {number} [column1Row0=0.0] The value for column 1, row 0.
@@ -87,6 +86,7 @@ class Matrix4 {
     column2Row3,
     column3Row3,
   ) {
+    super(16);
     this[0] = column0Row0 ?? 0.0;
     this[1] = column0Row1 ?? 0.0;
     this[2] = column0Row2 ?? 0.0;
@@ -1259,13 +1259,9 @@ class Matrix4 {
     //>>includeEnd('debug');
 
     const startIndex = index * 4;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const x = matrix[startIndex];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const y = matrix[startIndex + 1];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const z = matrix[startIndex + 2];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const w = matrix[startIndex + 3];
 
     result.x = x;
@@ -1314,13 +1310,9 @@ class Matrix4 {
 
     result = Matrix4.clone(matrix, result);
     const startIndex = index * 4;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[startIndex] = cartesian.x;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[startIndex + 1] = cartesian.y;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[startIndex + 2] = cartesian.z;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[startIndex + 3] = cartesian.w;
     return result;
   }
@@ -1362,13 +1354,9 @@ class Matrix4 {
     Check.typeOf.object("result", result);
     //>>includeEnd('debug');
 
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const x = matrix[index];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const y = matrix[index + 4];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const z = matrix[index + 8];
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     const w = matrix[index + 12];
 
     result.x = x;
@@ -1416,13 +1404,9 @@ class Matrix4 {
     //>>includeEnd('debug');
 
     result = Matrix4.clone(matrix, result);
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[index] = cartesian.x;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[index + 4] = cartesian.y;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[index + 8] = cartesian.z;
-    // @ts-expect-error TODO(tsd-jsdoc): Requires index signature support.
     result[index + 12] = cartesian.w;
     return result;
   }
@@ -3067,25 +3051,23 @@ Matrix4.fromArray = Matrix4.unpack;
  * @type {Matrix4}
  * @constant
  */
-Matrix4.IDENTITY = Object.freeze(
-  new Matrix4(
-    1.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    1.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    1.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    1.0,
-  ),
+Matrix4.IDENTITY = new Matrix4(
+  1.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  1.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  1.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  1.0,
 );
 
 /**
@@ -3094,25 +3076,23 @@ Matrix4.IDENTITY = Object.freeze(
  * @type {Matrix4}
  * @constant
  */
-Matrix4.ZERO = Object.freeze(
-  new Matrix4(
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-  ),
+Matrix4.ZERO = new Matrix4(
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
 );
 
 /**

--- a/packages/engine/Source/Core/Transforms.js
+++ b/packages/engine/Source/Core/Transforms.js
@@ -1138,25 +1138,23 @@ Transforms.rotationMatrixFromPositionVelocity = function (
  * @constant
  * @private
  */
-Transforms.SWIZZLE_3D_TO_2D_MATRIX = Object.freeze(
-  new Matrix4(
-    0.0,
-    0.0,
-    1.0,
-    0.0,
-    1.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    1.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    1.0,
-  ),
+Transforms.SWIZZLE_3D_TO_2D_MATRIX = new Matrix4(
+  0.0,
+  0.0,
+  1.0,
+  0.0,
+  1.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  1.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  1.0,
 );
 
 const scratchCartographic = new Cartographic();

--- a/packages/engine/Specs/Core/Matrix3Spec.js
+++ b/packages/engine/Specs/Core/Matrix3Spec.js
@@ -358,7 +358,7 @@ describe("Core/Matrix3", function () {
 
   it("fromRotationX works without a result parameter", function () {
     const matrix = Matrix3.fromRotationX(0.0);
-    expect(matrix).toEqual(Matrix3.IDENTITY);
+    expect(Matrix3.equals(matrix, Matrix3.IDENTITY)).toBe(true);
   });
 
   it("fromRotationX works with a result parameter", function () {
@@ -371,7 +371,7 @@ describe("Core/Matrix3", function () {
 
   it("fromRotationY works without a result parameter", function () {
     const matrix = Matrix3.fromRotationY(0.0);
-    expect(matrix).toEqual(Matrix3.IDENTITY);
+    expect(Matrix3.equals(matrix, Matrix3.IDENTITY)).toBe(true);
   });
 
   it("fromRotationY works with a result parameter", function () {
@@ -384,7 +384,7 @@ describe("Core/Matrix3", function () {
 
   it("fromRotationZ works without a result parameter", function () {
     const matrix = Matrix3.fromRotationZ(0.0);
-    expect(matrix).toEqual(Matrix3.IDENTITY);
+    expect(Matrix3.equals(matrix, Matrix3.IDENTITY)).toBe(true);
   });
 
   it("fromRotationZ works with a result parameter", function () {

--- a/packages/engine/Specs/Core/Matrix4Spec.js
+++ b/packages/engine/Specs/Core/Matrix4Spec.js
@@ -727,7 +727,7 @@ describe("Core/Matrix4", function () {
       direction: Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()),
       up: Cartesian3.UNIT_Y,
     });
-    expect(expected).toEqual(returnedResult);
+    expect(Matrix4.equals(expected, returnedResult)).toBe(true);
   });
 
   it("fromCamera works with a result parameter", function () {
@@ -742,7 +742,7 @@ describe("Core/Matrix4", function () {
       result,
     );
     expect(returnedResult).toBe(result);
-    expect(returnedResult).toEqual(expected);
+    expect(Matrix4.equals(expected, returnedResult)).toBe(true);
   });
 
   it("computeOrthographicOffCenter works", function () {
@@ -1392,7 +1392,7 @@ describe("Core/Matrix4", function () {
 
   it("setRotation works", function () {
     const scaleVec = new Cartesian3(2.0, 3.0, 4.0);
-    const scale = Matrix4.fromScale(scaleVec, new Matrix3());
+    const scale = Matrix4.fromScale(scaleVec, new Matrix4());
     const rotation = Matrix3.fromRotationX(0.5, new Matrix3());
     const scaleRotation = Matrix4.setRotation(scale, rotation, new Matrix4());
 

--- a/packages/engine/Specs/Scene/CameraSpec.js
+++ b/packages/engine/Specs/Scene/CameraSpec.js
@@ -130,7 +130,7 @@ describe("Scene/Camera", function () {
       1.0,
     );
     const expected = Matrix4.multiply(rotation, translation, new Matrix4());
-    expect(viewMatrix).toEqual(expected);
+    expect(Matrix4.equals(viewMatrix, expected)).toBe(true);
   });
 
   it("get inverse view matrix", function () {

--- a/packages/engine/Specs/Scene/GltfLoaderUtilSpec.js
+++ b/packages/engine/Specs/Scene/GltfLoaderUtilSpec.js
@@ -328,7 +328,9 @@ describe(
       });
 
       expect(modelTexture.texCoord).toBe(1);
-      expect(modelTexture.transform).toEqual(expectedTransform);
+      expect(Matrix3.equals(modelTexture.transform, expectedTransform)).toBe(
+        true,
+      );
     });
 
     it("createModelTextureReader handles KHR_texture_transform rotation correctly", function () {

--- a/packages/engine/Specs/Scene/PropertyTexturePropertySpec.js
+++ b/packages/engine/Specs/Scene/PropertyTexturePropertySpec.js
@@ -109,7 +109,9 @@ describe(
       const modelTextureReader = propertyTextureProperty.textureReader;
       expect(modelTextureReader.texture).toBe(texture);
       expect(modelTextureReader.texCoord).toBe(1);
-      expect(modelTextureReader.transform).toEqual(expectedTransform);
+      expect(
+        Matrix3.equals(modelTextureReader.transform, expectedTransform),
+      ).toBe(true);
       expect(modelTextureReader.channels).toBe("rgb");
     });
 


### PR DESCRIPTION
# Description

Convert `Matrix4` and `Matrix3` to be based on `Float64Array`. This provides a significant 2x speedup of Matrix multiplication and other methods, and saves memory. This results in a 4x improvement on Model.pick and propagates throughout other areas.

Matrices are at the heart of 3D graphics, and any performance improvement here radiates throughout the entire codebase.

I approached this primarily to speed up `pickModel`, where `getVertexPosition` is primarily limited by the performance of `Matrix4.multiplyByPoint`. 

By making Matrix4 a class extending `Float64Array`, we get a 2x speedup in that method (as well as various levels of speedups on other methods):

<img width="300" height="190" alt="Image" src="https://github.com/user-attachments/assets/2fc8dc24-4220-4dcd-bfae-ecb4f559dca5" />

I show the performance improvements of this combined with @javagl 's branch #12658 in #11814.

Importantly, changing the backing datastructure to `Float64Array` has 100% identical behavior and results as the previous implementation. As per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding, regular numbers in JS are also 64 bit floats. By using the `class .. extends` syntax, we continue having values accessed by doing `matrix[i]`, rather than forcing something like `matrix.buffer[i]`.
## Testing plan

Test suite + visual comparison between sandcastles.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
