### PR TITLE
Add Firefox style import hack back

### DIFF
--- a/packages/sandcastle/src/util/bucket-client.ts
+++ b/packages/sandcastle/src/util/bucket-client.ts
@@ -36,7 +36,10 @@ function loadSandcastle(code: string, html: string) {
   });
 
   const div = document.createElement("div");
-  div.innerHTML = sanitized;
+  // Stylesheet imports are weirdly broken in Firefox 140+. This is a hacky workaround
+  // confirmed still broken on v147
+  // https://github.com/CesiumGS/cesium/issues/12700
+  div.innerHTML = sanitized.replace(/@import/, "@import ");
   document.body.appendChild(div);
 
   const script = document.createElement("script");


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

A niche Firefox only bug has sprouted back up after the changes in #13154. See this issue https://github.com/CesiumGS/cesium/issues/12700 and the previous PR that added the hack in legacy Sandcastle for more details and discussion https://github.com/CesiumGS/cesium/pull/12704

I'm still unable to reproduce this in a minimal example. The previous structure of Sandcastle seemed to not have the bug at all and I hoped it was gone. However now that we're applying the html/styles from the viewer bucket itself it seems to be back. 

There is an active bug tracked on Mozilla's issue tracker here: https://bugzilla.mozilla.org/show_bug.cgi?id=1975508

Why does adding a random space here work? No idea, it's very bizarre. However since [we already proved](https://github.com/CesiumGS/cesium/blob/c3786f716969c0b97c95dc675d1461300e5ad386/Apps/Sandcastle/CesiumSandcastle.js#L621-L623) that this solution worked in the legacy sandcastle I'm comfortable including it here too. Worst case it does nothing and the CSS is still valid CSS, Best case it fixes the bug on Firefox.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12700 again

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Do the following _in Firefox_
- Open the [CI build](https://ci-builds.cesium.com/cesium/ff-sandcastle-styles/Apps/Sandcastle2/index.html) and make sure the viewer loads correctly
- Run `npm run build-sandcastle` and `npm start
- Open sandcastle at `localhost:8080` and make sure the viewer loads correctly
- Switch to the sandcastle package and run `npm run dev`
- Open sandcastle at `localhost:5173` and make sure the viewer loads correctly here too

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
