### PR TITLE
Skip animation updates when model is not shown

### DIFF
--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -2488,8 +2488,8 @@ function updateSceneGraph(model, frameState) {
   }
 
   let updateForAnimations = false;
-  // Animations are disabled for classification models.
-  if (!defined(model.classificationType)) {
+  // Animations are disabled for classification models and when the model is not shown.
+  if (!defined(model.classificationType) && model._show) {
     updateForAnimations =
       model._userAnimationDirty || model._activeAnimations.update(frameState);
   }

--- a/packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js
@@ -906,6 +906,47 @@ describe(
         expect(spyUpdate.calls.argsFor(4)[2]).toEqual(0.0);
       });
     });
+
+    it("does not animate when model.show is false", function () {
+      return loadAndZoomToModelAsync(
+        {
+          gltf: animatedTriangleUrl,
+        },
+        scene,
+      ).then(function (model) {
+        const time = defaultDate;
+        const animationCollection = model.activeAnimations;
+        const animation = animationCollection.add({
+          index: 0,
+          startTime: time,
+        });
+
+        const spyUpdate = jasmine.createSpy("listener");
+        animation.update.addEventListener(spyUpdate);
+
+        // Render with model shown - animation should update
+        scene.renderForSpecs(time);
+        expect(spyUpdate.calls.count()).toEqual(1);
+
+        // Hide the model
+        model.show = false;
+
+        // Render with model hidden - animation should NOT update
+        scene.renderForSpecs(
+          JulianDate.addSeconds(time, 1.0, scratchJulianDate),
+        );
+        expect(spyUpdate.calls.count()).toEqual(1); // Still 1, no new updates
+
+        // Show the model again
+        model.show = true;
+
+        // Render with model shown again - animation should update
+        scene.renderForSpecs(
+          JulianDate.addSeconds(time, 2.0, scratchJulianDate),
+        );
+        expect(spyUpdate.calls.count()).toEqual(2); // Now 2, animation updated
+      });
+    });
   },
   "WebGL",
 );


### PR DESCRIPTION
Fixes #12633

## Description

This PR fixes a performance issue where model animations were being calculated for unavailable entities, causing significant FPS drops even when no entities were visible.

When entity availability ends, `ModelVisualizer` sets `model.show = false`, but the `updateSceneGraph` function was still processing animations each frame. This caused unnecessary CPU work for models that weren't being rendered.

The fix adds a check for `model._show` in the `updateSceneGraph` function to skip animation updates when the model is hidden.

## Issue number and link

Fixes #12633

## Testing plan

1. Create a scene with many model entities that have animations
2. Set availability of entities to end at some point in the future
3. Play viewer and observe FPS as time passes the availability end time
4. **Before fix**: FPS remains low even when entities are no longer available
5. **After fix**: FPS recovers when entities become unavailable

Added a unit test `does not animate when model.show is false` in `ModelAnimationCollectionSpec.js` that verifies:
- Animations update when model is shown
- Animations do NOT update when model is hidden
- Animations resume updating when model is shown again

```
 packages/engine/Source/Scene/Model/Model.js        |  4 +--
 .../Scene/Model/ModelAnimationCollectionSpec.js    | 41 ++++++++++++++++++++++
 2 files changed, 43 insertions(+), 2 deletions(-)
```

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change (N/A - minor bug fix)
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant (N/A - no API changes)
- [x] I have performed a self-review of my code