### PR TITLE
Draft for sandcastle gallery pattern fix

### DIFF
--- a/packages/sandcastle/scripts/buildGallery.js
+++ b/packages/sandcastle/scripts/buildGallery.js
@@ -118,7 +118,7 @@ export async function buildGalleryList(options = {}) {
   };
 
   const galleryFilesGlobbyPatterns = galleryFilesPattern.map((pattern) => {
-    // The join function will return the pah in a form that is normalized
+    // The join function will return the path in a form that is normalized
     // for the OS, meaning that it contains backslashes "\" on Windows
     const baseGlobbyPattern = join(rootDirectory, pattern, "**/*");
 


### PR DESCRIPTION
This is a **draft**, not supposed to be merged (in its current form). It is just intended for showing how to resolve https://github.com/CesiumGS/cesium/issues/12951

@jjspace This was another `/`-vs`\`-issue. All the path handling on Windows has to use `\`, and getting that sorted out with the mix of paths and URLs is already tricky enough. But then, `globby` comes along and casually says that it only accepts `/` in its patterns, so ... at this point, all the paths that have previously been carefully treated as such, with `\`'s everywhere, have to undergo some `\`-to-`/`-replacement again.

The solution here is a draft, with debug logs and ... _comments_. The debug logs could be removed. 

The globby documentation talks about `posix.join` for joining paths, but I'm not sure what's the best solution here, so I just used `replace`, because I felt like...

`¯\_(ツ)_/¯` or
`¯/_(ツ)_/¯` or
`¯\_(ツ)_\¯` or
`¯/_(ツ)_\¯`

---

An aside:

The wrong globby pattern caused it to not find any gallery definitions, saying
```
Successfully built gallery list.
Processed 0 gallery examples.
```
during the build. When afterwards opening the sandcastle, it showed an error in the Browser console:
```
Uncaught (in promise) Error: Pagefind Error: No language indexes found.
    at PagefindInstance.findIndex (pagefind.js:2:355)
    at PagefindInstance.init (pagefind.js:1:20007)
    at async Pagefind.init (pagefind.js:6:7599)
```

**This is independent of the search pattern fix!**

The point is: It should not show this error at runtime, _even if_ no gallery files have been found.
(But I don't have the slightest clue what's the best place for handling this...)

