### PR TITLE
Build types in core-math and core-utils with tsc

### DIFF
--- a/packages/core-math/.gitignore
+++ b/packages/core-math/.gitignore
@@ -1,5 +1,6 @@
 index.js
 index.d.ts
+index.tsc.d.ts
 Build
 Specs/SpecList.js
 docs

--- a/packages/core-math/Source/Cartesian2.js
+++ b/packages/core-math/Source/Cartesian2.js
@@ -1,6 +1,9 @@
 import { Check, defined, DeveloperError } from "@cesium/core-utils";
 import CesiumMath from "./Math.js";
 
+/** @ignore @typedef {import('./Cartesian3.js')} Cartesian3 */
+/** @ignore @typedef {import('./Cartesian4.js')} Cartesian4 */
+
 /**
  * A 2D Cartesian point.
  * @alias Cartesian2

--- a/packages/core-math/Source/Cartesian4.js
+++ b/packages/core-math/Source/Cartesian4.js
@@ -1,6 +1,8 @@
 import { Check, defined, DeveloperError } from "@cesium/core-utils";
 import CesiumMath from "./Math.js";
 
+/** @ignore @typedef {import('@cesium/engine').Color} Color */
+
 /**
  * A 4D Cartesian point.
  * @alias Cartesian4

--- a/packages/core-math/Source/Matrix4.js
+++ b/packages/core-math/Source/Matrix4.js
@@ -10,6 +10,10 @@ import {
 import CesiumMath from "./Math.js";
 import Matrix3 from "./Matrix3.js";
 
+/** @ignore @typedef {import('@cesium/engine').Camera} Camera */
+/** @ignore @typedef {import('@cesium/engine').TranslationRotationScale} TranslationRotationScale */
+/** @ignore @typedef {import('@cesium/engine').Quaternion} Quaternion */
+
 /**
  * A 4x4 matrix, indexable as a column-major order array.
  * Constructor parameters are in row-major order for code readability.

--- a/packages/core-math/package.json
+++ b/packages/core-math/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "build": "gulp build --workspace @cesium/core-math",
     "build-ts": "gulp buildTs --workspace @cesium/core-math",
+    "build-tsc": "tsc --checkJs false",
     "coverage": "gulp coverage --workspace @cesium/core-math",
     "test": "gulp test --workspace @cesium/core-math",
     "postversion": "gulp postversion --workspace @cesium/core-math",

--- a/packages/core-math/tsconfig.json
+++ b/packages/core-math/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["index.js", "Source/**/*.js"],
+  "include": ["Source/**/*.js"],
   "compilerOptions": {
     // module configuration
     "moduleResolution": "bundler",
@@ -7,8 +7,14 @@
     "target": "ES2022",
 
     // i/o
-    "noEmit": true,
+    "declaration": true,
+    "declarationDir": "Build/Types",
+    "emitDeclarationOnly": true,
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+
+    // ignore type definitions in other modules for now, we need types
+    // to be correct and to resolve imports first.
+    "skipLibCheck": true
   }
 }

--- a/packages/core-utils/.gitignore
+++ b/packages/core-utils/.gitignore
@@ -1,5 +1,6 @@
 index.js
 index.d.ts
+index.tsc.d.ts
 Build
 Specs/SpecList.js
 docs

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "gulp build --workspace @cesium/core-utils",
     "build-ts": "gulp buildTs --workspace @cesium/core-utils",
+    "build-tsc": "tsc --checkJs false",
     "build-docs": "typedoc ./index.js --skipErrorChecking",
     "coverage": "gulp coverage --workspace @cesium/core-utils",
     "test": "gulp test --workspace @cesium/core-utils",

--- a/packages/core-utils/tsconfig.json
+++ b/packages/core-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["index.js", "Source/**/*.js"],
+  "include": ["Source/**/*.js"],
   "compilerOptions": {
     // module configuration
     "moduleResolution": "bundler",
@@ -7,8 +7,14 @@
     "target": "ES2022",
 
     // i/o
-    "noEmit": true,
+    "declaration": true,
+    "declarationDir": "Build/Types",
+    "emitDeclarationOnly": true,
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+
+    // ignore type definitions in other modules for now, we need types
+    // to be correct and to resolve imports first.
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Mostly superceded by #13104, but one interesting piece in this PR is generation of `.d.ts` files with tsc (for TS-compatible JSDoc files only).