### PR TITLE
Types: Clean up detached member types

### DIFF
--- a/packages/engine/Source/Core/TerrainPicker.js
+++ b/packages/engine/Source/Core/TerrainPicker.js
@@ -73,6 +73,7 @@ const incrementallyBuildTerrainPickerTaskProcessor = new TaskProcessor(
 Object.defineProperties(TerrainPicker.prototype, {
   /**
    * Indicates whether the terrain picker needs to be rebuilt due to changes in the underlying terrain mesh's vertices or indices.
+   * @memberof TerrainPicker.prototype
    * @type {boolean}
    */
   needsRebuild: {

--- a/packages/engine/Source/Scene/Material.js
+++ b/packages/engine/Source/Scene/Material.js
@@ -354,6 +354,7 @@ function Material(options) {
 
     /**
      * The {@link TextureMinificationFilter} to apply to this material's textures.
+     * @memberof Material.prototype
      * @type {TextureMinificationFilter}
      * @default TextureMinificationFilter.LINEAR
      */
@@ -368,6 +369,7 @@ function Material(options) {
 
     /**
      * The {@link TextureMagnificationFilter} to apply to this material's textures.
+     * @memberof Material.prototype
      * @type {TextureMagnificationFilter}
      * @default TextureMagnificationFilter.LINEAR
      */

--- a/packages/engine/Source/Scene/Megatexture.js
+++ b/packages/engine/Source/Scene/Megatexture.js
@@ -158,6 +158,7 @@ function Megatexture(
 Object.defineProperties(Megatexture.prototype, {
   /**
    * Gets or sets the nearest sampling flag.
+   * @memberof Megatexture.prototype
    * @type {boolean}
    */
   nearestSampling: {

--- a/packages/engine/Source/Scene/PickedMetadataInfo.js
+++ b/packages/engine/Source/Scene/PickedMetadataInfo.js
@@ -8,6 +8,7 @@
  * proper metadata values in `Picking.pickMetadata`, using the structural
  * information about the metadata that is stored here.
  *
+ * @constructor
  * @private
  */
 function PickedMetadataInfo(


### PR DESCRIPTION

# Description

Cleans up a small handful of JSDoc typos causing type definitions for class properties to become detached from their parent class. I've been testing API Extractor locally, and it found these errors. There were some remaining obstacles running API Extractor, which weren't necessarily problems in Cesium.js so I'm not sure about adding the tool to CI just yet.

For example, `needsRebuild` was exported in type defs as a global variable, when it should have been attached to the TerrainData class:

```typescript
/**
 * Indicates whether the terrain picker needs to be rebuilt due to changes in the underlying terrain mesh's vertices or indices.
 */
export var needsRebuild: boolean;
```

## Issue number and link

n/a

## Testing plan

Diff comparing Cesium.d.ts before/after:

```diff
diff --git a/Source/Cesium.main.d.ts b/Source/Cesium.d.ts
index 5908a2beca..5e3f9c1afd 100644
--- a/Source/Cesium.main.d.ts
+++ b/Source/Cesium.d.ts
@@ -16775,11 +16775,6 @@ export class TerrainData {
     wasCreatedByUpsampling(): boolean;
 }
 
-/**
- * Indicates whether the terrain picker needs to be rebuilt due to changes in the underlying terrain mesh's vertices or indices.
- */
-export var needsRebuild: boolean;
-
 /**
  * Creates an axis-aligned bounding box for a quadtree node at the given tree-space coordinates and level.
  * This AABB is in the tree's local space (where the root node of the tree is a unit cube in its own local space).
@@ -37917,6 +37912,14 @@ export class Material {
      * the geometry is expected to appear translucent.
      */
     translucent: boolean | ((...params: any[]) => any);
+    /**
+     * The {@link TextureMinificationFilter} to apply to this material's textures.
+     */
+    minificationFilter: TextureMinificationFilter;
+    /**
+     * The {@link TextureMagnificationFilter} to apply to this material's textures.
+     */
+    magnificationFilter: TextureMagnificationFilter;
     /**
      * Creates a new material using an existing material type.
      * <br /><br />
@@ -38076,16 +38079,6 @@ export class Material {
     static readonly WaterMaskType: string;
 }
 
-/**
- * The {@link TextureMinificationFilter} to apply to this material's textures.
- */
-export var minificationFilter: TextureMinificationFilter;
-
-/**
- * The {@link TextureMagnificationFilter} to apply to this material's textures.
- */
-export var magnificationFilter: TextureMagnificationFilter;
-
 /**
  * Loads the images for a cubemap uniform, if it has changed since the last time this was called.
  * @param material - The material to load the cubemap images for.
@@ -38246,11 +38239,6 @@ export namespace MaterialAppearance {
     }
 }
 
-/**
- * Gets or sets the nearest sampling flag.
- */
-export var nearestSampling: boolean;
-
 /**
  * A metadata class.
  *
@@ -41058,35 +41046,6 @@ export class PerInstanceColorAppearance {
     getRenderState(): any;
 }
 
-/**
- * The optional ID of the metadata schema
- */
-export var schemaId: string | undefined;
-
-/**
- * The name of the metadata class
- */
-export var className: string;
-
-/**
- * The name of the metadata property
- */
-export var propertyName: string;
-
-/**
- * The the `MetadataClassProperty` that is described by this
- * structure, as obtained from the `MetadataSchema`
- */
-export var classProperty: MetadataClassProperty;
-
-/**
- * The `PropertyTextureProperty` or `PropertyAttributeProperty` that
- * is described by this structure, as obtained from the property texture
- * or property attribute of the `StructuralMetadata` that matches the
- * class name and property name.
- */
-export var metadataProperty: any;
-
 /**
  * Compute the rectangle that describes the part of the drawing buffer
  * that is relevant for picking.

```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [ ] ~~I have updated the inline documentation, and included code examples where relevant~~
- [x] I have performed a self-review of my code



#### PR Dependency Tree


* **PR #13281** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)