### PR TITLE
Gulpfile deduplication

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -966,7 +966,7 @@ export async function test() {
  * Fix the typescript definitions output to match what we need.
  *
  * - Change declare => export since we are wrapping everything in a namespace
- * - Change CesiumMath => Math (because no CesiumJS build step would be complete without special logic for the Math class)
+ * - Change CesiumMath => Math to help avoid conflicts with the native Math class
  * - Fix up the WebGLConstants aliasing by simply unquoting the strings.
 
  * @param {string} source


### PR DESCRIPTION
# Description

_Describe your changes in detail_

Removes duplication from `gulpfile.js`

_Consider: Why is this change required? What problem does it solve_

It's not "required", and that's not a sensible criterion for such a change. It may not even be "important". But the point is that this duplication causes maintenance effort. And the amount of time that I (alone) already spent with this duplication is certainly _higher_ than the amount time that it would have taken to _avoid_ this duplication right from the beginning, 10 years ago.

_Include screenshots if appropriate_

Here is an animated GIF comparing two code blocks:

![Cesium Glup Duplication](https://github.com/user-attachments/assets/3dade2a5-79dc-4321-9b7c-f17d56a1b7f6)

A list of unreadable and unmaintainable regexes and workarounds. This block existed **twice**. Now it exists only **once**. Maybe that number could be reduced even further.

Another code block:

![Cesium Glup Duplication 0002](https://github.com/user-attachments/assets/2ffdbb1e-9c5c-4e21-aa8c-21de6751b21e)

Some workaround with some undocumented, highly specific AST processing. This block existed **twice**. Now it exists only **once**. Maybe that number could be reduced even further.

(Duplications, right?)

## Issue number and link

**n/a**

## Testing plan

Not sure. I think that the changes are not dangerous, and I cannot imagine how it could "break" anything. But running 
`npm run build-ts`
should cover most of what is done here.


# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- **n/a** I have updated `CHANGES.md` with a short summary of my change
- **n/a** I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

