### PR TITLE
feat(EntityCluster.js): kdBush 4.0.2 new KdBush() use Float64Array

### DIFF
--- a/packages/engine/Source/DataSources/EntityCluster.js
+++ b/packages/engine/Source/DataSources/EntityCluster.js
@@ -330,7 +330,7 @@ function createDeclutterCallback(entityCluster) {
     let collectionIndex;
 
     if (points.length > 0) {
-      const index = new KDBush(points.length, 64, Uint32Array);
+      const index = new KDBush(points.length, 64, Float64Array);
       for (let p = 0; p < points.length; ++p) {
         index.add(points[p].coord.x, points[p].coord.y);
       }


### PR DESCRIPTION
https://github.com/CesiumGS/cesium/issues/13062

Based on this issue, I have reviewed the source code of ElementCluster.js and found that using kdBush after upgrading from v3.0.0 to v4.0.2, continue  use Uint32Array will result in negative numbers being represented as 2 ^ 32. When using `index. range` in the code, there will be no expected results.

If not filled in here, the default will still be Float64Array

Expected adoption