### PR TITLE
Mark `PickId` as private to fix types

### DIFF
--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -1658,7 +1658,7 @@ Context.prototype.getObjectByPickColor = function (pickColor) {
 };
 
 /**
- *
+ * @private
  * @param {Map<number, object>} pickObjects
  * @param {number} key
  * @param {Color} color


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The `Context.js` file is included in the types for `widgets` to include some globals. This meant the `PickId` was getting defined twice. It's not a public function anyway so the easiest fix is just to mark it `@private`

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes #13274 

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- `npm install`
- `npm run build-ts`
- Check that `Source/Cesium.d.ts` does not include a definition for `PickId`
- Check that `packages/widgets/index.d.ts` does not include a definition for `PickId`

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
