### PR TITLE
Remove legacy sandcastle from zip file

### DIFF
--- a/gulpfile.makezip.js
+++ b/gulpfile.makezip.js
@@ -146,7 +146,6 @@ export const makeZip = gulp.series(
         gulp.src(
           [
             "Apps/**",
-            "Apps/Sandcastle/.jshintrc",
             "packages/engine/index.js",
             "packages/engine/index.d.ts",
             "packages/engine/LICENSE.md",
@@ -171,6 +170,7 @@ export const makeZip = gulp.series(
             "CHANGES.md",
             "README.md",
             "web.config",
+            "!Apps/Sandcastle/**",
             "!scripts/buildSandcastle.js",
             "!**/*.gitignore",
             "!Specs/e2e/*-snapshots/**",

--- a/index.release.html
+++ b/index.release.html
@@ -47,7 +47,7 @@
       <div class="section">
         <a href="https://cesium.com/cesiumjs/"
           ><img
-            src="./Apps/Sandcastle/images/Cesium_Logo_Color_Overlay.png"
+            src="./Apps/Sandcastle2/images/Cesium_Logo_Color_Overlay.png"
             style="width: 400px"
         /></a>
       </div>


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Small PR to no longer bundle the legacy sandcastle with the release zip. The files will remain in the repo a little longer specifically because our e2e tests still rely on them. (That update probably sometime next month)

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Part of #12894 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `npm run make-zip`
- copy and extract that zip file somewhere else
- run `npm install` and `npm start`
- Make sure the link to sandcastle still works (and the logo shows up)
- Make sure there are no legacy sandcastle files in extracted the filetree
- Test the other links on the zip release homepage and make sure they all work too

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
