### PR TITLE
Add asynchronous hint to entities [#5127]

### DIFF
--- a/packages/engine/Source/DataSources/Entity.js
+++ b/packages/engine/Source/DataSources/Entity.js
@@ -98,6 +98,7 @@ function createPropertyTypeDescriptor(name, Type) {
  * @property {PolylineVolumeGraphics | PolylineVolumeGraphics.ConstructorOptions} [polylineVolume] A polylineVolume to associate with this entity.
  * @property {RectangleGraphics | RectangleGraphics.ConstructorOptions} [rectangle] A rectangle to associate with this entity.
  * @property {WallGraphics | WallGraphics.ConstructorOptions} [wall] A wall to associate with this entity.
+ * @property {boolean} [asynchronous=true] Determines if the underlying primitives will be created asynchronously or block until ready.
  */
 
 /**
@@ -121,6 +122,7 @@ function Entity(options) {
 
   this._availability = undefined;
   this._id = id;
+  this._asynchronous = options.asynchronous ?? true;
   this._definitionChanged = new Event();
   this._name = options.name;
   this._show = options.show ?? true;
@@ -247,6 +249,16 @@ Object.defineProperties(Entity.prototype, {
   id: {
     get: function () {
       return this._id;
+    },
+  },
+  /**
+   * Gets whether the underlying primitives should be created asynchronously or block until ready.
+   * @memberof Entity.prototype
+   * @type {boolean}
+   */
+  asynchronous: {
+    get: function () {
+      return this._asynchronous;
     },
   },
   /**

--- a/packages/engine/Source/DataSources/GeometryUpdater.js
+++ b/packages/engine/Source/DataSources/GeometryUpdater.js
@@ -50,6 +50,7 @@ function GeometryUpdater(options) {
   const geometryPropertyName = options.geometryPropertyName;
 
   this._entity = entity;
+  this._asynchronous = entity.asynchronous;
   this._scene = options.scene;
   this._fillEnabled = false;
   this._isClosed = false;
@@ -240,6 +241,19 @@ Object.defineProperties(GeometryUpdater.prototype, {
   isDynamic: {
     get: function () {
       return this._dynamic;
+    },
+  },
+  /**
+   * Gets a value indicating if the geometry should be created asynchronously
+   *
+   * @memberof GeometryUpdater.prototype
+   *
+   * @type {boolean}
+   * @readonly
+   */
+  asynchronous: {
+    get: function () {
+      return this._asynchronous;
     },
   },
   /**

--- a/packages/engine/Source/DataSources/StaticGeometryColorBatch.js
+++ b/packages/engine/Source/DataSources/StaticGeometryColorBatch.js
@@ -27,6 +27,7 @@ function Batch(
   depthFailMaterialProperty,
   closed,
   shadows,
+  asynchronous,
 ) {
   this.translucent = translucent;
   this.appearanceType = appearanceType;
@@ -48,6 +49,7 @@ function Batch(
   this.showsUpdated = new AssociativeArray();
   this.itemsToRemove = [];
   this.invalidated = false;
+  this.asynchronous = asynchronous ?? true;
 
   let removeMaterialSubscription;
   if (defined(depthFailMaterialProperty)) {
@@ -156,7 +158,7 @@ Batch.prototype.update = function (time) {
 
       primitive = new Primitive({
         show: false,
-        asynchronous: true,
+        asynchronous: this.asynchronous,
         geometryInstances: geometries.slice(),
         appearance: new this.appearanceType({
           translucent: this.translucent,
@@ -430,7 +432,10 @@ StaticGeometryColorBatch.prototype.add = function (time, updater) {
   const length = items.length;
   for (let i = 0; i < length; i++) {
     const item = items[i];
-    if (item.isMaterial(updater)) {
+    if (
+      item.isMaterial(updater) &&
+      item.asynchronous === updater.asynchronous
+    ) {
       item.add(updater, instance);
       return;
     }
@@ -443,6 +448,7 @@ StaticGeometryColorBatch.prototype.add = function (time, updater) {
     updater.depthFailMaterialProperty,
     this._closed,
     this._shadows,
+    updater.asynchronous,
   );
   batch.add(updater, instance);
   items.push(batch);


### PR DESCRIPTION
# Description

This is a draft PR attempting to solve #5127. The issue has comments mentions several use cases, I'd personally like to add the use case of "hover" behavior which currently requires either using callback properties (not efficient on the scale in our app) or the primitive API directly (difficult to support compatibility with the entire Entity API).

The basic concept of this PR:

1. Add getter-only `asynchronous` property to `Entity` and `GeometryUpdater` (analogous to the getter-only `asynchronous` property on `Primitive`), which defaults to `true`
2. Similarly, add the property to all relevant `<TYPE>Batch` classes. Each batch will pass its asynchronous flag to its internal `Primitive`
3. In the `<TYPe>Batch.prototype.add` method, when checking whether to create a new `Batch`, compare the `asynchronous` flags between the existing `Batch`'s and the `updater`, similarly as is done for materials, zIndex, etc...

**Questions:**

1. All the `Dynamic<TYPE>Updater` classes always create a `Primitive` with `asynchronous: false`. I can't see the value in setting this to `true`, so most likely the flag on the `Entity` should just have a comment mentioning this. Should setting `asynchronous: true` on a graphics with a dynamic property throw a runtime/developer error?
2. The pipeline for polyline visualization is pretty different than most other geometry types, luckily `StaticGroundPolylinePerMaterialBatch` at least already supports an `asynchronous` flag it just isn't used. Other than that I think I can get it working there as well
3. Points, billboards, and labels have no such concept of an `asynchronous` creation state. Again I'm assuming that the flag having no effect here is a legitimate behavior. This leads me to the main question in terms of API design: should this be a flag on the `Entity`, or only on the relevant `<TYPE>Graphics` which even support asynchronous creation?

## Issue number and link

#5127

## Testing plan

[Initial example](http://localhost:8080/Apps/Sandcastle2/index.html#c=vVVtT9swEP4rXr+QTsVlYqWiL2hQsoFUVkQH00TQ5CbXxltiR7bTLpv473PspGkbNqRN4kuSs5/n7p7z+ULjhAuFXiMi0QgkTWM0FzxGXsM3ltfoe8xjPmdSoSWFFQg0RAxWBRrfmTWnxI84U4QyEF6jhX55DCEJEfiKcnbJAuoTxUUPzUkkoZXvUjbnZ/xHtfTY7JfhpA8MdDQbFhtTb5o3DmCWLqYhX70XJAZ5DWIKmhZovBIpbGTt84jnSRcJj3ITn41vXbyiKjyNkpA4B7hTxU2o/330FOmLOx5PPm/Rjo+bJlSRIzBFFQWJSRA4Rn7Co2zBWc8WA6GQgiDCD7Pe2jcRSn8Rdojz0p/DQgDIUyFI5txbEkL73QN80EKH5rl/VDfeWqNbGZb60Cw+QqCLUPVQuRETBYKSqLet8cY936mLwT+WR/MSUjtG3Vur7rBmlFI7/yn1iR54ca1HXSPvyCjqdOpGccbdtfFvWj/cuO7HZ8RW3e/merPq6tX1E5kxPxSc8VRu3eegh/ZyF3utZ8p0//CsgvVFXGeqx4m+8jvTwmPtNrriS0AqBJQIGutkjUWUWYp1koCoRBojkOJmUfEEl5pDwoJod7JNfX1gbJoQH9ylrsCFBTl2/viELYnMwxdkLEFdsiRVp2baOfOUmQ/kxDpsrB00bRWqMkMwmX3Tw1HHtU7zxTVcVz245pLmTvI4urhz5BTJBTDXUzZwNt00m2WZbQgoT3EThGnQ3wTZvYvyXDTa0nBxdHh9ZAUtT6LqkToMvRoOd72uE0Por9QasYj5aF8b3LwNqlGvEQh0R5Rh6kDTMBapu6b1pzP+lCWArya3U/fr1eTObfYbrcZAqiyCk5z7jtrfZSoiB+O2gjiJdLfK9izVaSvsS9MRg3ZJGQR0qe/E8InfI/IjIqXemadRNKU/wWucDNoav0WLOAkoW0x040YkyyHhm5OxXcQYD9rarLMU59GMiA2PvwE)

TBD

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
