### PR TITLE
fix(textureatlas): Allocate texture space more incrementally on resize

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,11 @@
 
 #### Fixes :wrench:
 
-- Improved scaling of SVGs in billboards [#13020](https://github.com/CesiumGS/cesium/issues/13020)
+- Improved scaling of SVGs in billboards [#13020](https://github.com/CesiumGS/cesium/pull/13020)
 - Billboards using `imageSubRegion` now render as expected. [#12585](https://github.com/CesiumGS/cesium/issues/12585)
 - Fixed depth testing bug with billboards and labels clipping through models [#13012](https://github.com/CesiumGS/cesium/issues/13012)
-- Fixed unexpected outline artifacts around billboards [#13038](https://github.com/CesiumGS/cesium/issues/13038)
+- Fixed unexpected outline artifacts around billboards [#4525](https://github.com/CesiumGS/cesium/issues/4525)
+- Fix texture coordinates in large billboard collections [#13042](https://github.com/CesiumGS/cesium/pull/13042)
 
 #### Additions :tada:
 


### PR DESCRIPTION
# Description

Texture coordinates are currently compressed to 12-bit precision, effectively on a 4096x4096 grid. That could be revisited (see #13050), but regardless, billboard-related code must be careful with texture coordinate precision, especially in large atlases. This PR makes two changes along those lines:

1. Atlases are now constrained to power-of-two dimensions on resize, aligning the atlas pixel grid cleanly with the 4096x4096 texture coordinate quantization grid, and ensuring we get the same visual results on WebGL1- and WebGL2-compatible devices.
2. When resizing atlases, TextureAtlas.js now considers more candidate sizes, and in most cases should not allocate space in the atlas with a [packing density](https://en.wikipedia.org/wiki/Packing_density) <<0.5.

Previously as the current candidate atlas size became larger, the iterative resize algorithm would use a larger multiplier to select the next candidate size, (2x, 4x, 8x, 16x, ...). In the particular case of #5154 this created a 2K-by-8K atlas, which required 16x more memory than required and (more visibly) exceeded the 4096px limit at which the 12-bit texcoord quantization could precisely address pixels in the atlas. 

Preview:

| before | after |
|--------|-------|
| <img width="212" height="77" alt="Screenshot 2025-11-20 at 5 04 37 PM" src="https://github.com/user-attachments/assets/a08323ac-2b44-41c6-9270-c6735d75b3c9" /> | <img width="218" height="71" alt="Screenshot 2025-11-20 at 5 05 19 PM" src="https://github.com/user-attachments/assets/ef12f971-4bbe-4601-821e-c58c4f77d42f" /> |

This improves image alignment with each billboard, but isn't a complete fix for all such issues. More changes in upcoming PRs, but this change seemed worthwhile on its own.

## Issue number and link

- Partial fix for #5154

## Testing plan

I'm looking through existing examples with one or more billboards. For each relevant example, compare computed texture atlas size before vs. after. Check that atlas size is "reasonable", i.e. not >> 2x the total area of the input images.

- [iTwin Feature Service](http://localhost:8080/Apps/Sandcastle2/index.html?id=itwin-feature-service)
  - Before: 768 x 3072
  - After: 1024 x 1024
- [Billboards](http://localhost:8080/Apps/Sandcastle2/index.html?id=billboards)
  - Before: 236 x 120
  - After: 128 x 32
- [Clustering](http://localhost:8080/Apps/Sandcastle2/index.html?id=clustering)
  - Before: 264 x 1040, 752 x 220, 768 x 192, 256 x 256
  - After: 512 x 512, 256 x 128, 256 x 256
- [Map Pins](http://localhost:8080/Apps/Sandcastle2/index.html?id=map-pins)
  - Before: 192 x 192
  - After: 128 x 128
- [GeoJSON simplestyle](http://localhost:8080/Apps/Sandcastle2/index.html?id=geojson-simplestyle)
  - Before: 768 x 3072
  - After: 1024 x 512
- [Particle System Tails](http://localhost:8080/Apps/Sandcastle2/index.html?id=particle-system-tails)
  - Before: 320 x 1280
  - After: 256 x 256
- [LocalToFixedFrame](http://localhost:8080/Apps/Sandcastle2/index.html?id=localtofixedframe)
  - Before: 264 x 912
  - After: 512 x 256
- [Moon](http://localhost:8080/Apps/Sandcastle2/index.html?id=moon)
  - Before: 848 x 232 
  - After: 256 x 256
- [Mars](http://localhost:8080/Apps/Sandcastle2/index.html?id=mars)
  - Before: 1072 x 268, 768 x 192
  - After: 512 x 512, 256 x 256
- [Particle System Fireworks](http://localhost:8080/Apps/Sandcastle2/index.html?id=particle-system-fireworks)
  - Before: 10240 x 1280
  - After: 1024 x 1024

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code






#### PR Dependency Tree


* **PR #13042** 👈
  * **PR #13050**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)