### PR TITLE
Cartesian2-4: .pack/.packArray return type compatibility fix

### DIFF
--- a/packages/engine/Source/Core/Cartesian2.js
+++ b/packages/engine/Source/Core/Cartesian2.js
@@ -79,7 +79,7 @@ class Cartesian2 {
    * Stores the provided instance into the provided array.
    *
    * @param {Cartesian2} value The value to pack.
-   * @param {number[]|TypedArray} array The array to pack into.
+   * @param {number[]} array The array to pack into.
    * @param {number} [startingIndex=0] The index into the array at which to start packing the elements.
    *
    * @returns {number[]} The array that was packed into
@@ -95,14 +95,13 @@ class Cartesian2 {
     array[startingIndex++] = value.x;
     array[startingIndex] = value.y;
 
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/issues/10455.
     return array;
   }
 
   /**
    * Retrieves an instance from a packed array.
    *
-   * @param {number[]|TypedArray} array The packed array.
+   * @param {number[]} array The packed array.
    * @param {number} [startingIndex=0] The starting index of the element to be unpacked.
    * @param {Cartesian2} [result] The object into which to store the result.
    * @returns {Cartesian2} The modified result parameter or a new Cartesian2 instance if one was not provided.
@@ -126,7 +125,7 @@ class Cartesian2 {
    * Flattens an array of Cartesian2s into an array of components.
    *
    * @param {Cartesian2[]} array The array of cartesians to pack.
-   * @param {number[]|TypedArray} [result] The array onto which to store the result. If this is a typed array, it must have array.length * 2 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 2) elements.
+   * @param {number[]} [result] The array onto which to store the result. If this is a typed array, it must have array.length * 2 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 2) elements.
    * @returns {number[]} The packed array.
    */
   static packArray(array, result) {
@@ -138,6 +137,7 @@ class Cartesian2 {
     const resultLength = length * 2;
     if (!defined(result)) {
       result = new Array(resultLength);
+      // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
     } else if (!Array.isArray(result) && result.length !== resultLength) {
       //>>includeStart('debug', pragmas.debug);
       throw new DeveloperError(
@@ -152,7 +152,6 @@ class Cartesian2 {
       Cartesian2.pack(array[i], result, i * 2);
     }
 
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/issues/10455.
     return result;
   }
 

--- a/packages/engine/Source/Core/Cartesian3.js
+++ b/packages/engine/Source/Core/Cartesian3.js
@@ -117,7 +117,7 @@ class Cartesian3 {
    * Stores the provided instance into the provided array.
    *
    * @param {Cartesian3} value The value to pack.
-   * @param {number[]|TypedArray} array The array to pack into.
+   * @param {number[]} array The array to pack into.
    * @param {number} [startingIndex=0] The index into the array at which to start packing the elements.
    *
    * @returns {number[]} The array that was packed into
@@ -134,14 +134,13 @@ class Cartesian3 {
     array[startingIndex++] = value.y;
     array[startingIndex] = value.z;
 
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/issues/10455.
     return array;
   }
 
   /**
    * Retrieves an instance from a packed array.
    *
-   * @param {number[]|TypedArray} array The packed array.
+   * @param {number[]} array The packed array.
    * @param {number} [startingIndex=0] The starting index of the element to be unpacked.
    * @param {Cartesian3} [result] The object into which to store the result.
    * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if one was not provided.
@@ -166,7 +165,7 @@ class Cartesian3 {
    * Flattens an array of Cartesian3s into an array of components.
    *
    * @param {Cartesian3[]} array The array of cartesians to pack.
-   * @param {number[]|TypedArray} [result] The array onto which to store the result. If this is a typed array, it must have array.length * 3 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 3) elements.
+   * @param {number[]} [result] The array onto which to store the result. If this is a typed array, it must have array.length * 3 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 3) elements.
    * @returns {number[]} The packed array.
    */
   static packArray(array, result) {
@@ -178,6 +177,7 @@ class Cartesian3 {
     const resultLength = length * 3;
     if (!defined(result)) {
       result = new Array(resultLength);
+      // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
     } else if (!Array.isArray(result) && result.length !== resultLength) {
       //>>includeStart('debug', pragmas.debug);
       throw new DeveloperError(
@@ -192,14 +192,13 @@ class Cartesian3 {
       Cartesian3.pack(array[i], result, i * 3);
     }
 
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/issues/10455.
     return result;
   }
 
   /**
    * Unpacks an array of cartesian components into an array of Cartesian3s.
    *
-   * @param {number[]|TypedArray} array The array of components to unpack.
+   * @param {number[]} array The array of components to unpack.
    * @param {Cartesian3[]} [result] The array onto which to store the result.
    * @returns {Cartesian3[]} The unpacked array.
    */

--- a/packages/engine/Source/Core/Cartesian4.js
+++ b/packages/engine/Source/Core/Cartesian4.js
@@ -124,7 +124,7 @@ class Cartesian4 {
    * Stores the provided instance into the provided array.
    *
    * @param {Cartesian4} value The value to pack.
-   * @param {number[]|TypedArray} array The array to pack into.
+   * @param {number[]} array The array to pack into.
    * @param {number} [startingIndex=0] The index into the array at which to start packing the elements.
    *
    * @returns {number[]} The array that was packed into
@@ -142,14 +142,13 @@ class Cartesian4 {
     array[startingIndex++] = value.z;
     array[startingIndex] = value.w;
 
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/issues/10455.
     return array;
   }
 
   /**
    * Retrieves an instance from a packed array.
    *
-   * @param {number[]|TypedArray} array The packed array.
+   * @param {number[]} array The packed array.
    * @param {number} [startingIndex=0] The starting index of the element to be unpacked.
    * @param {Cartesian4} [result] The object into which to store the result.
    * @returns {Cartesian4}  The modified result parameter or a new Cartesian4 instance if one was not provided.
@@ -175,7 +174,7 @@ class Cartesian4 {
    * Flattens an array of Cartesian4s into an array of components.
    *
    * @param {Cartesian4[]} array The array of cartesians to pack.
-   * @param {number[]|TypedArray} [result] The array onto which to store the result. If this is a typed array, it must have array.length * 4 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 4) elements.
+   * @param {number[]} [result] The array onto which to store the result. If this is a typed array, it must have array.length * 4 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 4) elements.
    * @returns {number[]} The packed array.
    */
   static packArray(array, result) {
@@ -187,6 +186,7 @@ class Cartesian4 {
     const resultLength = length * 4;
     if (!defined(result)) {
       result = new Array(resultLength);
+      // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
     } else if (!Array.isArray(result) && result.length !== resultLength) {
       //>>includeStart('debug', pragmas.debug);
       throw new DeveloperError(
@@ -201,14 +201,13 @@ class Cartesian4 {
       Cartesian4.pack(array[i], result, i * 4);
     }
 
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/issues/10455.
     return result;
   }
 
   /**
    * Unpacks an array of cartesian components into an array of Cartesian4s.
    *
-   * @param {number[]|TypedArray} array The array of components to unpack.
+   * @param {number[]} array The array of components to unpack.
    * @param {Cartesian4[]} [result] The array onto which to store the result.
    * @returns {Cartesian4[]} The unpacked array.
    */

--- a/packages/engine/Source/Scene/BufferPoint.js
+++ b/packages/engine/Source/Scene/BufferPoint.js
@@ -102,6 +102,7 @@ class BufferPoint extends BufferPrimitive {
    */
   getPosition(result) {
     const positionF64 = this._collection._positionView;
+    // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
     return Cartesian3.fromArray(positionF64, this.vertexOffset * 3, result);
   }
 

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -152,6 +152,7 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
 
       // Update vertex arrays.
       for (let j = 0, jl = polygon.vertexCount; j < jl; j++) {
+        // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
         Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
         EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
 

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -179,17 +179,22 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
         const isLastSegment = j === jl - 1;
 
         // For first/last vertices, infer missing vertices by mirroring the segment.
+        // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
         Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
         if (isFirstSegment) {
+          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
           Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
           Cartesian3.subtract(cartesian, nextCartesian, prevCartesian);
           Cartesian3.add(cartesian, prevCartesian, prevCartesian);
         } else if (isLastSegment) {
+          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
           Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
           Cartesian3.subtract(cartesian, prevCartesian, nextCartesian);
           Cartesian3.add(cartesian, nextCartesian, nextCartesian);
         } else {
+          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
           Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
+          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
           Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
         }
 


### PR DESCRIPTION
# Description

Following up on earlier discussions (see issue links below), I think our best option right now might be to keep the public-facing types as stable as possible, so that users don't need to do temporary migrations (adding/removing `as Cartesian3` casts) for issues that will no longer exist after we've converted to ES6 classes and resolved #10455.

This PR takes a first step on that, reverting a change to the return types of pack/unpack methods, and maintaining backward-compatibility with previous releases. I've kept the correct _parameter types_ intact, since there's no compatibility issue with those and it's one less thing we need to override.

## Issue number and link

- https://github.com/CesiumGS/cesium/pull/13168#issuecomment-4054866265
- https://github.com/CesiumGS/cesium/pull/13282#issuecomment-4056181130

## Testing plan

Diff for Cesium.d.ts, before / after:

```diff
diff --git a/Source/SrcCesium.d.ts b/Source/Cesium.d.ts
index 0b09075bb2..83ce2ca07b 100644
--- a/Source/SrcCesium.d.ts
+++ b/Source/Cesium.d.ts
@@ -1528,7 +1528,7 @@ export class Cartesian2 {
      * @param [startingIndex = 0] - The index into the array at which to start packing the elements.
      * @returns The array that was packed into
      */
-    static pack(value: Cartesian2, array: number[] | TypedArray, startingIndex?: number): number[] | TypedArray;
+    static pack(value: Cartesian2, array: number[] | TypedArray, startingIndex?: number): number[];
     /**
      * Retrieves an instance from a packed array.
      * @param array - The packed array.
@@ -1543,7 +1543,7 @@ export class Cartesian2 {
      * @param [result] - The array onto which to store the result. If this is a typed array, it must have array.length * 2 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 2) elements.
      * @returns The packed array.
      */
-    static packArray(array: Cartesian2[], result?: number[] | TypedArray): number[] | TypedArray;
+    static packArray(array: Cartesian2[], result?: number[] | TypedArray): number[];
     /**
      * Unpacks an array of cartesian components into an array of Cartesian2s.
      * @param array - The array of components to unpack.
@@ -1878,7 +1878,7 @@ export class Cartesian3 {
      * @param [startingIndex = 0] - The index into the array at which to start packing the elements.
      * @returns The array that was packed into
      */
-    static pack(value: Cartesian3, array: number[] | TypedArray, startingIndex?: number): number[] | TypedArray;
+    static pack(value: Cartesian3, array: number[] | TypedArray, startingIndex?: number): number[];
     /**
      * Retrieves an instance from a packed array.
      * @param array - The packed array.
@@ -1893,7 +1893,7 @@ export class Cartesian3 {
      * @param [result] - The array onto which to store the result. If this is a typed array, it must have array.length * 3 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 3) elements.
      * @returns The packed array.
      */
-    static packArray(array: Cartesian3[], result?: number[] | TypedArray): number[] | TypedArray;
+    static packArray(array: Cartesian3[], result?: number[] | TypedArray): number[];
     /**
      * Unpacks an array of cartesian components into an array of Cartesian3s.
      * @param array - The array of components to unpack.
@@ -2312,7 +2312,7 @@ export class Cartesian4 {
      * @param [startingIndex = 0] - The index into the array at which to start packing the elements.
      * @returns The array that was packed into
      */
-    static pack(value: Cartesian4, array: number[] | TypedArray, startingIndex?: number): number[] | TypedArray;
+    static pack(value: Cartesian4, array: number[] | TypedArray, startingIndex?: number): number[];
     /**
      * Retrieves an instance from a packed array.
      * @param array - The packed array.
@@ -2327,7 +2327,7 @@ export class Cartesian4 {
      * @param [result] - The array onto which to store the result. If this is a typed array, it must have array.length * 4 components, else a {@link DeveloperError} will be thrown. If it is a regular array, it will be resized to have (array.length * 4) elements.
      * @returns The packed array.
      */
-    static packArray(array: Cartesian4[], result?: number[] | TypedArray): number[] | TypedArray;
+    static packArray(array: Cartesian4[], result?: number[] | TypedArray): number[];
     /**
      * Unpacks an array of cartesian components into an array of Cartesian4s.
      * @param array - The array of components to unpack.

```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code



#### PR Dependency Tree


* **PR #13302** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)