### PR TITLE
(bugfix) Match Google credit to ion 

### DIFF
--- a/packages/engine/Source/Core/GoogleMaps.js
+++ b/packages/engine/Source/Core/GoogleMaps.js
@@ -33,7 +33,7 @@ GoogleMaps.mapTilesApiEndpoint = new Resource({
 
 GoogleMaps.getDefaultCredit = function () {
   return new Credit(
-    `<img src="https://assets.ion.cesium.com/google-credit.png" style="vertical-align: -5px" alt="Google">`,
+    `<img alt=\"Google\" src=\"https://assets.ion.cesium.com/google-credit.png\" style=\"vertical-align:-6px\">`,
     true,
   );
 };


### PR DESCRIPTION
## Description

This is a one line fix to address a bug uncovered in https://github.com/CesiumGS/cesium/pull/13153#discussion_r2835650270 that was causing duplicate "Google Maps" credits in the viewer.

The html string for the "Google Maps" credit in JS did not match the html string in ion, so logo credits for Google defined in ion and JS were not deduplicating. This changes JS to match ion.

GoogleMaps.getDefaultCredit is not part of the public API so no changelog entry should be needed.

## Testing plan

This issue can be reproduced by loading a Google Maps asset from ion (ie. the Google Maps credit is defined in ion) and a Google Maps asset where the credit is defined in CesiumJS into the same scene. Note you will need to add a Google Maps Tiles API key to load the later asset in the sandcastle.

[sandcastle](https://sandcastle.cesium.com/#c=nVNRb9MwEP4rp/DSouBmmzRNXVdRDQkmhkAweCE8uMklPeHYke10yqr+d+y4XlutCAk/5e6+77vv7As1rdIWXgM3cIuGugYqrRrIk2KI8uQ6l7kslDQW1oSPqOEGJD7u0OzHkBtF/K2SlpNEnSfjgRm5pOQ97wf2jnnX8Bp1P2SZb/pFqzWVqBeml8Uol+BOxCq5g0fQwFgYg/auHF1cXWRnV5fj1JN83+CU0UELw3hZjqKNaG6n/16pWuAn3hpWYsU7YRctfcTeuc2TUARXhQcSaMAXPqDGo8upB9QAiB73swaJ83enhviuxWgTplVr1IIHvw99i1PXXfjgq+Jlw9s8SQPQ2N71mcLPEPqz2X8+I7SHbGDVDUqvsqyq8DJPYJvCBgy3nebW3cgU3pxnsP2V7iW26V+VK/REjP60s/bsKx4U2KC0EVOjatDq/gXu0KWgemUlGhedZVnwuCZDSxJkey9jqGkFVYSln+GUXZ/bHi+edKvzf7t34kX/uV8H3cbXSZrMhgnnnveWwr/WufdmbGLRDcMtmsmyK36jZYUxXno2iZRZSWug8ubEvwWF4Ma4StUJ8Y2e3CrOZxOHP6IJ9zQk689hqzxkdTa/D0nG2Gziwpcsq5RYcn2g+Ac)



<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [X] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [NA] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
