### PR TITLE
Fixes regex for custom shader used metadata variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 - Fixed precision of point cloud attributes when accessed in a custom fragment shader. [#13170](https://github.com/CesiumGS/cesium/pull/13170)
 - Fixed shader cache lookup for day/night alpha in Columbus View. [#13216](https://github.com/CesiumGS/cesium/pull/13216)
 - Fixed a point-rendering regression which caused points to render as circles rather than squares. Such points now will only render as circles when their width is specified via the [BENTLEY_materials_point_style](https://github.com/CesiumGS/glTF/pull/91) glTF extension (which requires that such points be circular). [#13217](https://github.com/CesiumGS/cesium/issues/13217)
+- Fixes a regex expression used to find metadata variables in `CustomShader`s, which did not escape a period. Also extends the regex to find used metadata from `metadataClass` and `metadataStatistics`. [#13231](https://github.com/CesiumGS/cesium/pull/13231).
 
 ### @cesium/sandcastle
 

--- a/packages/engine/Source/Scene/Model/CustomShader.js
+++ b/packages/engine/Source/Scene/Model/CustomShader.js
@@ -303,7 +303,8 @@ function findUsedVariables(customShader) {
   //  - vsInput.metadata.<property>
   //  - vsInput.metadataClass.<property>
   //  - vsInput.metadataStatistics.<property>
-  const metadataRegex = /[vf]sInput\.(?:metadata|metadataClass|metadataStatistics)\.(\w+)/g;
+  const metadataRegex =
+    /[vf]sInput\.(?:metadata|metadataClass|metadataStatistics)\.(\w+)/g;
   let attributeSet;
 
   const vertexShaderText = customShader.vertexShaderText;

--- a/packages/engine/Specs/Scene/Model/CustomShaderSpec.js
+++ b/packages/engine/Specs/Scene/Model/CustomShaderSpec.js
@@ -234,11 +234,11 @@ describe("Scene/Model/CustomShader", function () {
       vertexShaderText: [
         "void vertexMain(VertexInput vsInput, inout czm_modelVertexOutput vsOutput)",
         "{",
-        "    float value = vsInput.metadata.temperature;",                    // should match "temperature"
-        "    float value2 = vsInput.metadataClass.testProperty.noData;",      // should match "testProperty"
-        "    float value3 = vsInput.metadataStatistics.testStatistic.mean;",  // should match "testStatistic"
+        "    float value = vsInput.metadata.temperature;", // should match "temperature"
+        "    float value2 = vsInput.metadataClass.testProperty.noData;", // should match "testProperty"
+        "    float value3 = vsInput.metadataStatistics.testStatistic.mean;", // should match "testStatistic"
         "}",
-      ].join("\n")
+      ].join("\n"),
     });
 
     const expectedVertexVariables = {


### PR DESCRIPTION
# Description

The regex expression used to determine what metadata variables are used in a given `CustomShader` both has a bug and is incomplete:
1. It does not escape the `.` after "metadata", so rather than matching a period, it matches one of any character after "metadata". This means that expressions like `vsInput.metadataClass.temperature.noData` will result in the substring "lass" being treated as a metadata variable.
2. Further, it only searches for variable names of the form `vsInput.metadata.<property>`. But metadata can also be accessed as `vsInput.metadataClass.<property>...` OR `vsInput.metadataStatistics.<property>...`. Those properties should also be captured here.



## Issue number and link

No issue

## Testing plan

Testing is a bit hard. [Here's a sandcastle](http://localhost:8080/Apps/Sandcastle2/index.html#c=zRlrd9M49q9osrMHh0mdttB59LXbpg/KNA3QFBgmc0CxlUTEtjyW3CRl+t/3XslybMcthd05LB9oLN2Xru5bPIxFoshjQiXpMMnTkIwSEZJBw9Nfg8bOIBpEZss9E5HrsxFNA3XgAYDsiymLyN4gIoDBFs8nw1OP9/jzs6ubs40LfibPoldbXufsx7Np/PZ15/kvLgD96Z9OEWjy7ujVx3enzz9eXG4EFzdni/P+y9m7/rH6re89+Y2vb3ZPu1sXp2cb3c2XT971p/y88zx+B8S6N8ezXr/7FL9/e/uS9z4eP7n4+HLeOxrf9Pr+L+7h25jOpr2u97abJuvnW72t6433vWfeq87a5c3N4qfpn5Of/nx9tQj8l9kB222yV/xHDtmYR9skENQnigdMMkVoBL9ZklAeVaDbbSQSAEy2/yIR19xnCfwNuWTAQyUL8gkVVQ9B9jL9u+ZPvwzl4q1cJYGDFFDZE6Viud1u+2IWoZCunHEpx0wErjdpewF/n/Fpe5O1TbhHRGyCHLfEo8qbEIc1jTyeiKQImBuIsfPhOElEok/No7EVdZt8/4m5Idw3HbPbD5oKnhcxFbnmbMYSkD9iM3uG13rNsVbUEZECOiwZNFqGKYvoMGAdEQRcchEdMcU8BT+2yYgGkrUKitouEs7U4tQrsQmCNXeWokmPRahZI6KrP3fspkeja7D6fNd859vjQAwRVyO5+ivfYyB2LAX3YV/vuPmK5m5w5HRxKOYAkkbgNHB83My2vISx6DKmHuvQkCUUNZSANkCOu1QDhLRuciKGs89iNekzqQ7GoBCp+tZAiUpStpPbpbHhkiFmZr1H6IxyVba/J0d9s60tDxz/QMLHme88hX8//ryZ3SMhQ+pNT/AcKQgcjYsXePvF9mZY3m9vGdCLhIdc8evlHcV2RbrU950MDrGrKG5I5zxMw8vlNRhB9si6u16H4LNhOr6ciNmhgNsEWV+LIA1ZUcuZGd0IEfaFU6XQrA8zx5H/hUHmrkiFuGlMvFQqiN9yQsEtiDOCQyWg3FSSUPhpQNGSmpqJJwLYlGqB13YXqyuITLRCVAlLixE1YeSaJYqDoxMx0t9DkbAJ3DCINA5ZpKSm1DE0LjUNid5HUiAeMkV9qqhJO4gOtFmATPwEb1dNeFF2VxM7AclDYEN8QOeBbAEv+BCe3CY2MprQ43oibAeMJlG28FG2EzZaA9i2EclI5E5UGPzLC6iUJzyAC9gzhzZntrZnVGkwyhGvSMvRdp5GHLQfgkSZp4Dcp+CyNAB7paCeEfWUSFokEgq8SDKfgJPTaJHrxDV46fuxRrtErJwa+O8ihs+M/5Xh1oc19+S8d9BvWbBrGqQAt7G+ni3dGufU/+PdsbkRu8/m4HofDNA1Rjez28WA+1r/PIviFCK+1H9bhEcCPr2b8L2+NAPTS5UBMj+ahl4uNSEjsHdFfA6BT2k1ZvTc/Nzes8vTw2eXJu4dJVxHlqMMYWdJiY+Is6SzSqiD13k/NTcSRwDZLAqI/xKm0iQq8NIRqHyEzLH2lmdpk013fVTAslpwYyE58u92yA9LQalSCR+mCkJWBLdHA9h+TByndOVkjWwA1SbsGI7NjMEt/vnQypPeStTyCkYJYhat14ajNxy8COIGep4MMJcS9ARIcQx9l2AAGRetFhxTwxqimZG7xWKgqx14z2i0ZLrWBiUE0pOAjpe+cTbyDrOwsa1DaitfP2UCBPNW1l/wmF2aCFPdOkx5gEH62BwCqoP5wsBoyweFFavaaSS8KRiyqxLIZU5+BFTqZ0Dc/CTNvDhQQgRDivqGGJMif3fMVCbK4QJS6KCRwQwadTxoHAeLQ67TjFzyalnKzVrhgUdvKFlyjdVDEWvQKNwBcHRlOoT6gw+ZM0ojU1o4OkhkTlA0ExfsKQstIHbJLLGWM2g7uQU+UKil2lC8wt0/RDzI2ZB5MBdfQu5iTs7+a5lbA/smzAtW/E3417nKfyXIIMoRVmAMKpajKAbUvD7PKlvoTxo6qmG8cYwjjUBMSDGkztts3MAM8F0NwO+I/EcTi03Fo6xCswhl5t/tGfaFFFAG+AH3yV9/kUzEQi5YAfwwGDwaDL7/pAuJC8gKt7CAxRUgf/8JhbodND7sZGEI/6wKtFcVaFVZusbOxMnorAR/rOxYpUgplPbmSgoctst88gI+K77rS9e/p+qsLXAFVCMJJCgoHbFj0lcLLZOsJWKaOYxeBzbFYtilQwirbI6ha9BYx/CLVVnEmA/VF2Q2LFxGELUllmKY5gydnJ6IoLP2ptiK5V5hHcJAaGzjDcVW8LP93iuhsJ6u9nifR+wnNJLB1+G+g17la1hCgfwVaOdCTAtopi+ViiaqK6AVeJFVSDtmI6ys2aY91P5ty4sE1VZpO0OwFGgQZjTxq8uHkL3r1q/i6sqRmEXVtXM2UtW1V3w8KSzeFqYPE7D3oNonFFvOawi4zwyQY8zH+FuGiNary8QDbWmFQIyMMVrnpmeU4lptLNtSUtYj9sorCi+MnmALftHoiesFImLZtMmyy4vYVj5Mat11Lt2InB+f9N8f9d5cfN25qqLncrDIL1jGZ4To9q4uj993e6+PHyiFPeU92rU2/JDzX72opEVIzUgQTPRXtuhA3oJ859u8KmdcT0sKSygCdMqDBoC/GTS2bZYyLQqsFww+T1FLlMu7UKwz1OC8vAvnKq6BPr4LGp2oBv7oLnjtTDUIB3choEfm8NlkugpZnL6Z4h9vI6/Nqe/rCzvnUkEcSxwzzJ6yha+l17a+NI7CpeRFCuZ5nASu3Ct0YHiNO8vSA3t2MVpimeIjF7FUhVjD+91C/1H066z9M228DT/G0h5wtjT+vzuZ9al7j2ZntQGUuZCN+5CMV0+5PJOGK8wdlS0eClNf/N5Z1mIr7l5Ry4z7agL4Wb6HegBYv8HFnSLYhKEtV+Ge6dW8GMWxmBAJ1N+Yv511d72FA8gmMAkCMmRkNmEJy6ZiOC2bUUl0BcJ8t8gNp8xOKVy6c7JWE+vdeZO0zRlK4i6AwFqFwqKewgIpTFYOgpNCFBQ0ToO1RJ+ezrnUFX1sglqAFUAa60eLZotAVaZRsq7yPVaSOcqCzjKEAJy8rQk23ZxdH8eCYxz2EmpGgaDDNKEBGTEcH070fFEPlSe2ZHwkjXRVPiVVIssTPZkz0+CftkqKAkqgCX2vSDJPiW86JTAWpboww8Z5mV/zJekyKtWFSNTkKu6LEz5n/kkCFB1Dv1kilsYdESypdClUtPOn2OJ1cAodOUVuLbLZKtX8Nqc/dZplskbrV3GlR8hrAEfzdectI4C7sD9uLJ3VssFMsfgNcyz1Vs4n5240h4ouQM3J44Lua2CvYmdRA5O1P+hKcOdjllcJRMZQ1y8nq2gHPoQIGnnMjqqzaGBnWmkyosvN/E3HrYaPZ9a5lyCe1UFfoDrEOKHxhHtO6Rjl+snNnchS1znQlPJwyRN8pnBKHNtkSweJDYwSdUGrUAoUqgfNvLDlWEa5CmvI2PKgjo7dexAhuPkaEnCdD0HGEqIOHdcfRABLhDoCuP4gArooqaOgN1ZJ3N731PMFTWyj1djVPfw+Ev43Ny/1aRI4rttWLIyx6ZPtYQrZQLmelNYg2o+J67oMApyuVjFRwzd53M63u3RqgrWdVQZ0gZN8hW3amn53geQZ8KmZ84qZXPPZdVOTIOQfFkv5VivmCQjiPvj+GPqmkPtQY2c+HEOCBkHWlIAuazOeV5aHQikR1u0kprf6OdvIPD1nz7F6/x3rjr1BI0HfHzT+sBLpFLdNNp6u52TvEfI2V82vjMXmzQkMQYCOzLAC0kzCggXGEa4yPbjZvLzCcX39n0WabkCHkJAyIAhAcG+LbTLEyiQTLKTJmEe5IraW591tWwuA3z6/Jtzfq3lUJ3rcBDujNAguIfoOGvu7bYDfL6Jlr6w90AOIgCCTjf1zswgGstuGT4tVxMuH1doQd7WR7BvJd9VQ+It9W9ftqmR/+faxq/z94qNK9vhlhsdLqHYJrIq0q2+5/DZTvvLyntWEuZvqbsgj2IPgubJB57ABd1fdgJIy1igb1R18YFrDeRJsZ29shel4Nhu/igEMdh7pYzwq02jXnNQeTrE5dDZEwmXC1xP4eT8/ACiSK2kVPpIH3lFxFv8/uCJvwrzpUMzv052GYf728lXILb0I3KWx/+KI+cT/mx5x+e7wNxyx+K7wTU9ZeuD4Gw5a+4DxbU239knlS48OP/PYCr+zoGvj838A) with a custom shader where `metadataClass` is used. Without this PR, no geometry shows up because `CustomShader` thinks "lass" is a variable. Then the `CustomShaderPipelineStage` will check the variables available to each primitive, see that "lass" isn't one of them, and disable the custom shader for each primitive.

With this PR, some geometry from the tileset shows up.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
