### PR TITLE
Fix jittering artifacts with primitives on Intel Arc GPUs (minus WebGL2 requirement)

### DIFF
--- a/packages/engine/Source/Scene/Primitive.js
+++ b/packages/engine/Source/Scene/Primitive.js
@@ -752,10 +752,23 @@ Primitive._modifyShaderPosition = function (
         computeFunctions +=
           `${functionName}\n` +
           `{\n` +
-          `    return czm_columbusViewMorph(\n` +
-          `             czm_translateRelativeToEye(${name}2DHigh.zxy, ${name}2DLow.zxy),\n` +
-          `             czm_translateRelativeToEye(${name}3DHigh, ${name}3DLow),\n` +
-          `             czm_morphTime);\n` +
+          `    vec4 p;\n` +
+          `    if (czm_morphTime == 1.0)\n` +
+          `    {\n` +
+          `        p = czm_translateRelativeToEye(${name}3DHigh, ${name}3DLow);\n` +
+          `    }\n` +
+          `    else if (czm_morphTime == 0.0)\n` +
+          `    {\n` +
+          `        p = czm_translateRelativeToEye(${name}2DHigh.zxy, ${name}2DLow.zxy);\n` +
+          `    }\n` +
+          `    else\n` +
+          `    {\n` +
+          `        p = czm_columbusViewMorph(\n` +
+          `                czm_translateRelativeToEye(${name}2DHigh.zxy, ${name}2DLow.zxy),\n` +
+          `                czm_translateRelativeToEye(${name}3DHigh, ${name}3DLow),\n` +
+          `                czm_morphTime);\n` +
+          `    }\n` +
+          `    return p;\n` +
           `}\n\n`;
       } else {
         computeFunctions +=


### PR DESCRIPTION
This is an alternative to #13096. That PR requires WebGL2, this one does not. It avoids the jitter issue on every system I tested (Across NVidia, Intel, and Apple Silicon GPUs). However, it's probably a tiny bit slower because it does a manual `mix` rather than using the GLSL function.

Fixes #12879