### PR TITLE
fix(labels): Scale SDF glyphs to max label size

### DIFF
--- a/packages/engine/Source/Scene/SDFSettings.js
+++ b/packages/engine/Source/Scene/SDFSettings.js
@@ -5,12 +5,20 @@
  */
 const SDFSettings = {
   /**
-   * The font size in pixels
+   * Minimum font size in pixels
    *
    * @type {number}
    * @constant
    */
-  FONT_SIZE: 48.0,
+  MIN_FONT_SIZE: 48.0,
+
+  /**
+   * Maximum font size in pixels
+   *
+   * @type {number}
+   * @constant
+   */
+  MAX_FONT_SIZE: 256.0,
 
   /**
    * Whitespace padding around glyphs.


### PR DESCRIPTION
# Description

DRAFT - for discussion.

Currently label screen-space size is derived from `label.font x label.scale`, while SDF size (used to display the font in WebGL) is fixed at 48px:

https://github.com/CesiumGS/cesium/blob/aebb58ad06733fced57b2bc4a099c2ffd85f1540/packages/engine/Source/Scene/SDFSettings.js#L6-L13

The idea explored by this PR is to use SDFSettings.FONT_SIZE as a _minimum_, scaling up the glyph size to match the maximum font size present in the label collection. Increasing label font size should then never result in deteriorating quality. Note that `.scale` does not change the size of the SDF glyph, and could still magnify a low-resolution glyph, but I think that's acceptable.

Two big tradeoffs: 

1. **Texture atlas size.** Large font sizes require larger glyphs and a larger atlas. Using the max font size (not all requested font sizes) is a compromise so that only one font size is stored in the atlas at a time. I expect that label sizes larger than 48px are rare, so most users will continue to have current SDF size (48px) unchanged. That said, I'd be open to the argument that each unique size should be stored; in a collection with many small labels (and, say, 1000+ characters in some languages) and only 1–2 very large labels, it would reduce atlas size to store each label's glyphs at exactly the requested font size.

2. **Custom [`measureText()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText) implementation performance.** We iterate over pixels to compute glyph bounding boxes, and becomes slower as glyph sizes increase. For example, a 30-character label at fontSize=400px spends 100ms in `rebindAllGlyphs` compared to 25ms at fontSize/48px. Perhaps this could be resolved separately by https://github.com/CesiumGS/cesium/issues/9767. I think it's only a minor issue at this stage.

Preview:

| fontSize=12 | fontSize=48 | fontSize=144 |
|---|---|---|
| <img width="341" height="189" alt="fontSize=12" src="https://github.com/user-attachments/assets/14de9fcd-af54-4dd9-a4f1-54debcb23156" /> | <img width="331" height="184" alt="fontSize=48" src="https://github.com/user-attachments/assets/0f93f01a-55ed-4176-a9c4-012c0dc154a3" /> | <img width="338" height="186" alt="fontSize=144" src="https://github.com/user-attachments/assets/9a79eeac-83da-4cce-a460-99441566c699" /> |


## Issue number and link

- Fixes #11377

## Testing plan

TODO

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code






#### PR Dependency Tree


* **PR #13081**
  * **PR #13070** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)