### PR TITLE
chore(Billboards): Add deprecation notice for legacy WebGL fallbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@
 - Fixes label positioning in workflows that delete and recreate clamped labels [#12949](https://github.com/CesiumGS/cesium/issues/12949)
 - Fixes texture coordinates in large billboard collections [#13042](https://github.com/CesiumGS/cesium/pull/13042)
 
+#### Deprecated :hourglass_flowing_sand:
+
+- Beginning in CesiumJS 1.140, billboards and labels will require device support for WebGL 2, or WebGL 1 with ANGLE_instanced_arrays and MAX_VERTEX_TEXTURE_IMAGE_UNITS > 0. For more information or to share feedback, please see [#13053](https://github.com/CesiumGS/cesium/issues/13053). [#13067](https://github.com/CesiumGS/cesium/issues/13067)
+
 ## 1.136 - 2025-12-01
 
 ### @cesium/engine

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -35,6 +35,7 @@ import TextureAtlas from "../Renderer/TextureAtlas.js";
 import VerticalOrigin from "./VerticalOrigin.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import WebGLConstants from "../Core/WebGLConstants.js";
+import deprecationWarning from "../Core/deprecationWarning.js";
 
 const SHOW_INDEX = Billboard.SHOW_INDEX;
 const POSITION_INDEX = Billboard.POSITION_INDEX;
@@ -1784,6 +1785,19 @@ BillboardCollection.prototype.update = function (frameState) {
   }
 
   const context = frameState.context;
+
+  if (
+    !context.instancedArrays ||
+    !(ContextLimits.maximumVertexTextureImageUnits > 0)
+  ) {
+    deprecationWarning(
+      "Billboard-unsupported-ANGLE_instanced_arrays",
+      "Beginning in CesiumJS 1.140, billboards and labels will require device support for WebGL 2, " +
+        "or WebGL 1 with ANGLE_instanced_arrays and MAX_VERTEX_TEXTURE_IMAGE_UNITS > 0. For more " +
+        "information or to share feedback, see: https://github.com/CesiumGS/cesium/issues/13053",
+    );
+  }
+
   this._instanced = context.instancedArrays;
   attributeLocations = this._instanced
     ? attributeLocationsInstanced


### PR DESCRIPTION

# Description

Adds a deprecation notice when billboards are shown on devices that don't support WebGL 2 _or_ WebGL 1 with ANGLE_instanced_arrays and MAX_VERTEX_TEXTURE_IMAGE_UNITS > 0. Fallback support for rendering billboards and labels on devices without these features will be removed in Cesium 1.140.


## Issue number and link

For further details and feedback, see:

- https://github.com/CesiumGS/cesium/issues/13053

## Testing plan

n/a

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [ ] ~~I have updated the inline documentation, and included code examples where relevant~~
- [x] I have performed a self-review of my code



#### PR Dependency Tree


* **PR #13067** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)