### PR TITLE
Vector Tiles: Type checks and simplifications in parser

### DIFF
--- a/packages/engine/Source/Scene/GltfLoader.js
+++ b/packages/engine/Source/Scene/GltfLoader.js
@@ -63,6 +63,7 @@ const {
   Clearcoat,
   LineStyle,
   Material,
+  Vector,
 } = ModelComponents;
 
 /**
@@ -2214,7 +2215,7 @@ function loadPrimitive(loader, gltfPrimitive, hasInstances, frameState) {
   const extensions = gltfPrimitive.extensions ?? Frozen.EMPTY_OBJECT;
   const meshVectorExtension = extensions.CESIUM_mesh_vector;
   if (defined(meshVectorExtension)) {
-    primitive.meshVector = loadMeshVectorExtension(loader, meshVectorExtension);
+    primitive.vector = loadMeshVectorExtension(loader, meshVectorExtension);
   }
 
   let needsPostProcessing = false;
@@ -2369,26 +2370,28 @@ function loadPrimitiveOutline(loader, outlineExtension) {
   return loadAccessor(loader, accessor, useQuaternion);
 }
 
+/**
+ * Load CESIUM_mesh_vector.
+ * @param {GltfLoader} loader
+ * @param {*} meshVectorExtension
+ * @returns {ModelComponents.Vector}
+ * @ignore
+ */
 function loadMeshVectorExtension(loader, meshVectorExtension) {
   if (!defined(meshVectorExtension)) {
     return undefined;
   }
 
-  const result = {
-    vector: meshVectorExtension.vector,
-    count: meshVectorExtension.count,
-  };
+  const result = new Vector();
+  result.vector = meshVectorExtension.vector;
+  result.count = meshVectorExtension.count;
 
   const accessors = loader.gltfJson.accessors;
   function loadVectorAccessor(accessorId, name) {
     if (!defined(accessorId)) {
       return undefined;
     }
-    const accessor = accessors[accessorId];
-    if (!defined(accessor)) {
-      throw new RuntimeError(`CESIUM_mesh_vector ${name} accessor not found!`);
-    }
-    return loadAccessor(loader, accessor);
+    return loadAccessor(loader, accessors[accessorId]);
   }
 
   result.polygonAttributeOffsets = loadVectorAccessor(

--- a/packages/engine/Source/Scene/Model/ModelReader.js
+++ b/packages/engine/Source/Scene/Model/ModelReader.js
@@ -53,7 +53,7 @@ class ModelReader {
    *
    * The result will be THE actual attribute data.
    *
-   * @param {ModelComponents.Attribute} attribute The attribute
+   * @param {Attribute} attribute The attribute
    * @returns {TypedArray} The attribute data
    */
   static readAttributeAsTypedArray(attribute) {

--- a/packages/engine/Source/Scene/Model/ModelUtility.js
+++ b/packages/engine/Source/Scene/Model/ModelUtility.js
@@ -10,6 +10,8 @@ import CullFace from "../CullFace.js";
 import PrimitiveType from "../../Core/PrimitiveType.js";
 import Matrix3 from "../../Core/Matrix3.js";
 
+/** @import {Attribute} from "../ModelComponents.js"; */
+
 /**
  * Utility functions for {@link Model}.
  *
@@ -69,7 +71,7 @@ ModelUtility.getNodeTransform = function (node) {
  * @param {ModelComponents.Primitive|ModelComponents.Instances} object The primitive components or instances object
  * @param {VertexAttributeSemantic|InstanceAttributeSemantic} semantic The semantic to search for
  * @param {number} [setIndex] The set index of the semantic. May be undefined for some semantics (POSITION, NORMAL, TRANSLATION, ROTATION, for example)
- * @return {ModelComponents.Attribute} The selected attribute, or undefined if not found.
+ * @return {Attribute} The selected attribute, or undefined if not found.
  *
  * @private
  */

--- a/packages/engine/Source/Scene/Model/createVectorTileBuffersFromModelComponents.js
+++ b/packages/engine/Source/Scene/Model/createVectorTileBuffersFromModelComponents.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import Cartesian3 from "../../Core/Cartesian3.js";
 import assert from "../../Core/assert.js";
 import defined from "../../Core/defined.js";
@@ -13,69 +15,62 @@ import BufferPolylineCollection from "../BufferPolylineCollection.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
 import ModelReader from "./ModelReader.js";
 import ModelUtility from "./ModelUtility.js";
+import ModelComponents from "../ModelComponents.js";
 
-/** @import { TypedArrayConstructor } from "../../Core/globalTypes.js"; */
+/** @import { TypedArray } from "../../Core/globalTypes.js"; */
+/** @import BufferPrimitive from "../BufferPrimitive.js"; */
+/** @import BufferPrimitiveCollection from "../BufferPrimitiveCollection.js"; */
+/** @import VectorGltf3DTileContent from "../VectorGltf3DTileContent.js"; */
+/** @import {Attribute, Components, Node, Primitive} from "../ModelComponents.js"; */
 
-const scratchPointPosition = new Cartesian3();
-const scratchPointView = new BufferPoint();
-const scratchPolylineView = new BufferPolyline();
-const scratchPolygonView = new BufferPolygon();
+/**
+ * @typedef {object} VectorTileResult
+ * @property {Array<BufferPrimitiveCollection<BufferPrimitive>>} collections
+ * @property {Array<Matrix4>} collectionLocalMatrices
+ * @ignore
+ */
 
-function getPositionAttribute(primitive) {
-  return ModelUtility.getAttributeBySemantic(
-    primitive,
-    VertexAttributeSemantic.POSITION,
-  );
+const scratchPosition = new Cartesian3();
+const scratchPoint = new BufferPoint();
+const scratchPolyline = new BufferPolyline();
+const scratchPolygon = new BufferPolygon();
+
+/**
+ * Creates vector buffers from model components.
+ *
+ * @param {VectorGltf3DTileContent} content
+ * @param {Components} components
+ * @returns {VectorTileResult}
+ *
+ * @ignore
+ */
+function createVectorTileBuffersFromModelComponents(content, components) {
+  const rootNodes = components.scene.nodes;
+
+  /** @type {VectorTileResult} */
+  const result = { collections: [], collectionLocalMatrices: [] };
+
+  for (let i = 0; i < rootNodes.length; i++) {
+    appendNodeToBuffers(content, rootNodes[i], Matrix4.IDENTITY, result);
+  }
+
+  return result;
 }
 
-function getPositionCount(primitive) {
-  const attribute = getPositionAttribute(primitive);
-  return defined(attribute) ? attribute.count : 0;
-}
-
-function readAttributeTypedArray(attribute) {
-  if (!defined(attribute)) {
-    return undefined;
-  }
-  if (defined(attribute.typedArray)) {
-    return attribute.typedArray;
-  }
-  if (defined(attribute.buffer)) {
-    return ModelReader.readAttributeAsTypedArray(attribute);
-  }
-  return undefined;
-}
-
-function readIndices(primitive) {
-  const indices = primitive.indices;
-  if (!defined(indices)) {
-    return undefined;
-  }
-  if (defined(indices.typedArray)) {
-    return indices.typedArray;
-  }
-  if (defined(indices.buffer)) {
-    return ModelReader.readIndicesAsTypedArray(indices);
-  }
-  return undefined;
-}
-
-function getMeshVectorExtension(primitive) {
-  const meshVector = primitive.meshVector;
-
-  //>>includeStart('debug', pragmas.debug);
-  assert(defined(meshVector), "CESIUM_mesh_vector data is required.");
-  assert(meshVector.vector === true, "CESIUM_mesh_vector.vector must be true.");
-  //>>includeEnd('debug');
-
-  return meshVector;
-}
-
+/**
+ * @param {TypedArray} indices
+ * @ignore
+ */
 function getPrimitiveRestartIndex(indices) {
   const bits = indices.BYTES_PER_ELEMENT * 8;
   return Math.pow(2, bits) - 1;
 }
 
+/**
+ * @param {TypedArray} indices
+ * @param {Function} callback
+ * @ignore
+ */
 function forEachLineStripSegment(indices, callback) {
   const restart = getPrimitiveRestartIndex(indices);
   let segmentStart = 0;
@@ -90,151 +85,12 @@ function forEachLineStripSegment(indices, callback) {
   }
 }
 
-function isSequentialIndices(indices, start, count) {
-  if (count <= 1) {
-    return true;
-  }
-  const first = indices[start];
-  for (let i = 1; i < count; i++) {
-    if (indices[start + i] !== first + i) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function getFeatureIdSource(primitive) {
-  if (!defined(primitive.featureIds) || primitive.featureIds.length === 0) {
-    return undefined;
-  }
-
-  const featureIdSet = primitive.featureIds[0];
-  if (defined(featureIdSet.setIndex)) {
-    const featureIdAttribute = ModelUtility.getAttributeBySemantic(
-      primitive,
-      VertexAttributeSemantic.FEATURE_ID,
-      featureIdSet.setIndex,
-    );
-    const featureIds = readAttributeTypedArray(featureIdAttribute);
-    if (!defined(featureIds)) {
-      return undefined;
-    }
-    return {
-      values: featureIds,
-      nullFeatureId: featureIdSet.nullFeatureId,
-    };
-  }
-
-  if (defined(featureIdSet.offset) || defined(featureIdSet.repeat)) {
-    return {
-      offset: featureIdSet.offset ?? 0,
-      repeat: featureIdSet.repeat ?? 1,
-      nullFeatureId: featureIdSet.nullFeatureId,
-    };
-  }
-
-  return undefined;
-}
-
-function getFeatureId(featureIdSource, vertexIndex) {
-  if (!defined(featureIdSource)) {
-    return undefined;
-  }
-
-  let featureId;
-  if (defined(featureIdSource.values)) {
-    if (vertexIndex < 0 || vertexIndex >= featureIdSource.values.length) {
-      return undefined;
-    }
-    featureId = featureIdSource.values[vertexIndex];
-  } else {
-    featureId =
-      Math.floor(vertexIndex / featureIdSource.repeat) + featureIdSource.offset;
-  }
-
-  featureId = Math.trunc(featureId);
-  if (
-    defined(featureIdSource.nullFeatureId) &&
-    featureId === featureIdSource.nullFeatureId
-  ) {
-    return undefined;
-  }
-  return featureId;
-}
-
-function gatherPrimitiveStats(primitive, stats) {
-  const meshVector = getMeshVectorExtension(primitive);
-  if (!defined(meshVector)) {
-    return;
-  }
-
-  const primitiveType = primitive.primitiveType;
-  const positionCount = getPositionCount(primitive);
-  if (positionCount === 0) {
-    return;
-  }
-
-  if (primitiveType === PrimitiveType.POINTS) {
-    stats.pointPrimitiveCount += meshVector.count;
-    stats.pointVertexCount += meshVector.count;
-    return;
-  }
-
-  if (primitiveType === PrimitiveType.LINE_STRIP) {
-    const indices = readIndices(primitive);
-
-    //>>includeStart('debug', pragmas.debug);
-    assert(
-      defined(indices),
-      "Vector polylines with LINE_STRIP topology must be indexed.",
-    );
-    //>>includeEnd('debug');
-
-    stats.polylinePrimitiveCount += meshVector.count;
-    stats.polylineVertexCount += indices.length - (meshVector.count - 1);
-    return;
-  }
-
-  if (primitiveType === PrimitiveType.TRIANGLES) {
-    const indices = readIndices(primitive);
-
-    //>>includeStart('debug', pragmas.debug);
-    assert(
-      defined(indices),
-      "Vector polygons with TRIANGLES topology must be indexed.",
-    );
-    //>>includeEnd('debug');
-
-    const polygonAttributeOffsets = meshVector.polygonAttributeOffsets;
-    const polygonIndicesOffsets = meshVector.polygonIndicesOffsets;
-    const polygonHoleCounts = meshVector.polygonHoleCounts;
-
-    //>>includeStart('debug', pragmas.debug);
-    assert(
-      defined(polygonAttributeOffsets) && defined(polygonIndicesOffsets),
-      "Vector polygons require polygonAttributeOffsets and polygonIndicesOffsets.",
-    );
-    //>>includeEnd('debug');
-
-    const polygonCount = polygonAttributeOffsets.length;
-    stats.polygonPrimitiveCount += polygonCount;
-    stats.polygonVertexCount += positionCount;
-    stats.polygonTriangleCount += indices.length / 3;
-    if (polygonHoleCounts) {
-      for (let i = 0; i < polygonHoleCounts.length; i++) {
-        stats.polygonHoleCount += polygonHoleCounts[i];
-      }
-    }
-    return;
-  }
-
-  throw new RuntimeError(
-    `Vector primitives with primitive type ${primitiveType} are not supported.`,
-  );
-}
-
-function createStats() {
-  return {
+/**
+ * @param {Primitive} primitive
+ * @ignore
+ */
+function gatherPrimitiveStats(primitive) {
+  const stats = {
     pointPrimitiveCount: 0,
     pointVertexCount: 0,
     polylinePrimitiveCount: 0,
@@ -244,281 +100,178 @@ function createStats() {
     polygonHoleCount: 0,
     polygonTriangleCount: 0,
   };
-}
 
-function readPositions(primitive) {
-  const positionAttribute = getPositionAttribute(primitive);
-  const values = readAttributeTypedArray(positionAttribute);
-  if (!defined(values) || values.length === 0) {
-    return undefined;
-  }
-  return values;
-}
-
-function setPrimitiveFeatureId(primitiveView, featureIdSource, vertexIndex) {
-  const featureId = getFeatureId(featureIdSource, vertexIndex);
-  if (defined(featureId)) {
-    primitiveView.featureId = featureId;
-  }
-}
-
-function appendPointPrimitive(
-  pointCollection,
-  pointView,
-  featureIdSource,
-  positions,
-  vertexIndex,
-) {
-  const offset = vertexIndex * 3;
-  pointCollection.add(
-    {
-      position: Cartesian3.fromElements(
-        positions[offset],
-        positions[offset + 1],
-        positions[offset + 2],
-        scratchPointPosition,
-      ),
-    },
-    pointView,
-  );
-  setPrimitiveFeatureId(pointView, featureIdSource, vertexIndex);
-}
-
-function appendPolylinePrimitive(
-  polylineCollection,
-  polylineView,
-  featureIdSource,
-  positions,
-  indices,
-) {
-  if (indices.length < 2) {
-    return;
-  }
-
-  let values;
-  if (isSequentialIndices(indices, 0, indices.length)) {
-    const startIndex = indices[0];
-    const endIndex = startIndex + indices.length;
-    values = positions.subarray(startIndex * 3, endIndex * 3);
-  } else {
-    const TypedArray = /** @type {TypedArrayConstructor} */ (
-      positions.constructor
-    );
-    values = new TypedArray(indices.length * 3);
-    for (let i = 0; i < indices.length; i++) {
-      const vertexIndex = indices[i];
-      const srcOffset = vertexIndex * 3;
-      values[i * 3] = positions[srcOffset];
-      values[i * 3 + 1] = positions[srcOffset + 1];
-      values[i * 3 + 2] = positions[srcOffset + 2];
-    }
-  }
-
-  polylineCollection.add({ positions: values }, polylineView);
-  setPrimitiveFeatureId(polylineView, featureIdSource, indices[0]);
-}
-
-function appendPolygonPrimitive(
-  polygonCollection,
-  polygonView,
-  featureIdSource,
-  positions,
-  triangles,
-  holes,
-  featureIdVertexIndex,
-) {
-  if (!defined(triangles) || triangles.length < 3) {
-    return;
-  }
-
-  const options = {
-    positions: positions,
-    triangles: triangles,
-  };
-  if (defined(holes) && holes.length > 0) {
-    options.holes = holes;
-  }
-
-  polygonCollection.add(options, polygonView);
-  setPrimitiveFeatureId(polygonView, featureIdSource, featureIdVertexIndex);
-}
-
-function appendPrimitiveToBuffers(
-  primitive,
-  pointCollection,
-  polylineCollection,
-  polygonCollection,
-) {
-  const meshVector = getMeshVectorExtension(primitive);
-  if (!defined(meshVector)) {
-    return;
-  }
-
+  const vector = primitive.vector;
   const primitiveType = primitive.primitiveType;
-  const positions = readPositions(primitive);
-  if (!defined(positions)) {
-    return;
-  }
+  const positionAttribute = ModelUtility.getAttributeBySemantic(
+    primitive,
+    VertexAttributeSemantic.POSITION,
+  );
+  const positionCount = positionAttribute.count;
 
-  const vertexCount = positions.length / 3;
-  const featureIdSource = getFeatureIdSource(primitive);
+  const indices = primitive.indices
+    ? ModelReader.readIndicesAsTypedArray(primitive.indices)
+    : undefined;
 
+  // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
   if (primitiveType === PrimitiveType.POINTS) {
-    if (!defined(pointCollection)) {
-      return;
-    }
+    stats.pointPrimitiveCount += vector.count;
+    stats.pointVertexCount += vector.count;
 
-    const indices = readIndices(primitive);
-    for (let i = 0, il = indices ? indices.length : vertexCount; i < il; i++) {
-      appendPointPrimitive(
-        pointCollection,
-        scratchPointView,
-        featureIdSource,
-        positions,
-        indices ? indices[i] : i,
-      );
-    }
-    return;
-  }
-
-  if (primitiveType === PrimitiveType.LINE_STRIP) {
-    if (!defined(polylineCollection)) {
-      return;
-    }
-
-    const indices = readIndices(primitive);
-    if (!defined(indices)) {
-      throw new RuntimeError(
-        "Vector polylines with LINE_STRIP topology must be indexed.",
-      );
-    }
-
-    forEachLineStripSegment(indices, (segmentStart, segmentCount) => {
-      //>>includeStart('debug', pragmas.debug);
-      assert(
-        segmentCount >= 2,
-        "Vector polyline segments must contain at least 2 vertices.",
-      );
-      //>>includeEnd('debug');
-
-      const segment = indices.subarray(
-        segmentStart,
-        segmentStart + segmentCount,
-      );
-      appendPolylinePrimitive(
-        polylineCollection,
-        scratchPolylineView,
-        featureIdSource,
-        positions,
-        segment,
-      );
-    });
-    return;
-  }
-
-  if (primitiveType === PrimitiveType.TRIANGLES) {
-    if (!defined(polygonCollection)) {
-      return;
-    }
-
-    const indices = readIndices(primitive);
-    if (!defined(indices)) {
-      throw new RuntimeError(
-        "Vector polygons with TRIANGLES topology must be indexed.",
-      );
-    }
-
-    const polygonAttributeOffsets = meshVector.polygonAttributeOffsets;
-    const polygonIndicesOffsets = meshVector.polygonIndicesOffsets;
-    const polygonHoleCounts = meshVector.polygonHoleCounts;
-    const polygonHoleOffsets = meshVector.polygonHoleOffsets;
-
+    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
+  } else if (primitiveType === PrimitiveType.LINE_STRIP) {
     //>>includeStart('debug', pragmas.debug);
-    assert(
-      defined(polygonAttributeOffsets) && defined(polygonIndicesOffsets),
-      "Vector polygons require polygonAttributeOffsets and polygonIndicesOffsets.",
-    );
+    assert(defined(indices), "Vector LINE_STRIP primitive must be indexed.");
     //>>includeEnd('debug');
 
-    const hasHoles = defined(polygonHoleCounts) && defined(polygonHoleOffsets);
-    let holes;
+    stats.polylinePrimitiveCount += vector.count;
+    stats.polylineVertexCount += indices.length - (vector.count - 1);
 
-    let holeOffsetIndex = 0;
+    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
+  } else if (primitiveType === PrimitiveType.TRIANGLES) {
+    //>>includeStart('debug', pragmas.debug);
+    assert(defined(indices), "Vector TRIANGLES primitive must be indexed.");
+    //>>includeEnd('debug');
+
+    stats.polygonPrimitiveCount += vector.count;
+    stats.polygonVertexCount += positionCount;
+    stats.polygonTriangleCount += indices.length / 3;
+
+    const polygonHoleCounts = vector.polygonHoleCounts;
+    if (polygonHoleCounts) {
+      for (let i = 0; i < polygonHoleCounts.length; i++) {
+        stats.polygonHoleCount += polygonHoleCounts[i];
+      }
+    }
+  } else {
+    throw new RuntimeError(`Unexpected primitive type: ${primitiveType}`);
+  }
+
+  return stats;
+}
+
+/**
+ * @param {VectorGltf3DTileContent} content
+ * @param {Primitive} primitive
+ * @param {BufferPrimitiveCollection<BufferPrimitive>} collection
+ * @ignore
+ */
+function appendPrimitiveToBuffers(content, primitive, collection) {
+  const vector = primitive.vector;
+  const positionAttribute = ModelUtility.getAttributeBySemantic(
+    primitive,
+    VertexAttributeSemantic.POSITION,
+  );
+  /** @type {TypedArray} */
+  const collectionPositions =
+    positionAttribute.typedArray ??
+    ModelReader.readAttributeAsTypedArray(positionAttribute);
+  const vertexCount = collectionPositions.length / 3;
+
+  /** @type {TypedArray} */
+  const indices = primitive.indices
+    ? ModelReader.readIndicesAsTypedArray(primitive.indices)
+    : undefined;
+
+  const featureIdComponent = primitive.featureIds?.[0];
+  /** @type {Attribute} */
+  let featureIdAttribute;
+  /** @type {TypedArray} */
+  let featureIdArray;
+  if (featureIdComponent instanceof ModelComponents.FeatureIdAttribute) {
+    featureIdAttribute = ModelUtility.getAttributeBySemantic(
+      primitive,
+      VertexAttributeSemantic.FEATURE_ID,
+      featureIdComponent.setIndex,
+    );
+    featureIdArray =
+      featureIdAttribute.typedArray ??
+      ModelReader.readAttributeAsTypedArray(featureIdAttribute);
+  }
+
+  if (collection instanceof BufferPointCollection) {
+    for (let i = 0, il = indices ? indices.length : vertexCount; i < il; i++) {
+      const vertexOffset = indices ? indices[i] : i;
+      Cartesian3.fromArray(
+        // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+        collectionPositions,
+        vertexOffset * 3,
+        scratchPosition,
+      );
+      collection.add({ position: scratchPosition }, scratchPoint);
+
+      const featureId = Math.trunc(featureIdArray[vertexOffset]);
+      if (featureId !== featureIdComponent.nullFeatureId) {
+        scratchPoint.featureId = featureId;
+      }
+    }
+  } else if (collection instanceof BufferPolylineCollection) {
+    // @ts-expect-error TODO
+    forEachLineStripSegment(indices, (indexOffset, indexCount) => {
+      const vertexOffset = indices[indexOffset];
+      const positions = collectionPositions.subarray(
+        vertexOffset * 3,
+        (vertexOffset + indexCount) * 3,
+      );
+      collection.add({ positions }, scratchPolyline);
+
+      const featureId = Math.trunc(featureIdArray[vertexOffset]);
+      if (featureId !== featureIdComponent.nullFeatureId) {
+        scratchPolyline.featureId = featureId;
+      }
+    });
+  } else if (collection instanceof BufferPolygonCollection) {
+    const polygonAttributeOffsets = vector.polygonAttributeOffsets;
+    const polygonIndicesOffsets = vector.polygonIndicesOffsets;
+    const polygonHoleCounts = vector.polygonHoleCounts;
+    const polygonHoleOffsets = vector.polygonHoleOffsets;
+
     const polygonCount = polygonAttributeOffsets.length;
     for (let i = 0; i < polygonCount; i++) {
-      const polygonVertexOffset = polygonAttributeOffsets[i];
+      const polygonVertexStart = polygonAttributeOffsets[i];
       const polygonVertexEnd =
         i + 1 < polygonCount ? polygonAttributeOffsets[i + 1] : vertexCount;
-      const polygonVertexCount = Math.max(
-        polygonVertexEnd - polygonVertexOffset,
-        0,
-      );
-      if (polygonVertexCount === 0) {
-        continue;
-      }
 
-      const polygonPositions = positions.subarray(
-        polygonVertexOffset * 3,
+      const positions = collectionPositions.subarray(
+        polygonVertexStart * 3,
         polygonVertexEnd * 3,
       );
 
-      if (hasHoles) {
+      let holes;
+      if (defined(polygonHoleCounts) && polygonHoleCounts[i] > 0) {
         const holeCount = polygonHoleCounts[i];
-        if (holeCount > 0) {
-          const HoleArray = /** @type {TypedArrayConstructor} */ (
-            polygonHoleOffsets.constructor
-          );
-          holes = new HoleArray(holeCount);
-          for (let h = 0; h < holeCount; h++) {
-            holes[h] =
-              polygonHoleOffsets[holeOffsetIndex + h] - polygonVertexOffset;
-          }
-        }
-        holeOffsetIndex += holeCount;
-      }
-
-      const triangleIndexOffset = polygonIndicesOffsets[i];
-      const triangleIndexCount =
-        i + 1 < polygonCount
-          ? polygonIndicesOffsets[i + 1] - triangleIndexOffset
-          : indices.length - triangleIndexOffset;
-      let triangleIndices;
-      if (triangleIndexCount > 0) {
-        const IndexArray = /** @type {TypedArrayConstructor} */ (
-          indices.constructor
-        );
-        triangleIndices = new IndexArray(triangleIndexCount);
-        for (let t = 0; t < triangleIndexCount; t++) {
-          triangleIndices[t] =
-            indices[triangleIndexOffset + t] - polygonVertexOffset;
+        holes = polygonHoleOffsets.slice(i, i + holeCount);
+        for (let h = 0; h < holeCount; h++) {
+          holes[i] -= polygonVertexStart;
         }
       }
 
-      appendPolygonPrimitive(
-        polygonCollection,
-        scratchPolygonView,
-        featureIdSource,
-        polygonPositions,
-        triangleIndices,
-        holes,
-        polygonVertexOffset,
-      );
+      const triangleIndexStart = polygonIndicesOffsets[i];
+      const triangleIndexEnd =
+        i + 1 < polygonCount ? polygonIndicesOffsets[i + 1] : indices.length;
+      const triangles = indices.slice(triangleIndexStart, triangleIndexEnd);
+      for (let t = 0; t < triangleIndexEnd; t++) {
+        triangles[t] -= polygonVertexStart;
+      }
+
+      collection.add({ positions, triangles, holes }, scratchPolygon);
+
+      const featureId = Math.trunc(featureIdArray[polygonVertexStart]);
+      if (featureId !== featureIdComponent.nullFeatureId) {
+        scratchPolygon.featureId = featureId;
+      }
     }
-    return;
   }
-
-  throw new RuntimeError(
-    `Vector primitives with primitive type ${primitiveType} are not supported.`,
-  );
 }
 
-function appendNodeToBuffers(
-  node,
-  parentTransform,
-  points,
-  polylines,
-  polygons,
-) {
+/**
+ * @param {VectorGltf3DTileContent} content
+ * @param {Node} node
+ * @param {Matrix4} parentTransform
+ * @param {VectorTileResult} result
+ * @ignore
+ */
+function appendNodeToBuffers(content, node, parentTransform, result) {
   const localTransform = ModelUtility.getNodeTransform(node);
   const nodeTransform = Matrix4.multiplyTransformation(
     parentTransform,
@@ -529,102 +282,49 @@ function appendNodeToBuffers(
   const primitives = node.primitives;
   for (let i = 0; i < primitives.length; i++) {
     const primitive = primitives[i];
-    const stats = createStats();
-    gatherPrimitiveStats(primitive, stats);
+    const primitiveType = primitive.primitiveType;
+    if (!primitive.vector) {
+      continue;
+    }
 
+    /** @type {BufferPrimitiveCollection<BufferPrimitive>} */
     let collection;
 
-    if (stats.pointPrimitiveCount > 0) {
+    const stats = gatherPrimitiveStats(primitive);
+
+    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
+    if (primitiveType === PrimitiveType.POINTS) {
       collection = new BufferPointCollection({
         primitiveCountMax: stats.pointPrimitiveCount,
-        vertexCountMax: stats.pointVertexCount,
       });
-      points.push(collection);
-    } else if (stats.polylinePrimitiveCount > 0) {
+
+      // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
+    } else if (primitiveType === PrimitiveType.LINE_STRIP) {
       collection = new BufferPolylineCollection({
         primitiveCountMax: stats.polylinePrimitiveCount,
         vertexCountMax: stats.polylineVertexCount,
       });
-      polylines.push(collection);
-    } else if (stats.polygonPrimitiveCount > 0) {
+
+      // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
+    } else if (primitiveType === PrimitiveType.TRIANGLES) {
       collection = new BufferPolygonCollection({
         primitiveCountMax: stats.polygonPrimitiveCount,
         vertexCountMax: stats.polygonVertexCount,
         holeCountMax: stats.polygonHoleCount,
         triangleCountMax: stats.polygonTriangleCount,
       });
-      polygons.push(collection);
     }
 
-    if (!defined(collection)) {
-      continue;
-    }
+    result.collections.push(collection);
+    result.collectionLocalMatrices.push(Matrix4.clone(nodeTransform));
 
-    collection._vectorLocalModelMatrix = Matrix4.clone(nodeTransform);
-    appendPrimitiveToBuffers(
-      primitive,
-      stats.pointPrimitiveCount > 0 ? collection : undefined,
-      stats.polylinePrimitiveCount > 0 ? collection : undefined,
-      stats.polygonPrimitiveCount > 0 ? collection : undefined,
-    );
+    appendPrimitiveToBuffers(content, primitive, collection);
   }
 
   const children = node.children;
   for (let i = 0; i < children.length; i++) {
-    appendNodeToBuffers(
-      children[i],
-      nodeTransform,
-      points,
-      polylines,
-      polygons,
-    );
+    appendNodeToBuffers(content, children[i], nodeTransform, result);
   }
-}
-
-/**
- * @typedef {object} VectorTileBuffers
- * @property {BufferPointCollection[]} points
- * @property {BufferPolylineCollection[]} polylines
- * @property {BufferPolygonCollection[]} polygons
- */
-
-/**
- * Creates vector buffers from model components.
- *
- * @param {ModelComponents.Components} components
- * @returns {VectorTileBuffers|undefined}
- *
- * @private
- */
-function createVectorTileBuffersFromModelComponents(components) {
-  if (!defined(components) || !defined(components.scene)) {
-    return undefined;
-  }
-
-  const rootNodes = components.scene.nodes;
-  const points = [];
-  const polylines = [];
-  const polygons = [];
-
-  for (let i = 0; i < rootNodes.length; i++) {
-    appendNodeToBuffers(
-      rootNodes[i],
-      Matrix4.IDENTITY,
-      points,
-      polylines,
-      polygons,
-    );
-  }
-
-  if (points.length === 0 && polylines.length === 0 && polygons.length === 0) {
-    return undefined;
-  }
-
-  return {
-    points: points,
-    polylines: polylines,
-    polygons: polygons,
-  };
 }
 
 export default createVectorTileBuffersFromModelComponents;

--- a/packages/engine/Source/Scene/ModelComponents.js
+++ b/packages/engine/Source/Scene/ModelComponents.js
@@ -6,6 +6,7 @@ import Cartesian4 from "../Core/Cartesian4.js";
 import Matrix3 from "../Core/Matrix3.js";
 import Matrix4 from "../Core/Matrix4.js";
 
+/** @import { TypedArray } from "../Core/globalTypes.js"; */
 /** @import ArticulationStageType from "../Core/ArticulationStageType.js"; */
 /** @import AttributeType from "./AttributeType.js"; */
 /** @import Axis from "./Axis.js"; */
@@ -37,7 +38,7 @@ const ModelComponents = {};
  *
  * @ignore
  */
-class Quantization {
+export class Quantization {
   constructor() {
     /**
      * Whether the quantized attribute is oct-encoded.
@@ -129,7 +130,7 @@ class Quantization {
  *
  * @ignore
  */
-class Attribute {
+export class Attribute {
   constructor() {
     /**
      * The attribute name. Must be unique within the attributes array.
@@ -253,7 +254,7 @@ class Attribute {
     /**
      * Information about the quantized attribute.
      *
-     * @type {ModelComponents.Quantization}
+     * @type {Quantization}
      * @ignore
      */
     this.quantization = undefined;
@@ -299,7 +300,7 @@ class Attribute {
  *
  * @ignore
  */
-class Indices {
+export class Indices {
   constructor() {
     /**
      * The index data type of the attribute, e.g. IndexDatatype.UNSIGNED_SHORT.
@@ -341,7 +342,7 @@ class Indices {
  *
  * @ignore
  */
-class FeatureIdAttribute {
+export class FeatureIdAttribute {
   constructor() {
     /**
      * How many unique features are defined in this set of feature IDs
@@ -405,7 +406,7 @@ class FeatureIdAttribute {
  *
  * @ignore
  */
-class FeatureIdImplicitRange {
+export class FeatureIdImplicitRange {
   constructor() {
     /**
      * How many unique features are defined in this set of feature IDs
@@ -475,7 +476,7 @@ class FeatureIdImplicitRange {
  *
  * @ignore
  */
-class FeatureIdTexture {
+export class FeatureIdTexture {
   constructor() {
     /**
      * How many unique features are defined in this set of feature IDs
@@ -505,7 +506,7 @@ class FeatureIdTexture {
     /**
      * The texture reader containing feature IDs.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.textureReader = undefined;
@@ -536,12 +537,12 @@ class FeatureIdTexture {
  *
  * @ignore
  */
-class MorphTarget {
+export class MorphTarget {
   constructor() {
     /**
      * Attributes that are part of the morph target, e.g. positions, normals, and tangents.
      *
-     * @type {ModelComponents.Attribute[]}
+     * @type {Attribute[]}
      * @ignore
      */
     this.attributes = [];
@@ -553,12 +554,12 @@ class MorphTarget {
  *
  * @ignore
  */
-class Primitive {
+export class Primitive {
   constructor() {
     /**
      * The vertex attributes, e.g. positions, normals, etc.
      *
-     * @type {ModelComponents.Attribute[]}
+     * @type {Attribute[]}
      * @ignore
      */
     this.attributes = [];
@@ -566,7 +567,7 @@ class Primitive {
     /**
      * The morph targets.
      *
-     * @type {ModelComponents.MorphTarget[]}
+     * @type {MorphTarget[]}
      * @ignore
      */
     this.morphTargets = [];
@@ -574,7 +575,7 @@ class Primitive {
     /**
      * The indices.
      *
-     * @type {ModelComponents.Indices}
+     * @type {Indices}
      * @ignore
      */
     this.indices = undefined;
@@ -582,7 +583,7 @@ class Primitive {
     /**
      * The material.
      *
-     * @type {ModelComponents.Material}
+     * @type {Material}
      * @ignore
      */
     this.material = undefined;
@@ -598,16 +599,16 @@ class Primitive {
     /**
      * The CESIUM_mesh_vector extension data for this primitive.
      *
-     * @type {object}
+     * @type {Vector}
      * @ignore
      */
-    this.meshVector = undefined;
+    this.vector = undefined;
 
     /**
      * The feature IDs associated with this primitive. Feature ID types may
      * be interleaved
      *
-     * @type {Array<ModelComponents.FeatureIdAttribute|ModelComponents.FeatureIdImplicitRange|ModelComponents.FeatureIdTexture>}
+     * @type {Array<FeatureIdAttribute|FeatureIdImplicitRange|FeatureIdTexture>}
      * @ignore
      */
     this.featureIds = [];
@@ -664,12 +665,12 @@ class Primitive {
  *
  * @ignore
  */
-class Instances {
+export class Instances {
   constructor() {
     /**
      * The instance attributes, e.g. translation, rotation, scale, feature id, etc.
      *
-     * @type {ModelComponents.Attribute[]}
+     * @type {Attribute[]}
      * @ignore
      */
     this.attributes = [];
@@ -700,7 +701,7 @@ class Instances {
  *
  * @ignore
  */
-class Skin {
+export class Skin {
   constructor() {
     /**
      * The index of the skin in the glTF. This is useful for finding the skin
@@ -714,7 +715,7 @@ class Skin {
     /**
      * The joints.
      *
-     * @type {ModelComponents.Node[]}
+     * @type {Node[]}
      * @ignore
      */
     this.joints = [];
@@ -734,7 +735,7 @@ class Skin {
  *
  * @ignore
  */
-class Node {
+export class Node {
   constructor() {
     /**
      * The name of the node.
@@ -756,7 +757,7 @@ class Node {
     /**
      * The children nodes.
      *
-     * @type {ModelComponents.Node[]}
+     * @type {Node[]}
      * @ignore
      */
     this.children = [];
@@ -764,7 +765,7 @@ class Node {
     /**
      * The mesh primitives.
      *
-     * @type {ModelComponents.Primitive[]}
+     * @type {Primitive[]}
      * @ignore
      */
     this.primitives = [];
@@ -772,7 +773,7 @@ class Node {
     /**
      * Instances of this node.
      *
-     * @type {ModelComponents.Instances}
+     * @type {Instances}
      * @ignore
      */
     this.instances = undefined;
@@ -780,7 +781,7 @@ class Node {
     /**
      * The skin.
      *
-     * @type {ModelComponents.Skin}
+     * @type {Skin}
      * @ignore
      */
     this.skin = undefined;
@@ -852,12 +853,12 @@ class Node {
  *
  * @ignore
  */
-class Scene {
+export class Scene {
   constructor() {
     /**
      * The nodes belonging to the scene.
      *
-     * @type {ModelComponents.Node[]}
+     * @type {Node[]}
      * @ignore
      */
     this.nodes = [];
@@ -872,7 +873,7 @@ class Scene {
  *
  * @ignore
  */
-const AnimatedPropertyType = {
+export const AnimatedPropertyType = {
   TRANSLATION: "translation",
   ROTATION: "rotation",
   SCALE: "scale",
@@ -885,7 +886,7 @@ const AnimatedPropertyType = {
  *
  * @ignore
  */
-class AnimationSampler {
+export class AnimationSampler {
   constructor() {
     /**
      * The timesteps of the animation.
@@ -918,12 +919,12 @@ class AnimationSampler {
  *
  * @ignore
  */
-class AnimationTarget {
+export class AnimationTarget {
   constructor() {
     /**
      * The node that will be affected by the animation.
      *
-     * @type {ModelComponents.Node}
+     * @type {Node}
      * @ignore
      */
     this.node = undefined;
@@ -931,7 +932,7 @@ class AnimationTarget {
     /**
      * The property of the node to be animated.
      *
-     * @type {ModelComponents.AnimatedPropertyType}
+     * @type {AnimatedPropertyType}
      * @ignore
      */
     this.path = undefined;
@@ -943,12 +944,12 @@ class AnimationTarget {
  *
  * @ignore
  */
-class AnimationChannel {
+export class AnimationChannel {
   constructor() {
     /**
      * The sampler used as the source of the animation data.
      *
-     * @type {ModelComponents.AnimationSampler}
+     * @type {AnimationSampler}
      * @ignore
      */
     this.sampler = undefined;
@@ -956,7 +957,7 @@ class AnimationChannel {
     /**
      * The target of the animation.
      *
-     * @type {ModelComponents.AnimationTarget}
+     * @type {AnimationTarget}
      * @ignore
      */
     this.target = undefined;
@@ -968,7 +969,7 @@ class AnimationChannel {
  *
  * @ignore
  */
-class Animation {
+export class Animation {
   constructor() {
     /**
      * The name of the animation.
@@ -981,7 +982,7 @@ class Animation {
     /**
      * The samplers used in this animation.
      *
-     * @type {ModelComponents.AnimationSampler[]}
+     * @type {AnimationSampler[]}
      * @ignore
      */
     this.samplers = [];
@@ -989,7 +990,7 @@ class Animation {
     /**
      * The channels used in this animation.
      *
-     * @type {ModelComponents.AnimationChannel[]}
+     * @type {AnimationChannel[]}
      * @ignore
      */
     this.channels = [];
@@ -1002,7 +1003,7 @@ class Animation {
  *
  * @ignore
  */
-class ArticulationStage {
+export class ArticulationStage {
   constructor() {
     /**
      * The name of the articulation stage.
@@ -1051,7 +1052,7 @@ class ArticulationStage {
  *
  * @ignore
  */
-class Articulation {
+export class Articulation {
   constructor() {
     /**
      * The name of the articulation.
@@ -1065,7 +1066,7 @@ class Articulation {
      * The stages belonging to this articulation. The stages are applied to
      * the model in order of appearance.
      *
-     * @type {ModelComponents.ArticulationStage[]}
+     * @type {ArticulationStage[]}
      * @ignore
      */
     this.stages = [];
@@ -1077,7 +1078,7 @@ class Articulation {
  *
  * @ignore
  */
-class Asset {
+export class Asset {
   constructor() {
     /**
      * The credits of the model.
@@ -1094,7 +1095,7 @@ class Asset {
  *
  * @ignore
  */
-class Components {
+export class Components {
   constructor() {
     /**
      * The asset of the model.
@@ -1107,7 +1108,7 @@ class Components {
     /**
      * The default scene.
      *
-     * @type {ModelComponents.Scene}
+     * @type {Scene}
      * @ignore
      */
     this.scene = undefined;
@@ -1115,28 +1116,28 @@ class Components {
     /**
      * All nodes in the model.
      *
-     * @type {ModelComponents.Node[]}
+     * @type {Node[]}
      */
     this.nodes = [];
 
     /**
      * All skins in the model.
      *
-     * @type {ModelComponents.Skin[]}
+     * @type {Skin[]}
      */
     this.skins = [];
 
     /**
      * All animations in the model.
      *
-     * @type {ModelComponents.Animation[]}
+     * @type {Animation[]}
      */
     this.animations = [];
 
     /**
      * All articulations in the model as defined by the AGI_articulations extension.
      *
-     * @type {ModelComponents.Articulation[]}
+     * @type {Articulation[]}
      */
     this.articulations = [];
 
@@ -1189,7 +1190,7 @@ class Components {
  *
  * @ignore
  */
-class TextureReader {
+export class TextureReader {
   constructor() {
     /**
      * The underlying GPU texture. The {@link Texture} contains the sampler.
@@ -1249,7 +1250,7 @@ class TextureReader {
  *
  * @ignore
  */
-class MetallicRoughness {
+export class MetallicRoughness {
   /**
    * @ignore
    */
@@ -1269,7 +1270,7 @@ class MetallicRoughness {
     /**
      * The base color texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.baseColorTexture = undefined;
@@ -1277,7 +1278,7 @@ class MetallicRoughness {
     /**
      * The metallic roughness texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.metallicRoughnessTexture = undefined;
@@ -1318,7 +1319,7 @@ class MetallicRoughness {
  *
  * @ignore
  */
-class SpecularGlossiness {
+export class SpecularGlossiness {
   /**
    * @ignore
    */
@@ -1338,7 +1339,7 @@ class SpecularGlossiness {
     /**
      * The diffuse texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.diffuseTexture = undefined;
@@ -1346,7 +1347,7 @@ class SpecularGlossiness {
     /**
      * The specular glossiness texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.specularGlossinessTexture = undefined;
@@ -1384,7 +1385,7 @@ class SpecularGlossiness {
   }
 }
 
-class Specular {
+export class Specular {
   /**
    * @ignore
    */
@@ -1408,7 +1409,7 @@ class Specular {
     /**
      * The specular texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.specularTexture = undefined;
@@ -1427,14 +1428,14 @@ class Specular {
     /**
      * The specular color texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.specularColorTexture = undefined;
   }
 }
 
-class Anisotropy {
+export class Anisotropy {
   /**
    * @ignore
    */
@@ -1468,14 +1469,14 @@ class Anisotropy {
     /**
      * The anisotropy texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.anisotropyTexture = undefined;
   }
 }
 
-class Clearcoat {
+export class Clearcoat {
   /**
    * @ignore
    */
@@ -1499,7 +1500,7 @@ class Clearcoat {
     /**
      * The clearcoat layer intensity texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.clearcoatTexture = undefined;
@@ -1517,7 +1518,7 @@ class Clearcoat {
     /**
      * The clearcoat layer roughness texture.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.clearcoatRoughnessTexture = undefined;
@@ -1525,22 +1526,12 @@ class Clearcoat {
     /**
      * The clearcoat normal map texture.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.clearcoatNormalTexture = undefined;
   }
 }
-
-/**
- * @private
- */
-Clearcoat.DEFAULT_CLEARCOAT_FACTOR = 0.0;
-
-/**
- * @private
- */
-Clearcoat.DEFAULT_CLEARCOAT_ROUGHNESS_FACTOR = 0.0;
 
 /**
  * Material properties for the BENTLEY_materials_line_style extension.
@@ -1550,14 +1541,14 @@ Clearcoat.DEFAULT_CLEARCOAT_ROUGHNESS_FACTOR = 0.0;
  *
  * @private
  */
-function LineStyle() {
+export class LineStyle {
   /**
    * The line width in pixels for LINES primitives.
    *
    * @type {number|undefined}
    * @default undefined
    */
-  this.width = undefined;
+  width = undefined;
 
   /**
    * The line dash pattern for LINES primitives. Encoded as a 16-bit unsigned
@@ -1566,7 +1557,7 @@ function LineStyle() {
    * @type {number|undefined}
    * @default undefined
    */
-  this.pattern = undefined;
+  pattern = undefined;
 }
 
 /**
@@ -1574,7 +1565,7 @@ function LineStyle() {
  *
  * @ignore
  */
-class Material {
+export class Material {
   /**
    * @ignore
    */
@@ -1592,7 +1583,7 @@ class Material {
     /**
      * Material properties for the PBR specular glossiness shading model.
      *
-     * @type {ModelComponents.SpecularGlossiness}
+     * @type {SpecularGlossiness}
      * @ignore
      */
     this.specularGlossiness = undefined;
@@ -1600,7 +1591,7 @@ class Material {
     /**
      * Material properties for the PBR specular shading model.
      *
-     * @type {ModelComponents.Specular}
+     * @type {Specular}
      * @ignore
      */
     this.specular = undefined;
@@ -1608,7 +1599,7 @@ class Material {
     /**
      * Material properties for the PBR anisotropy shading model.
      *
-     * @type {ModelComponents.Anisotropy}
+     * @type {Anisotropy}
      * @ignore
      */
     this.anisotropy = undefined;
@@ -1616,7 +1607,7 @@ class Material {
     /**
      * Material properties for the PBR clearcoat shading model.
      *
-     * @type {ModelComponents.Clearcoat}
+     * @type {Clearcoat}
      * @ignore
      */
     this.clearcoat = undefined;
@@ -1624,7 +1615,7 @@ class Material {
     /**
      * The emissive texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.emissiveTexture = undefined;
@@ -1632,7 +1623,7 @@ class Material {
     /**
      * The normal texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.normalTexture = undefined;
@@ -1640,7 +1631,7 @@ class Material {
     /**
      * The occlusion texture reader.
      *
-     * @type {ModelComponents.TextureReader}
+     * @type {TextureReader}
      * @ignore
      */
     this.occlusionTexture = undefined;
@@ -1704,11 +1695,36 @@ class Material {
     /**
      * Material properties for the BENTLEY_materials_line_style extension.
      *
-     * @type {ModelComponents.LineStyle}
+     * @type {LineStyle}
      * @ignore
      */
     this.lineStyle = undefined;
   }
+}
+
+/**
+ * Vector data in the model, as defined by the CESIUM_mesh_vector extension.
+ *
+ * @ignore
+ */
+export class Vector {
+  /** @type {true} */
+  vector = true;
+
+  /** @type {number} */
+  count = 0;
+
+  /** @type {TypedArray} */
+  polygonAttributeOffsets = undefined;
+
+  /** @type {TypedArray} */
+  polygonHoleCounts = undefined;
+
+  /** @type {TypedArray} */
+  polygonHoleOffsets = undefined;
+
+  /** @type {TypedArray} */
+  polygonIndicesOffsets = undefined;
 }
 
 ModelComponents.Quantization = Quantization;
@@ -1740,5 +1756,6 @@ ModelComponents.Anisotropy = Anisotropy;
 ModelComponents.Clearcoat = Clearcoat;
 ModelComponents.LineStyle = LineStyle;
 ModelComponents.Material = Material;
+ModelComponents.Vector = Vector;
 
 export default ModelComponents;

--- a/packages/engine/Source/Scene/VectorGltf3DTileContent.js
+++ b/packages/engine/Source/Scene/VectorGltf3DTileContent.js
@@ -46,6 +46,9 @@ const polylineMaterial = new BufferPolylineMaterial();
 /** @ignore */
 const polygonMaterial = new BufferPolygonMaterial();
 
+/** @ignore */
+const scratchTileModelMatrix = new Matrix4();
+
 /**
  * Vector glTF tile content. This path decodes glTF primitives into vector
  * buffers, then renders with dedicated vector primitives.
@@ -72,6 +75,9 @@ class VectorGltf3DTileContent {
     /** @type {Array<BufferPrimitiveCollection<BufferPrimitive>>} */
     this._collections = [];
 
+    /** @type {Array<Matrix4>} */
+    this._collectionLocalMatrices = [];
+
     /** @type {ImplicitMetadataView} */
     this._metadata = undefined;
     /** @type {Cesium3DContentGroup} */
@@ -84,9 +90,7 @@ class VectorGltf3DTileContent {
     this._ready = false;
 
     /** @type {Matrix4} */
-    this._vectorBaseTransform = Matrix4.clone(Matrix4.IDENTITY);
-    /** @type {Matrix4} */
-    this._computedVectorModelMatrix = Matrix4.clone(Matrix4.IDENTITY);
+    this._modelMatrix = Matrix4.clone(Matrix4.IDENTITY);
   }
 
   get featuresLength() {
@@ -264,18 +268,17 @@ class VectorGltf3DTileContent {
 
     Matrix4.multiplyTransformation(
       this._tile.computedTransform,
-      this._vectorBaseTransform,
-      this._computedVectorModelMatrix,
+      this._modelMatrix,
+      scratchTileModelMatrix,
     );
 
-    for (const collection of this._collections) {
+    for (let i = 0; i < this._collections.length; i++) {
       Matrix4.multiplyTransformation(
-        this._computedVectorModelMatrix,
-        // @ts-expect-error TODO: Find type-safe place to store this.
-        collection._vectorLocalModelMatrix,
-        collection.modelMatrix,
+        scratchTileModelMatrix,
+        this._collectionLocalMatrices[i],
+        this._collections[i].modelMatrix,
       );
-      collection.update(frameState);
+      this._collections[i].update(frameState);
     }
   }
 
@@ -355,36 +358,25 @@ function makeDecodeModelOptions(tileset, tile, content, gltf) {
  * @ignore
  */
 function initializeVectorPrimitives(content) {
-  const model = content._decodeModel;
-
   // @ts-expect-error Requires Model conversion to ES6 class.
-  if (!defined(model) || !defined(model.sceneGraph)) {
-    return;
-  }
+  const components = content._decodeModel.sceneGraph.components;
 
-  // @ts-expect-error Requires Model conversion to ES6 class.
-  const components = model.sceneGraph.components;
   const axisCorrection = ModelUtility.getAxisCorrectionMatrix(
     components.upAxis,
     components.forwardAxis,
     new Matrix4(),
   );
+
   Matrix4.multiplyTransformation(
     components.transform,
     axisCorrection,
-    content._vectorBaseTransform,
+    content._modelMatrix,
   );
 
-  const vectorBuffers = createVectorTileBuffersFromModelComponents(components);
-  if (!defined(vectorBuffers)) {
-    return;
-  }
+  const result = createVectorTileBuffersFromModelComponents(this, components);
 
-  content._collections = [
-    ...vectorBuffers.points,
-    ...vectorBuffers.polylines,
-    ...vectorBuffers.polygons,
-  ];
+  content._collections = result.collections;
+  content._collectionLocalMatrices = result.collectionLocalMatrices;
 }
 
 export default VectorGltf3DTileContent;

--- a/packages/engine/Specs/Scene/Model/createVectorTileBuffersFromModelComponentsSpec.js
+++ b/packages/engine/Specs/Scene/Model/createVectorTileBuffersFromModelComponentsSpec.js
@@ -54,7 +54,7 @@ function createIndices(typedArray) {
 function createPrimitive(options) {
   const primitive = new ModelComponents.Primitive();
   primitive.primitiveType = options.primitiveType;
-  primitive.meshVector = options.meshVector;
+  primitive.vector = options.vector;
   primitive.attributes.push(createPositionAttribute(options.positions));
 
   if (options.featureIds) {
@@ -79,12 +79,14 @@ function createComponents(rootNode) {
 }
 
 describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
+  const mockTileContent = {};
+
   it("creates one point collection per mesh primitive and preserves local transforms", function () {
     const firstPrimitive = createPrimitive({
       primitiveType: PrimitiveType.POINTS,
       positions: new Float32Array([1.0, 2.0, 3.0]),
       indices: new Uint16Array([0]),
-      meshVector: {
+      vector: {
         vector: true,
         count: 1,
       },
@@ -95,7 +97,7 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
       primitiveType: PrimitiveType.POINTS,
       positions: new Float32Array([4.0, 5.0, 6.0]),
       indices: new Uint16Array([0]),
-      meshVector: {
+      vector: {
         vector: true,
         count: 1,
       },
@@ -106,45 +108,33 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
     node.translation = new Cartesian3(10.0, 20.0, 30.0);
     node.primitives.push(firstPrimitive, secondPrimitive);
 
-    const vectorBuffers = createVectorTileBuffersFromModelComponents(
-      createComponents(node),
-    );
+    const { collections, collectionLocalMatrices } =
+      createVectorTileBuffersFromModelComponents(
+        mockTileContent,
+        createComponents(node),
+      );
 
-    expect(vectorBuffers.points).toBeDefined();
-    expect(vectorBuffers.points.length).toBe(2);
-    expect(vectorBuffers.polylines.length).toBe(0);
-    expect(vectorBuffers.polygons.length).toBe(0);
+    expect(collections.length).toBe(2);
 
-    const firstCollection = vectorBuffers.points[0];
-    const secondCollection = vectorBuffers.points[1];
-    expect(firstCollection.primitiveCount).toBe(1);
-    expect(secondCollection.primitiveCount).toBe(1);
+    expect(collections[0].primitiveCount).toBe(1);
+    expect(collections[1].primitiveCount).toBe(1);
 
     const expectedTransform = Matrix4.fromTranslation(
       node.translation,
       new Matrix4(),
     );
-    expect(
-      Matrix4.equals(
-        firstCollection._vectorLocalModelMatrix,
-        expectedTransform,
-      ),
-    ).toBe(true);
-    expect(
-      Matrix4.equals(
-        secondCollection._vectorLocalModelMatrix,
-        expectedTransform,
-      ),
-    ).toBe(true);
+
+    expect(collectionLocalMatrices[0]).toEqual(expectedTransform);
+    expect(collectionLocalMatrices[1]).toEqual(expectedTransform);
 
     const point = new BufferPoint();
-    firstCollection.get(0, point);
+    collections[0].get(0, point);
     expect(point.getPosition(new Cartesian3())).toEqual(
       new Cartesian3(1.0, 2.0, 3.0),
     );
     expect(point.featureId).toBe(7);
 
-    secondCollection.get(0, point);
+    collections[1].get(0, point);
     expect(point.getPosition(new Cartesian3())).toEqual(
       new Cartesian3(4.0, 5.0, 6.0),
     );
@@ -159,7 +149,7 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
         0.0,
       ]),
       indices: new Uint32Array([0, 1, 2, 0xffffffff, 2, 3, 4]),
-      meshVector: {
+      vector: {
         vector: true,
         count: 2,
       },
@@ -170,23 +160,19 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
     node.translation = new Cartesian3(5.0, 6.0, 7.0);
     node.primitives.push(primitive);
 
-    const vectorBuffers = createVectorTileBuffersFromModelComponents(
-      createComponents(node),
-    );
+    const { collections, collectionLocalMatrices } =
+      createVectorTileBuffersFromModelComponents(
+        mockTileContent,
+        createComponents(node),
+      );
 
-    expect(vectorBuffers.points.length).toBe(0);
-    expect(vectorBuffers.polylines).toBeDefined();
-    expect(vectorBuffers.polylines.length).toBe(1);
-    expect(vectorBuffers.polygons.length).toBe(0);
+    expect(collections.length).toBe(1);
 
-    const collection = vectorBuffers.polylines[0];
+    const collection = collections[0];
     expect(collection.primitiveCount).toBe(2);
-    expect(
-      Matrix4.equals(
-        collection._vectorLocalModelMatrix,
-        Matrix4.fromTranslation(node.translation, new Matrix4()),
-      ),
-    ).toBe(true);
+    expect(collectionLocalMatrices[0]).toEqual(
+      Matrix4.fromTranslation(node.translation, new Matrix4()),
+    );
 
     const polyline = new BufferPolyline();
     collection.get(0, polyline);
@@ -210,7 +196,7 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
         0.0, 2.0, 1.0, 0.0,
       ]),
       indices: new Uint32Array([0, 1, 2, 3, 4, 5]),
-      meshVector: {
+      vector: {
         vector: true,
         count: 2,
         polygonAttributeOffsets: new Uint32Array([0, 3]),
@@ -222,16 +208,14 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
     const node = new ModelComponents.Node();
     node.primitives.push(primitive);
 
-    const vectorBuffers = createVectorTileBuffersFromModelComponents(
+    const { collections } = createVectorTileBuffersFromModelComponents(
+      mockTileContent,
       createComponents(node),
     );
 
-    expect(vectorBuffers.points.length).toBe(0);
-    expect(vectorBuffers.polylines.length).toBe(0);
-    expect(vectorBuffers.polygons).toBeDefined();
-    expect(vectorBuffers.polygons.length).toBe(1);
+    expect(collections.length).toBe(1);
 
-    const collection = vectorBuffers.polygons[0];
+    const collection = collections[0];
     expect(collection.primitiveCount).toBe(2);
     expect(collection.triangleCount).toBe(2);
     expect(collection.holeCount).toBe(0);
@@ -260,7 +244,7 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
         0.0, 2.0, 1.0, 0.0, 1.0, 2.0, 0.0,
       ]),
       indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
-      meshVector: {
+      vector: {
         vector: true,
         count: 1,
         polygonAttributeOffsets: new Uint32Array([0]),
@@ -274,10 +258,14 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
     const node = new ModelComponents.Node();
     node.primitives.push(primitive);
 
-    const vectorBuffers = createVectorTileBuffersFromModelComponents(
+    const { collections } = createVectorTileBuffersFromModelComponents(
+      mockTileContent,
       createComponents(node),
     );
-    const collection = vectorBuffers.polygons[0];
+
+    expect(collections.length).toBe(1);
+
+    const collection = collections[0];
 
     expect(collection.primitiveCount).toBe(1);
     expect(collection.holeCount).toBe(1);
@@ -291,13 +279,16 @@ describe("Scene/Model/createVectorTileBuffersFromModelComponents", function () {
     expect(polygon.featureId).toBe(5);
   });
 
-  it("returns undefined when the model contains no vector primitives", function () {
+  it("returns empty result when the model contains no vector primitives", function () {
     const node = new ModelComponents.Node();
 
-    const vectorBuffers = createVectorTileBuffersFromModelComponents(
-      createComponents(node),
-    );
+    const { collections, collectionLocalMatrices } =
+      createVectorTileBuffersFromModelComponents(
+        mockTileContent,
+        createComponents(node),
+      );
 
-    expect(vectorBuffers).toBeUndefined();
+    expect(collections).toEqual([]);
+    expect(collectionLocalMatrices).toEqual([]);
   });
 });


### PR DESCRIPTION

# Description

Type checking and minor cleanup for `createVectorTileBuffersFromModelComponents.js`. The main snag in this PR was that TypeScript doesn't understand our JSDoc references to `@param {ModelComponents.Foo}`. While I'm interested in a more general fix for fully supporting multiple exports (see #13203) we don't need that here, the componnets are internal so it's safe to just export them so TypeScript can see them. Otherwise PR does lose much of it's type information.

## Issue number and link

n/a

## Testing plan

As in other type checking PRs, it's important to check the output of `npm run build-ts` and confirm that any changes in `Cesium.d.ts` are intended. The only changes introduced by this PR are hiding some internal types that weren't intended to be public:

```diff
diff --git a/Source/Cesium.main.d.ts b/Source/Cesium.d.ts
index 42848258c5..13a535655f 100644
--- a/Source/Cesium.main.d.ts
+++ b/Source/Cesium.d.ts
@@ -40616,14 +40616,6 @@ export enum VaryingType {
     MAT4 = "mat4"
 }
 
-export const scratchPointPosition: any;
-
-export type VectorTileBuffers = {
-    points: BufferPointCollection[];
-    polylines: BufferPolylineCollection[];
-    polygons: BufferPolygonCollection[];
-};
-
 /**
  * Determines if and how a glTF animation is looped.
  */
```

Beyond that we can test:

- `npm run tsc` passes
- unit tests pass
- three vector examples at the end of `http://localhost:8080/Apps/Sandcastle2/index.html?id=3d-tiles-formats` render correctly 

As the points currently default to 1px I would just add:

```javascript
tileset.style = new Cesium.Cesium3DTileStyle({
  pointSize: "12",
});
```

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code


#### PR Dependency Tree


* **PR #13337** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)