### PR TITLE
Fix misplaced changelog entry for #13042

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Fixes label positioning in workflows that delete and recreate clamped labels [#12949](https://github.com/CesiumGS/cesium/issues/12949)
+- Fixes texture coordinates in large billboard collections [#13042](https://github.com/CesiumGS/cesium/pull/13042)
 
 ## 1.136 - 2025-12-01
 
@@ -18,7 +19,6 @@
 - Billboards using `imageSubRegion` now render as expected. [#12585](https://github.com/CesiumGS/cesium/issues/12585)
 - Fixed depth testing bug with billboards and labels clipping through models [#13012](https://github.com/CesiumGS/cesium/issues/13012)
 - Fixed unexpected outline artifacts around billboards [#4525](https://github.com/CesiumGS/cesium/issues/4525)
-- Fix texture coordinates in large billboard collections [#13042](https://github.com/CesiumGS/cesium/pull/13042)
 
 #### Additions :tada:
 


### PR DESCRIPTION

# Description

Followup from https://github.com/CesiumGS/cesium/pull/13042#discussion_r2599493353. The PR didn't land in time for 1.136, and the changelog entry should be moved to 1.137.

## Issue number and link

- https://github.com/CesiumGS/cesium/pull/13042#discussion_r2599493353

## Testing plan

n/a

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code



#### PR Dependency Tree


* **PR #13112** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)