### PR TITLE
Don't refresh page gallery search

### DIFF
--- a/packages/sandcastle/src/Gallery/GalleryItemSearch.tsx
+++ b/packages/sandcastle/src/Gallery/GalleryItemSearch.tsx
@@ -3,7 +3,7 @@ import GalleryItemSearchInput from "./GalleryItemSearchInput.tsx";
 
 export function GalleryItemSearch() {
   return (
-    <form role="search">
+    <form role="search" onSubmit={(e) => e.preventDefault()}>
       <GalleryItemSearchInput />
       <GalleryItemSearchFilter />
     </form>


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

A consequence of how browsers treat `form` elements with inputs is that they can refresh the page with the inputs as query params. Sometimes useful, not so in this case.

- Disable the default behavior of submit on the gallery search input/form

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

no issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run sandcastle
- Open the gallery and type anything into the search input
- Press enter
- Make sure the page does not reload

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
