### PR TITLE
Doc Fix - CubeMapPanorama transform

### DIFF
--- a/packages/engine/Source/Scene/CubeMapPanorama.js
+++ b/packages/engine/Source/Scene/CubeMapPanorama.js
@@ -29,7 +29,7 @@ import Credit from "../Core/Credit.js";
  * Initialization options for the CubeMapPanorama constructor
  *
  * @property {object} [options.sources] The source URL or <code>Image</code> object for each of the six cube map faces.  See the example below.
- * @property {Matrix3} [options.transform] A 3x3 transformation matrix that defines the panorama’s orientation
+ * @property {Matrix3} [options.transform] A 3x3 transformation matrix that defines the panorama’s orientation. If not specified, the default orientation is defined using the True Equator Mean Equinox (TEME) axes.
  * @property {boolean} [options.show=true] Determines if this primitive will be shown.
  * @property {Credit|string} [options.credit] A credit for the panorama, which is displayed on the canvas.
  *
@@ -122,7 +122,7 @@ function CubeMapPanorama(options) {
 
 Object.defineProperties(CubeMapPanorama.prototype, {
   /**
-   * Gets the transform of the panorama.
+   * Gets the transform of the panorama. If undefined, the default orientation uses the True Equator Mean Equinox (TEME) axes.
    * @memberof CubeMapPanorama.prototype
    * @type {Matrix3}
    * @readonly


### PR DESCRIPTION
# Description

Fixes documentation for CubeMapPanorama.transform, which expects a Matrix3, not a Matrix4.
Also fixes a line with unnecessary nullish coalescing

## Issue number and link

https://github.com/CesiumGS/cesium/issues/11749#issuecomment-4142766991

## Testing plan

Just docs

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ NA ] I have updated `CHANGES.md` with a short summary of my change
- [ NA ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
