### PR TITLE
Types: Convert ResourceLoaders to ES6 classes

### DIFF
--- a/packages/engine/Source/Scene/BufferLoader.js
+++ b/packages/engine/Source/Scene/BufferLoader.js
@@ -23,33 +23,30 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  *
  * @private
  */
-function BufferLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-  const typedArray = options.typedArray;
-  const resource = options.resource;
-  const cacheKey = options.cacheKey;
+class BufferLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  if (defined(typedArray) === defined(resource)) {
-    throw new DeveloperError(
-      "One of options.typedArray and options.resource must be defined.",
-    );
+    options = options ?? Frozen.EMPTY_OBJECT;
+    const typedArray = options.typedArray;
+    const resource = options.resource;
+    const cacheKey = options.cacheKey;
+
+    //>>includeStart('debug', pragmas.debug);
+    if (defined(typedArray) === defined(resource)) {
+      throw new DeveloperError(
+        "One of options.typedArray and options.resource must be defined.",
+      );
+    }
+    //>>includeEnd('debug');
+
+    this._typedArray = typedArray;
+    this._resource = resource;
+    this._cacheKey = cacheKey;
+    this._state = ResourceLoaderState.UNLOADED;
+    this._promise = undefined;
   }
-  //>>includeEnd('debug');
 
-  this._typedArray = typedArray;
-  this._resource = resource;
-  this._cacheKey = cacheKey;
-  this._state = ResourceLoaderState.UNLOADED;
-  this._promise = undefined;
-}
-
-if (defined(Object.create)) {
-  BufferLoader.prototype = Object.create(ResourceLoader.prototype);
-  BufferLoader.prototype.constructor = BufferLoader;
-}
-
-Object.defineProperties(BufferLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -59,11 +56,10 @@ Object.defineProperties(BufferLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return this._cacheKey;
-    },
-  },
+  get cacheKey() {
+    return this._cacheKey;
+  }
+
   /**
    * The typed array containing the embedded buffer contents.
    *
@@ -73,31 +69,45 @@ Object.defineProperties(BufferLoader.prototype, {
    * @readonly
    * @private
    */
-  typedArray: {
-    get: function () {
-      return this._typedArray;
-    },
-  },
-});
+  get typedArray() {
+    return this._typedArray;
+  }
 
-/**
- * Loads the resource.
- * @returns {Promise<BufferLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-BufferLoader.prototype.load = async function () {
-  if (defined(this._promise)) {
+  /**
+   * Loads the resource.
+   * @returns {Promise<BufferLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  async load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    if (defined(this._typedArray)) {
+      this._promise = Promise.resolve(this);
+      return this._promise;
+    }
+
+    this._promise = loadExternalBuffer(this);
     return this._promise;
   }
 
-  if (defined(this._typedArray)) {
-    this._promise = Promise.resolve(this);
-    return this._promise;
+  /**
+   * Exposed for testing
+   * @private
+   */
+  static _fetchArrayBuffer(resource) {
+    return resource.fetchArrayBuffer();
   }
 
-  this._promise = loadExternalBuffer(this);
-  return this._promise;
-};
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    this._typedArray = undefined;
+  }
+}
 
 async function loadExternalBuffer(bufferLoader) {
   const resource = bufferLoader._resource;
@@ -121,21 +131,5 @@ async function loadExternalBuffer(bufferLoader) {
     throw bufferLoader.getError(errorMessage, error);
   }
 }
-
-/**
- * Exposed for testing
- * @private
- */
-BufferLoader._fetchArrayBuffer = function (resource) {
-  return resource.fetchArrayBuffer();
-};
-
-/**
- * Unloads the resource.
- * @private
- */
-BufferLoader.prototype.unload = function () {
-  this._typedArray = undefined;
-};
 
 export default BufferLoader;

--- a/packages/engine/Source/Scene/DracoLoader.js
+++ b/packages/engine/Source/Scene/DracoLoader.js
@@ -6,7 +6,85 @@ import TaskProcessor from "../Core/TaskProcessor.js";
 /**
  * @private
  */
-function DracoLoader() {}
+class DracoLoader {
+  static _getDecoderTaskProcessor() {
+    if (!defined(DracoLoader._decoderTaskProcessor)) {
+      const processor = new TaskProcessor(
+        "decodeDraco",
+        DracoLoader._maxDecodingConcurrency,
+      );
+      processor
+        .initWebAssemblyModule({
+          wasmBinaryFile: "ThirdParty/draco_decoder.wasm",
+        })
+        .then(function (result) {
+          if (result) {
+            DracoLoader._taskProcessorReady = true;
+          } else {
+            DracoLoader._error = new RuntimeError(
+              "Draco decoder could not be initialized.",
+            );
+          }
+        })
+        .catch((error) => {
+          DracoLoader._error = error;
+        });
+      DracoLoader._decoderTaskProcessor = processor;
+    }
+
+    return DracoLoader._decoderTaskProcessor;
+  }
+
+  /**
+   * Decodes a compressed point cloud. Returns undefined if the task cannot be scheduled.
+   * @private
+   *
+   * @exception {RuntimeError} Draco decoder could not be initialized.
+   */
+  static decodePointCloud(parameters) {
+    const decoderTaskProcessor = DracoLoader._getDecoderTaskProcessor();
+    if (defined(DracoLoader._error)) {
+      throw DracoLoader._error;
+    }
+
+    if (!DracoLoader._taskProcessorReady) {
+      // The task processor is not ready to schedule tasks
+      return;
+    }
+    return decoderTaskProcessor.scheduleTask(parameters, [
+      parameters.buffer.buffer,
+    ]);
+  }
+
+  /**
+   * Decodes a buffer view. Returns undefined if the task cannot be scheduled.
+   *
+   * @param {object} options Object with the following properties:
+   * @param {Uint8Array} options.array The typed array containing the buffer view data.
+   * @param {object} options.bufferView The glTF buffer view object.
+   * @param {Object<string, number>} options.compressedAttributes The compressed attributes.
+   * @param {boolean} options.dequantizeInShader Whether POSITION and NORMAL attributes should be dequantized on the GPU.
+   *
+   * @returns {Promise} A promise that resolves to the decoded indices and attributes.
+   * @private
+   *
+   * @exception {RuntimeError} Draco decoder could not be initialized.
+   */
+  static decodeBufferView(options) {
+    const decoderTaskProcessor = DracoLoader._getDecoderTaskProcessor();
+
+    if (defined(DracoLoader._error)) {
+      throw DracoLoader._error;
+    }
+
+    if (!DracoLoader._taskProcessorReady) {
+      // The task processor is not ready to schedule tasks
+      return;
+    }
+
+    return decoderTaskProcessor.scheduleTask(options, [options.array.buffer]);
+  }
+}
 
 // Maximum concurrency to use when decoding draco models
 DracoLoader._maxDecodingConcurrency = Math.max(
@@ -18,82 +96,5 @@ DracoLoader._maxDecodingConcurrency = Math.max(
 DracoLoader._decoderTaskProcessor = undefined;
 DracoLoader._taskProcessorReady = false;
 DracoLoader._error = undefined;
-DracoLoader._getDecoderTaskProcessor = function () {
-  if (!defined(DracoLoader._decoderTaskProcessor)) {
-    const processor = new TaskProcessor(
-      "decodeDraco",
-      DracoLoader._maxDecodingConcurrency,
-    );
-    processor
-      .initWebAssemblyModule({
-        wasmBinaryFile: "ThirdParty/draco_decoder.wasm",
-      })
-      .then(function (result) {
-        if (result) {
-          DracoLoader._taskProcessorReady = true;
-        } else {
-          DracoLoader._error = new RuntimeError(
-            "Draco decoder could not be initialized.",
-          );
-        }
-      })
-      .catch((error) => {
-        DracoLoader._error = error;
-      });
-    DracoLoader._decoderTaskProcessor = processor;
-  }
-
-  return DracoLoader._decoderTaskProcessor;
-};
-
-/**
- * Decodes a compressed point cloud. Returns undefined if the task cannot be scheduled.
- * @private
- *
- * @exception {RuntimeError} Draco decoder could not be initialized.
- */
-DracoLoader.decodePointCloud = function (parameters) {
-  const decoderTaskProcessor = DracoLoader._getDecoderTaskProcessor();
-  if (defined(DracoLoader._error)) {
-    throw DracoLoader._error;
-  }
-
-  if (!DracoLoader._taskProcessorReady) {
-    // The task processor is not ready to schedule tasks
-    return;
-  }
-  return decoderTaskProcessor.scheduleTask(parameters, [
-    parameters.buffer.buffer,
-  ]);
-};
-
-/**
- * Decodes a buffer view. Returns undefined if the task cannot be scheduled.
- *
- * @param {object} options Object with the following properties:
- * @param {Uint8Array} options.array The typed array containing the buffer view data.
- * @param {object} options.bufferView The glTF buffer view object.
- * @param {Object<string, number>} options.compressedAttributes The compressed attributes.
- * @param {boolean} options.dequantizeInShader Whether POSITION and NORMAL attributes should be dequantized on the GPU.
- *
- * @returns {Promise} A promise that resolves to the decoded indices and attributes.
- * @private
- *
- * @exception {RuntimeError} Draco decoder could not be initialized.
- */
-DracoLoader.decodeBufferView = function (options) {
-  const decoderTaskProcessor = DracoLoader._getDecoderTaskProcessor();
-
-  if (defined(DracoLoader._error)) {
-    throw DracoLoader._error;
-  }
-
-  if (!DracoLoader._taskProcessorReady) {
-    // The task processor is not ready to schedule tasks
-    return;
-  }
-
-  return decoderTaskProcessor.scheduleTask(options, [options.array.buffer]);
-};
 
 export default DracoLoader;

--- a/packages/engine/Source/Scene/GltfBufferViewLoader.js
+++ b/packages/engine/Source/Scene/GltfBufferViewLoader.js
@@ -26,75 +26,72 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  *
  * @private
  */
-function GltfBufferViewLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-  const resourceCache = options.resourceCache;
-  const gltf = options.gltf;
-  const bufferViewId = options.bufferViewId;
-  const gltfResource = options.gltfResource;
-  const baseResource = options.baseResource;
-  const cacheKey = options.cacheKey;
+class GltfBufferViewLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.func("options.resourceCache", resourceCache);
-  Check.typeOf.object("options.gltf", gltf);
-  Check.typeOf.number("options.bufferViewId", bufferViewId);
-  Check.typeOf.object("options.gltfResource", gltfResource);
-  Check.typeOf.object("options.baseResource", baseResource);
-  //>>includeEnd('debug');
+    options = options ?? Frozen.EMPTY_OBJECT;
+    const resourceCache = options.resourceCache;
+    const gltf = options.gltf;
+    const bufferViewId = options.bufferViewId;
+    const gltfResource = options.gltfResource;
+    const baseResource = options.baseResource;
+    const cacheKey = options.cacheKey;
 
-  const bufferView = gltf.bufferViews[bufferViewId];
-  let bufferId = bufferView.buffer;
-  let byteOffset = bufferView.byteOffset;
-  let byteLength = bufferView.byteLength;
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.func("options.resourceCache", resourceCache);
+    Check.typeOf.object("options.gltf", gltf);
+    Check.typeOf.number("options.bufferViewId", bufferViewId);
+    Check.typeOf.object("options.gltfResource", gltfResource);
+    Check.typeOf.object("options.baseResource", baseResource);
+    //>>includeEnd('debug');
 
-  let hasMeshopt = false;
-  let meshoptByteStride;
-  let meshoptCount;
-  let meshoptMode;
-  let meshoptFilter;
+    const bufferView = gltf.bufferViews[bufferViewId];
+    let bufferId = bufferView.buffer;
+    let byteOffset = bufferView.byteOffset;
+    let byteLength = bufferView.byteLength;
 
-  if (hasExtension(bufferView, "EXT_meshopt_compression")) {
-    const meshopt = bufferView.extensions.EXT_meshopt_compression;
-    bufferId = meshopt.buffer;
-    byteOffset = meshopt.byteOffset ?? 0;
-    byteLength = meshopt.byteLength;
+    let hasMeshopt = false;
+    let meshoptByteStride;
+    let meshoptCount;
+    let meshoptMode;
+    let meshoptFilter;
 
-    hasMeshopt = true;
-    meshoptByteStride = meshopt.byteStride;
-    meshoptCount = meshopt.count;
-    meshoptMode = meshopt.mode;
-    meshoptFilter = meshopt.filter ?? "NONE";
+    if (hasExtension(bufferView, "EXT_meshopt_compression")) {
+      const meshopt = bufferView.extensions.EXT_meshopt_compression;
+      bufferId = meshopt.buffer;
+      byteOffset = meshopt.byteOffset ?? 0;
+      byteLength = meshopt.byteLength;
+
+      hasMeshopt = true;
+      meshoptByteStride = meshopt.byteStride;
+      meshoptCount = meshopt.count;
+      meshoptMode = meshopt.mode;
+      meshoptFilter = meshopt.filter ?? "NONE";
+    }
+
+    const buffer = gltf.buffers[bufferId];
+
+    this._hasMeshopt = hasMeshopt;
+    this._meshoptByteStride = meshoptByteStride;
+    this._meshoptCount = meshoptCount;
+    this._meshoptMode = meshoptMode;
+    this._meshoptFilter = meshoptFilter;
+
+    this._resourceCache = resourceCache;
+    this._gltfResource = gltfResource;
+    this._baseResource = baseResource;
+    this._buffer = buffer;
+    this._bufferId = bufferId;
+    this._byteOffset = byteOffset;
+    this._byteLength = byteLength;
+    this._cacheKey = cacheKey;
+    this._bufferLoader = undefined;
+    this._typedArray = undefined;
+    this._state = ResourceLoaderState.UNLOADED;
+    this._promise = undefined;
   }
 
-  const buffer = gltf.buffers[bufferId];
-
-  this._hasMeshopt = hasMeshopt;
-  this._meshoptByteStride = meshoptByteStride;
-  this._meshoptCount = meshoptCount;
-  this._meshoptMode = meshoptMode;
-  this._meshoptFilter = meshoptFilter;
-
-  this._resourceCache = resourceCache;
-  this._gltfResource = gltfResource;
-  this._baseResource = baseResource;
-  this._buffer = buffer;
-  this._bufferId = bufferId;
-  this._byteOffset = byteOffset;
-  this._byteLength = byteLength;
-  this._cacheKey = cacheKey;
-  this._bufferLoader = undefined;
-  this._typedArray = undefined;
-  this._state = ResourceLoaderState.UNLOADED;
-  this._promise = undefined;
-}
-
-if (defined(Object.create)) {
-  GltfBufferViewLoader.prototype = Object.create(ResourceLoader.prototype);
-  GltfBufferViewLoader.prototype.constructor = GltfBufferViewLoader;
-}
-
-Object.defineProperties(GltfBufferViewLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -104,11 +101,10 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return this._cacheKey;
-    },
-  },
+  get cacheKey() {
+    return this._cacheKey;
+  }
+
   /**
    * The typed array containing buffer view data.
    *
@@ -118,12 +114,38 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    * @readonly
    * @private
    */
-  typedArray: {
-    get: function () {
-      return this._typedArray;
-    },
-  },
-});
+  get typedArray() {
+    return this._typedArray;
+  }
+
+  /**
+   * Loads the resource.
+   * @returns {Promise<GltfBufferViewLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  async load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    this._state = ResourceLoaderState.LOADING;
+    this._promise = loadResources(this);
+    return this._promise;
+  }
+
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    if (defined(this._bufferLoader) && !this._bufferLoader.isDestroyed()) {
+      this._resourceCache.unload(this._bufferLoader);
+    }
+
+    this._bufferLoader = undefined;
+    this._typedArray = undefined;
+  }
+}
 
 /**
  * Load the resources associated with the loader.
@@ -182,21 +204,6 @@ async function loadResources(loader) {
 }
 
 /**
- * Loads the resource.
- * @returns {Promise<GltfBufferViewLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-GltfBufferViewLoader.prototype.load = async function () {
-  if (defined(this._promise)) {
-    return this._promise;
-  }
-
-  this._state = ResourceLoaderState.LOADING;
-  this._promise = loadResources(this);
-  return this._promise;
-};
-
-/**
  * Get the buffer loader for the specified buffer view loader.
  * Attempts to retrieve from the resource cache first. If a buffer loader is
  * not found, creates a new buffer loader and adds it to the resource cache.
@@ -225,18 +232,5 @@ function getBufferLoader(bufferViewLoader) {
     typedArray: source,
   });
 }
-
-/**
- * Unloads the resource.
- * @private
- */
-GltfBufferViewLoader.prototype.unload = function () {
-  if (defined(this._bufferLoader) && !this._bufferLoader.isDestroyed()) {
-    this._resourceCache.unload(this._bufferLoader);
-  }
-
-  this._bufferLoader = undefined;
-  this._typedArray = undefined;
-};
 
 export default GltfBufferViewLoader;

--- a/packages/engine/Source/Scene/GltfJsonLoader.js
+++ b/packages/engine/Source/Scene/GltfJsonLoader.js
@@ -37,39 +37,36 @@ import ModelUtility from "./Model/ModelUtility.js";
  *
  * @private
  */
-function GltfJsonLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-  const resourceCache = options.resourceCache;
-  const gltfResource = options.gltfResource;
-  const baseResource = options.baseResource;
-  const typedArray = options.typedArray;
-  const gltfJson = options.gltfJson;
-  const cacheKey = options.cacheKey;
+class GltfJsonLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.func("options.resourceCache", resourceCache);
-  Check.typeOf.object("options.gltfResource", gltfResource);
-  Check.typeOf.object("options.baseResource", baseResource);
-  //>>includeEnd('debug');
+    options = options ?? Frozen.EMPTY_OBJECT;
+    const resourceCache = options.resourceCache;
+    const gltfResource = options.gltfResource;
+    const baseResource = options.baseResource;
+    const typedArray = options.typedArray;
+    const gltfJson = options.gltfJson;
+    const cacheKey = options.cacheKey;
 
-  this._resourceCache = resourceCache;
-  this._gltfResource = gltfResource;
-  this._baseResource = baseResource;
-  this._typedArray = typedArray;
-  this._gltfJson = gltfJson;
-  this._cacheKey = cacheKey;
-  this._gltf = undefined;
-  this._bufferLoaders = [];
-  this._state = ResourceLoaderState.UNLOADED;
-  this._promise = undefined;
-}
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.func("options.resourceCache", resourceCache);
+    Check.typeOf.object("options.gltfResource", gltfResource);
+    Check.typeOf.object("options.baseResource", baseResource);
+    //>>includeEnd('debug');
 
-if (defined(Object.create)) {
-  GltfJsonLoader.prototype = Object.create(ResourceLoader.prototype);
-  GltfJsonLoader.prototype.constructor = GltfJsonLoader;
-}
+    this._resourceCache = resourceCache;
+    this._gltfResource = gltfResource;
+    this._baseResource = baseResource;
+    this._typedArray = typedArray;
+    this._gltfJson = gltfJson;
+    this._cacheKey = cacheKey;
+    this._gltf = undefined;
+    this._bufferLoaders = [];
+    this._state = ResourceLoaderState.UNLOADED;
+    this._promise = undefined;
+  }
 
-Object.defineProperties(GltfJsonLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -79,11 +76,10 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return this._cacheKey;
-    },
-  },
+  get cacheKey() {
+    return this._cacheKey;
+  }
+
   /**
    * The glTF JSON.
    *
@@ -93,38 +89,62 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    * @readonly
    * @private
    */
-  gltf: {
-    get: function () {
-      return this._gltf;
-    },
-  },
-});
+  get gltf() {
+    return this._gltf;
+  }
 
-/**
- * Loads the resource.
- * @returns {Promise<GltfJsonLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-GltfJsonLoader.prototype.load = async function () {
-  if (defined(this._promise)) {
+  /**
+   * Loads the resource.
+   * @returns {Promise<GltfJsonLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  async load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    this._state = ResourceLoaderState.LOADING;
+
+    if (defined(this._gltfJson)) {
+      this._promise = processGltfJson(this, this._gltfJson);
+      return this._promise;
+    }
+
+    if (defined(this._typedArray)) {
+      this._promise = processGltfTypedArray(this, this._typedArray);
+      return this._promise;
+    }
+
+    this._promise = loadFromUri(this);
     return this._promise;
   }
 
-  this._state = ResourceLoaderState.LOADING;
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    const bufferLoaders = this._bufferLoaders;
+    const bufferLoadersLength = bufferLoaders.length;
+    for (let i = 0; i < bufferLoadersLength; ++i) {
+      bufferLoaders[i] =
+        !bufferLoaders[i].isDestroyed() &&
+        this._resourceCache.unload(bufferLoaders[i]);
+    }
+    this._bufferLoaders.length = 0;
 
-  if (defined(this._gltfJson)) {
-    this._promise = processGltfJson(this, this._gltfJson);
-    return this._promise;
+    this._gltf = undefined;
   }
 
-  if (defined(this._typedArray)) {
-    this._promise = processGltfTypedArray(this, this._typedArray);
-    return this._promise;
+  /**
+   * Exposed for testing
+   *
+   * @private
+   */
+  _fetchGltf() {
+    return this._gltfResource.fetchArrayBuffer();
   }
-
-  this._promise = loadFromUri(this);
-  return this._promise;
-};
+}
 
 async function loadFromUri(gltfJsonLoader) {
   let typedArray;
@@ -284,31 +304,5 @@ async function processGltfTypedArray(gltfJsonLoader, typedArray) {
 
   return processGltfJson(gltfJsonLoader, gltf);
 }
-
-/**
- * Unloads the resource.
- * @private
- */
-GltfJsonLoader.prototype.unload = function () {
-  const bufferLoaders = this._bufferLoaders;
-  const bufferLoadersLength = bufferLoaders.length;
-  for (let i = 0; i < bufferLoadersLength; ++i) {
-    bufferLoaders[i] =
-      !bufferLoaders[i].isDestroyed() &&
-      this._resourceCache.unload(bufferLoaders[i]);
-  }
-  this._bufferLoaders.length = 0;
-
-  this._gltf = undefined;
-};
-
-/**
- * Exposed for testing
- *
- * @private
- */
-GltfJsonLoader.prototype._fetchGltf = function () {
-  return this._gltfResource.fetchArrayBuffer();
-};
 
 export default GltfJsonLoader;

--- a/packages/engine/Source/Scene/GltfStructuralMetadataLoader.js
+++ b/packages/engine/Source/Scene/GltfStructuralMetadataLoader.js
@@ -32,62 +32,56 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-function GltfStructuralMetadataLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-  const {
-    gltf,
-    extension,
-    extensionLegacy,
-    gltfResource,
-    baseResource,
-    supportedImageFormats,
-    frameState,
-    cacheKey,
-    asynchronous = true,
-  } = options;
+class GltfStructuralMetadataLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("options.gltf", gltf);
-  Check.typeOf.object("options.gltfResource", gltfResource);
-  Check.typeOf.object("options.baseResource", baseResource);
-  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
-  Check.typeOf.object("options.frameState", frameState);
+    options = options ?? Frozen.EMPTY_OBJECT;
+    const {
+      gltf,
+      extension,
+      extensionLegacy,
+      gltfResource,
+      baseResource,
+      supportedImageFormats,
+      frameState,
+      cacheKey,
+      asynchronous = true,
+    } = options;
 
-  if (!defined(options.extension) && !defined(options.extensionLegacy)) {
-    throw new DeveloperError(
-      "One of options.extension or options.extensionLegacy must be specified",
-    );
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("options.gltf", gltf);
+    Check.typeOf.object("options.gltfResource", gltfResource);
+    Check.typeOf.object("options.baseResource", baseResource);
+    Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+    Check.typeOf.object("options.frameState", frameState);
+
+    if (!defined(options.extension) && !defined(options.extensionLegacy)) {
+      throw new DeveloperError(
+        "One of options.extension or options.extensionLegacy must be specified",
+      );
+    }
+    //>>includeEnd('debug');
+
+    this._gltfResource = gltfResource;
+    this._baseResource = baseResource;
+    this._gltf = gltf;
+    this._extension = extension;
+    this._extensionLegacy = extensionLegacy;
+    this._supportedImageFormats = supportedImageFormats;
+    this._frameState = frameState;
+    this._cacheKey = cacheKey;
+    this._asynchronous = asynchronous;
+    this._bufferViewLoaders = [];
+    this._bufferViewIds = [];
+    this._textureLoaders = [];
+    this._textureIds = [];
+    this._schemaLoader = undefined;
+    this._structuralMetadata = undefined;
+    this._state = ResourceLoaderState.UNLOADED;
+    this._promise = undefined;
   }
-  //>>includeEnd('debug');
 
-  this._gltfResource = gltfResource;
-  this._baseResource = baseResource;
-  this._gltf = gltf;
-  this._extension = extension;
-  this._extensionLegacy = extensionLegacy;
-  this._supportedImageFormats = supportedImageFormats;
-  this._frameState = frameState;
-  this._cacheKey = cacheKey;
-  this._asynchronous = asynchronous;
-  this._bufferViewLoaders = [];
-  this._bufferViewIds = [];
-  this._textureLoaders = [];
-  this._textureIds = [];
-  this._schemaLoader = undefined;
-  this._structuralMetadata = undefined;
-  this._state = ResourceLoaderState.UNLOADED;
-  this._promise = undefined;
-}
-
-if (defined(Object.create)) {
-  GltfStructuralMetadataLoader.prototype = Object.create(
-    ResourceLoader.prototype,
-  );
-  GltfStructuralMetadataLoader.prototype.constructor =
-    GltfStructuralMetadataLoader;
-}
-
-Object.defineProperties(GltfStructuralMetadataLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -97,11 +91,10 @@ Object.defineProperties(GltfStructuralMetadataLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return this._cacheKey;
-    },
-  },
+  get cacheKey() {
+    return this._cacheKey;
+  }
+
   /**
    * The parsed structural metadata
    *
@@ -111,12 +104,118 @@ Object.defineProperties(GltfStructuralMetadataLoader.prototype, {
    * @readonly
    * @private
    */
-  structuralMetadata: {
-    get: function () {
-      return this._structuralMetadata;
-    },
-  },
-});
+  get structuralMetadata() {
+    return this._structuralMetadata;
+  }
+
+  /**
+   * Loads the resource.
+   * @returns {Promise<GltfStructuralMetadataLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    this._state = ResourceLoaderState.LOADING;
+    this._promise = loadResources(this);
+    return this._promise;
+  }
+
+  /**
+   * Processes the resource until it becomes ready.
+   *
+   * @param {FrameState} frameState The frame state.
+   * @private
+   */
+  process(frameState) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("frameState", frameState);
+    //>>includeEnd('debug');
+
+    if (this._state === ResourceLoaderState.READY) {
+      return true;
+    }
+
+    if (this._state !== ResourceLoaderState.LOADED) {
+      return false;
+    }
+
+    const textureLoaders = this._textureLoaders;
+    const textureLoadersLength = textureLoaders.length;
+    let ready = true;
+    for (let i = 0; i < textureLoadersLength; ++i) {
+      const textureLoader = textureLoaders[i];
+      const textureReady = textureLoader.process(frameState);
+      ready = ready && textureReady;
+    }
+
+    if (!ready) {
+      return false;
+    }
+
+    const schema = this._schemaLoader.schema;
+    const bufferViews = {};
+    for (let i = 0; i < this._bufferViewIds.length; ++i) {
+      const bufferViewId = this._bufferViewIds[i];
+      const bufferViewLoader = this._bufferViewLoaders[i];
+      if (!bufferViewLoader.isDestroyed()) {
+        // Copy the typed array and let the underlying ArrayBuffer be freed
+        const bufferViewTypedArray = new Uint8Array(
+          bufferViewLoader.typedArray,
+        );
+        bufferViews[bufferViewId] = bufferViewTypedArray;
+      }
+    }
+
+    const textures = {};
+    for (let i = 0; i < this._textureIds.length; ++i) {
+      const textureId = this._textureIds[i];
+      const textureLoader = textureLoaders[i];
+      if (!textureLoader.isDestroyed()) {
+        textures[textureId] = textureLoader.texture;
+      }
+    }
+    if (defined(this._extension)) {
+      this._structuralMetadata = parseStructuralMetadata({
+        extension: this._extension,
+        schema: schema,
+        bufferViews: bufferViews,
+        textures: textures,
+      });
+    } else {
+      this._structuralMetadata = parseFeatureMetadataLegacy({
+        extension: this._extensionLegacy,
+        schema: schema,
+        bufferViews: bufferViews,
+        textures: textures,
+      });
+    }
+
+    // Buffer views can be unloaded after the data has been copied
+    unloadBufferViews(this);
+
+    this._state = ResourceLoaderState.READY;
+    return true;
+  }
+
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    unloadBufferViews(this);
+    unloadTextures(this);
+
+    if (defined(this._schemaLoader)) {
+      ResourceCache.unload(this._schemaLoader);
+    }
+    this._schemaLoader = undefined;
+
+    this._structuralMetadata = undefined;
+  }
+}
 
 async function loadResources(loader) {
   try {
@@ -145,21 +244,6 @@ async function loadResources(loader) {
     throw loader.getError(errorMessage, error);
   }
 }
-
-/**
- * Loads the resource.
- * @returns {Promise<GltfStructuralMetadataLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-GltfStructuralMetadataLoader.prototype.load = function () {
-  if (defined(this._promise)) {
-    return this._promise;
-  }
-
-  this._state = ResourceLoaderState.LOADING;
-  this._promise = loadResources(this);
-  return this._promise;
-};
 
 function gatherBufferViewIdsFromProperties(properties, bufferViewIdSet) {
   for (const propertyId in properties) {
@@ -391,81 +475,6 @@ async function loadSchema(structuralMetadataLoader) {
   }
 }
 
-/**
- * Processes the resource until it becomes ready.
- *
- * @param {FrameState} frameState The frame state.
- * @private
- */
-GltfStructuralMetadataLoader.prototype.process = function (frameState) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("frameState", frameState);
-  //>>includeEnd('debug');
-
-  if (this._state === ResourceLoaderState.READY) {
-    return true;
-  }
-
-  if (this._state !== ResourceLoaderState.LOADED) {
-    return false;
-  }
-
-  const textureLoaders = this._textureLoaders;
-  const textureLoadersLength = textureLoaders.length;
-  let ready = true;
-  for (let i = 0; i < textureLoadersLength; ++i) {
-    const textureLoader = textureLoaders[i];
-    const textureReady = textureLoader.process(frameState);
-    ready = ready && textureReady;
-  }
-
-  if (!ready) {
-    return false;
-  }
-
-  const schema = this._schemaLoader.schema;
-  const bufferViews = {};
-  for (let i = 0; i < this._bufferViewIds.length; ++i) {
-    const bufferViewId = this._bufferViewIds[i];
-    const bufferViewLoader = this._bufferViewLoaders[i];
-    if (!bufferViewLoader.isDestroyed()) {
-      // Copy the typed array and let the underlying ArrayBuffer be freed
-      const bufferViewTypedArray = new Uint8Array(bufferViewLoader.typedArray);
-      bufferViews[bufferViewId] = bufferViewTypedArray;
-    }
-  }
-
-  const textures = {};
-  for (let i = 0; i < this._textureIds.length; ++i) {
-    const textureId = this._textureIds[i];
-    const textureLoader = textureLoaders[i];
-    if (!textureLoader.isDestroyed()) {
-      textures[textureId] = textureLoader.texture;
-    }
-  }
-  if (defined(this._extension)) {
-    this._structuralMetadata = parseStructuralMetadata({
-      extension: this._extension,
-      schema: schema,
-      bufferViews: bufferViews,
-      textures: textures,
-    });
-  } else {
-    this._structuralMetadata = parseFeatureMetadataLegacy({
-      extension: this._extensionLegacy,
-      schema: schema,
-      bufferViews: bufferViews,
-      textures: textures,
-    });
-  }
-
-  // Buffer views can be unloaded after the data has been copied
-  unloadBufferViews(this);
-
-  this._state = ResourceLoaderState.READY;
-  return true;
-};
-
 function unloadBufferViews(structuralMetadataLoader) {
   const bufferViewLoaders = structuralMetadataLoader._bufferViewLoaders;
   const bufferViewLoadersLength = bufferViewLoaders.length;
@@ -485,21 +494,5 @@ function unloadTextures(structuralMetadataLoader) {
   structuralMetadataLoader._textureLoaders.length = 0;
   structuralMetadataLoader._textureIds.length = 0;
 }
-
-/**
- * Unloads the resource.
- * @private
- */
-GltfStructuralMetadataLoader.prototype.unload = function () {
-  unloadBufferViews(this);
-  unloadTextures(this);
-
-  if (defined(this._schemaLoader)) {
-    ResourceCache.unload(this._schemaLoader);
-  }
-  this._schemaLoader = undefined;
-
-  this._structuralMetadata = undefined;
-};
 
 export default GltfStructuralMetadataLoader;

--- a/packages/engine/Source/Scene/GltfTextureLoader.js
+++ b/packages/engine/Source/Scene/GltfTextureLoader.js
@@ -34,58 +34,55 @@ import resizeImageToNextPowerOfTwo from "../Core/resizeImageToNextPowerOfTwo.js"
  *
  * @private
  */
-function GltfTextureLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-  const resourceCache = options.resourceCache;
-  const gltf = options.gltf;
-  const textureInfo = options.textureInfo;
-  const gltfResource = options.gltfResource;
-  const baseResource = options.baseResource;
-  const supportedImageFormats = options.supportedImageFormats;
-  const cacheKey = options.cacheKey;
-  const asynchronous = options.asynchronous ?? true;
+class GltfTextureLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.func("options.resourceCache", resourceCache);
-  Check.typeOf.object("options.gltf", gltf);
-  Check.typeOf.object("options.textureInfo", textureInfo);
-  Check.typeOf.object("options.gltfResource", gltfResource);
-  Check.typeOf.object("options.baseResource", baseResource);
-  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
-  //>>includeEnd('debug');
+    options = options ?? Frozen.EMPTY_OBJECT;
+    const resourceCache = options.resourceCache;
+    const gltf = options.gltf;
+    const textureInfo = options.textureInfo;
+    const gltfResource = options.gltfResource;
+    const baseResource = options.baseResource;
+    const supportedImageFormats = options.supportedImageFormats;
+    const cacheKey = options.cacheKey;
+    const asynchronous = options.asynchronous ?? true;
 
-  const textureId = textureInfo.index;
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.func("options.resourceCache", resourceCache);
+    Check.typeOf.object("options.gltf", gltf);
+    Check.typeOf.object("options.textureInfo", textureInfo);
+    Check.typeOf.object("options.gltfResource", gltfResource);
+    Check.typeOf.object("options.baseResource", baseResource);
+    Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+    //>>includeEnd('debug');
 
-  // imageId is guaranteed to be defined otherwise the GltfTextureLoader
-  // wouldn't have been created
-  const imageId = GltfLoaderUtil.getImageIdFromTexture({
-    gltf: gltf,
-    textureId: textureId,
-    supportedImageFormats: supportedImageFormats,
-  });
+    const textureId = textureInfo.index;
 
-  this._resourceCache = resourceCache;
-  this._gltf = gltf;
-  this._textureInfo = textureInfo;
-  this._imageId = imageId;
-  this._gltfResource = gltfResource;
-  this._baseResource = baseResource;
-  this._cacheKey = cacheKey;
-  this._asynchronous = asynchronous;
-  this._imageLoader = undefined;
-  this._image = undefined;
-  this._mipLevels = undefined;
-  this._texture = undefined;
-  this._state = ResourceLoaderState.UNLOADED;
-  this._promise = undefined;
-}
+    // imageId is guaranteed to be defined otherwise the GltfTextureLoader
+    // wouldn't have been created
+    const imageId = GltfLoaderUtil.getImageIdFromTexture({
+      gltf: gltf,
+      textureId: textureId,
+      supportedImageFormats: supportedImageFormats,
+    });
 
-if (defined(Object.create)) {
-  GltfTextureLoader.prototype = Object.create(ResourceLoader.prototype);
-  GltfTextureLoader.prototype.constructor = GltfTextureLoader;
-}
+    this._resourceCache = resourceCache;
+    this._gltf = gltf;
+    this._textureInfo = textureInfo;
+    this._imageId = imageId;
+    this._gltfResource = gltfResource;
+    this._baseResource = baseResource;
+    this._cacheKey = cacheKey;
+    this._asynchronous = asynchronous;
+    this._imageLoader = undefined;
+    this._image = undefined;
+    this._mipLevels = undefined;
+    this._texture = undefined;
+    this._state = ResourceLoaderState.UNLOADED;
+    this._promise = undefined;
+  }
 
-Object.defineProperties(GltfTextureLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -95,11 +92,10 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return this._cacheKey;
-    },
-  },
+  get cacheKey() {
+    return this._cacheKey;
+  }
+
   /**
    * The texture.
    *
@@ -109,99 +105,148 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    * @readonly
    * @private
    */
-  texture: {
-    get: function () {
-      return this._texture;
-    },
-  },
-});
-
-const scratchTextureJob = new CreateTextureJob();
-
-async function loadResources(loader) {
-  const resourceCache = loader._resourceCache;
-  try {
-    const imageLoader = resourceCache.getImageLoader({
-      gltf: loader._gltf,
-      imageId: loader._imageId,
-      gltfResource: loader._gltfResource,
-      baseResource: loader._baseResource,
-    });
-    loader._imageLoader = imageLoader;
-    await imageLoader.load();
-
-    if (loader.isDestroyed()) {
-      return;
-    }
-
-    // Now wait for process() to run to finish loading
-    loader._image = imageLoader.image;
-    loader._mipLevels = imageLoader.mipLevels;
-    loader._state = ResourceLoaderState.LOADED;
-
-    return loader;
-  } catch (error) {
-    if (loader.isDestroyed()) {
-      return;
-    }
-
-    loader.unload();
-    loader._state = ResourceLoaderState.FAILED;
-    const errorMessage = "Failed to load texture";
-    throw loader.getError(errorMessage, error);
+  get texture() {
+    return this._texture;
   }
-}
 
-/**
- * Loads the resource.
- * @returns {Promise<GltfDracoLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-GltfTextureLoader.prototype.load = async function () {
-  if (defined(this._promise)) {
+  /**
+   * Loads the resource.
+   * @returns {Promise<GltfDracoLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  async load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    this._state = ResourceLoaderState.LOADING;
+    this._promise = loadResources(this);
     return this._promise;
   }
 
-  this._state = ResourceLoaderState.LOADING;
-  this._promise = loadResources(this);
-  return this._promise;
-};
+  /**
+   * Processes the resource until it becomes ready.
+   *
+   * @param {FrameState} frameState The frame state.
+   * @returns {boolean} true once all resourced are ready.
+   * @private
+   */
+  process(frameState) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("frameState", frameState);
+    //>>includeEnd('debug');
 
-function CreateTextureJob() {
-  this.gltf = undefined;
-  this.textureInfo = undefined;
-  this.textureId = undefined;
-  this.image = undefined;
-  this.context = undefined;
-  this.texture = undefined;
+    if (this._state === ResourceLoaderState.READY) {
+      return true;
+    }
+
+    if (
+      this._state !== ResourceLoaderState.LOADED &&
+      this._state !== ResourceLoaderState.PROCESSING
+    ) {
+      return false;
+    }
+
+    if (defined(this._texture)) {
+      // Already created texture
+      return false;
+    }
+
+    if (!defined(this._image)) {
+      // Not ready to create texture
+      return false;
+    }
+
+    this._state = ResourceLoaderState.PROCESSING;
+
+    let texture;
+    if (this._asynchronous) {
+      const textureJob = scratchTextureJob;
+      textureJob.set(
+        this._gltf,
+        this._textureInfo,
+        this._cacheKey,
+        this._image,
+        this._mipLevels,
+        frameState.context,
+      );
+      const jobScheduler = frameState.jobScheduler;
+      if (!jobScheduler.execute(textureJob, JobType.TEXTURE)) {
+        // Job scheduler is full. Try again next frame.
+        return;
+      }
+      texture = textureJob.texture;
+    } else {
+      texture = createTexture(
+        this._gltf,
+        this._textureInfo,
+        this._cacheKey,
+        this._image,
+        this._mipLevels,
+        frameState.context,
+      );
+    }
+
+    // Unload everything except the texture
+    this.unload();
+
+    this._texture = texture;
+    this._state = ResourceLoaderState.READY;
+    this._resourceCache.statistics.addTextureLoader(this);
+    return true;
+  }
+
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    if (defined(this._texture)) {
+      this._texture.destroy();
+    }
+
+    if (defined(this._imageLoader) && !this._imageLoader.isDestroyed()) {
+      this._resourceCache.unload(this._imageLoader);
+    }
+
+    this._imageLoader = undefined;
+    this._image = undefined;
+    this._mipLevels = undefined;
+    this._texture = undefined;
+    this._gltf = undefined;
+  }
 }
 
-CreateTextureJob.prototype.set = function (
-  gltf,
-  textureInfo,
-  textureId,
-  image,
-  mipLevels,
-  context,
-) {
-  this.gltf = gltf;
-  this.textureInfo = textureInfo;
-  this.textureId = textureId;
-  this.image = image;
-  this.mipLevels = mipLevels;
-  this.context = context;
-};
+class CreateTextureJob {
+  constructor() {
+    this.gltf = undefined;
+    this.textureInfo = undefined;
+    this.textureId = undefined;
+    this.image = undefined;
+    this.context = undefined;
+    this.texture = undefined;
+  }
 
-CreateTextureJob.prototype.execute = function () {
-  this.texture = createTexture(
-    this.gltf,
-    this.textureInfo,
-    this.textureId,
-    this.image,
-    this.mipLevels,
-    this.context,
-  );
-};
+  set(gltf, textureInfo, textureId, image, mipLevels, context) {
+    this.gltf = gltf;
+    this.textureInfo = textureInfo;
+    this.textureId = textureId;
+    this.image = image;
+    this.mipLevels = mipLevels;
+    this.context = context;
+  }
+
+  execute() {
+    this.texture = createTexture(
+      this.gltf,
+      this.textureInfo,
+      this.textureId,
+      this.image,
+      this.mipLevels,
+      this.context,
+    );
+  }
+}
 
 function createTexture(
   gltf,
@@ -304,96 +349,40 @@ function createTexture(
   return texture;
 }
 
-/**
- * Processes the resource until it becomes ready.
- *
- * @param {FrameState} frameState The frame state.
- * @returns {boolean} true once all resourced are ready.
- * @private
- */
-GltfTextureLoader.prototype.process = function (frameState) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("frameState", frameState);
-  //>>includeEnd('debug');
+const scratchTextureJob = new CreateTextureJob();
 
-  if (this._state === ResourceLoaderState.READY) {
-    return true;
-  }
+async function loadResources(loader) {
+  const resourceCache = loader._resourceCache;
+  try {
+    const imageLoader = resourceCache.getImageLoader({
+      gltf: loader._gltf,
+      imageId: loader._imageId,
+      gltfResource: loader._gltfResource,
+      baseResource: loader._baseResource,
+    });
+    loader._imageLoader = imageLoader;
+    await imageLoader.load();
 
-  if (
-    this._state !== ResourceLoaderState.LOADED &&
-    this._state !== ResourceLoaderState.PROCESSING
-  ) {
-    return false;
-  }
-
-  if (defined(this._texture)) {
-    // Already created texture
-    return false;
-  }
-
-  if (!defined(this._image)) {
-    // Not ready to create texture
-    return false;
-  }
-
-  this._state = ResourceLoaderState.PROCESSING;
-
-  let texture;
-  if (this._asynchronous) {
-    const textureJob = scratchTextureJob;
-    textureJob.set(
-      this._gltf,
-      this._textureInfo,
-      this._cacheKey,
-      this._image,
-      this._mipLevels,
-      frameState.context,
-    );
-    const jobScheduler = frameState.jobScheduler;
-    if (!jobScheduler.execute(textureJob, JobType.TEXTURE)) {
-      // Job scheduler is full. Try again next frame.
+    if (loader.isDestroyed()) {
       return;
     }
-    texture = textureJob.texture;
-  } else {
-    texture = createTexture(
-      this._gltf,
-      this._textureInfo,
-      this._cacheKey,
-      this._image,
-      this._mipLevels,
-      frameState.context,
-    );
+
+    // Now wait for process() to run to finish loading
+    loader._image = imageLoader.image;
+    loader._mipLevels = imageLoader.mipLevels;
+    loader._state = ResourceLoaderState.LOADED;
+
+    return loader;
+  } catch (error) {
+    if (loader.isDestroyed()) {
+      return;
+    }
+
+    loader.unload();
+    loader._state = ResourceLoaderState.FAILED;
+    const errorMessage = "Failed to load texture";
+    throw loader.getError(errorMessage, error);
   }
-
-  // Unload everything except the texture
-  this.unload();
-
-  this._texture = texture;
-  this._state = ResourceLoaderState.READY;
-  this._resourceCache.statistics.addTextureLoader(this);
-  return true;
-};
-
-/**
- * Unloads the resource.
- * @private
- */
-GltfTextureLoader.prototype.unload = function () {
-  if (defined(this._texture)) {
-    this._texture.destroy();
-  }
-
-  if (defined(this._imageLoader) && !this._imageLoader.isDestroyed()) {
-    this._resourceCache.unload(this._imageLoader);
-  }
-
-  this._imageLoader = undefined;
-  this._image = undefined;
-  this._mipLevels = undefined;
-  this._texture = undefined;
-  this._gltf = undefined;
-};
+}
 
 export default GltfTextureLoader;

--- a/packages/engine/Source/Scene/GltfVertexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfVertexBufferLoader.js
@@ -42,102 +42,99 @@ import CesiumMath from "../Core/Math.js";
  *
  * @private
  */
-function GltfVertexBufferLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-  const resourceCache = options.resourceCache;
-  const gltf = options.gltf;
-  const gltfResource = options.gltfResource;
-  const baseResource = options.baseResource;
-  const bufferViewId = options.bufferViewId;
-  const primitive = options.primitive;
-  const draco = options.draco;
-  const attributeSemantic = options.attributeSemantic;
-  const accessorId = options.accessorId;
-  const cacheKey = options.cacheKey;
-  const spz = options.spz;
-  const asynchronous = options.asynchronous ?? true;
-  const loadBuffer = options.loadBuffer ?? false;
-  const loadTypedArray = options.loadTypedArray ?? false;
+class GltfVertexBufferLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.func("options.resourceCache", resourceCache);
-  Check.typeOf.object("options.gltf", gltf);
-  Check.typeOf.object("options.gltfResource", gltfResource);
-  Check.typeOf.object("options.baseResource", baseResource);
-  if (!loadBuffer && !loadTypedArray) {
-    throw new DeveloperError(
-      "At least one of loadBuffer and loadTypedArray must be true.",
-    );
+    options = options ?? Frozen.EMPTY_OBJECT;
+    const resourceCache = options.resourceCache;
+    const gltf = options.gltf;
+    const gltfResource = options.gltfResource;
+    const baseResource = options.baseResource;
+    const bufferViewId = options.bufferViewId;
+    const primitive = options.primitive;
+    const draco = options.draco;
+    const attributeSemantic = options.attributeSemantic;
+    const accessorId = options.accessorId;
+    const cacheKey = options.cacheKey;
+    const spz = options.spz;
+    const asynchronous = options.asynchronous ?? true;
+    const loadBuffer = options.loadBuffer ?? false;
+    const loadTypedArray = options.loadTypedArray ?? false;
+
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.func("options.resourceCache", resourceCache);
+    Check.typeOf.object("options.gltf", gltf);
+    Check.typeOf.object("options.gltfResource", gltfResource);
+    Check.typeOf.object("options.baseResource", baseResource);
+    if (!loadBuffer && !loadTypedArray) {
+      throw new DeveloperError(
+        "At least one of loadBuffer and loadTypedArray must be true.",
+      );
+    }
+
+    const hasBufferViewId = defined(bufferViewId);
+    const hasPrimitive = defined(primitive);
+    const hasDraco = hasDracoCompression(draco, attributeSemantic);
+    const hasAttributeSemantic = defined(attributeSemantic);
+    const hasAccessorId = defined(accessorId);
+    const hasSpz = defined(spz);
+    if (hasBufferViewId === (hasDraco !== hasSpz)) {
+      throw new DeveloperError(
+        "One of options.bufferViewId, options.draco, or options.spz must be defined.",
+      );
+    }
+
+    if (hasDraco && !hasAttributeSemantic) {
+      throw new DeveloperError(
+        "When options.draco is defined options.attributeSemantic must also be defined.",
+      );
+    }
+
+    if (hasDraco && !hasAccessorId) {
+      throw new DeveloperError(
+        "When options.draco is defined options.accessorId must also be defined.",
+      );
+    }
+
+    if (hasDraco && !hasPrimitive) {
+      throw new DeveloperError(
+        "When options.draco is defined options.primitive must also be defined.",
+      );
+    }
+
+    if (hasDraco) {
+      Check.typeOf.object("options.primitive", primitive);
+      Check.typeOf.object("options.draco", draco);
+      Check.typeOf.string("options.attributeSemantic", attributeSemantic);
+      Check.typeOf.number("options.accessorId", accessorId);
+    }
+
+    //>>includeEnd('debug');
+
+    this._resourceCache = resourceCache;
+    this._gltfResource = gltfResource;
+    this._baseResource = baseResource;
+    this._gltf = gltf;
+    this._bufferViewId = bufferViewId;
+    this._primitive = primitive;
+    this._draco = draco;
+    this._spz = spz;
+    this._attributeSemantic = attributeSemantic;
+    this._accessorId = accessorId;
+    this._cacheKey = cacheKey;
+    this._asynchronous = asynchronous;
+    this._loadBuffer = loadBuffer;
+    this._loadTypedArray = loadTypedArray;
+    this._bufferViewLoader = undefined;
+    this._dracoLoader = undefined;
+    this._quantization = undefined;
+    this._typedArray = undefined;
+    this._buffer = undefined;
+    this._state = ResourceLoaderState.UNLOADED;
+    this._promise = undefined;
   }
 
-  const hasBufferViewId = defined(bufferViewId);
-  const hasPrimitive = defined(primitive);
-  const hasDraco = hasDracoCompression(draco, attributeSemantic);
-  const hasAttributeSemantic = defined(attributeSemantic);
-  const hasAccessorId = defined(accessorId);
-  const hasSpz = defined(spz);
-  if (hasBufferViewId === (hasDraco !== hasSpz)) {
-    throw new DeveloperError(
-      "One of options.bufferViewId, options.draco, or options.spz must be defined.",
-    );
-  }
-
-  if (hasDraco && !hasAttributeSemantic) {
-    throw new DeveloperError(
-      "When options.draco is defined options.attributeSemantic must also be defined.",
-    );
-  }
-
-  if (hasDraco && !hasAccessorId) {
-    throw new DeveloperError(
-      "When options.draco is defined options.accessorId must also be defined.",
-    );
-  }
-
-  if (hasDraco && !hasPrimitive) {
-    throw new DeveloperError(
-      "When options.draco is defined options.primitive must also be defined.",
-    );
-  }
-
-  if (hasDraco) {
-    Check.typeOf.object("options.primitive", primitive);
-    Check.typeOf.object("options.draco", draco);
-    Check.typeOf.string("options.attributeSemantic", attributeSemantic);
-    Check.typeOf.number("options.accessorId", accessorId);
-  }
-
-  //>>includeEnd('debug');
-
-  this._resourceCache = resourceCache;
-  this._gltfResource = gltfResource;
-  this._baseResource = baseResource;
-  this._gltf = gltf;
-  this._bufferViewId = bufferViewId;
-  this._primitive = primitive;
-  this._draco = draco;
-  this._spz = spz;
-  this._attributeSemantic = attributeSemantic;
-  this._accessorId = accessorId;
-  this._cacheKey = cacheKey;
-  this._asynchronous = asynchronous;
-  this._loadBuffer = loadBuffer;
-  this._loadTypedArray = loadTypedArray;
-  this._bufferViewLoader = undefined;
-  this._dracoLoader = undefined;
-  this._quantization = undefined;
-  this._typedArray = undefined;
-  this._buffer = undefined;
-  this._state = ResourceLoaderState.UNLOADED;
-  this._promise = undefined;
-}
-
-if (defined(Object.create)) {
-  GltfVertexBufferLoader.prototype = Object.create(ResourceLoader.prototype);
-  GltfVertexBufferLoader.prototype.constructor = GltfVertexBufferLoader;
-}
-
-Object.defineProperties(GltfVertexBufferLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -147,11 +144,10 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return this._cacheKey;
-    },
-  },
+  get cacheKey() {
+    return this._cacheKey;
+  }
+
   /**
    * The vertex buffer. This is only defined when <code>loadAsTypedArray</code> is false.
    *
@@ -161,11 +157,10 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @readonly
    * @private
    */
-  buffer: {
-    get: function () {
-      return this._buffer;
-    },
-  },
+  get buffer() {
+    return this._buffer;
+  }
+
   /**
    * The typed array containing vertex buffer data. This is only defined when <code>loadAsTypedArray</code> is true.
    *
@@ -175,11 +170,10 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @readonly
    * @private
    */
-  typedArray: {
-    get: function () {
-      return this._typedArray;
-    },
-  },
+  get typedArray() {
+    return this._typedArray;
+  }
+
   /**
    * Information about the quantized vertex attribute after Draco decode.
    *
@@ -189,12 +183,142 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @readonly
    * @private
    */
-  quantization: {
-    get: function () {
-      return this._quantization;
-    },
-  },
-});
+  get quantization() {
+    return this._quantization;
+  }
+
+  /**
+   * Loads the resource.
+   * @returns {Promise<GltfVertexBufferLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  async load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    if (defined(this._spz)) {
+      this._promise = loadFromSpz(this);
+      return this._promise;
+    }
+
+    if (hasDracoCompression(this._draco, this._attributeSemantic)) {
+      this._promise = loadFromDraco(this);
+      return this._promise;
+    }
+
+    this._promise = loadFromBufferView(this);
+    return this._promise;
+  }
+
+  /**
+   * Processes the resource until it becomes ready.
+   *
+   * @param {FrameState} frameState The frame state.
+   * @private
+   */
+  process(frameState) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("frameState", frameState);
+    //>>includeEnd('debug');
+
+    if (this._state === ResourceLoaderState.READY) {
+      return true;
+    }
+
+    if (
+      this._state !== ResourceLoaderState.LOADED &&
+      this._state !== ResourceLoaderState.PROCESSING
+    ) {
+      return false;
+    }
+
+    if (defined(this._dracoLoader)) {
+      try {
+        const ready = this._dracoLoader.process(frameState);
+        if (!ready) {
+          return false;
+        }
+      } catch (error) {
+        handleError(this, error);
+      }
+
+      processDraco(this);
+    }
+
+    if (defined(this._spzLoader)) {
+      try {
+        const ready = this._spzLoader.process(frameState);
+        if (!ready) {
+          return false;
+        }
+      } catch (error) {
+        handleError(this, error);
+      }
+
+      processSpz(this);
+    }
+
+    let buffer;
+    const typedArray = this._typedArray;
+    if (this._loadBuffer && this._asynchronous) {
+      const vertexBufferJob = scratchVertexBufferJob;
+      vertexBufferJob.set(typedArray, frameState.context);
+      const jobScheduler = frameState.jobScheduler;
+      if (!jobScheduler.execute(vertexBufferJob, JobType.BUFFER)) {
+        // Job scheduler is full. Try again next frame.
+        return false;
+      }
+      buffer = vertexBufferJob.buffer;
+    } else if (this._loadBuffer) {
+      buffer = createVertexBuffer(typedArray, frameState.context);
+    }
+
+    // Unload everything except the vertex buffer
+    this.unload();
+
+    this._buffer = buffer;
+    this._typedArray = this._loadTypedArray ? typedArray : undefined;
+    this._state = ResourceLoaderState.READY;
+    this._resourceCache.statistics.addGeometryLoader(this);
+    return true;
+  }
+
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    if (defined(this._buffer)) {
+      this._buffer.destroy();
+    }
+
+    const resourceCache = this._resourceCache;
+
+    if (
+      defined(this._bufferViewLoader) &&
+      !this._bufferViewLoader.isDestroyed()
+    ) {
+      resourceCache.unload(this._bufferViewLoader);
+    }
+
+    if (defined(this._dracoLoader)) {
+      resourceCache.unload(this._dracoLoader);
+    }
+
+    if (defined(this._spzLoader)) {
+      resourceCache.unload(this._spzLoader);
+    }
+
+    this._bufferViewLoader = undefined;
+    this._dracoLoader = undefined;
+    this._spzLoader = undefined;
+    this._typedArray = undefined;
+    this._buffer = undefined;
+    this._gltf = undefined;
+    this._primitive = undefined;
+  }
+}
 
 function hasDracoCompression(draco, semantic) {
   return (
@@ -203,30 +327,6 @@ function hasDracoCompression(draco, semantic) {
     defined(draco.attributes[semantic])
   );
 }
-
-/**
- * Loads the resource.
- * @returns {Promise<GltfVertexBufferLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-GltfVertexBufferLoader.prototype.load = async function () {
-  if (defined(this._promise)) {
-    return this._promise;
-  }
-
-  if (defined(this._spz)) {
-    this._promise = loadFromSpz(this);
-    return this._promise;
-  }
-
-  if (hasDracoCompression(this._draco, this._attributeSemantic)) {
-    this._promise = loadFromDraco(this);
-    return this._promise;
-  }
-
-  this._promise = loadFromBufferView(this);
-  return this._promise;
-};
 
 function getQuantizationInformation(
   dracoQuantization,
@@ -496,20 +596,22 @@ function handleError(vertexBufferLoader, error) {
   throw vertexBufferLoader.getError(errorMessage, error);
 }
 
-function CreateVertexBufferJob() {
-  this.typedArray = undefined;
-  this.context = undefined;
-  this.buffer = undefined;
+class CreateVertexBufferJob {
+  constructor() {
+    this.typedArray = undefined;
+    this.context = undefined;
+    this.buffer = undefined;
+  }
+
+  set(typedArray, context) {
+    this.typedArray = typedArray;
+    this.context = context;
+  }
+
+  execute() {
+    this.buffer = createVertexBuffer(this.typedArray, this.context);
+  }
 }
-
-CreateVertexBufferJob.prototype.set = function (typedArray, context) {
-  this.typedArray = typedArray;
-  this.context = context;
-};
-
-CreateVertexBufferJob.prototype.execute = function () {
-  this.buffer = createVertexBuffer(this.typedArray, this.context);
-};
 
 function createVertexBuffer(typedArray, context) {
   const buffer = Buffer.createVertexBuffer({
@@ -522,113 +624,5 @@ function createVertexBuffer(typedArray, context) {
 }
 
 const scratchVertexBufferJob = new CreateVertexBufferJob();
-
-/**
- * Processes the resource until it becomes ready.
- *
- * @param {FrameState} frameState The frame state.
- * @private
- */
-GltfVertexBufferLoader.prototype.process = function (frameState) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("frameState", frameState);
-  //>>includeEnd('debug');
-
-  if (this._state === ResourceLoaderState.READY) {
-    return true;
-  }
-
-  if (
-    this._state !== ResourceLoaderState.LOADED &&
-    this._state !== ResourceLoaderState.PROCESSING
-  ) {
-    return false;
-  }
-
-  if (defined(this._dracoLoader)) {
-    try {
-      const ready = this._dracoLoader.process(frameState);
-      if (!ready) {
-        return false;
-      }
-    } catch (error) {
-      handleError(this, error);
-    }
-
-    processDraco(this);
-  }
-
-  if (defined(this._spzLoader)) {
-    try {
-      const ready = this._spzLoader.process(frameState);
-      if (!ready) {
-        return false;
-      }
-    } catch (error) {
-      handleError(this, error);
-    }
-
-    processSpz(this);
-  }
-
-  let buffer;
-  const typedArray = this._typedArray;
-  if (this._loadBuffer && this._asynchronous) {
-    const vertexBufferJob = scratchVertexBufferJob;
-    vertexBufferJob.set(typedArray, frameState.context);
-    const jobScheduler = frameState.jobScheduler;
-    if (!jobScheduler.execute(vertexBufferJob, JobType.BUFFER)) {
-      // Job scheduler is full. Try again next frame.
-      return false;
-    }
-    buffer = vertexBufferJob.buffer;
-  } else if (this._loadBuffer) {
-    buffer = createVertexBuffer(typedArray, frameState.context);
-  }
-
-  // Unload everything except the vertex buffer
-  this.unload();
-
-  this._buffer = buffer;
-  this._typedArray = this._loadTypedArray ? typedArray : undefined;
-  this._state = ResourceLoaderState.READY;
-  this._resourceCache.statistics.addGeometryLoader(this);
-  return true;
-};
-
-/**
- * Unloads the resource.
- * @private
- */
-GltfVertexBufferLoader.prototype.unload = function () {
-  if (defined(this._buffer)) {
-    this._buffer.destroy();
-  }
-
-  const resourceCache = this._resourceCache;
-
-  if (
-    defined(this._bufferViewLoader) &&
-    !this._bufferViewLoader.isDestroyed()
-  ) {
-    resourceCache.unload(this._bufferViewLoader);
-  }
-
-  if (defined(this._dracoLoader)) {
-    resourceCache.unload(this._dracoLoader);
-  }
-
-  if (defined(this._spzLoader)) {
-    resourceCache.unload(this._spzLoader);
-  }
-
-  this._bufferViewLoader = undefined;
-  this._dracoLoader = undefined;
-  this._spzLoader = undefined;
-  this._typedArray = undefined;
-  this._buffer = undefined;
-  this._gltf = undefined;
-  this._primitive = undefined;
-};
 
 export default GltfVertexBufferLoader;

--- a/packages/engine/Source/Scene/MetadataSchemaLoader.js
+++ b/packages/engine/Source/Scene/MetadataSchemaLoader.js
@@ -25,33 +25,32 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-function MetadataSchemaLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-  const schema = options.schema;
-  const resource = options.resource;
-  const cacheKey = options.cacheKey;
+class MetadataSchemaLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  if (defined(schema) === defined(resource)) {
-    throw new DeveloperError(
-      "One of options.schema and options.resource must be defined.",
-    );
+    options = options ?? Frozen.EMPTY_OBJECT;
+    const schema = options.schema;
+    const resource = options.resource;
+    const cacheKey = options.cacheKey;
+
+    //>>includeStart('debug', pragmas.debug);
+    if (defined(schema) === defined(resource)) {
+      throw new DeveloperError(
+        "One of options.schema and options.resource must be defined.",
+      );
+    }
+    //>>includeEnd('debug');
+
+    this._schema = defined(schema)
+      ? MetadataSchema.fromJson(schema)
+      : undefined;
+    this._resource = resource;
+    this._cacheKey = cacheKey;
+    this._state = ResourceLoaderState.UNLOADED;
+    this._promise = undefined;
   }
-  //>>includeEnd('debug');
 
-  this._schema = defined(schema) ? MetadataSchema.fromJson(schema) : undefined;
-  this._resource = resource;
-  this._cacheKey = cacheKey;
-  this._state = ResourceLoaderState.UNLOADED;
-  this._promise = undefined;
-}
-
-if (defined(Object.create)) {
-  MetadataSchemaLoader.prototype = Object.create(ResourceLoader.prototype);
-  MetadataSchemaLoader.prototype.constructor = MetadataSchemaLoader;
-}
-
-Object.defineProperties(MetadataSchemaLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -61,11 +60,10 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return this._cacheKey;
-    },
-  },
+  get cacheKey() {
+    return this._cacheKey;
+  }
+
   /**
    * The metadata schema object.
    *
@@ -75,31 +73,37 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    * @readonly
    * @private
    */
-  schema: {
-    get: function () {
-      return this._schema;
-    },
-  },
-});
+  get schema() {
+    return this._schema;
+  }
 
-/**
- * Loads the resource.
- * @returns {Promise<MetadataSchemaLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-MetadataSchemaLoader.prototype.load = async function () {
-  if (defined(this._promise)) {
+  /**
+   * Loads the resource.
+   * @returns {Promise<MetadataSchemaLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  async load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    if (defined(this._schema)) {
+      this._promise = Promise.resolve(this);
+      return this._promise;
+    }
+
+    this._promise = loadExternalSchema(this);
     return this._promise;
   }
 
-  if (defined(this._schema)) {
-    this._promise = Promise.resolve(this);
-    return this._promise;
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    this._schema = undefined;
   }
-
-  this._promise = loadExternalSchema(this);
-  return this._promise;
-};
+}
 
 async function loadExternalSchema(schemaLoader) {
   const resource = schemaLoader._resource;
@@ -123,13 +127,5 @@ async function loadExternalSchema(schemaLoader) {
     throw schemaLoader.getError(errorMessage, error);
   }
 }
-
-/**
- * Unloads the resource.
- * @private
- */
-MetadataSchemaLoader.prototype.unload = function () {
-  this._schema = undefined;
-};
 
 export default MetadataSchemaLoader;

--- a/packages/engine/Source/Scene/Model/B3dmLoader.js
+++ b/packages/engine/Source/Scene/Model/B3dmLoader.js
@@ -55,71 +55,68 @@ const FeatureIdAttribute = ModelComponents.FeatureIdAttribute;
  * @param {boolean} [options.loadPrimitiveOutline=true] If <code>true</code>, load outlines from the {@link https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/CESIUM_primitive_outline|CESIUM_primitive_outline} extension. This can be set false to avoid post-processing geometry at load time.
  * @param {boolean} [options.loadForClassification=false] If <code>true</code> and if the model has feature IDs, load the feature IDs and indices as typed arrays. This is useful for batching features for classification.
  * */
-function B3dmLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class B3dmLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  const b3dmResource = options.b3dmResource;
-  let baseResource = options.baseResource;
-  const arrayBuffer = options.arrayBuffer;
-  const byteOffset = options.byteOffset ?? 0;
-  const releaseGltfJson = options.releaseGltfJson ?? false;
-  const asynchronous = options.asynchronous ?? true;
-  const incrementallyLoadTextures = options.incrementallyLoadTextures ?? true;
-  const upAxis = options.upAxis ?? Axis.Y;
-  const forwardAxis = options.forwardAxis ?? Axis.X;
-  const loadAttributesAsTypedArray =
-    options.loadAttributesAsTypedArray ?? false;
-  const loadAttributesFor2D = options.loadAttributesFor2D ?? false;
-  const enablePick = options.enablePick ?? false;
-  const loadIndicesForWireframe = options.loadIndicesForWireframe ?? false;
-  const loadPrimitiveOutline = options.loadPrimitiveOutline ?? true;
-  const loadForClassification = options.loadForClassification ?? false;
+    options = options ?? Frozen.EMPTY_OBJECT;
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("options.b3dmResource", b3dmResource);
-  Check.typeOf.object("options.arrayBuffer", arrayBuffer);
-  //>>includeEnd('debug');
+    const b3dmResource = options.b3dmResource;
+    let baseResource = options.baseResource;
+    const arrayBuffer = options.arrayBuffer;
+    const byteOffset = options.byteOffset ?? 0;
+    const releaseGltfJson = options.releaseGltfJson ?? false;
+    const asynchronous = options.asynchronous ?? true;
+    const incrementallyLoadTextures = options.incrementallyLoadTextures ?? true;
+    const upAxis = options.upAxis ?? Axis.Y;
+    const forwardAxis = options.forwardAxis ?? Axis.X;
+    const loadAttributesAsTypedArray =
+      options.loadAttributesAsTypedArray ?? false;
+    const loadAttributesFor2D = options.loadAttributesFor2D ?? false;
+    const enablePick = options.enablePick ?? false;
+    const loadIndicesForWireframe = options.loadIndicesForWireframe ?? false;
+    const loadPrimitiveOutline = options.loadPrimitiveOutline ?? true;
+    const loadForClassification = options.loadForClassification ?? false;
 
-  baseResource = defined(baseResource) ? baseResource : b3dmResource.clone();
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("options.b3dmResource", b3dmResource);
+    Check.typeOf.object("options.arrayBuffer", arrayBuffer);
+    //>>includeEnd('debug');
 
-  this._b3dmResource = b3dmResource;
-  this._baseResource = baseResource;
-  this._arrayBuffer = arrayBuffer;
-  this._byteOffset = byteOffset;
-  this._releaseGltfJson = releaseGltfJson;
-  this._asynchronous = asynchronous;
-  this._incrementallyLoadTextures = incrementallyLoadTextures;
-  this._upAxis = upAxis;
-  this._forwardAxis = forwardAxis;
-  this._loadAttributesAsTypedArray = loadAttributesAsTypedArray;
-  this._loadAttributesFor2D = loadAttributesFor2D;
-  this._enablePick = enablePick;
-  this._loadIndicesForWireframe = loadIndicesForWireframe;
-  this._loadPrimitiveOutline = loadPrimitiveOutline;
-  this._loadForClassification = loadForClassification;
+    baseResource = defined(baseResource) ? baseResource : b3dmResource.clone();
 
-  this._state = B3dmLoaderState.UNLOADED;
+    this._b3dmResource = b3dmResource;
+    this._baseResource = baseResource;
+    this._arrayBuffer = arrayBuffer;
+    this._byteOffset = byteOffset;
+    this._releaseGltfJson = releaseGltfJson;
+    this._asynchronous = asynchronous;
+    this._incrementallyLoadTextures = incrementallyLoadTextures;
+    this._upAxis = upAxis;
+    this._forwardAxis = forwardAxis;
+    this._loadAttributesAsTypedArray = loadAttributesAsTypedArray;
+    this._loadAttributesFor2D = loadAttributesFor2D;
+    this._enablePick = enablePick;
+    this._loadIndicesForWireframe = loadIndicesForWireframe;
+    this._loadPrimitiveOutline = loadPrimitiveOutline;
+    this._loadForClassification = loadForClassification;
 
-  this._promise = undefined;
+    this._state = B3dmLoaderState.UNLOADED;
 
-  this._gltfLoader = undefined;
+    this._promise = undefined;
 
-  // Loaded results.
-  this._batchLength = 0;
-  this._propertyTable = undefined;
+    this._gltfLoader = undefined;
 
-  // The batch table object contains a json and a binary component access using keys of the same name.
-  this._batchTable = undefined;
-  this._components = undefined;
-  this._transform = Matrix4.IDENTITY;
-}
+    // Loaded results.
+    this._batchLength = 0;
+    this._propertyTable = undefined;
 
-if (defined(Object.create)) {
-  B3dmLoader.prototype = Object.create(ResourceLoader.prototype);
-  B3dmLoader.prototype.constructor = B3dmLoader;
-}
+    // The batch table object contains a json and a binary component access using keys of the same name.
+    this._batchTable = undefined;
+    this._components = undefined;
+    this._transform = Matrix4.IDENTITY;
+  }
 
-Object.defineProperties(B3dmLoader.prototype, {
   /**
    * true if textures are loaded, useful when incrementallyLoadTextures is true
    *
@@ -129,11 +126,10 @@ Object.defineProperties(B3dmLoader.prototype, {
    * @readonly
    * @private
    */
-  texturesLoaded: {
-    get: function () {
-      return this._gltfLoader?.texturesLoaded;
-    },
-  },
+  get texturesLoaded() {
+    return this._gltfLoader?.texturesLoaded;
+  }
+
   /**
    * The cache key of the resource
    *
@@ -143,11 +139,9 @@ Object.defineProperties(B3dmLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return undefined;
-    },
-  },
+  get cacheKey() {
+    return undefined;
+  }
 
   /**
    * The loaded components.
@@ -158,94 +152,142 @@ Object.defineProperties(B3dmLoader.prototype, {
    * @readonly
    * @private
    */
-  components: {
-    get: function () {
-      return this._components;
-    },
-  },
-});
+  get components() {
+    return this._components;
+  }
 
-/**
- * Loads the resource.
- * @returns {Promise<B3dmLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-B3dmLoader.prototype.load = function () {
-  if (defined(this._promise)) {
+  /**
+   * Loads the resource.
+   * @returns {Promise<B3dmLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  load() {
+    if (defined(this._promise)) {
+      return this._promise;
+    }
+
+    const b3dm = B3dmParser.parse(this._arrayBuffer, this._byteOffset);
+
+    let batchLength = b3dm.batchLength;
+    const featureTableJson = b3dm.featureTableJson;
+    const featureTableBinary = b3dm.featureTableBinary;
+    const batchTableJson = b3dm.batchTableJson;
+    const batchTableBinary = b3dm.batchTableBinary;
+
+    const featureTable = new Cesium3DTileFeatureTable(
+      featureTableJson,
+      featureTableBinary,
+    );
+    batchLength = featureTable.getGlobalProperty("BATCH_LENGTH");
+    // Set batch length.
+    this._batchLength = batchLength;
+    // Set the RTC Center transform, if present.
+    const rtcCenter = featureTable.getGlobalProperty(
+      "RTC_CENTER",
+      ComponentDatatype.FLOAT,
+      3,
+    );
+    if (defined(rtcCenter)) {
+      this._transform = Matrix4.fromTranslation(
+        Cartesian3.fromArray(rtcCenter),
+      );
+    }
+
+    this._batchTable = {
+      json: batchTableJson,
+      binary: batchTableBinary,
+    };
+
+    const gltfLoader = new GltfLoader({
+      typedArray: b3dm.gltf,
+      upAxis: this._upAxis,
+      forwardAxis: this._forwardAxis,
+      gltfResource: this._b3dmResource,
+      baseResource: this._baseResource,
+      releaseGltfJson: this._releaseGltfJson,
+      incrementallyLoadTextures: this._incrementallyLoadTextures,
+      loadAttributesAsTypedArray: this._loadAttributesAsTypedArray,
+      loadAttributesFor2D: this._loadAttributesFor2D,
+      enablePick: this._enablePick,
+      loadIndicesForWireframe: this._loadIndicesForWireframe,
+      loadPrimitiveOutline: this._loadPrimitiveOutline,
+      loadForClassification: this._loadForClassification,
+      renameBatchIdSemantic: true,
+    });
+
+    this._gltfLoader = gltfLoader;
+    this._state = B3dmLoaderState.LOADING;
+
+    const that = this;
+    this._promise = gltfLoader
+      .load()
+      .then(function () {
+        if (that.isDestroyed()) {
+          return;
+        }
+
+        that._state = B3dmLoaderState.PROCESSING;
+        return that;
+      })
+      .catch(function (error) {
+        if (that.isDestroyed()) {
+          return;
+        }
+
+        return handleError(that, error);
+      });
+
     return this._promise;
   }
 
-  const b3dm = B3dmParser.parse(this._arrayBuffer, this._byteOffset);
+  process(frameState) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("frameState", frameState);
+    //>>includeEnd('debug');
 
-  let batchLength = b3dm.batchLength;
-  const featureTableJson = b3dm.featureTableJson;
-  const featureTableBinary = b3dm.featureTableBinary;
-  const batchTableJson = b3dm.batchTableJson;
-  const batchTableBinary = b3dm.batchTableBinary;
+    if (this._state === B3dmLoaderState.READY) {
+      return true;
+    }
 
-  const featureTable = new Cesium3DTileFeatureTable(
-    featureTableJson,
-    featureTableBinary,
-  );
-  batchLength = featureTable.getGlobalProperty("BATCH_LENGTH");
-  // Set batch length.
-  this._batchLength = batchLength;
-  // Set the RTC Center transform, if present.
-  const rtcCenter = featureTable.getGlobalProperty(
-    "RTC_CENTER",
-    ComponentDatatype.FLOAT,
-    3,
-  );
-  if (defined(rtcCenter)) {
-    this._transform = Matrix4.fromTranslation(Cartesian3.fromArray(rtcCenter));
+    if (this._state !== B3dmLoaderState.PROCESSING) {
+      return false;
+    }
+
+    const ready = this._gltfLoader.process(frameState);
+    if (!ready) {
+      return false;
+    }
+
+    const components = this._gltfLoader.components;
+
+    // Combine the RTC_CENTER transform from the b3dm and the CESIUM_RTC
+    // transform from the glTF. In practice usually only one or the
+    // other is supplied. If they don't exist the transforms will
+    // be identity matrices.
+    components.transform = Matrix4.multiplyTransformation(
+      this._transform,
+      components.transform,
+      components.transform,
+    );
+    createStructuralMetadata(this, components);
+    this._components = components;
+
+    // Now that we have the parsed components, we can release the array buffer
+    this._arrayBuffer = undefined;
+
+    this._state = B3dmLoaderState.READY;
+    return true;
   }
 
-  this._batchTable = {
-    json: batchTableJson,
-    binary: batchTableBinary,
-  };
+  unload() {
+    if (defined(this._gltfLoader) && !this._gltfLoader.isDestroyed()) {
+      this._gltfLoader.unload();
+    }
 
-  const gltfLoader = new GltfLoader({
-    typedArray: b3dm.gltf,
-    upAxis: this._upAxis,
-    forwardAxis: this._forwardAxis,
-    gltfResource: this._b3dmResource,
-    baseResource: this._baseResource,
-    releaseGltfJson: this._releaseGltfJson,
-    incrementallyLoadTextures: this._incrementallyLoadTextures,
-    loadAttributesAsTypedArray: this._loadAttributesAsTypedArray,
-    loadAttributesFor2D: this._loadAttributesFor2D,
-    enablePick: this._enablePick,
-    loadIndicesForWireframe: this._loadIndicesForWireframe,
-    loadPrimitiveOutline: this._loadPrimitiveOutline,
-    loadForClassification: this._loadForClassification,
-    renameBatchIdSemantic: true,
-  });
-
-  this._gltfLoader = gltfLoader;
-  this._state = B3dmLoaderState.LOADING;
-
-  const that = this;
-  this._promise = gltfLoader
-    .load()
-    .then(function () {
-      if (that.isDestroyed()) {
-        return;
-      }
-
-      that._state = B3dmLoaderState.PROCESSING;
-      return that;
-    })
-    .catch(function (error) {
-      if (that.isDestroyed()) {
-        return;
-      }
-
-      return handleError(that, error);
-    });
-
-  return this._promise;
-};
+    this._components = undefined;
+    this._arrayBuffer = undefined;
+  }
+}
 
 function handleError(b3dmLoader, error) {
   b3dmLoader.unload();
@@ -254,45 +296,6 @@ function handleError(b3dmLoader, error) {
   error = b3dmLoader.getError(errorMessage, error);
   return Promise.reject(error);
 }
-
-B3dmLoader.prototype.process = function (frameState) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("frameState", frameState);
-  //>>includeEnd('debug');
-
-  if (this._state === B3dmLoaderState.READY) {
-    return true;
-  }
-
-  if (this._state !== B3dmLoaderState.PROCESSING) {
-    return false;
-  }
-
-  const ready = this._gltfLoader.process(frameState);
-  if (!ready) {
-    return false;
-  }
-
-  const components = this._gltfLoader.components;
-
-  // Combine the RTC_CENTER transform from the b3dm and the CESIUM_RTC
-  // transform from the glTF. In practice usually only one or the
-  // other is supplied. If they don't exist the transforms will
-  // be identity matrices.
-  components.transform = Matrix4.multiplyTransformation(
-    this._transform,
-    components.transform,
-    components.transform,
-  );
-  createStructuralMetadata(this, components);
-  this._components = components;
-
-  // Now that we have the parsed components, we can release the array buffer
-  this._arrayBuffer = undefined;
-
-  this._state = B3dmLoaderState.READY;
-  return true;
-};
 
 function createStructuralMetadata(loader, components) {
   const batchTable = loader._batchTable;
@@ -355,14 +358,5 @@ function processNode(node) {
     }
   }
 }
-
-B3dmLoader.prototype.unload = function () {
-  if (defined(this._gltfLoader) && !this._gltfLoader.isDestroyed()) {
-    this._gltfLoader.unload();
-  }
-
-  this._components = undefined;
-  this._arrayBuffer = undefined;
-};
 
 export default B3dmLoader;

--- a/packages/engine/Source/Scene/Model/GeoJsonLoader.js
+++ b/packages/engine/Source/Scene/Model/GeoJsonLoader.js
@@ -41,23 +41,20 @@ import addAllToArray from "../../Core/addAllToArray.js";
  * @param {object} options Object with the following properties:
  * @param {object} options.geoJson The GeoJson object.
  */
-function GeoJsonLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class GeoJsonLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("options.geoJson", options.geoJson);
-  //>>includeEnd('debug');
+    options = options ?? Frozen.EMPTY_OBJECT;
 
-  this._geoJson = options.geoJson;
-  this._components = undefined;
-}
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("options.geoJson", options.geoJson);
+    //>>includeEnd('debug');
 
-if (defined(Object.create)) {
-  GeoJsonLoader.prototype = Object.create(ResourceLoader.prototype);
-  GeoJsonLoader.prototype.constructor = GeoJsonLoader;
-}
+    this._geoJson = options.geoJson;
+    this._components = undefined;
+  }
 
-Object.defineProperties(GeoJsonLoader.prototype, {
   /**
    * The cache key of the resource.
    *
@@ -67,11 +64,10 @@ Object.defineProperties(GeoJsonLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return undefined;
-    },
-  },
+  get cacheKey() {
+    return undefined;
+  }
+
   /**
    * The loaded components.
    *
@@ -81,41 +77,47 @@ Object.defineProperties(GeoJsonLoader.prototype, {
    * @readonly
    * @private
    */
-  components: {
-    get: function () {
-      return this._components;
-    },
-  },
-});
+  get components() {
+    return this._components;
+  }
 
-/**
- * Loads the resource.
- * @returns {Promise<GeoJsonLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-GeoJsonLoader.prototype.load = function () {
-  return Promise.resolve(this);
-};
+  /**
+   * Loads the resource.
+   * @returns {Promise<GeoJsonLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  load() {
+    return Promise.resolve(this);
+  }
 
-/**
- * Processes the resource until it becomes ready.
- *
- * @param {FrameState} frameState The frame state.
- * @private
- */
-GeoJsonLoader.prototype.process = function (frameState) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("frameState", frameState);
-  //>>includeEnd('debug');
+  /**
+   * Processes the resource until it becomes ready.
+   *
+   * @param {FrameState} frameState The frame state.
+   * @private
+   */
+  process(frameState) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("frameState", frameState);
+    //>>includeEnd('debug');
 
-  if (defined(this._components)) {
+    if (defined(this._components)) {
+      return true;
+    }
+
+    this._components = parse(this._geoJson, frameState);
+    this._geoJson = undefined;
     return true;
   }
 
-  this._components = parse(this._geoJson, frameState);
-  this._geoJson = undefined;
-  return true;
-};
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {
+    this._components = undefined;
+  }
+}
 
 function ParsedFeature() {
   this.lines = undefined;
@@ -685,13 +687,5 @@ function parse(geoJson, frameState) {
 
   return components;
 }
-
-/**
- * Unloads the resource.
- * @private
- */
-GeoJsonLoader.prototype.unload = function () {
-  this._components = undefined;
-};
 
 export default GeoJsonLoader;

--- a/packages/engine/Source/Scene/Model/PntsLoader.js
+++ b/packages/engine/Source/Scene/Model/PntsLoader.js
@@ -47,40 +47,37 @@ const MetallicRoughness = ModelComponents.MetallicRoughness;
  * @param {number} [options.byteOffset] The byte offset to the beginning of the pnts contents in the array buffer
  * @param {boolean} [options.loadAttributesFor2D=false] If true, load the positions buffer as a typed array for accurately projecting models to 2D.
  */
-function PntsLoader(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class PntsLoader extends ResourceLoader {
+  constructor(options) {
+    super();
 
-  const arrayBuffer = options.arrayBuffer;
-  const byteOffset = options.byteOffset ?? 0;
+    options = options ?? Frozen.EMPTY_OBJECT;
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("options.arrayBuffer", arrayBuffer);
-  //>>includeEnd('debug');
+    const arrayBuffer = options.arrayBuffer;
+    const byteOffset = options.byteOffset ?? 0;
 
-  this._arrayBuffer = arrayBuffer;
-  this._byteOffset = byteOffset;
-  this._loadAttributesFor2D = options.loadAttributesFor2D ?? false;
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("options.arrayBuffer", arrayBuffer);
+    //>>includeEnd('debug');
 
-  this._parsedContent = undefined;
-  this._decodePromise = undefined;
-  this._decodedAttributes = undefined;
+    this._arrayBuffer = arrayBuffer;
+    this._byteOffset = byteOffset;
+    this._loadAttributesFor2D = options.loadAttributesFor2D ?? false;
 
-  this._promise = undefined;
-  this._error = undefined;
-  this._state = ResourceLoaderState.UNLOADED;
-  this._buffers = [];
+    this._parsedContent = undefined;
+    this._decodePromise = undefined;
+    this._decodedAttributes = undefined;
 
-  // The batch table object contains a json and a binary component access using keys of the same name.
-  this._components = undefined;
-  this._transform = Matrix4.IDENTITY;
-}
+    this._promise = undefined;
+    this._error = undefined;
+    this._state = ResourceLoaderState.UNLOADED;
+    this._buffers = [];
 
-if (defined(Object.create)) {
-  PntsLoader.prototype = Object.create(ResourceLoader.prototype);
-  PntsLoader.prototype.constructor = PntsLoader;
-}
+    // The batch table object contains a json and a binary component access using keys of the same name.
+    this._components = undefined;
+    this._transform = Matrix4.IDENTITY;
+  }
 
-Object.defineProperties(PntsLoader.prototype, {
   /**
    * The cache key of the resource
    *
@@ -90,11 +87,9 @@ Object.defineProperties(PntsLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    get: function () {
-      return undefined;
-    },
-  },
+  get cacheKey() {
+    return undefined;
+  }
 
   /**
    * The loaded components.
@@ -105,11 +100,9 @@ Object.defineProperties(PntsLoader.prototype, {
    * @readonly
    * @private
    */
-  components: {
-    get: function () {
-      return this._components;
-    },
-  },
+  get components() {
+    return this._components;
+  }
 
   /**
    * A world-space transform to apply to the primitives.
@@ -121,50 +114,60 @@ Object.defineProperties(PntsLoader.prototype, {
    * @readonly
    * @private
    */
-  transform: {
-    get: function () {
-      return this._transform;
-    },
-  },
-});
-
-/**
- * Loads the resource.
- * @returns {Promise<PntsLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-PntsLoader.prototype.load = function () {
-  if (defined(this._promise)) {
-    return this._promise;
+  get transform() {
+    return this._transform;
   }
 
-  this._parsedContent = PntsParser.parse(this._arrayBuffer, this._byteOffset);
-  this._state = ResourceLoaderState.PROCESSING;
-
-  this._promise = Promise.resolve(this);
-};
-
-PntsLoader.prototype.process = function (frameState) {
-  if (defined(this._error)) {
-    const error = this._error;
-    this._error = undefined;
-    throw error;
-  }
-
-  if (this._state === ResourceLoaderState.READY) {
-    return true;
-  }
-
-  if (this._state === ResourceLoaderState.PROCESSING) {
-    if (defined(this._decodePromise)) {
-      return false;
+  /**
+   * Loads the resource.
+   * @returns {Promise<PntsLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  load() {
+    if (defined(this._promise)) {
+      return this._promise;
     }
 
-    this._decodePromise = decodeDraco(this, frameState.context);
+    this._parsedContent = PntsParser.parse(this._arrayBuffer, this._byteOffset);
+    this._state = ResourceLoaderState.PROCESSING;
+
+    this._promise = Promise.resolve(this);
   }
 
-  return false;
-};
+  process(frameState) {
+    if (defined(this._error)) {
+      const error = this._error;
+      this._error = undefined;
+      throw error;
+    }
+
+    if (this._state === ResourceLoaderState.READY) {
+      return true;
+    }
+
+    if (this._state === ResourceLoaderState.PROCESSING) {
+      if (defined(this._decodePromise)) {
+        return false;
+      }
+
+      this._decodePromise = decodeDraco(this, frameState.context);
+    }
+
+    return false;
+  }
+
+  unload() {
+    const buffers = this._buffers;
+    for (let i = 0; i < buffers.length; i++) {
+      buffers[i].destroy();
+    }
+    buffers.length = 0;
+
+    this._components = undefined;
+    this._parsedContent = undefined;
+    this._arrayBuffer = undefined;
+  }
+}
 
 function decodeDraco(loader, context) {
   const parsedContent = loader._parsedContent;
@@ -700,17 +703,5 @@ function addPropertyAttributesToPrimitive(
   // it will always be index 0
   primitive.propertyAttributeIds = [0];
 }
-
-PntsLoader.prototype.unload = function () {
-  const buffers = this._buffers;
-  for (let i = 0; i < buffers.length; i++) {
-    buffers[i].destroy();
-  }
-  buffers.length = 0;
-
-  this._components = undefined;
-  this._parsedContent = undefined;
-  this._arrayBuffer = undefined;
-};
 
 export default PntsLoader;

--- a/packages/engine/Source/Scene/ResourceLoader.js
+++ b/packages/engine/Source/Scene/ResourceLoader.js
@@ -17,9 +17,7 @@ import RuntimeError from "../Core/RuntimeError.js";
  *
  * @private
  */
-function ResourceLoader() {}
-
-Object.defineProperties(ResourceLoader.prototype, {
+class ResourceLoader {
   /**
    * The cache key of the resource.
    *
@@ -29,99 +27,97 @@ Object.defineProperties(ResourceLoader.prototype, {
    * @readonly
    * @private
    */
-  cacheKey: {
-    // eslint-disable-next-line getter-return
-    get: function () {
-      DeveloperError.throwInstantiationError();
-    },
-  },
-});
-
-/**
- * Loads the resource.
- * @returns {Promise<ResourceLoader>} A promise which resolves to the loader when the resource loading is completed.
- * @private
- */
-ResourceLoader.prototype.load = function () {
-  DeveloperError.throwInstantiationError();
-};
-
-/**
- * Unloads the resource.
- * @private
- */
-ResourceLoader.prototype.unload = function () {};
-
-/**
- * Processes the resource until it becomes ready.
- *
- * @param {FrameState} frameState The frame state.
- * @returns {boolean} true once all resourced are ready.
- * @private
- */
-ResourceLoader.prototype.process = function (frameState) {
-  return false;
-};
-
-/**
- * Constructs a {@link RuntimeError} from an errorMessage and an error.
- *
- * @param {string} errorMessage The error message.
- * @param {Error} [error] The error.
- *
- * @returns {RuntimeError} The runtime error.
- * @private
- */
-ResourceLoader.prototype.getError = function (errorMessage, error) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.string("errorMessage", errorMessage);
-  //>>includeEnd('debug');
-
-  if (defined(error) && defined(error.message)) {
-    errorMessage += `\n${error.message}`;
+  // eslint-disable-next-line getter-return
+  get cacheKey() {
+    DeveloperError.throwInstantiationError();
   }
 
-  const runtimeError = new RuntimeError(errorMessage);
-  if (defined(error)) {
-    runtimeError.stack = `Original stack:\n${error.stack}\nHandler stack:\n${runtimeError.stack}`;
+  /**
+   * Loads the resource.
+   * @returns {Promise<ResourceLoader>} A promise which resolves to the loader when the resource loading is completed.
+   * @private
+   */
+  load() {
+    DeveloperError.throwInstantiationError();
   }
 
-  return runtimeError;
-};
+  /**
+   * Unloads the resource.
+   * @private
+   */
+  unload() {}
 
-/**
- * Returns true if this object was destroyed; otherwise, false.
- * <br /><br />
- * If this object was destroyed, it should not be used; calling any function other than
- * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.
- *
- * @returns {boolean} <code>true</code> if this object was destroyed; otherwise, <code>false</code>.
- *
- * @see ResourceLoader#destroy
- * @private
- */
-ResourceLoader.prototype.isDestroyed = function () {
-  return false;
-};
+  /**
+   * Processes the resource until it becomes ready.
+   *
+   * @param {FrameState} frameState The frame state.
+   * @returns {boolean} true once all resourced are ready.
+   * @private
+   */
+  process(frameState) {
+    return false;
+  }
 
-/**
- * Destroys the loaded resource.
- * <br /><br />
- * Once an object is destroyed, it should not be used; calling any function other than
- * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.  Therefore,
- * assign the return value (<code>undefined</code>) to the object as done in the example.
- *
- * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
- *
- * @example
- * resourceLoader = resourceLoader && resourceLoader.destroy();
- *
- * @see ResourceLoader#isDestroyed
- * @private
- */
-ResourceLoader.prototype.destroy = function () {
-  this.unload();
-  return destroyObject(this);
-};
+  /**
+   * Constructs a {@link RuntimeError} from an errorMessage and an error.
+   *
+   * @param {string} errorMessage The error message.
+   * @param {Error} [error] The error.
+   *
+   * @returns {RuntimeError} The runtime error.
+   * @private
+   */
+  getError(errorMessage, error) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.string("errorMessage", errorMessage);
+    //>>includeEnd('debug');
+
+    if (defined(error) && defined(error.message)) {
+      errorMessage += `\n${error.message}`;
+    }
+
+    const runtimeError = new RuntimeError(errorMessage);
+    if (defined(error)) {
+      runtimeError.stack = `Original stack:\n${error.stack}\nHandler stack:\n${runtimeError.stack}`;
+    }
+
+    return runtimeError;
+  }
+
+  /**
+   * Returns true if this object was destroyed; otherwise, false.
+   * <br /><br />
+   * If this object was destroyed, it should not be used; calling any function other than
+   * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.
+   *
+   * @returns {boolean} <code>true</code> if this object was destroyed; otherwise, <code>false</code>.
+   *
+   * @see ResourceLoader#destroy
+   * @private
+   */
+  isDestroyed() {
+    return false;
+  }
+
+  /**
+   * Destroys the loaded resource.
+   * <br /><br />
+   * Once an object is destroyed, it should not be used; calling any function other than
+   * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.  Therefore,
+   * assign the return value (<code>undefined</code>) to the object as done in the example.
+   *
+   * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+   *
+   * @example
+   * resourceLoader = resourceLoader && resourceLoader.destroy();
+   *
+   * @see ResourceLoader#isDestroyed
+   * @private
+   */
+  destroy() {
+    this.unload();
+    return destroyObject(this);
+  }
+}
 
 export default ResourceLoader;


### PR DESCRIPTION
# Description

Converts `ResourceLoader` and its subclasses to ES6 classes.

1. Grepped for `new \w+Loader\.[a-z]` invalid use of `new` on non-constructor factory methods (none found)
2. Grepped to find subclasses of ResourceLoader, and converted them. DracoLoader isn't a subclass, but is included anyway.
3. Using the script from #13125, run `node ./lebab-batch.js "packages/engine/Source/Scene/*Loader.js"` and `node ./lebab-batch.js "packages/engine/Source/Scene/Model/*Loader.js"`. Manually handled tool warnings in GeoJsonLoader.js.

In this case I think it's simplest to get the conversion to ES6 classes done first, and enable type checking (with many more manual fixes) later. As before, review is much easier with GitHub's split view, and whitespace changes hidden ([`?diff=split&w=1`](https://github.com/CesiumGS/cesium/pull/13201/changes?w=1)). Lebab shouldn't change the order of class members unnecessarily.

## Issue number and link

- #8359 

## Testing plan

Mainly, ESLint and unit tests should pass. It wasn't obvious (to me) which sandcastle examples use which loaders. One way of checking that during a manual review of sandcastles is to temporarily add a small constructor in ResourceLoader:

```javascript
constructor() {
  console.count(this.constructor.name);
}
```

ESLint verifies that all subclasses invoke `super()` in their own constructors.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] ~~I have updated the inline documentation, and included code examples where relevant~~
- [x] I have performed a self-review of my code
