### PR TITLE
Add ScreenSpaceCameraController.collisionHeightReference

### DIFF
--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3831,12 +3831,26 @@ function callAfterRenderFunctions(scene) {
   functions.length = 0;
 }
 
+/**
+ * Calculate the height of the globe at the camera position based on the value of {@link ScreenSpaceCameraController.collisionHeightReference},
+ * or undefined if the height cannot be determined.
+ *
+ * @param {Scene} scene
+ * @returns {number|undefined}
+ */
 function getGlobeHeight(scene) {
-  if (scene.mode === SceneMode.MORPHING) {
+  if (
+    scene.mode === SceneMode.MORPHING ||
+    scene._screenSpaceCameraController.collisionHeightReference ===
+      HeightReference.NONE
+  ) {
     return;
   }
   const cartographic = scene.camera.positionCartographic;
-  return scene.getHeight(cartographic);
+  return scene.getHeight(
+    cartographic,
+    scene._screenSpaceCameraController.collisionHeightReference,
+  );
 }
 
 function getMaxPrimitiveHeight(primitive, cartographic, scene) {

--- a/packages/engine/Source/Scene/ScreenSpaceCameraController.js
+++ b/packages/engine/Source/Scene/ScreenSpaceCameraController.js
@@ -24,6 +24,7 @@ import MapMode2D from "./MapMode2D.js";
 import SceneMode from "./SceneMode.js";
 import SceneTransforms from "./SceneTransforms.js";
 import TweenCollection from "./TweenCollection.js";
+import HeightReference from "./HeightReference.js";
 
 /**
  * Modifies the camera position and orientation based on mouse input to a canvas.
@@ -265,13 +266,13 @@ function ScreenSpaceCameraController(scene) {
     : ellipsoid.minimumRadius * 1.175;
   this._minimumTrackBallHeight = this.minimumTrackBallHeight;
   /**
-   * When disabled, the values of <code>maximumZoomDistance</code> and <code>minimumZoomDistance</code> are ignored.
-   * Also used in conjunction with {@link Cesium3DTileset#enableCollision} to prevent the camera from moving through or below a 3D Tileset surface.
-   * This may also affect clamping behavior when using {@link HeightReference.CLAMP_TO_GROUND} on 3D Tiles.
-   * @type {boolean}
-   * @default true
+   * This value controls the height reference for the {@link ScreenSpaceCameraController} collision, which is used to limit the camera minimum and maximum zoom.
+   * When set to {@link HeightReference.NONE}, the camera can go underground, and the values of <code>maximumZoomDistance</code> and <code>minimumZoomDistance</code> are ignored.
+   * For all other values, the camera is constrained to be above the terrain and/or 3D Tiles (depending on {@link Cesium3DTileset#enableCollision}).
+   * @type {HeightReference}
+   * @default HeightReference.CLAMP_TO_GROUND
    */
-  this.enableCollisionDetection = true;
+  this.collisionHeightReference = HeightReference.CLAMP_TO_GROUND;
   /**
    * The angle, relative to the ellipsoid normal, restricting the maximum amount that the user can tilt the camera. If <code>undefined</code>, the angle of the camera tilt is unrestricted.
    * @type {number|undefined}
@@ -352,6 +353,27 @@ function ScreenSpaceCameraController(scene) {
   this._minimumUndergroundPickDistance = 2000.0;
   this._maximumUndergroundPickDistance = 10000.0;
 }
+
+Object.defineProperties(ScreenSpaceCameraController.prototype, {
+  /**
+   * When disabled, the values of <code>maximumZoomDistance</code> and <code>minimumZoomDistance</code> are ignored.
+   * Also used in conjunction with {@link Cesium3DTileset#enableCollision} to prevent the camera from moving through or below a 3D Tileset surface.
+   * This may also affect clamping behavior when using {@link HeightReference.CLAMP_TO_GROUND} on 3D Tiles.
+   * @type {boolean}
+   * @default true
+   * @deprecated Use {@link ScreenSpaceCameraController#collisionHeightReference} instead.
+   */
+  enableCollisionDetection: {
+    get: function () {
+      return this.collisionHeightReference !== HeightReference.NONE;
+    },
+    set: function (value) {
+      this.collisionHeightReference = value
+        ? HeightReference.CLAMP_TO_GROUND
+        : HeightReference.NONE;
+    },
+  },
+});
 
 function decay(time, coefficient) {
   if (time < 0) {


### PR DESCRIPTION
# Description

When a 3D tileset is added to the map, height clamping of the camera to the scene takes about 25% of total frame time, mostly due to Model.pick. This PR proposes a new flag on the `ScreenSpaceCameraController`, that will allows users to continue clamping entities to the 3D tileset without also sampling the camera height off the 3D tileset every frame.

This is useful when 3D tiles are used in conjuction and closely map to a regular `TerrainProvider`, so entities can use `HeightReference.CLAMP_TO_GROUND` and clamp to both terrain and 3D tiles, while the camera can choose to clamp only to the terrain using `HeightReference.CLAMP_TO_TERRAIN`.

This is important, as unlike entities which in the future we can improve their clamping performance, every frame that the camera moves it must sample the 3D tiles as well. The current API is insufficient in providing users with a solution to this problem, as they are either forced to disable collision entirely (including against terrain) on the camera, or disable clamping to 3D tilesets entirely (including for entities). 

## Example

```js
import * as Cesium from "cesium";

const widget = new Cesium.CesiumWidget("cesiumContainer", {
  terrain: Cesium.Terrain.fromWorldTerrain(),
});
const scene = widget.scene;

scene.camera.setView({
  destination: new Cesium.Cartesian3(
    1216411.0748779264,
    -4736313.10747583,
    4081359.5125561724,
  ),
  orientation: new Cesium.HeadingPitchRoll(
    4.239925103568368,
    -0.4911293834802475,
    6.279849292088564,
  ),
  endTransform: Cesium.Matrix4.IDENTITY,
});

const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(40866);
tileset.enableCollision = true;
scene.primitives.add(tileset);

// This billboard will clamp to the 3D tileset
widget.entities.add({
  billboard: {
    image: "../images/facility.gif",
    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
  },
  position: new Cesium.Cartesian3(
    1216390.063324395,
    -4736314.814479433,
    4081341.9787972216,
  ),
});

const screenSpaceCameraController = widget.scene.screenSpaceCameraController;
// Previously, we could only disable collision detection entirely
screenSpaceCameraController.enableCollisionDetection = false;
// Now, we can pick and choose:
screenSpaceCameraController.collisionHeightReference = HeightReference.CLAMP_TO_TERRAIN; // The camera will only collide against terrain
```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
