### PR TITLE
Fix gallery build for prod

### DIFF
--- a/scripts/buildSandcastle.js
+++ b/scripts/buildSandcastle.js
@@ -134,16 +134,25 @@ export async function buildSandcastleApp({
 
   await buildStatic(config);
   // Build the gallery after sandcastle to avoid clobbering the files
-  await buildSandcastleGallery({ includeDevelopment });
+  await buildSandcastleGallery({
+    includeDevelopment,
+    outputDir: outputToBuildDir
+      ? "../../Build/Sandcastle2"
+      : "../../Apps/Sandcastle2",
+  });
 }
 
 /**
  * Indexes Sandcastle gallery files and writes gallery files to the configured Sandcastle output directory.
  * @param {object} options
  * @param {boolean} options.includeDevelopment true if gallery items flagged as development should be included.
+ * @param {string} [options.outputDir] change the directory the gallery is built to. Defaults to /Apps/Sandcastle2
  * @returns {Promise<void>} A promise that resolves once the gallery files have been indexed and written.
  */
-export async function buildSandcastleGallery({ includeDevelopment }) {
+export async function buildSandcastleGallery({
+  includeDevelopment,
+  outputDir = "../../Apps/Sandcastle2",
+}) {
   const { configPath, root, gallery, sourceUrl } = await getSandcastleConfig();
 
   // Use an absolute path to avoid any descrepency between working directories
@@ -163,7 +172,7 @@ export async function buildSandcastleGallery({ includeDevelopment }) {
 
   await buildGalleryList({
     rootDirectory,
-    publicDirectory: "../../Apps/Sandcastle2",
+    publicDirectory: outputDir,
     galleryFiles,
     sourceUrl,
     defaultThumbnail,


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Small oversight in #12904 that the gallery was not getting built into the `Build/Sandcastle2` directory when in `PROD`. This is needed for the website deployments. Small edit to the build files to make sure it's included.

I tested this by deploying to `dev-sandcastle.cesium.com` from this branch and the gallery showed up again.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

No issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `git clean -dxf`
- run `npm run build` and `npm run build-ts`
- run `PROD=true npm run build-sandcastle`
- Verify that the `Build/Sandcastle2/gallery` directory exists and has all the gallery files.
- Extra points if you run `cd Build/Sandcastle2 && npx http-server` to test an isolated local server mimicking prod

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
