### PR TITLE
refactor(labels): Remove custom measureText implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Fixes jitter artifacts on Intel Arc GPUs [#12879](https://github.com/CesiumGS/cesium/issues/12879)
+- Fixed label sizing for some fonts and characters [#9767](https://github.com/CesiumGS/cesium/issues/9767)
 
 ## 1.137 - 2026-01-05
 


### PR DESCRIPTION
# Description

Revival of @javagl's #11747. One difference from the original PR, I've aimed to replace the custom measureText implementation with as little divergence from the current results as possible. So I've intentionally not tried to fix #10649 here. Along the same lines, I'm rounding some metrics to the nearest pixel to match the previous behavior. This helps with the test case shown below.

## Issue number and link

- Fixes #9767
- Fixes #11705

## Testing plan

Primarily, I've tested the PR by programmatically comparing output metrics with the previous implementation, for sample characters in English, Spanish, French, and Chinese Simplified alphabets:

```javascript
const MAX_ERR_PX = 1;

describe("Core/measureText", () => {
  let canvas;
  let ctx;

  beforeEach(() => {
    canvas = document.createElement("canvas");
    canvas.width = canvas.height = 1;
    ctx = canvas.getContext("2d", { willReadFrequently: true });
    document.body.appendChild(canvas);
  });

  afterEach(() => {
    document.body.removeChild(canvas);
  });

  it("ascii lowercase", () => {
    ctx.font = "12px sans-serif";
    for (const char of "abcdefghijklmnopqrstuvwxyz0123456789".split("")) {
      const m1 = measureText1(ctx, char, ctx.font, false, true, 1);
      const m2 = measureText2(ctx, char, ctx.font, false, true, 2);
      expect(Math.abs(m1.width - m2.width)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.height - m2.height)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.ascent - m2.ascent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.descent - m2.descent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.minx - m2.minx)).toBeLessThanOrEqual(MAX_ERR_PX);
    }
  });

  it("ascii uppercase", () => {
    ctx.font = "12px sans-serif";
    for (const char of "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")) {
      const m1 = measureText1(ctx, char, ctx.font, false, true, 1);
      const m2 = measureText2(ctx, char, ctx.font, false, true, 2);
      expect(Math.abs(m1.width - m2.width)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.height - m2.height)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.ascent - m2.ascent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.descent - m2.descent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.minx - m2.minx)).toBeLessThanOrEqual(MAX_ERR_PX);
    }
  });

  it("chinese simplified", () => {
    ctx.font = "12px sans-serif";
    for (const char of "世界您好".split("")) {
      const m1 = measureText1(ctx, char, ctx.font, false, true, 1);
      const m2 = measureText2(ctx, char, ctx.font, false, true, 2);
      expect(Math.abs(m1.width - m2.width)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.height - m2.height)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.ascent - m2.ascent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.descent - m2.descent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.minx - m2.minx)).toBeLessThanOrEqual(MAX_ERR_PX);
    }
  });

  it("spanish", () => {
    ctx.font = "12px sans-serif";
    for (const char of "áéíóúüñ¿¡".split("")) {
      const m1 = measureText1(ctx, char, ctx.font, false, true, 1);
      const m2 = measureText2(ctx, char, ctx.font, false, true, 2);
      expect(Math.abs(m1.width - m2.width)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.height - m2.height)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.ascent - m2.ascent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.descent - m2.descent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.minx - m2.minx)).toBeLessThanOrEqual(MAX_ERR_PX);
    }
  });

  it("french", () => {
    ctx.font = "12px sans-serif";
    for (const char of "çéâêîôûàèìòùëïü".split("")) {
      const m1 = measureText1(ctx, char, ctx.font, false, true, 1);
      const m2 = measureText2(ctx, char, ctx.font, false, true, 2);
      expect(Math.abs(m1.width - m2.width)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.height - m2.height)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.ascent - m2.ascent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.descent - m2.descent)).toBeLessThanOrEqual(MAX_ERR_PX);
      expect(Math.abs(m1.minx - m2.minx)).toBeLessThanOrEqual(MAX_ERR_PX);
    }
  });
});
```

The purpose of the test is to confirm that no metric is off by more than 1px, for any character, compared to the previous implementation. The tests pass. Notably, if the `Math.round` calls are removed from the implementation, many of these tests begin to fail.

I also did some basic screenshot comparisons. Visual results are not identical, but — per the 1px target — are very close. 

**Labels**

| before | after |
|---|---|
| <img width="453" height="173" alt="labels_before" src="https://github.com/user-attachments/assets/a57f8824-e411-4bd6-82a4-9f86f2207bf0" /> | <img width="453" height="173" alt="labels_after" src="https://github.com/user-attachments/assets/7d94954e-bd38-4aa7-8be9-22cf5ebed970" /> |

Difference of a few pixels. Main concern here would be if the font baseline is misaligned, but both appear fine in tests so far.

**Sandbox from #11747**

| before | after |
|---|---|
| <img width="572" height="364" alt="punctuation_prod" src="https://github.com/user-attachments/assets/7b9fa36e-3c72-4bbc-a086-16431ad5455c" /> | <img width="572" height="364" alt="punctuation_round" src="https://github.com/user-attachments/assets/cadbcbc3-b327-4aca-a9b8-4c9acdbc492d" /> |

Some visible differences. Unscientifically, I think `writeTextToCanvas` is now more tightly fitting the canvas to the text when padding=0, which seems ... not bad? Based on #10649, the previous behavior might not be ideal, but I've tried to just minimize changes and avoid a regression in this PR so far, leaving a fix for future work.

**Sandbox from #11705**

| case | image |
|---|---|
| before | <img width="800" height="219" alt="padding_prod" src="https://github.com/user-attachments/assets/17d09aa1-f5fa-49b0-b6cf-9f01cb0910c5" /> |
| after | <img width="800" height="219" alt="padding_round" src="https://github.com/user-attachments/assets/82828f87-b8d1-4009-b7fb-da4278ba76ff" /> |

Improvement. The padding in the original screenshot was a bug, believed to be caused by our custom implementation not supporting some fonts correctly.


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code









#### PR Dependency Tree


* **PR #13081** 👈
  * **PR #13070**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)