### PR TITLE
Account for broken double-encoded sandcastle links

### DIFF
--- a/packages/sandcastle/src/Gallery/loadFromUrl.ts
+++ b/packages/sandcastle/src/Gallery/loadFromUrl.ts
@@ -96,7 +96,14 @@ export function loadFromUrl(
 
   const legacyId = searchParams.get("src");
   if (legacyId) {
-    const item = selectItemByLegacyId(legacyId);
+    // there was long period when our doc generation double encoded sandcastle links that were already
+    // encoded causing space to be `%2520`. When this loads here the string comparison doesn't match `%20` with ` `
+    // attempt to check a second decode only when a match is not found
+    // see https://github.com/CesiumGS/cesium/issues/13122
+    const item =
+      selectItemByLegacyId(legacyId) ??
+      selectItemByLegacyId(decodeURI(legacyId));
+
     if (!item) {
       if (items.length > 0) {
         throw new Error(


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Add an attempt to load legacy ids that were double encoded by decoding once more after processing the `URLSearchParams`

It looks like the legacy sandcastle accidentally "accounted" for this by using the [demo name directly in the request](https://github.com/CesiumGS/cesium/blob/8a0087956455547bec8ca5dc14646920bf03687c/Apps/Sandcastle/CesiumSandcastle.js#L800) to load it. This meant it didn't matter if the request was sent using spaces ` ` or `%20`s. This approach doesn't work when we're doing direct string comparisons in the new Sandcastle.

This is a companion PR to https://github.com/CesiumGS/cesium/pull/13134 which actually fixes all the incorrect links in the JSDoc itself

For the record I also tried changing the `buildGallery` script to just include the encoded version of legacy ids but that added about 7kb to the list file size. That felt like it'd be worse in the long run than a single JS transformation that only happens some of the time.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Related to https://github.com/CesiumGS/cesium/issues/13122

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `npm run build-sandcastle`
- run `npm start`
- Load these urls and make sure they load valid sandcastles
    - http://localhost:8080/Apps/Sandcastle2/index.html?src=Map%2520Pins.html
    - http://localhost:8080/Apps/Sandcastle2/index.html?src=Spheres%2520and%2520Ellipsoids.html
    - Or check them in CI like here https://ci-builds.cesium.com/cesium/sandcastle-double-encoding/Apps/Sandcastle2/index.html?src=Spheres%2520and%2520Ellipsoids.html

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
