### PR TITLE
Types: Add CHANGES.md entry about ES6 classes and factory methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ### @cesium/engine
 
+#### Breaking Changes :mega:
+
+- Cartesian2, Cartesian3, and Cartesian4 are now [ES6 Classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes). This change should have no impact on most users, but note that using `new` on a static factory method, like `new Cartesian3.fromArray(...)`, will now throw an error. Omit `new` unless you are invoking a constructor directly, for these and all other factory methods, as more classes will be migrated to ES6 Classes soon. [#8359](https://github.com/CesiumGS/cesium/issues/8359)
+
 #### Additions :tada:
 
 - Added `AttributeCompression.encodeRGB8` and `decodeRGB8` for packing colors. [#13174](https://github.com/CesiumGS/cesium/pull/13174)


### PR DESCRIPTION
# Description

Adds a changelog entry about a potential breaking change. Prior to migrating to ES6 classes, using `new` with a static factory method, like `new Cartesian3.fromArray(...)` was unnecessary but did not throw an error. With ES6 classes this same syntax deos throw an error. I'd assumed this was a typo (there were few examples in our codebase) but in case it's something external users will run into I'm adding a changelog entry. Thanks @mzschwartz5 for flagging this!

## Issue number and link

- #8359

## Testing plan

n/a

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [ ] ~~I have updated the inline documentation, and included code examples where relevant~~
- [x] I have performed a self-review of my code



#### PR Dependency Tree


* **PR #13206** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)