### PR TITLE
override the cesium viewer color-scheme

### DIFF
--- a/packages/sandcastle/gallery/mars/main.js
+++ b/packages/sandcastle/gallery/mars/main.js
@@ -379,10 +379,10 @@ function createPickedFeatureDescription(entity) {
               width="50%"\
               style="float:left; margin: 0 1em 1em 0;"\
               src=${entity.properties.imageURL}>\
-            <p style="color: black">${entity.properties.description}</p>\
-            <p style="color: black">\
+            <p>${entity.properties.description}</p>\
+            <p>\
               Source: \
-              <a style="color: black"\
+              <a style="color: white"\
                 target="_blank"\
                 href="${entity.properties.sourceURL}">${entity.properties.source}</a>\
             </p>`;

--- a/packages/sandcastle/public/styles/stratakit-mimic/adjustments.css
+++ b/packages/sandcastle/public/styles/stratakit-mimic/adjustments.css
@@ -57,6 +57,9 @@
     :after {
       all: revert-layer;
     }
+    /* Stratakit sets color-scheme to dark when setting up variables
+     * But this messes with iframes like the InfoBox */
+    color-scheme: light;
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<img width="450" height="383" alt="image" src="https://github.com/user-attachments/assets/6ff854bd-2d8b-4f4a-b88d-85242f1bdd13" />


Another instance of the stratakit styles affecting the global styles unexpectedly. Stratakit needs `data-color-scheme` set on the `body` to set up the correct variables. We want this to be dark for the darker buttons. This also sets `color-scheme: dark` for the whole page but our `InfoBox` element expects light for things like tables.

- override the `color-scheme` to be `light` for the viewer. Very similar to how we undo the `reset` css layer
- Undid some custom styling in the mars sandcastle that I think was there to account for this accidental change

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Load any sandcastle that displays info in the info box. For example, mars or the imodel mesh export for tables
- Click an entity/part of the model so it displays the infobox
- make sure it renders nicely how you'd expect from old sandcastle

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
