### PR TITLE
Fix misleading scale/offset defaults in voxel shapes

### DIFF
--- a/packages/engine/Source/Scene/VoxelCylinderShape.js
+++ b/packages/engine/Source/Scene/VoxelCylinderShape.js
@@ -416,8 +416,8 @@ VoxelCylinderShape.prototype.update = function (
 
   if (shapeAngleRange <= epsilonAngle) {
     shaderUniforms.cylinderLocalToShapeUvAngle = Cartesian2.fromElements(
-      0.0,
       1.0,
+      0.0,
       shaderUniforms.cylinderLocalToShapeUvAngle,
     );
   } else {

--- a/packages/engine/Source/Scene/VoxelEllipsoidShape.js
+++ b/packages/engine/Source/Scene/VoxelEllipsoidShape.js
@@ -573,8 +573,8 @@ VoxelEllipsoidShape.prototype.update = function (
 
     if (shapeLongitudeRange <= epsilonLongitude) {
       shaderUniforms.ellipsoidLocalToShapeUvLongitude = Cartesian2.fromElements(
-        0.0,
         1.0,
+        0.0,
         shaderUniforms.ellipsoidLocalToShapeUvLongitude,
       );
     } else {
@@ -687,8 +687,8 @@ VoxelEllipsoidShape.prototype.update = function (
 
     if (shapeLatitudeRange < epsilonLatitude) {
       shaderUniforms.ellipsoidLocalToShapeUvLatitude = Cartesian2.fromElements(
-        0.0,
         1.0,
+        0.0,
         shaderUniforms.ellipsoidLocalToShapeUvLatitude,
       );
     } else {


### PR DESCRIPTION
Fixes #12782

## Description

This PR fixes misleading default values for scale and offset properties in voxel shapes. When no transformation is needed, the default values should be scale=1.0 and offset=0.0, not scale=0.0 and offset=1.0.

The issue affects three locations where Cartesian2 elements are used to pass scale (X component) and offset (Y component) to shaders:

- **VoxelCylinderShape.js**: Fixed `cylinderLocalToShapeUvAngle` default values when `shapeAngleRange <= epsilonAngle`
- **VoxelEllipsoidShape.js**: Fixed `ellipsoidLocalToShapeUvLongitude` default values when `shapeLongitudeRange <= epsilonLongitude`
- **VoxelEllipsoidShape.js**: Fixed `ellipsoidLocalToShapeUvLatitude` default values when `shapeLatitudeRange < epsilonLatitude`

While this bug hasn't manifested in practical use cases, correcting these values improves code quality and prevents potential confusion for future development.

## Issue number and link

Fixes #12782

## Testing plan

The changes are minimal and only affect default initialization values:
- Verified that the syntax is correct in both modified files
- Confirmed that the values are now consistent with the expected pattern (scale=1.0, offset=0.0 for no transformation)
- The fix maintains the same logic flow, only correcting the misleading default values

## Changes

```
packages/engine/Source/Scene/VoxelCylinderShape.js   | 2 +-
packages/engine/Source/Scene/VoxelEllipsoidShape.js  | 4 ++--
2 files changed, 3 insertions(+), 3 deletions(-)
```

# Author checklist

- [x] I have performed a self-review of my code
- [ ] I have submitted a Contributor License Agreement (will be handled after PR creation)
- [ ] I have added my name to `CONTRIBUTORS.md` (not required for this minor fix)
- [ ] I have updated `CHANGES.md` with a short summary of my change (not required for this bug fix that doesn't affect API)
- [ ] I have added or updated unit tests to ensure consistent code coverage (existing tests should continue to pass)
- [ ] I have updated the inline documentation, and included code examples where relevant (no documentation changes needed)