### PR TITLE
Remove banner pointing to legacy sandcastle

### DIFF
--- a/packages/sandcastle/src/App.css
+++ b/packages/sandcastle/src/App.css
@@ -4,20 +4,9 @@
   height: 100vh;
   --header-height: min-content;
   --app-bar-width: 53px;
-  grid-template-rows: min-content var(--header-height) auto;
+  grid-template-rows: var(--header-height) auto;
   grid-template-columns: var(--app-bar-width) auto;
-  grid-template-areas: "banner banner" "header header" "app-bar content";
-
-  .banner {
-    grid-area: banner;
-    background: var(--stratakit-color-bg-elevation-overlay);
-    padding: var(--stratakit-space-x2);
-    text-align: center;
-
-    a {
-      color: var(--stratakit-color-text-accent-base);
-    }
-  }
+  grid-template-areas: "header header" "app-bar content";
 
   --highlight-color-bg: var(--stratakit-color-bg-accent-muted);
   --highlight-color-bg-hover: color-mix(

--- a/packages/sandcastle/src/App.tsx
+++ b/packages/sandcastle/src/App.tsx
@@ -487,14 +487,6 @@ function App() {
       colorScheme={settings.theme}
       synchronizeColorScheme
     >
-      <div className="banner">
-        <Anchor
-          href="https://cesium.com/downloads/cesiumjs/releases/1.134/Apps/Sandcastle/index.html"
-          tone="accent"
-        >
-          Looking for the old Sandcastle? It's still here (for a little while) →
-        </Anchor>
-      </div>
       <header className="header">
         <a className="logo" href={getBaseUrl()}>
           <img


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

In this release we're removing the banner pointing to legacy sandcastle as the new version of sandcastle should be stable and is the one we want people to use.

The legacy version still exists in the repo and the downloaded zip file should someone really needed. As per discussion in #12904 this will likely change next release.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Open sandcastle locally or [in CI](https://ci-builds.cesium.com/cesium/remove-banner/Apps/Sandcastle2/index.html)
- Verify the banner is gone on the new sandcastle

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
