### PR TITLE
Fixes update height callback in quadtree primitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 #### Fixes :wrench:
 
 - Fixed memory leak when rendering Gaussian splat 3D tilesets. [#13229](https://github.com/CesiumGS/cesium/pull/13229/)
+- Fixes update height callback in QuadtreePrimitive. [#13249](https://github.com/CesiumGS/cesium/issues/13249)
 
 ## 1.139 - 2026-03-02
 

--- a/packages/engine/Source/Scene/QuadtreePrimitive.js
+++ b/packages/engine/Source/Scene/QuadtreePrimitive.js
@@ -1541,6 +1541,7 @@ function updateHeights(primitive, frameState) {
               position,
               scratchCartographic,
             );
+            positionCarto.height = position.height; // Preserve the original height
             data.callback(positionCarto);
           }
           data.level = tile.level;


### PR DESCRIPTION
# Description

The update height callback in `QuadtreePrimitive` was broken in #12555. That PR converted the argument to the callback to cartographic first, but in doing so erased any terrain height in the position (replacing it with the ellipsoid height). This PR preserves the original height.

This bug manifests as clamping to terrain not working when exaggeration changes.

## Issue number and link

#13249 - see [comment](https://github.com/CesiumGS/cesium/issues/13249#issuecomment-3992925490).

## Testing plan

Test with the [terrain exaggeration sandcastle](https://sandcastle.cesium.com/?id=terrain-exaggeration). In current state, the red ball does not move as the terrain exaggeration changes. With this PR, it once again moves.

[Another example I put together](http://localhost:8080/Apps/Sandcastle2/index.html#c=xVbpjxo3FP9XLL4EUtbMwTBACGp3EzWVkmy0OfqhVJGZMWCt8YxsDxta7f/eZ8/NsaWR2kba4Hl+5+8dfmybJlKj54godEMVy7ZoJZMtWnQi+7XovFgIljN9JCKOiNKcljw1xfItRJQIpdGO0Qcq0Usk6EOhFX+xtG6p9yYRmjBB5aLTR38uBEKaSgmUaSnwKf/GxtSvieRxQej2+gvx2GuYUxEVFKzlZrH9hGv7i3dUahYR/vobWa+pJJolAng97DzJckc5/O7oG8rWG20Eho5jZUqpiGyBFyuqTWhdG0NMlWbCKpg2g78hUsOJCL9r2BDy/VEwCrHjB8Nw4oSO38/pwWg0HI3H2BmGI8cbTsYF3Zt4vucMsQ8Mk5Hv+p696Nn/E8kooHlk9Q0lMRPrD0xHm7uE88K2iz0v9L2x64+9kT/xRkFh5MrBvuf5k5Hr+aEDf4E7LK4gdMcLPQfkJo47HrmO748rF4psFPiDL0wzqjCJ4xyWNFHsAkzcYRCEEKLvhnAMgwqTYBJ6Pg5Ddzz23Mpdg0ngj3EwdEPfdybhuIEJ5ZylKmHxNK8uhCSAwc55YJPbR82fXmFmS6AyGeFVYd4kPJH47vWrgmFjS+SOrqikIqLTGv4WHd+8/endh6+fbr/+fHf7+X0u/Vijx6lpHJURzv6gR+WnZUYt2yoTka3hLI3Bs3eFd91eHidboe4ZLb0SibxrNqXqS5vgRVOattvpvI6WFOHphgA7eL3BW+hl18Dd0vUcas0Lei0xTvZ2nBT+Q3a/aSriz+kDkbGaWnD67btXyYM4eSs0dAtQfyspqFZbZ3NawvMDcm1NNFkiUwDtSjKUrq0dG5E95cEW8TQUPPYvNR1catmtLLtty99j+Lstfk+QV/9TkGD48sTWOb0wsb8Xp8eijPP2WPNkSXE5T6CeCyORpEB7zenOtsA1PKpVW1chWBXT/KeyYxvDFLM9VFbz7nmEIahoCcIZFzIR0xW8w3EuAtNoIQ4ny8HL/i6JKS+7sdm70yfGgHVNtubJ9OLJY4bkqeHXlCgH4JOv/vtsu4QlpIoCN93PUfsHK8GRtnZ8ub4TYD6aUIrc34skuk8yjbUk0X2ty/DlkOsk4Utixl+cRNkWBhheUw3VYo7X+19i2KkKnkXHiB1qJmnK99dMmF1A1Rb6pWYjs0ok6ub2BOw1iIk61a2XpQx1Q9Ttg/ggkxSQ2neNUK96YA48KKvV+H27VFTuyJLTpidWvGJT2VJFki1p9zjNvUadLkS9f5pl41OyXnN6nWkN5WDYFp0v5VOIyuyhPDmwdhqOM0+lvauKrRttaHRP4yq+8890wVm0/Ync51Mib6lD7202Svc7d3SbgLvN4M2uXHtVuHO6mMEX166rTQZ56G6+0dp50el3ZkrvOZ0bmR+LlT+TvIvxQNNtCqJUDZYZxKdxpJQRmg1KkVnMdojFL0/s9yjiRCm4WWWcfwTUFp35bAD8LTGe2GX1FjoPhplh2bjztzkRYzwbwOexVFX41uuZNoU1z8Gf6WUS7+dlVc20nNejeqbjeRPZ2QAI7evmwzBjIq3rOP+n9ykFDyQRa4iofQerDVw5R2TyDcjuEV1pmhp+7LiHV1BA5GoJzQv3O8IzeAKaae4jS/xsC22Knlk/n7WVDE6EUnqvYVuCDCnICnwFcPwbg8DR1NfCDT7kE3gfdOC/AvkVPOpnYJ+cuCmAvwT1du/8J7i3TV6IPByruodz0RBl5/wF) where labels are clamped to terrain. In current state, these labels do not move as the terrain exaggeration is changed. After this PR, they do.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
