### PR TITLE
Round heights instead of clamping when upsampling heightmaps

### DIFF
--- a/packages/engine/Source/Core/HeightmapTerrainData.js
+++ b/packages/engine/Source/Core/HeightmapTerrainData.js
@@ -898,6 +898,6 @@ function setHeight(
       divisor /= elementMultiplier;
     }
   }
-  heights[index + i] = height;
+  heights[index + i] = Math.round(height);
 }
 export default HeightmapTerrainData;


### PR DESCRIPTION
Fixes #13065

This PR is a proof-of-concept (hence the draft status), but it appears to ~fix~ significantly reduce the problem and I don't think it should have any major side effects. Please see [that issue](https://github.com/CesiumGS/cesium/issues/13065#issuecomment-3726954176) for more details.