### PR TITLE
Sandcastle dev server warnings

### DIFF
--- a/packages/sandcastle/vite.config.dev.ts
+++ b/packages/sandcastle/vite.config.dev.ts
@@ -3,6 +3,9 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { createSandcastleConfig } from "./scripts/buildStatic.js";
 import { readFileSync } from "fs";
+import { Target } from "vite-plugin-static-copy";
+import { globby } from "globby";
+import { exit } from "process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 function getCesiumVersion() {
@@ -11,13 +14,74 @@ function getCesiumVersion() {
   return version;
 }
 
-export default defineConfig(({ command }) => {
+async function checkForFiles(extraFilesList: Target[]) {
+  for (const target of extraFilesList) {
+    const files = await globby(target.src);
+    if (files.length === 0) {
+      // check for at least 1 file in each location. Some of the directories like Assets/
+      // will have many and it's hard to offer suggestions for every file that we might need
+
+      if (target.src.includes(".d.ts")) {
+        // probably a missing types file
+        console.error(
+          "\nYou might be missing types files. Try running `npm run build-ts` at the repo root",
+        );
+      } else if (target.src.includes(".js") || target.src.includes("/Build/")) {
+        // probably missing some built JS files
+        console.error(
+          "\nYou might be missing built JS files. Try running `npm run build` at the repo root",
+        );
+      }
+
+      throw new Error(`Missing files for glob: ${target.src}`);
+    }
+  }
+}
+
+export default defineConfig(async ({ command }) => {
   if (command === "build") {
     throw Error("This config should not be used to build!");
   }
 
   const cesiumSource = "../../Build/CesiumUnminified";
   const cesiumBaseUrl = "Build/CesiumUnminified";
+
+  const extraFiles = [
+    {
+      src: join(__dirname, `${cesiumSource}/ThirdParty`),
+      dest: cesiumBaseUrl,
+    },
+    { src: join(__dirname, `${cesiumSource}/Workers`), dest: cesiumBaseUrl },
+    { src: join(__dirname, `${cesiumSource}/Assets`), dest: cesiumBaseUrl },
+    { src: join(__dirname, `${cesiumSource}/Widgets`), dest: cesiumBaseUrl },
+    {
+      src: join(__dirname, `${cesiumSource}/*.(js|cjs)`),
+      dest: cesiumBaseUrl,
+    },
+    { src: join(__dirname, "../../Apps/SampleData"), dest: "Apps" },
+    { src: join(__dirname, "../../Apps/SampleData"), dest: "" },
+    { src: join(__dirname, `../../Source/Cesium.(d.ts|js)`), dest: "Source" },
+    { src: join(__dirname, `../engine/index.d.ts`), dest: "packages/engine" },
+    {
+      src: join(__dirname, `../engine/Build/Unminified/index.js`),
+      dest: "packages/engine/Build/Unminified",
+    },
+    {
+      src: join(__dirname, `../widgets/index.d.ts`),
+      dest: "packages/widgets",
+    },
+    {
+      src: join(__dirname, `../widgets/Build/Unminified/index.js`),
+      dest: "packages/widgets/Build/Unminified",
+    },
+  ];
+
+  try {
+    await checkForFiles(extraFiles);
+  } catch (error) {
+    console.error(`\n${error instanceof Error ? error.message : error}\n`);
+    exit(1);
+  }
 
   const config = createSandcastleConfig({
     outDir: join(__dirname, "../../Build/Sandcastle2"),
@@ -43,35 +107,7 @@ export default defineConfig(({ command }) => {
     // IN DEV THIS DOES NOT COPY FILES it simply sets up in-memory server routes
     // to the correct locations on disk in the parent directories
     // This config should not be used for the actual build, only development of Sandcastle itself
-    copyExtraFiles: [
-      {
-        src: join(__dirname, `${cesiumSource}/ThirdParty`),
-        dest: cesiumBaseUrl,
-      },
-      { src: join(__dirname, `${cesiumSource}/Workers`), dest: cesiumBaseUrl },
-      { src: join(__dirname, `${cesiumSource}/Assets`), dest: cesiumBaseUrl },
-      { src: join(__dirname, `${cesiumSource}/Widgets`), dest: cesiumBaseUrl },
-      {
-        src: join(__dirname, `${cesiumSource}/*.(js|cjs)`),
-        dest: cesiumBaseUrl,
-      },
-      { src: join(__dirname, "../../Apps/SampleData"), dest: "Apps" },
-      { src: join(__dirname, "../../Apps/SampleData"), dest: "" },
-      { src: join(__dirname, `../../Source/Cesium.(d.ts|js)`), dest: "Source" },
-      { src: join(__dirname, `../engine/index.d.ts`), dest: "packages/engine" },
-      {
-        src: join(__dirname, `../engine/Build/Unminified/index.js`),
-        dest: "packages/engine/Build/Unminified",
-      },
-      {
-        src: join(__dirname, `../widgets/index.d.ts`),
-        dest: "packages/widgets",
-      },
-      {
-        src: join(__dirname, `../widgets/Build/Unminified/index.js`),
-        dest: "packages/widgets/Build/Unminified",
-      },
-    ],
+    copyExtraFiles: extraFiles,
   });
 
   return config;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

While reviewing #13154 @lukemckinstry was having some issues with the dev server not having all the files it expected. This change tries to check for them before starting and provide some suggestions on how to resolve potentially common errors.

The Sandcastle dev server is _not_ meant to be used for active CesiumJS development so it uses the built versions of the library and types. These do not update to changes without re-running the build scripts.

This PR stacks on top of #13214 simply because I worked on them together but wanted to separate PRs for easier review

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `git clean -dxf` to start fresh
- run `npm install`
- `cd packages/sandcastle`
- run `npm run dev` and follow the warnings until it starts successfully
- Make sure sandcastle loads correctly at http://localhost:5173

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
