### PR TITLE
fix(billboards): Rasterize SVG content at billboard resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Billboards using `imageSubRegion` now render as expected. [#12585](https://github.com/CesiumGS/cesium/issues/12585)
+- Improved scaling of SVGs in billboards [#TODO](https://github.com/CesiumGS/cesium/issues/TODO)
 
 #### Additions :tada:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -105,6 +105,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Daniel Zhong](https://github.com/danielzhong)
   - [Mark Schlosser](https://github.com/markschlosseratbentley)
   - [Adam Larkeryd](https://github.com/alarkbentley)
+  - [Don McCurdy](https://github.com/donmccurdy)
 - [Flightradar24 AB](https://www.flightradar24.com)
   - [Aleksei Kalmykov](https://github.com/kalmykov)
 - [BIT Systems](http://www.caci.com/bit-systems)

--- a/packages/engine/Source/DataSources/BillboardGraphics.js
+++ b/packages/engine/Source/DataSources/BillboardGraphics.js
@@ -10,7 +10,7 @@ import createPropertyDescriptor from "./createPropertyDescriptor.js";
  * Initialization options for the BillboardGraphics constructor
  *
  * @property {Property | boolean} [show=true] A boolean Property specifying the visibility of the billboard.
- * @property {Property | string | HTMLCanvasElement} [image] A Property specifying the Image, URI, or Canvas to use for the billboard.
+ * @property {Property | string | HTMLImageElement | HTMLCanvasElement} [image] A Property specifying the Image, URI, or Canvas to use for the billboard.
  * @property {Property | number} [scale=1.0] A numeric Property specifying the scale to apply to the image size.
  * @property {Property | Cartesian2} [pixelOffset=Cartesian2.ZERO] A {@link Cartesian2} Property specifying the pixel offset.
  * @property {Property | Cartesian3} [eyeOffset=Cartesian3.ZERO] A {@link Cartesian3} Property specifying the eye offset.

--- a/packages/engine/Source/DataSources/BillboardVisualizer.js
+++ b/packages/engine/Source/DataSources/BillboardVisualizer.js
@@ -131,10 +131,6 @@ BillboardVisualizer.prototype.update = function (time) {
     }
 
     billboard.show = show;
-    if (item.textureValue !== textureValue) {
-      billboard.image = textureValue;
-      item.textureValue = textureValue;
-    }
     billboard.position = position;
     billboard.color = Property.getValueOrDefault(
       billboardGraphics._color,
@@ -226,6 +222,13 @@ BillboardVisualizer.prototype.update = function (time) {
       time,
       defaultSplitDirection,
     );
+
+    // Apply .image last, so any necessary property values are available
+    // in Billboard#_computeImageTextureSize before adding to the atlas.
+    if (item.textureValue !== textureValue) {
+      billboard.image = textureValue;
+      item.textureValue = textureValue;
+    }
 
     const subRegion = Property.getValueOrUndefined(
       billboardGraphics._imageSubRegion,

--- a/packages/engine/Source/Renderer/TextureAtlas.js
+++ b/packages/engine/Source/Renderer/TextureAtlas.js
@@ -648,9 +648,11 @@ async function resolveImage(image, id) {
  * @param {string} id An identifier to detect whether the image already exists in the atlas.
  * @param {HTMLImageElement|HTMLCanvasElement|string|Resource|Promise|TextureAtlas.CreateImageCallback} image An image or canvas to add to the texture atlas,
  *        or a URL to an Image, or a Promise for an image, or a function that creates an image.
+ * @param {number} width A number specifying the width of the texture. If undefined, the image width will be used.
+ * @param {number} height A number specifying the height of the texture. If undefined, the image height will be used.
  * @returns {Promise<number>} A Promise that resolves to the image region index, or -1 if resources are in the process of being destroyed.
  */
-TextureAtlas.prototype.addImage = function (id, image) {
+TextureAtlas.prototype.addImage = function (id, image, width, height) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("id", id);
   Check.defined("image", image);
@@ -671,17 +673,24 @@ TextureAtlas.prototype.addImage = function (id, image) {
   this._indexById.set(id, index);
 
   const resolveAndAddImage = async () => {
-    image = await resolveImage(image, id);
+    const resolvedImage = await resolveImage(image, id);
     //>>includeStart('debug', pragmas.debug);
-    Check.defined("image", image);
+    Check.defined("image", resolvedImage);
     //>>includeEnd('debug');
 
-    if (this.isDestroyed() || !defined(image)) {
+    if (this.isDestroyed() || !defined(resolvedImage)) {
       this._indexPromiseById.delete(id);
       return -1;
     }
 
-    const imageIndex = await this._addImage(index, image);
+    if (defined(width)) {
+      resolvedImage.width = width;
+    }
+    if (defined(height)) {
+      resolvedImage.height = height;
+    }
+
+    const imageIndex = await this._addImage(index, resolvedImage);
     this._indexPromiseById.delete(id);
     return imageIndex;
   };

--- a/packages/engine/Source/Scene/BillboardTexture.js
+++ b/packages/engine/Source/Scene/BillboardTexture.js
@@ -160,8 +160,15 @@ BillboardTexture.prototype.unload = async function () {
  * @param {string} id An identifier to detect whether the image already exists in the atlas.
  * @param {HTMLImageElement|HTMLCanvasElement|string|Resource|Promise|TextureAtlas.CreateImageCallback} image An image or canvas to add to the texture atlas,
  *        or a URL to an Image, or a Promise for an image, or a function that creates an image.
+ * @param {number} width A number specifying the width of the texture. If undefined, the image width will be used.
+ * @param {number} height A number specifying the height of the texture. If undefined, the image height will be used.
  */
-BillboardTexture.prototype.loadImage = async function (id, image) {
+BillboardTexture.prototype.loadImage = async function (
+  id,
+  image,
+  width,
+  height,
+) {
   if (this._id === id) {
     // This image has already been loaded
     return;
@@ -192,7 +199,7 @@ BillboardTexture.prototype.loadImage = async function (id, image) {
   let index;
   const atlas = this._billboardCollection.textureAtlas;
   try {
-    index = await atlas.addImage(id, image);
+    index = await atlas.addImage(id, image, width, height);
   } catch (error) {
     // There was an error loading the image
     billboardTexture._loadState = BillboardLoadState.ERROR;

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -347,6 +347,40 @@ describe("Scene/BillboardCollection", function () {
     expect(b.image.length).toBe(guidLength);
   });
 
+  it("image property setter computes SVG width and height", function () {
+    const b = billboards.add();
+
+    // Don't override image size if billboard size is unspecified.
+    b.image = "icon.svg";
+    expect(b.image).toBe("icon.svg");
+    expect(b._imageWidth).toBeUndefined();
+    expect(b._imageHeight).toBeUndefined();
+
+    // Don't override image size for raster images.
+    b.width = b.height = 50;
+    b.image = "icon.png";
+    expect(b._imageWidth).toBeUndefined();
+    expect(b._imageHeight).toBeUndefined();
+
+    // Override image size with billboard size for SVGs.
+    b.width = b.height = 50;
+    b.image = "icon.svg";
+    expect(b._imageWidth).toBe(50);
+    expect(b._imageHeight).toBe(50);
+
+    // Limit billboard-derived SVG size to 512px.
+    b.width = b.height = 10000;
+    b.image = "icon-lg.svg";
+    expect(b._imageWidth).toBe(512);
+    expect(b._imageHeight).toBe(512);
+
+    // Don't override image size if billboard is not sized in pixels.
+    b.sizeInMeters = true;
+    b.image = "icon.svg";
+    expect(b._imageWidth).toBeUndefined();
+    expect(b._imageHeight).toBeUndefined();
+  });
+
   it("is not destroyed", function () {
     expect(billboards.isDestroyed()).toEqual(false);
   });


### PR DESCRIPTION
# Description

This PR is a draft for discussion, proposing two related changes when rendering SVG content in billboards:

1. When billboard.image is a URL for an SVG, rasterize the SVG using billboard width/height if specified.
2. Extend JSDoc types to allowing billboard.image to be an HTMLImageElement (already supported, other than types)

These changes are intended to improve visual quality for SVG content in billboards. Because SVGs are scalable, the internal viewBox and width/height are not necessarily the size the user wants to display, and if the user has added a billboard at 50px x 50px size, the billboard will appear pixelated if the (somewhat arbitrary) internal size of the SVG is different. Either of these changes independently provides a workaround for the issue. With (1) the SVG is automatically rasterized at billboard resolution, and with (2) the user can construct the HTMLImageElement themselves, resize it, and pass that to the billboard constructor.

It's not obvious to me that these changes, especially (1), are the 'right' approach ... is it OK for the billboard size to determine the resolution of the SVG in the texture atlas? ~~What if billboard size were in meters?~~ (fixed) But it seemed like a good place to start discussion.

Test code:

```javascript
viewer.entities.add({
  position: Cartesian3.fromDegrees(-75.59777, 40.03883),
  billboard: { image: "icon.svg", width: 100, height: 100 },
});

viewer.entities.add({
  position: Cartesian3.fromDegrees(-50.59777, 40.03883),
  billboard: { image: "icon.svg" }
});
```

Before:
<img width="263" height="163" alt="before" src="https://github.com/user-attachments/assets/160c7729-b007-4c70-9877-ff385eb193f4" />

After:
<img width="303" height="171" alt="after" src="https://github.com/user-attachments/assets/3febb12f-0bd5-46c6-8e32-c1e482001b26" />


Remaining work and known issues:

- [x] Unit tests not yet added or updated
- [x] If the same SVG URL is provided for two billboards of different size, the first determines the texture atlas resolution and the second will use a cached texture.
  - See discussion below.
- [x] Changes to the billboard width/height probably will not change the resolution of the texture (untested).
  - See discussion below.

## Issue number and link

Related:

- #4235

This PR doesn't fully fix the issue, but improves quality when the billboard and SVG sizes don't match. More fixes (probably related to pixel alignment and anti-aliasing, as discussed in the issue) would be good followups in another PR.

## Testing plan

[Large billboard = high-resolution SVG texture](http://localhost:8080/Apps/Sandcastle2/index.html#c=1Vptb9y4Ef4r2wAGktariG8ilcsFvShxcIAOVyC9figM9Na7sr3IemVo13bcQ/57qZkhOdJq4xx6H9pDLnkecTgzHFHDIbnrm9u228/+PFvsZlWzW9/dzC679mZ2/mwJ7PzZd+fb8+2y3e72s/t189B0s+9n2+aBpLN/wLPnQb5qt/vFett0589esJ7rm8VV4zsuu2axbz7eX/3SbZ6jACrNmu1+vV83u2yxWj3/zTfsb9udf9JuXwVT1aLbe7TYqqz38V1z1TXN7vncmsyU1trTmc6zXDmnXpz2Ci7Wm81Fu+hWr2a/oQens4f1an/9aiby/HR23ayvrvdAZl98jy/o0OXddtnbHTk7807NZl2zv+u2s19Xi/3iFeh8ubu/+svnm83piapO1JlHJzK/b7qdV3Gi3p1IKbLc/+2fNj4aq/X2Ch//8vezucOG3X6xXS027bbBpm3bP1dnJ+q91+oNeBnwHJulvf2MHXEI9NSFp31I37af8bG3nff/S9v/RQZH/gl86n3f7vDZ9X5/e6J+OJFn/s/Dw0P2oLK2836ceW1e3Rk4xTr98Hmz3n56qrMoy9L/g7L9EPvx/Wk+93o+NH7WLPZtBz3zj5+a/fLaA5W5TPl/n8vS5fKFR730gYmL9rq58XMDI5wt25veyaDEWwBTfo5tfIzff+jau9s+Hv1Lk2fhsWerZrf0qIJ3v4K476+jPxnKkxCIX+4Q+SE1i+5Dt1it/VzuAyPiCzAYqkd6ojKT28KovIhNnyW9i5yJ07OyyHQplS7K2LReYdPQ6FzEmO727S1MrPZ2vmw3fVTfQVfl3qlCvUU17eXlrtkP3YTufex6DU/oeudEbuWhrjSKQ22ejEL1e8OXf1PU+LMj4ZL/v+GCSRim3hUb4t98SpqLkFa69lNMKT65sKdzlk9I/NLny7Fw/2ze3W1IS3PfbNvVKrrKLcM3xWLK29Z+GZhv1hfdonscG7vz2dUHZ/xuXkwq+vh4c9FudpNtb+8uLjbNZNOP23m9vpj/uGxj83LdLXvpKPPz/WIzV5Sql5Q9hf9W6ckjPdGZsnlZWIvPu6FgeDukPtCrb0Hc42bT3Pg47OZK+j9oat8ttrvLtrtBEaAbn6aeyyyH/05kBRkT2XQE68Vj0/1LHH+FT9gyA1vFga3bBeRL0viTzrSX9Jkrr1Xm/6lc1i9ElU/rQApw2AI2DGsUQqKgoQAsARvAAtX2FhzKe8nK9nbygB1gDbi3XEtww6IFCW5YsCDBmgULAQsUAgKPeycKMCDBiQIMeKUSiEV5BUSDlADcGxBgrAADlQClBroL8M9AbwGaDASjyqGHgSjlTChHCyiiQamAxyYaCFihkIke5TQGA9gC7jXVOblnsUcZRxdwCdhRLCqoGyhGgqKt4mgw2jRMfA0YJHxtGCN85z5gOk4GSe/WMuxQCEkZ30MZX1SJL0oBxBkiAOs4E0rQXuHUKWlagBaaLv0YRY6KNOJ+NBo0CYigJyqRWkMsSgyxJsXYR0dP2AeQ4D+H69LH68VtM86LPieewX88rcDXxb+zp1SEj/UrKsKnKvDFwdv2Lw5fKbxcnJMIe4BBYphDnC1IaoHzJfTAuQfqcoxiIhBzjKVnYBBen8gB9hEvSRm8yRLePJKS9NoR9kJow0GDPsAlCqlIEEtAvQ8SPeckYBQSEddlhDhNMRHkMH9xjucwxwnj7Md5nUPGq2Be5w59wBE4suagAa31jkKWqyBc8HVVMOVz+Ow8loALwCRkgGho0IANYAUYUgAkP0y7PRFAHHZHAqY90uxfTA0VfCk5pAyPJcMKhUAeHICMg59MDpnIY3AAUpQnFnsgcSClDnCJPTBfCuyRyBALwPCaiggrhL17CRkYDOLaUAKGYRpK2QakipiZA7bYQ4fUbGgdkCAjYzo2tCag0piMNaVZy7DD1JKIZrlYU8IuUciyhrBgJUQClpJSEdN1wCZlMZg4ecAuZjEbTClacQlBjDVld4kiMq7cmEFxSQ/YhCyLiV7HzI55uMRUXcbUHjDmdhdxrSj/66OkSJUEpIx8iF1cDqJBvh6Qc3FhCKuBjCOO6wQtDTql+sRMYjjVkw4b7XBfAkmTAUeCi4wJMwfHami1UwxLnIEihhBn4ACnSYrBn8KOCznWYAGnd1gbWqALJEWq4wyr4wJGNxxNpNpQVebCZ4n1Q5qaBVUbOn3nOH8DljEz2JAMNM39gmqkMqYb+rICsazBxvxUhDRkWUMqmAr6/AwKJRIwZroy4tqmiszGos1SnipjMsaisLaUVgwSF7MSfoeUwwIWCScRzJFuAuEbCI8J4xojI644cZR1LcMFCumYzAPGtc6k7O8o48u4CAZsI65x1dRpAcX1ZgrVJS1VLq3gitZ/jnVazwIpkBRxCawC0dDFTmL8MGODiytrwFgCkNsHBD5xWqOpvFEIVVzSKUPQYk/1EZYBAit1rA8qqqqwchiTMhKs0KhBxLqDwVoIKikU1XwyskjkmNRUG8pQB5LXVCsaKqCEoEos1JM2ll9CUCVHpIwVWy0k1X44As6EpEKNiI41YhUVFtwweZGq2nrAfBWe/6QpUVGFngithY5WVI6fEHIjXGvKeS6tw4eqjjpCbjre6rgHllnl2HEPBj3cpNRRGwMC7hhKtAZzt4xFQxWIiWvRIY5COq4nQWigNhE0GuuLehpqOmEQYXmkZWaEvqIhwWgR16T6CKRRjZ5X4XlJRjkayVI8RVoJFdefTjQqTg4xX6jjEu9i5Jm7zKpLa6Fhy9wQTwg5JuQOhVJdamIBauioRaAjlpMiFKlc3I6UFCEKvMExF1L5HF3gAxgPpj5KKDhJXz1JiqMtB2SgUfPWQ1LEKqEu2E7heA9QXrANRj0iaRtScTLEx7sfIWTWpb0PJxgfqmUKtkMq2M6JaitD9RTHLtU+R22AB5ZqESp7UmEyhSeE5CSueY8BQaOx5qoTpE1yqMUOsRzKM0gjkbzGSyT0V6xcVGmLHhQPW44Qbom1DWEVQlGy2I3xdNfBOyl58FgfHSpcNU1waSAyxMcVJ0I+mFiv1pxUnFh2+mCpLi1QqJhsOKp2QMiDIhbD9YjYWBrXXxNLZKBRcQ8V84pjyVVI3kPGg6IhJrXTDdxczQl45uh8yGIdPyAqFupjcrxPIqRexROmuCsRbLsi2K5EJEu/r4dghDYitUu7DBd3H46dhlE3blOOHRgQGpDhwx0QfUiKdF6o6IzwENu00QoNxaRQ/WQP+7UeNIAybqDqEUkbpfprYomAxpLttdJOK+6zgrzCrZVgJJlLkKkUqSXBqWdjiDroFQi+h+Tk2PMnCFMuw5ZWp71byQ6ES7YT5Lie7F4m5QUXHZC0m6y/JpbIQKPhrSadxku2bZZspxx7lGnrOUnUt5OKkymsuZAeNZRsn1wfHRYMGnbu1EhYxx29THcUA6iYhBo+JijpfiRdIFSRoaIBOfCB+cf28PWAVdNmCYopeb7pz/lxwHErwQtNG//6v8CoS8RzgzqcaAxuk3gLHiKEk4ynWTVgzNTAasL/G3d16VcCo1s7SecgdHUm6YwEzxMFZQs8vRa4J5QiniLBTFd0QWGwTcdbVWHDLTSo1HTHLOIRtKTy06WTEMG++nmOIcbDjJwuhPn1mQxX5QbJaCRENTaWqTExSaLpZl3wOz+BJyI5nSbhPJvndG2DTXg1XaYyaZ7HXfScbiwV3U1LDItNxygyXE2aFEsBszl81DRggX7DBI4DHo2CqBhEQx7Eph7SP26GxklFn0h4FQKnFOQBLBFEidF1OL0oIeKnKmjPp7FNpesU9pMAoeNPBcJtvEzH6YatfpCtcPYIvHLBuIZaEiZE+inCge+Bamws2DSKTJJougIQ4XbWJbt0qUwnszkNM5x3pl0K/TTC0QfjcAaJOEgRTynY10mrJtoQeEklw2U8jlXg3VRw2wxYGkTBZlEcvTwITT2kf8As+tYfOtHvR9X7X78733453z47ffZ6t3/cNG/639j+dY0/Su5/GJZlL/fNzW3/y6Pdy4u75admny13u/6Xuq9fhi6vV+v72Xr1/cSPkGfLzWK38y2Xd5vNx/W/m/Nnb16/9PKDbpt20f9q9Of7ptssHnuRa/GmxodZlr1+6elhr33bbi4WHdP4Hw): Given a larger billboard (100px x 100px), the billboard texture should be scaled up so that the SVG appears crisp.

[Billboard size in meters = default texture size](http://localhost:8080/Apps/Sandcastle2/index.html#c=1Vptb9y4Ef4r2wAGkjariC8SqVwu6J0SBwEU3KHp9UNhoCfvyvYi65Whle34ivz3UjNDcqTVxjn0PrSBYz9DDmeGQ3I4JLW5vmm7fvHnRb1flM1+c3u9uOja68XZkxVQZ0++O9ud7Vbtbt8v7jbNfdMtvl/smnviTv4BZU89f9nu+nqza7qzJ89Yy811fdm4hquuqfvm493lL932KTKg0KTZ9Zt+0+yTer1++m9X0d+0e1fS7l56VWXd9Q7VO5UMNr5pLrum2T9dZmmSFcaY5wudJqmyVj17Pgg432y3523drV8uQOBZD2Y8R3y/WfdXLxfSpGnq+r9u7jar5ufN52b7t9qpJa6rZnN51T/Ktt/81rzffWj6ptu/XPTdLWr54n5/wW6e7S5ud6uhPxMnDLYtFl3T33a7xa/ruq9fgpkv9neXf/l8vX1+osoTderQiUzvnHwn4kS9OZFSJKn77Uob5+X1ZneJxb/8/XRpsWLf17t1vW13DVbt2qFcnZ6ot06qU+B4wA9YLc3NZ2yI3aZS60uHofqx/YzFTnc6/Jdm+EUKJ/YJLHW27/ZYdtX3NyfqhxN56n7u7++Te5W0nbPj1Elz4k7BKNboh8/bze7TY41FURTuD/IOXRz696fl0sl517jZWPdtBy3Tj5+afnXlgEpsotzfp7KwqXzm0MB9oOK8vWqu3ZxDDyer9now0gtxGkCVm7tb5+O377r29mbwxzBo8tQXO2rd7FcOlTD2a/B7fxXsSZCfmID9Yo/Idampu3ddvd64NTI4RoQByNBVD1Sikiw1eabSPFR9ljQWKWOnsiJPdCGVzotQtVlj1VjpUgSf7vv2BiZWe7NctdvBq2+gqbJvVK5+RDHtxcW+6cdmQvPBd4OER2S9sSI18lBW7MWhNEdMXPV73Zd+k9d42RF3yf9fd8Ek9FPvknXxZxeSlsKHla79FEKKCy6sdMniCbFfuDg8ZR7Klt3tlqQ0d82uXa+DqVwzrCnmU163cdvLcrs57+ruYars1kVX55zp2DybFfTx4fq83e5n6368PT/fNrNV73fLanO+fL9qQ/Vq060G7sDz0129XSoK1SuKnsKtVSp5oBKdKJMWuTFY3o0Z/eiQeE9efgviFjfb5tr5Yb9U0v2gqr6rd/uLtrtGFiC3Lkw9lUkK/05kCRETqXkPVvVD0/1LHB/CR3RlI135ga6bGuIlSfygE+04XeRKK5W4P6VNho2odGEdiBwMNoAzhjUyIaGgIgcsAWeABYodNFjkd5ylGfSkHlvAGvCguZJghkENEswwoEGCNgMaPBbIBAQUD0bkoECCETkocEIlEAb5FRAauATgQYEAZTkoKAUIzaC5APsyaC1AUgbOKFNokYGXUsaUogZk0SBUQHEWFHiskCkLFqXUhwywATxIqlIyz2CLIvTO4wKwJV+UkDeQjwR5W4XeoLepmzgM6CQcNvQRjrlzmA6TQdLYGoYtMiFRhHEowkAVOFAKIM4QAViHmVCA9BKnTkHTAqTQdBn6KFIUpBEPvdEgSYAHHaEiUWnwRYEu1iQY2+hgCVsAEf5zvC99vKpvmmlcdDHxFP7xsAKri6+zx0T4xfoVEX6pChw4GG03cDikMLg4JxEOAJ3EMIc4W5CoBM4X3wLnHohL0YuRAJ+jLx0FCmH4RApw8HhBwmAkCxh5JAqSaybYMaEOCxX6ABfIpAKBWAIabJBoOSc8RiYRcFUEiNMUA0EK8xfneApznDDOfpzXKUS8EuZ1atEG7IElbRYqUNtgKES5EtwFq6uEKZ/CsnNYAs4BE1MGhIYKDTgDrABDCIDgh2F3IAQQFpsjAaod0uwvhoYSVkoKIcNhybBCJuAHAyDi4JJJIRI5DAZAiHKEwRZIWOBSB7jAFhgvBbaIxBgLwDBMeYAlwsG8iDLoDOIqowAM3cwoZGfAlYfI7LHBFtqH5oz2AQk8MoTjjPYEFBqCsaYwaxi2GFoioVks1hSwC2QyrMJvWBERg6GglIdw7XEWoxhMnNRjG6KY8aoU7biEwMeaortEFhl2boyguKV7nPkoi4Feh8iOcbjAUF2E0O4xxnYbcKUo/uujRB4zCQgZ6RjbsB0EhXw/IOPCxuB3Axl6HPYJ2hp0DPWRyiKFUz3KMEEPt8UTcTJgT3CTyfzMwb5mtNsphiXOQBFciDNwhOMkRefPYcuZLKswgOMYVhlt0DkSeczjMpbHeYxmWJpIVUZZmfXLEvOHODVzyjZ0XOc4fz2WITIYHww0zf2ccqQihBtaWZ4wrMKE+JT7MGRYRUyYclp+GTJFwmOMdEXAlYkZmQlJm6E4VYRgjElhZSisZEjYEJVwHVIM81hEHFkwRtoZhCPgiwnjHiMDLjlhKeoahnNk0iGYe4x7XRajv6WIL8Mm6LEJuMJdU8cNFPebOVQVtFXZuIMr2v851nE/80SORB62wNITGpqYWYwLM1TYsLN6jCkAmX1AwBKnPZrSG4VQhS2dIgRt9pQfYRogMFPH/KCkrAozhylRBAIzNKoQIe9gsBKCUgpFOZ8MVCDklKgoN5Q+DySrKVfMKIESgjIxn0+akH4JQZkcEUXI2CohKffDHnBKSErUiNAhRyyDwJwrJitiVluNKJeFpx80BSrK0CNBe6GlHZXjR5jsBFeaYp6N+/ChqKOGkJmW11pugWFaObbcglELO8t1VMeIAHMyCrQZxm4ZkobSE1nYiw5xYNJhP/FMI7GRQKUhv6jmoaYbBuG3R9pmJugrEiIMGnFPqo5A6tWkvPTlBSnlaMJL/hRxJ1RcfrzRKDlxiPlGHbZ4GzzPzGVabdwLM7bNjfEMk2VM9pAp5qVZSEAzumoRaIjhRO6TVM5uJkJy7wVeYZkJMX0OJvAOTDtTHSXIOVFeNUvkR2sOiJFEzWsPiTxkCVXOTgrHW4DwnB0wqgkRjyElJ8b4ePMjBKm18ezDCfQP5TI5OyHl7OREuVVG+RTHNuY+R3WABYZyEUp7YmIyh2eY5CyueIsRgUpDzlVFSIdkn4sdYjnmZ5B6InmOFwnfXrF0UcUjuhc8rjlCcE2sbgxL74qC+W6K55uOxqTgzmNttM9w1TyBWwMRY3xccCTIhizkqxUnSk4YdvtgKC/NkSmfrTgqdkSQBXlIhqsJYUJqXH2NLRIjiYpbqJhVHEsuQvIWMlwUjTGJna/g6ipOgGWW7ocM5vEjQoVEfUocbxMJEq/CDVM4lQh2XBHsVCKipt/XQjCCDiKVjacMG04flt2GUTOuU04NGBHUoYx3d0ToQyKP94WK7ggPsYkHLV+RzzJVj7YwX2tBHSjCAaqaEPGgVH2NLRIgsWBnrXjSCucsz6/waCUYEdVFyESKWBPhXNkUogwaAsHPkJw4Vv4IwYRLf6TV8exWsAvhgp0EOa5mmxdReM5ZR0Q8TVZfY4vESGLGa7N4Gy/ZsVmyk3JoUcSj5yyhvp0oOTGHNWfSk4qCnZOro92CTsPJnSoJ63Cil/GNYgQV41DjYoKS3kfiA0IZKBQ0Ig5sYPaxM3w1osp5tQTFHD8/9Kf8OuC4Fm+FpoN/9V9glCXCvUHlbzRGr0m8Bi8R/E3G41Q5opiqkdaI/zfe6uJXApNXO0n3IPR0JumOBO8TBUULvL0WeCaUItwiwUxX9ECRYZ0Or6rC+FdoEKnpjVmEK2hJ6aeNNyGCrfplii7Gy4yUHoT585n0T+UZEpOeEKmxsoiVkZLEGl/WBX/zE3gjktJtEs6zZUrPNliFT9NFTJOWaThFL+nFUtHbtES3mHiNIv3TZBZ9KWA2+0VNHRZoN0zg0OFJL4gUI2/IA99UY/KPm6FhUtES8UMhcEpBHMAUQRToXYvTiwIiLlVBZz6NdSo+p7BPAoQOnwr413gZr9MztvtBtMLZI/DJBf3qc0mYEPFThAPbPamxMmfTKFCSWOMTgPCvszbqpUdluplNqZv+vjOeUujTCEsLxuIMEqGTItxSsNVJuybqEPhIJf1jPPZV4NuUNzsbUbETOZtFoffywDXVmPwDZtG3fuhE34+qt79+d7b7crZ78vzJq33/sG1eD9/Y/nWDHzsPH4YlyYu+ub4Zvjzavzi/XX1q+mS13w/f6r564Zu8Wm/uFpv19zMfNy9W23q/dzUXt9vtx81vzdmT169eOP5Rs21bD1+N/nTXdNv6YWC5Eq8rLEyS5NULRx626tt2e153TOJ/AA): If billboard enables sizeInMeters, we cannot use width/height as indicators of billboard texture size, and the default browser-detected size will be used instead.

[Multiple billboards, mixed sizes](http://localhost:8080/Apps/Sandcastle2/index.html#c=1Vptb9y4Ef4r2wAGkjariG8ilcsFvShxcIAOVyC9figM9Na7sr3IemVo13bcQ/57qZkhOdJq4wTNh/aQS56HHM4MXzQckru+vmm7/ezPs8VuVjW79e317KJrr2dnT5bAzp78cLY92y7b7W4/u1s39003+3G2be5JOvsHlD0N8lW73S/W26Y7e/KMtVxfLy4b33DZNYt98+Hu8rdu8xQFUGnWbPfr/brZZYvV6ukfvmJ/0+58Sbt9GUxVi27v0WKrst7Ht81l1zS7p3OXZ6a01j6f6TzLlXPq2fNewfl6szlvF93q5ewP9OD57H692l+9nBXm+eyqWV9e7V/OSjn77OU/fzd3zDe7o/Pkjs6/rzvlt4+OZO7IgTtn24vb7bK3O5rKmXdqNuua/W23nf2+WuwXL0Hni93d5V8+XW+en6jqRJ16dCLzu6bbeRUn6u2JlCLL/d++tPFrZbXeXmLxb38/nTus2O0X29Vi024brNq2fbk6PVHvvFZvwMuA51gt7c0nbIh9oFIXSvshfdN+wmJvO+//l7b/iwyO/BNY6n3f7rDsar+/OVE/nchT/+f+/j67V1nbeT9OvTav7hScYo1++rRZbz8+1liUZen/Qdm+i33//jSfez3vG/9NLfZtBy3zDx+b/fLKA5W5TPl/n8rS5fKZR730gYnz9qq59msDRzhbtte9k0GJtwCm/Brb+DF+975rb2/68egnTZ6GYs9WzW7pUQVzv4Jx319FfzKUJyEQv9gh8l1qFt37brFa+7XcD4yIE2BwqB6oRGUmt4VReRGrPkmai5yJU1lZZLqUShdlrFqvsGpodC7imO727Q0srPZmvmw3/ai+habKvVWFeoNq2ouLXbMfugnN+7HrNTyi660TuZWHulIvDrV5Mhqqbx2+/KtGjZcdGS75/ztcsAjD0rtkXfybD0lzEcJK136MIcUHF1Y6Z/GExC98vBwL92Xz7nZDWpq7ZtuuVtFVbhm+KTamvG7tN8n5Zn3eLbqHsbFbH1394Izn5tmkog8P1+ftZjdZ9+b2/HzTTFb9vJ3X6/P5z8s2Vi/X3bKXjjK/3i02c0WheknRU/hvlUoeqERnyuZlYS2Wd0PBMDukPtDLr0Hc42bTXPtx2M2V9H/Q1L5bbHcXbXeNIkA3Pkw9lVkO/53ICiImsukRrBcPTfcvcXwKH7FlBraKA1s3C4iXpPEXnWkv6SNXXqvM/1O5rN+IKh/WgRTgsAVsGNYohERBRQFYAjaABartLTiU95KV7e3kATvAGnBvuZbghkULEtywYEGCNQsWAhYoBASKeycKMCDBiQIMeKUSiEV5BUSDlADcGxBgrAADlQClBpoL8M9AawGaDAxGlUMLA6OUM6EcLaCIBqUCik00ELBCIRM9yqkPBrAF3Guqc3LPYosy9i7gErCjsaggb6AxEjTaKvYGR5u6idOAg4TThmOEc+4HTMfFIGluLcMOhZCUcR7KOFElTpQCiCtEANZxJZSgvcKlU9KyAC20XPo+ihwVacR9bzRoEjCCnqhEag1jUeIQa1KMbXT0hH0ACf5zuC99uFrcNOO46GPiKfzHwwp8Xfw7e0xF+Fi/oCJ8qgInDmbbTxxOKUwurkmEPcBBYphDXC1IaoHrJbTAtQfqchzFRGDMcSw9A4MwfSIH2I94ScpgJkuYeSQl6bUj7IXQhoMKfYBLFFKRIJaAeh8kes5JwCgkIq7LCHGZYiDIYf3iGs9hjRPG1Y/rOoeIV8G6zh36gD1wZM1BBVrrHYUoV8FwwddVwZLP4bPzWAIuAJOQAaKhQgM2gBVgCAEQ/DDs9kQAcdgcCZj2SLN/MTRU8KXkEDI8lgwrFAJ5cAAiDn4yOUQij8EBCFGeWGyBxIGUOsAltsB4KbBFIkMsAMM0FRFWCHv3EjLQGcS1oQAM3TQUsg1IFTEyB2yxhQ6h2dA+IEFGxnBsaE9ApTEYawqzlmGHoSURzWKxpoBdopBlFWHDSogELAWlIobrgE2KYrBw8oBdjGI2mFK04xKCMdYU3SWKyLhzYwTFLT1gE6IsBnodIzvG4RJDdRlDe8AY213EtaL4r4+SImUSEDLyIXZxO4gG+X5AzsWNIewGMvY47hO0NegU6hMzieFSTzpstMN9CSQtBuwJbjImrBzsq6HdTjEscQWKOIS4Agc4LVIc/CnsuJBjFRZwmsPa0AZdIClSHmdYHhcwuuFoIdWGsjIXPkvMH9LSLCjb0Ok7x/UbsIyRwYZgoGntF5QjlTHc0JcViGUVNsanIoQhyypSwlTQ52dQKJGAMdKVEdc2ZWQ2Jm2W4lQZgzEmhbWlsGKQuBiV8DukGBawSDiJYIx0EwhnIBQTxj1GRlxx4ijqWoYLFNIxmAeMe51J0d9RxJdxEwzYRlzjrqnTBor7zRSqS9qqXNrBFe3/HOu0nwVSICniFlgFoqGJncT4YcYKF3fWgDEFILcPCHzitEdTeqMQqrilU4SgzZ7yI0wDBGbqmB9UlFVh5jAmZSSYoVGFiHkHg7UQlFIoyvlkZJHIMakpN5QhDySvKVc0lEAJQZlYyCdtTL+EoEyOSBkztlpIyv2wB5wJSYkaER1zxCoqLLhh8iJltfWA+Sw8/0VToKIMPRHaCx3tqBw/IuRGuNYU81zahw9VHXWE3HS81nEPLLPKseMeDFq4SamjNgYE3DEUaA3GbhmThioQE/eiQxyFdNxPgtBAbSJoNOYX9TTUdMMgwvZI28wIfUFDgtEi7kn1EUi9GpVXobwkoxyNZGk8RdoJFdefbjQqTg4x36jjFu/iyDN3mVWX9kLDtrkhnhByTMgdCqW81MQE1NBVi0BHLCdFSFK5uB0pKcIo8ArHXEjpc3SBd2DcmfooocFJ+upJUhytOSADjZrXHpIiZgl1wU4Kx1uA8oIdMOoRSceQipMhPt78CCGzLp19OMHxoVymYCekgp2cKLcylE9x7FLuc9QGeGApF6G0JyUmU3hCSE7imrcYEDQac646QTokh1zsEMuhPIPUE8lzvERCe8XSRZWO6EHxsOYI4ZZY3RBWYShKNnZjPN10MCclHzzWRocMV00T3BqIDPFxxYmQDybmqzUnFSeW3T5YyksLFComK46qHRDyoIjJcD0iNqbG9ZfEEhloVNxDxbziWHIVkreQ8aJoiEntdAU3V3MCnjm6H7KYxw+Iion6mBxvkwipV/GGKZ5KBDuuCHYqEcnSt7UQjNBBpHbplOHi6cOx2zBqxm3KsQMDQh0yvLsDog9Jke4LFd0RHmKbDlqhopgUqh9tYb/UgjpQxgNUPSLpoFR/SSwR0Fiys1Y6acVzVpBXeLQSjCRzCTKVItUkOFU2hqiDpkDwMyQnx8ofIUy5DEdanc5uJbsQLtlJkON6snmZlBdcdEDSabL+klgiA42G15p0Gy/ZsVmyk3JsUaaj5yRRX08qTqaw5kJ6VFGyc3J9tFvQaTi5UyVhHU/0Mr1RDKBiEmpYTFDS+0h6QKgiQ0UDcuAD84+d4esBq6bNEhRT8vzQn/PrgONWgheaDv71f4FRl4j3BnW40Ri8JvEavEQINxmPs2rAmKmB1YT/N97q0q8ERq92ku5B6OlM0h0J3icKihZ4ey3wTChFvEWCla7ogcJgnY6vqsKGV2hQqemNWcQraEnpp0s3IYJ99fMchxgvM3J6EObPZzI8lRsko54Q1VhZpsrEJImml3XB3/wE3ojkdJuE62ye07MNVuHTdJnSpHkeT9FzerFU9DYtcVhsukaR4WnSpLEUsJrDR00dFug3LODY4VEviIrBaMiDsamH9Put0Lio6BMJUyFwSUEcwBRBlDi6DpcXBUT8VAWd+TTWqfScwn4SIHT8qUB4jZfpOt2w3Q+iFa4egU8uOK4hl4QFkX6KcOB7oBorC7aMIpMkmp4ARHiddckuPSrTzWxO3Qz3nemUQj+NcPTBOFxBInZSxFsK9nXSrok2BD5SyfAYj30V+DYV3DYDljpRsFUUey8PhqYe0u+wir72h070+1H17vcfzrafz7ZPnj95tds/bJrX/W9s/7rGn2z3PwzLshf75vqm/+XR7sX57fJjs8+Wu13/W91XL0KTV6v13Wy9+nHiJ9qz5Wax2/mai9vN5sP6383Zk9evXnj5QbNNu+h/NfrrXdNtFg+9yJV4XWNhlmWvXnh62GrftpvzRcc0/gc): Given multiple billboards of different sizes reusing the same SVG, each billboard must (at least) render at the expected on-screen size. Optimal texture resolution is not guaranteed - the first billboard texture for a given URL is cached — but this behavior may change in the future.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code