### PR TITLE
Prevent selecting console index in sandcastle

### DIFF
--- a/packages/sandcastle/src/ConsoleMirror.css
+++ b/packages/sandcastle/src/ConsoleMirror.css
@@ -29,10 +29,19 @@
       gap: var(--stratakit-space-x2);
       margin: var(--stratakit-space-x1);
       padding: var(--stratakit-space-x1) 0 var(--stratakit-space-x05);
+      font-family: var(--stratakit-font-family-mono);
     }
     .message + .message {
       border-top: var(--stratakit-ext-border-border) solid
         var(--stratakit-color-border-neutral-muted);
+    }
+    .no-icon {
+      /* "Filler" icon to take up the same space */
+      width: 1rem;
+      height: 1rem;
+    }
+    .message-index {
+      user-select: none;
     }
     .content {
       text-wrap: wrap;

--- a/packages/sandcastle/src/ConsoleMirror.tsx
+++ b/packages/sandcastle/src/ConsoleMirror.tsx
@@ -13,6 +13,16 @@ export type ConsoleMessage = {
   id: string;
 };
 
+function ConsoleIcon({ type }: { type: ConsoleMessageType }) {
+  if (type === "error") {
+    return <Icon href={statusError} />;
+  }
+  if (type === "warn") {
+    return <Icon href={statusWarning} />;
+  }
+  return <div className="no-icon"></div>;
+}
+
 export function ConsoleMirror({
   logs,
   expanded: consoleExpanded,
@@ -63,12 +73,6 @@ export function ConsoleMirror({
           </div>
         )}
         {logs.map((log, i) => {
-          let icon = "";
-          if (log.type === "warn") {
-            icon = statusWarning;
-          } else if (log.type === "error") {
-            icon = statusError;
-          }
           return (
             <div
               key={i}
@@ -77,10 +81,9 @@ export function ConsoleMirror({
                 error: log.type === "error",
               })}
             >
-              <Icon href={icon} />
-              <pre className="content">
-                {i + 1}: {log.message}
-              </pre>
+              <ConsoleIcon type={log.type} />
+              <span className="message-index">{i + 1}:</span>
+              <pre className="content">{log.message}</pre>
             </div>
           );
         })}


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The way the console mirror index was added before meant it was included in text when selecting and copying it. This is not really desired.

This PR separates the info into different elements and prevents `user-select` to make sure only the actual log values are selected.

<img width="200" height="297" alt="image" src="https://github.com/user-attachments/assets/bbc24d80-24bc-4efe-9f6b-7791f63779ce" />

I also adjusted the icon rendering slightly because I noticed we were re-rendering them way more than needed. There is definitely more to optimize here and overall but I didn't want to go too deep at the moment.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Reported in https://github.com/CesiumGS/cesium/issues/12857#issuecomment-3415988760

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run/build and run sandcastle
- Open sandcastle and log anything in the sandcastle.
- Select the output in the console tab and make sure it doesn't include the numbers
- Check that log, warn and error all work

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
