### PR TITLE
Adds a short-circuit to prevent playwright install if OS is unsupported

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "yargs": "^18.0.0"
   },
   "scripts": {
-    "prepare": "gulp prepare && husky && node scripts/isCI.js || playwright install --with-deps",
+    "prepare": "gulp prepare && husky && node scripts/isCI.js || node scripts/supportsPlaywright.js || playwright install --with-deps",
     "start": "node server.js",
     "start-public": "node server.js --public",
     "build": "gulp build",

--- a/scripts/supportsPlaywright.js
+++ b/scripts/supportsPlaywright.js
@@ -1,0 +1,71 @@
+// Checks if the current operating system supports Playwright.
+// System requirements based on https://playwright.dev/docs/intro#system-requirements
+//
+// Exit codes follow the same convention as isCI.js:
+//   Exit 1 = supported (triggers the next command in an || chain)
+//   Exit 0 = not supported (stops the || chain)
+
+import { platform, release } from "node:os";
+import { readFileSync } from "node:fs";
+
+function isWindowsSupported() {
+  // Windows 10+ or Windows Server 2016+ (both report NT kernel >= 10.0)
+  const major = parseInt(release().split(".")[0], 10);
+  return major >= 10;
+}
+
+function isMacOSSupported() {
+  // Darwin kernel 22.x maps to macOS 13 Ventura, which is the minimum.
+  const major = parseInt(release().split(".")[0], 10);
+  return major >= 22;
+}
+
+function isLinuxSupported() {
+  // Supported distros: Ubuntu 20.04+, Debian 11+
+  let osRelease;
+  try {
+    osRelease = readFileSync("/etc/os-release", "utf-8");
+  } catch {
+    return false;
+  }
+
+  const id = osRelease
+    .match(/^ID=(.*)$/m)?.[1]
+    ?.replace(/"/g, "")
+    .trim();
+  const versionId = osRelease
+    .match(/^VERSION_ID=(.*)$/m)?.[1]
+    ?.replace(/"/g, "")
+    .trim();
+
+  if (!id || !versionId) {
+    return false;
+  }
+
+  const majorVersion = parseInt(versionId.split(".")[0], 10);
+
+  switch (id) {
+    case "ubuntu":
+      return majorVersion >= 20;
+    case "debian":
+      return majorVersion >= 11;
+    default:
+      return false;
+  }
+}
+
+let isSupported = false;
+
+switch (platform()) {
+  case "win32":
+    isSupported = isWindowsSupported();
+    break;
+  case "darwin":
+    isSupported = isMacOSSupported();
+    break;
+  case "linux":
+    isSupported = isLinuxSupported();
+    break;
+}
+
+process.exit(isSupported ? 1 : 0);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

Playwright is not fully supported on every operating system or even every Linux distribution. This is most noticeable within the Linux world, where outside of Debian and Ubuntu, it ranges from unsupported to [partially supported](https://github.com/microsoft/playwright/issues/29559).

What this does is adds a check to the `prepare` step in `package.json` to short circuit if being run on an unsupported system and quit before the playwright step.

I've had this locally on my Fedora system for a little while now and it has worked well.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

No issue.

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

Tested this out on Fedora by just running `npm install` which calls `prepare`.

I haven't tested it on Windows, macOS, or Ubuntu.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
