### PR TITLE
Types: Add "cesiumTypes" JSDoc plugin, update Runtime- and DeveloperError.js

### DIFF
--- a/Tools/jsdoc/cesiumTags.js
+++ b/Tools/jsdoc/cesiumTags.js
@@ -64,8 +64,8 @@ exports.defineTags = function (dictionary) {
   // https://github.com/microsoft/TypeScript/issues/22160#issuecomment-2021459033
   // https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#type-imports-in-jsdoc
   dictionary.defineTag("import", {
-    canHaveType: true,
-    canHaveName: true,
     mustHaveValue: true,
+    canHaveType: false,
+    canHaveName: false,
   });
 };

--- a/Tools/jsdoc/cesiumTypes.js
+++ b/Tools/jsdoc/cesiumTypes.js
@@ -1,0 +1,32 @@
+const SYNTAX_REGEXP = /\{\s*(typeof|asserts)\s+([^\s]+)\s*\}/g;
+const TOKEN = "{any}";
+
+const dim = (str) => `\x1b[2m${str}\x1b[0m`;
+const red = (str) => `\x1b[31m${str}\x1b[0m`;
+
+// Handles certain type syntax that TypeScript supports but JSDoc does not,
+// temporarily replacing them with a special token, and then checking that
+// this token is not emitted to public documentation or .d.ts files.
+//
+// Makes syntax like 'typeof' safe for inline type assertions, while enforcing
+// that all public/documented APIs still use JSCompatible types.
+//
+// References:
+// - https://github.com/jsdoc/jsdoc/issues/1349
+// - https://github.com/cancerberoSgx/jsdoc-typeof-plugin
+exports.handlers = {
+  jsdocCommentFound: (e) => {
+    if (e.comment && e.comment.match(SYNTAX_REGEXP)) {
+      e.comment = e.comment.replace(SYNTAX_REGEXP, TOKEN);
+    }
+  },
+  newDoclet: (e) => {
+    const { ignore, comment, meta } = e.doclet;
+    if (!ignore && comment.includes(TOKEN)) {
+      const { filename, lineno } = meta;
+      console.error(`Error: Invalid public JSDoc, "${filename}#L${lineno}".\n`);
+      console.error(comment.split(TOKEN).map(dim).join(red(TOKEN)));
+      process.exit(2);
+    }
+  },
+};

--- a/Tools/jsdoc/conf.json
+++ b/Tools/jsdoc/conf.json
@@ -16,7 +16,8 @@
         "excludePattern": "(^|\\/|\\\\)_"
     },
     "plugins": [
-        "./Tools/jsdoc/cesiumTags"
+        "./Tools/jsdoc/cesiumTags",
+        "./Tools/jsdoc/cesiumTypes"
     ],
     "templates": {
         "cleverLinks": true,

--- a/Tools/jsdoc/ts-conf.json
+++ b/Tools/jsdoc/ts-conf.json
@@ -17,6 +17,7 @@
     },
     "plugins": [
         "./Tools/jsdoc/cesiumTags",
+        "./Tools/jsdoc/cesiumTypes",
         "tsd-jsdoc/dist/plugin"
     ],
     "templates": {

--- a/packages/engine/Source/Core/DeveloperError.js
+++ b/packages/engine/Source/Core/DeveloperError.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import defined from "./defined.js";
 
 /**
@@ -10,66 +12,66 @@ import defined from "./defined.js";
  * be thrown at runtime, e.g., out of memory, that the calling code should be prepared
  * to catch.
  *
- * @alias DeveloperError
- * @constructor
  * @extends Error
- *
- * @param {string} [message] The error message for this exception.
  *
  * @see RuntimeError
  */
-function DeveloperError(message) {
+class DeveloperError extends Error {
   /**
-   * 'DeveloperError' indicating that this exception was thrown due to a developer error.
-   * @type {string}
-   * @readonly
+   * @param {string} [message] The error message for this exception.
    */
-  this.name = "DeveloperError";
+  constructor(message) {
+    super(message);
 
-  /**
-   * The explanation for why this exception was thrown.
-   * @type {string}
-   * @readonly
-   */
-  this.message = message;
+    /**
+     * 'DeveloperError' indicating that this exception was thrown due to a developer error.
+     * @type {string}
+     * @readonly
+     */
+    this.name = "DeveloperError";
 
-  //Browsers such as IE don't have a stack property until you actually throw the error.
-  let stack;
-  try {
-    throw new Error();
-  } catch (e) {
-    stack = e.stack;
+    /**
+     * The explanation for why this exception was thrown.
+     * @type {string}
+     * @readonly
+     */
+    this.message = message;
+
+    //Browsers such as IE don't have a stack property until you actually throw the error.
+    let stack;
+    try {
+      throw new Error();
+    } catch (e) {
+      stack = e.stack;
+    }
+
+    /**
+     * The stack trace of this exception, if available.
+     * @type {string}
+     * @readonly
+     */
+    this.stack = stack;
+  }
+
+  toString() {
+    let str = `${this.name}: ${this.message}`;
+
+    if (defined(this.stack)) {
+      str += `\n${this.stack.toString()}`;
+    }
+
+    return str;
   }
 
   /**
-   * The stack trace of this exception, if available.
-   * @type {string}
-   * @readonly
+   * @returns {never}
+   * @ignore
    */
-  this.stack = stack;
-}
-
-if (defined(Object.create)) {
-  DeveloperError.prototype = Object.create(Error.prototype);
-  DeveloperError.prototype.constructor = DeveloperError;
-}
-
-DeveloperError.prototype.toString = function () {
-  let str = `${this.name}: ${this.message}`;
-
-  if (defined(this.stack)) {
-    str += `\n${this.stack.toString()}`;
+  static throwInstantiationError() {
+    throw new DeveloperError(
+      "This function defines an interface and should not be called directly.",
+    );
   }
+}
 
-  return str;
-};
-
-/**
- * @private
- */
-DeveloperError.throwInstantiationError = function () {
-  throw new DeveloperError(
-    "This function defines an interface and should not be called directly.",
-  );
-};
 export default DeveloperError;

--- a/packages/engine/Source/Core/RuntimeError.js
+++ b/packages/engine/Source/Core/RuntimeError.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import defined from "./defined.js";
 
 /**
@@ -9,57 +11,57 @@ import defined from "./defined.js";
  * to a developer error, e.g., invalid argument, that usually indicates a bug in the
  * calling code.
  *
- * @alias RuntimeError
- * @constructor
  * @extends Error
- *
- * @param {string} [message] The error message for this exception.
  *
  * @see DeveloperError
  */
-function RuntimeError(message) {
+class RuntimeError extends Error {
   /**
-   * 'RuntimeError' indicating that this exception was thrown due to a runtime error.
-   * @type {string}
-   * @readonly
+   *
+   * @param {string} [message] The error message for this exception.
    */
-  this.name = "RuntimeError";
+  constructor(message) {
+    super(message);
 
-  /**
-   * The explanation for why this exception was thrown.
-   * @type {string}
-   * @readonly
-   */
-  this.message = message;
+    /**
+     * 'RuntimeError' indicating that this exception was thrown due to a runtime error.
+     * @type {string}
+     * @readonly
+     */
+    this.name = "RuntimeError";
 
-  //Browsers such as IE don't have a stack property until you actually throw the error.
-  let stack;
-  try {
-    throw new Error();
-  } catch (e) {
-    stack = e.stack;
+    /**
+     * The explanation for why this exception was thrown.
+     * @type {string}
+     * @readonly
+     */
+    this.message = message;
+
+    //Browsers such as IE don't have a stack property until you actually throw the error.
+    let stack;
+    try {
+      throw new Error();
+    } catch (e) {
+      stack = e.stack;
+    }
+
+    /**
+     * The stack trace of this exception, if available.
+     * @type {string}
+     * @readonly
+     */
+    this.stack = stack;
   }
 
-  /**
-   * The stack trace of this exception, if available.
-   * @type {string}
-   * @readonly
-   */
-  this.stack = stack;
-}
+  toString() {
+    let str = `${this.name}: ${this.message}`;
 
-if (defined(Object.create)) {
-  RuntimeError.prototype = Object.create(Error.prototype);
-  RuntimeError.prototype.constructor = RuntimeError;
-}
+    if (defined(this.stack)) {
+      str += `\n${this.stack.toString()}`;
+    }
 
-RuntimeError.prototype.toString = function () {
-  let str = `${this.name}: ${this.message}`;
-
-  if (defined(this.stack)) {
-    str += `\n${this.stack.toString()}`;
+    return str;
   }
+}
 
-  return str;
-};
 export default RuntimeError;

--- a/packages/engine/Source/Scene/DerivedCommand.js
+++ b/packages/engine/Source/Scene/DerivedCommand.js
@@ -264,13 +264,13 @@ function getPickShaderProgram(context, shaderProgram, pickId) {
 
   const hasFragData = sources.some((source) => source.includes("out_FragData"));
   const outputColorVariable = hasFragData ? "out_FragData_0" : "out_FragColor";
-  const newMain = `void main () 
-{ 
-    czm_non_pick_main(); 
-    if (${outputColorVariable}.a == 0.0) { 
-        discard; 
-    } 
-    ${outputColorVariable} = ${pickId}; 
+  const newMain = `void main ()
+{
+    czm_non_pick_main();
+    if (${outputColorVariable}.a == 0.0) {
+        discard;
+    }
+    ${outputColorVariable} = ${pickId};
 } `;
 
   const length = sources.length;
@@ -360,7 +360,7 @@ DerivedCommand.createPickDerivedCommand = function (
  *
  * @param {string[]} defines The define directive identifiers
  * @param {string} defineName The name (identifier) of the define directive
- * @param {any} newDefineValue The new value whose string representation
+ * @param {unknown} newDefineValue The new value whose string representation
  * will become the token string for the define directive
  * @private
  */

--- a/packages/engine/tsd-conf.json
+++ b/packages/engine/tsd-conf.json
@@ -15,6 +15,7 @@
   },
   "plugins": [
     "./Tools/jsdoc/cesiumTags",
+    "./Tools/jsdoc/cesiumTypes",
     "tsd-jsdoc/dist/plugin"
   ],
   "templates": {

--- a/packages/widgets/tsd-conf.json
+++ b/packages/widgets/tsd-conf.json
@@ -15,6 +15,7 @@
   },
   "plugins": [
     "./Tools/jsdoc/cesiumTags",
+    "./Tools/jsdoc/cesiumTypes",
     "tsd-jsdoc/dist/plugin"
   ],
   "templates": {


### PR DESCRIPTION
# Description

Changes:

- Adds a custom JSDoc plugin, cesiumTypes.js, to help with the gap between syntax supported by JSDoc and syntax needed for type checking. The plugin detects basic JSDoc-incompatible syntax (e.g. 'typeof'), converts that to a special token (currently 'any'), and enforces that this token never leaks into public documentation or .d.ts files. This allows us to use TypeScript syntax for internal code and inline casting, without worrying about breaking tsd-jsdoc. The syntax regex can be expanded as needed.
- Converts RuntimeError.js and DeveloperError.js to ES6 classes, and enables type checking. Only one change was made by hand here, which was adding `@ignore` (for #13205) and `@returns {never}` annotations to `DeveloperError.throwInstantiationError()`. The return type is so the type checker understands that this method always throws; otherwise it will complain that an abstract method does not return the expected type.

Motivated by use cases in #13212, but split out here because that's already a very large PR. :) For example...

```javascript
  /**
   * @protected
   * @return {typeof BufferPrimitive}
   * @ignore
   */
  _getPrimitiveClass() {
    DeveloperError.throwInstantiationError();
  }
```

... as a workaround for https://github.com/jsdoc/jsdoc/issues/1349. Returns a BufferPrimitive subclass constructor, not an instance of a class.

In #13212, see:

- `packages/engine/Source/Scene/BufferPrimitiveCollection.js`
- `packages/engine/Source/Core/assert.js`



## Issue number and link

- #8359
- #4434 

## Testing plan

Run:

- npm run tsc
- npm run build-ts
- npm run build-docs

And check documentation, and Cesium.d.ts.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code









#### PR Dependency Tree


* **PR #13211** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)