### PR TITLE
Types: Convert Cartographic.js, Ellipsoid.js, MapProjection.js to ES6 classes

### DIFF
--- a/packages/engine/Source/Core/Cartesian3.js
+++ b/packages/engine/Source/Core/Cartesian3.js
@@ -876,8 +876,7 @@ class Cartesian3 {
 
     const radiiSquared = !defined(ellipsoid)
       ? Cartesian3._ellipsoidRadiiSquared
-      : // @ts-expect-error Requires type-checking on Ellipsoid.js.
-        ellipsoid.radiiSquared;
+      : ellipsoid.radiiSquared;
 
     const cosLatitude = Math.cos(latitude);
     scratchN.x = cosLatitude * Math.cos(longitude);

--- a/packages/engine/Source/Core/Cartographic.js
+++ b/packages/engine/Source/Core/Cartographic.js
@@ -1,304 +1,315 @@
+// @ts-check
+
 import Cartesian3 from "./Cartesian3.js";
 import Check from "./Check.js";
 import defined from "./defined.js";
 import CesiumMath from "./Math.js";
 import scaleToGeodeticSurface from "./scaleToGeodeticSurface.js";
 
+/** @import Ellipsoid from "./Ellipsoid.js"; */
+
 /**
  * A position defined by longitude, latitude, and height.
- * @alias Cartographic
- * @constructor
- *
- * @param {number} [longitude=0.0] The longitude, in radians.
- * @param {number} [latitude=0.0] The latitude, in radians.
- * @param {number} [height=0.0] The height, in meters, above the ellipsoid.
  *
  * @see Ellipsoid
  */
-function Cartographic(longitude, latitude, height) {
-  /**
-   * The longitude, in radians.
-   * @type {number}
-   * @default 0.0
-   */
-  this.longitude = longitude ?? 0.0;
+class Cartographic {
+  // TODO(DO NOT SUBMIT): Why isn't this a 'static' property in Cesium.d.ts?
+  // Does tsd-jsdoc not support that? Need @static or @readonly tags?
 
   /**
-   * The latitude, in radians.
-   * @type {number}
-   * @default 0.0
+   * An immutable Cartographic instance initialized to (0.0, 0.0, 0.0).
+   *
+   * @type {Cartographic}
+   * @constant
    */
-  this.latitude = latitude ?? 0.0;
+  static ZERO = Object.freeze(new Cartographic(0.0, 0.0, 0.0));
 
   /**
-   * The height, in meters, above the ellipsoid.
-   * @type {number}
-   * @default 0.0
+   * @param {number} [longitude=0.0] The longitude, in radians.
+   * @param {number} [latitude=0.0] The latitude, in radians.
+   * @param {number} [height=0.0] The height, in meters, above the ellipsoid.
    */
-  this.height = height ?? 0.0;
-}
+  constructor(longitude, latitude, height) {
+    /**
+     * The longitude, in radians.
+     * @type {number}
+     * @default 0.0
+     */
+    this.longitude = longitude ?? 0.0;
 
-/**
- * Creates a new Cartographic instance from longitude and latitude
- * specified in radians.
- *
- * @param {number} longitude The longitude, in radians.
- * @param {number} latitude The latitude, in radians.
- * @param {number} [height=0.0] The height, in meters, above the ellipsoid.
- * @param {Cartographic} [result] The object onto which to store the result.
- * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided.
- */
-Cartographic.fromRadians = function (longitude, latitude, height, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.number("longitude", longitude);
-  Check.typeOf.number("latitude", latitude);
-  //>>includeEnd('debug');
+    /**
+     * The latitude, in radians.
+     * @type {number}
+     * @default 0.0
+     */
+    this.latitude = latitude ?? 0.0;
 
-  height = height ?? 0.0;
-
-  if (!defined(result)) {
-    return new Cartographic(longitude, latitude, height);
+    /**
+     * The height, in meters, above the ellipsoid.
+     * @type {number}
+     * @default 0.0
+     */
+    this.height = height ?? 0.0;
   }
 
-  result.longitude = longitude;
-  result.latitude = latitude;
-  result.height = height;
-  return result;
-};
+  /**
+   * Creates a new Cartographic instance from longitude and latitude
+   * specified in radians.
+   *
+   * @param {number} longitude The longitude, in radians.
+   * @param {number} latitude The latitude, in radians.
+   * @param {number} [height=0.0] The height, in meters, above the ellipsoid.
+   * @param {Cartographic} [result] The object onto which to store the result.
+   * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided.
+   */
+  static fromRadians(longitude, latitude, height, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.number("longitude", longitude);
+    Check.typeOf.number("latitude", latitude);
+    //>>includeEnd('debug');
 
-/**
- * Creates a new Cartographic instance from longitude and latitude
- * specified in degrees.  The values in the resulting object will
- * be in radians.
- *
- * @param {number} longitude The longitude, in degrees.
- * @param {number} latitude The latitude, in degrees.
- * @param {number} [height=0.0] The height, in meters, above the ellipsoid.
- * @param {Cartographic} [result] The object onto which to store the result.
- * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided.
- */
-Cartographic.fromDegrees = function (longitude, latitude, height, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.number("longitude", longitude);
-  Check.typeOf.number("latitude", latitude);
-  //>>includeEnd('debug');
+    height = height ?? 0.0;
 
-  longitude = CesiumMath.toRadians(longitude);
-  latitude = CesiumMath.toRadians(latitude);
+    if (!defined(result)) {
+      return new Cartographic(longitude, latitude, height);
+    }
 
-  return Cartographic.fromRadians(longitude, latitude, height, result);
-};
+    result.longitude = longitude;
+    result.latitude = latitude;
+    result.height = height;
+    return result;
+  }
+
+  /**
+   * Creates a new Cartographic instance from longitude and latitude
+   * specified in degrees.  The values in the resulting object will
+   * be in radians.
+   *
+   * @param {number} longitude The longitude, in degrees.
+   * @param {number} latitude The latitude, in degrees.
+   * @param {number} [height=0.0] The height, in meters, above the ellipsoid.
+   * @param {Cartographic} [result] The object onto which to store the result.
+   * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided.
+   */
+  static fromDegrees(longitude, latitude, height, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.number("longitude", longitude);
+    Check.typeOf.number("latitude", latitude);
+    //>>includeEnd('debug');
+
+    longitude = CesiumMath.toRadians(longitude);
+    latitude = CesiumMath.toRadians(latitude);
+
+    return Cartographic.fromRadians(longitude, latitude, height, result);
+  }
+
+  /**
+   * Creates a new Cartographic instance from a Cartesian position. The values in the
+   * resulting object will be in radians.
+   *
+   * @param {Cartesian3} cartesian The Cartesian position to convert to cartographic representation.
+   * @param {Ellipsoid} [ellipsoid=Ellipsoid.default] The ellipsoid on which the position lies.
+   * @param {Cartographic} [result] The object onto which to store the result.
+   * @returns {Cartographic} The modified result parameter, new Cartographic instance if none was provided, or undefined if the cartesian is at the center of the ellipsoid.
+   */
+  static fromCartesian(cartesian, ellipsoid, result) {
+    const oneOverRadii = defined(ellipsoid)
+      ? ellipsoid.oneOverRadii
+      : Cartographic._ellipsoidOneOverRadii;
+    const oneOverRadiiSquared = defined(ellipsoid)
+      ? ellipsoid.oneOverRadiiSquared
+      : Cartographic._ellipsoidOneOverRadiiSquared;
+    const centerToleranceSquared = defined(ellipsoid)
+      ? ellipsoid._centerToleranceSquared
+      : Cartographic._ellipsoidCenterToleranceSquared;
+
+    //`cartesian is required.` is thrown from scaleToGeodeticSurface
+    const p = scaleToGeodeticSurface(
+      cartesian,
+      oneOverRadii,
+      oneOverRadiiSquared,
+      centerToleranceSquared,
+      cartesianToCartographicP,
+    );
+
+    if (!defined(p)) {
+      return undefined;
+    }
+
+    let n = Cartesian3.multiplyComponents(
+      p,
+      oneOverRadiiSquared,
+      cartesianToCartographicN,
+    );
+    n = Cartesian3.normalize(n, n);
+
+    const h = Cartesian3.subtract(cartesian, p, cartesianToCartographicH);
+
+    const longitude = Math.atan2(n.y, n.x);
+    const latitude = Math.asin(n.z);
+    const height =
+      CesiumMath.sign(Cartesian3.dot(h, cartesian)) * Cartesian3.magnitude(h);
+
+    if (!defined(result)) {
+      return new Cartographic(longitude, latitude, height);
+    }
+    result.longitude = longitude;
+    result.latitude = latitude;
+    result.height = height;
+    return result;
+  }
+
+  /**
+   * Creates a new Cartesian3 instance from a Cartographic input. The values in the inputted
+   * object should be in radians.
+   *
+   * @param {Cartographic} cartographic Input to be converted into a Cartesian3 output.
+   * @param {Ellipsoid} [ellipsoid=Ellipsoid.default] The ellipsoid on which the position lies.
+   * @param {Cartesian3} [result] The object onto which to store the result.
+   * @returns {Cartesian3} The position
+   */
+  static toCartesian(cartographic, ellipsoid, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("cartographic", cartographic);
+    //>>includeEnd('debug');
+
+    return Cartesian3.fromRadians(
+      cartographic.longitude,
+      cartographic.latitude,
+      cartographic.height,
+      ellipsoid,
+      result,
+    );
+  }
+
+  /**
+   * Duplicates a Cartographic instance.
+   *
+   * @param {Cartographic} cartographic The cartographic to duplicate.
+   * @param {Cartographic} [result] The object onto which to store the result.
+   * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided. (Returns undefined if cartographic is undefined)
+   */
+  static clone(cartographic, result) {
+    if (!defined(cartographic)) {
+      return undefined;
+    }
+    if (!defined(result)) {
+      return new Cartographic(
+        cartographic.longitude,
+        cartographic.latitude,
+        cartographic.height,
+      );
+    }
+    result.longitude = cartographic.longitude;
+    result.latitude = cartographic.latitude;
+    result.height = cartographic.height;
+    return result;
+  }
+
+  /**
+   * Compares the provided cartographics componentwise and returns
+   * <code>true</code> if they are equal, <code>false</code> otherwise.
+   *
+   * @param {Cartographic} [left] The first cartographic.
+   * @param {Cartographic} [right] The second cartographic.
+   * @returns {boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
+   */
+  static equals(left, right) {
+    return (
+      left === right ||
+      (defined(left) &&
+        defined(right) &&
+        left.longitude === right.longitude &&
+        left.latitude === right.latitude &&
+        left.height === right.height)
+    );
+  }
+
+  /**
+   * Compares the provided cartographics componentwise and returns
+   * <code>true</code> if they are within the provided epsilon,
+   * <code>false</code> otherwise.
+   *
+   * @param {Cartographic} [left] The first cartographic.
+   * @param {Cartographic} [right] The second cartographic.
+   * @param {number} [epsilon=0] The epsilon to use for equality testing.
+   * @returns {boolean} <code>true</code> if left and right are within the provided epsilon, <code>false</code> otherwise.
+   */
+  static equalsEpsilon(left, right, epsilon) {
+    epsilon = epsilon ?? 0;
+
+    return (
+      left === right ||
+      (defined(left) &&
+        defined(right) &&
+        Math.abs(left.longitude - right.longitude) <= epsilon &&
+        Math.abs(left.latitude - right.latitude) <= epsilon &&
+        Math.abs(left.height - right.height) <= epsilon)
+    );
+  }
+
+  /**
+   * Duplicates this instance.
+   *
+   * @param {Cartographic} [result] The object onto which to store the result.
+   * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided.
+   */
+  clone(result) {
+    return Cartographic.clone(this, result);
+  }
+
+  /**
+   * Compares the provided against this cartographic componentwise and returns
+   * <code>true</code> if they are equal, <code>false</code> otherwise.
+   *
+   * @param {Cartographic} [right] The second cartographic.
+   * @returns {boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
+   */
+  equals(right) {
+    return Cartographic.equals(this, right);
+  }
+
+  /**
+   * Compares the provided against this cartographic componentwise and returns
+   * <code>true</code> if they are within the provided epsilon,
+   * <code>false</code> otherwise.
+   *
+   * @param {Cartographic} [right] The second cartographic.
+   * @param {number} [epsilon=0] The epsilon to use for equality testing.
+   * @returns {boolean} <code>true</code> if left and right are within the provided epsilon, <code>false</code> otherwise.
+   */
+  equalsEpsilon(right, epsilon) {
+    return Cartographic.equalsEpsilon(this, right, epsilon);
+  }
+
+  /**
+   * Creates a string representing this cartographic in the format '(longitude, latitude, height)'.
+   *
+   * @returns {string} A string representing the provided cartographic in the format '(longitude, latitude, height)'.
+   */
+  toString() {
+    return `(${this.longitude}, ${this.latitude}, ${this.height})`;
+  }
+
+  // To avoid circular dependencies, these are set by Ellipsoid when Ellipsoid.default is set.
+  static _ellipsoidOneOverRadii = new Cartesian3(
+    1.0 / 6378137.0,
+    1.0 / 6378137.0,
+    1.0 / 6356752.3142451793,
+  );
+
+  static _ellipsoidOneOverRadiiSquared = new Cartesian3(
+    1.0 / (6378137.0 * 6378137.0),
+    1.0 / (6378137.0 * 6378137.0),
+    1.0 / (6356752.3142451793 * 6356752.3142451793),
+  );
+
+  static _ellipsoidCenterToleranceSquared = CesiumMath.EPSILON1;
+}
 
 const cartesianToCartographicN = new Cartesian3();
 const cartesianToCartographicP = new Cartesian3();
 const cartesianToCartographicH = new Cartesian3();
 
-// To avoid circular dependencies, these are set by Ellipsoid when Ellipsoid.default is set.
-Cartographic._ellipsoidOneOverRadii = new Cartesian3(
-  1.0 / 6378137.0,
-  1.0 / 6378137.0,
-  1.0 / 6356752.3142451793,
-);
-Cartographic._ellipsoidOneOverRadiiSquared = new Cartesian3(
-  1.0 / (6378137.0 * 6378137.0),
-  1.0 / (6378137.0 * 6378137.0),
-  1.0 / (6356752.3142451793 * 6356752.3142451793),
-);
-Cartographic._ellipsoidCenterToleranceSquared = CesiumMath.EPSILON1;
-
-/**
- * Creates a new Cartographic instance from a Cartesian position. The values in the
- * resulting object will be in radians.
- *
- * @param {Cartesian3} cartesian The Cartesian position to convert to cartographic representation.
- * @param {Ellipsoid} [ellipsoid=Ellipsoid.default] The ellipsoid on which the position lies.
- * @param {Cartographic} [result] The object onto which to store the result.
- * @returns {Cartographic} The modified result parameter, new Cartographic instance if none was provided, or undefined if the cartesian is at the center of the ellipsoid.
- */
-Cartographic.fromCartesian = function (cartesian, ellipsoid, result) {
-  const oneOverRadii = defined(ellipsoid)
-    ? ellipsoid.oneOverRadii
-    : Cartographic._ellipsoidOneOverRadii;
-  const oneOverRadiiSquared = defined(ellipsoid)
-    ? ellipsoid.oneOverRadiiSquared
-    : Cartographic._ellipsoidOneOverRadiiSquared;
-  const centerToleranceSquared = defined(ellipsoid)
-    ? ellipsoid._centerToleranceSquared
-    : Cartographic._ellipsoidCenterToleranceSquared;
-
-  //`cartesian is required.` is thrown from scaleToGeodeticSurface
-  const p = scaleToGeodeticSurface(
-    cartesian,
-    oneOverRadii,
-    oneOverRadiiSquared,
-    centerToleranceSquared,
-    cartesianToCartographicP,
-  );
-
-  if (!defined(p)) {
-    return undefined;
-  }
-
-  let n = Cartesian3.multiplyComponents(
-    p,
-    oneOverRadiiSquared,
-    cartesianToCartographicN,
-  );
-  n = Cartesian3.normalize(n, n);
-
-  const h = Cartesian3.subtract(cartesian, p, cartesianToCartographicH);
-
-  const longitude = Math.atan2(n.y, n.x);
-  const latitude = Math.asin(n.z);
-  const height =
-    CesiumMath.sign(Cartesian3.dot(h, cartesian)) * Cartesian3.magnitude(h);
-
-  if (!defined(result)) {
-    return new Cartographic(longitude, latitude, height);
-  }
-  result.longitude = longitude;
-  result.latitude = latitude;
-  result.height = height;
-  return result;
-};
-
-/**
- * Creates a new Cartesian3 instance from a Cartographic input. The values in the inputted
- * object should be in radians.
- *
- * @param {Cartographic} cartographic Input to be converted into a Cartesian3 output.
- * @param {Ellipsoid} [ellipsoid=Ellipsoid.default] The ellipsoid on which the position lies.
- * @param {Cartesian3} [result] The object onto which to store the result.
- * @returns {Cartesian3} The position
- */
-Cartographic.toCartesian = function (cartographic, ellipsoid, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("cartographic", cartographic);
-  //>>includeEnd('debug');
-
-  return Cartesian3.fromRadians(
-    cartographic.longitude,
-    cartographic.latitude,
-    cartographic.height,
-    ellipsoid,
-    result,
-  );
-};
-
-/**
- * Duplicates a Cartographic instance.
- *
- * @param {Cartographic} cartographic The cartographic to duplicate.
- * @param {Cartographic} [result] The object onto which to store the result.
- * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided. (Returns undefined if cartographic is undefined)
- */
-Cartographic.clone = function (cartographic, result) {
-  if (!defined(cartographic)) {
-    return undefined;
-  }
-  if (!defined(result)) {
-    return new Cartographic(
-      cartographic.longitude,
-      cartographic.latitude,
-      cartographic.height,
-    );
-  }
-  result.longitude = cartographic.longitude;
-  result.latitude = cartographic.latitude;
-  result.height = cartographic.height;
-  return result;
-};
-
-/**
- * Compares the provided cartographics componentwise and returns
- * <code>true</code> if they are equal, <code>false</code> otherwise.
- *
- * @param {Cartographic} [left] The first cartographic.
- * @param {Cartographic} [right] The second cartographic.
- * @returns {boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
- */
-Cartographic.equals = function (left, right) {
-  return (
-    left === right ||
-    (defined(left) &&
-      defined(right) &&
-      left.longitude === right.longitude &&
-      left.latitude === right.latitude &&
-      left.height === right.height)
-  );
-};
-
-/**
- * Compares the provided cartographics componentwise and returns
- * <code>true</code> if they are within the provided epsilon,
- * <code>false</code> otherwise.
- *
- * @param {Cartographic} [left] The first cartographic.
- * @param {Cartographic} [right] The second cartographic.
- * @param {number} [epsilon=0] The epsilon to use for equality testing.
- * @returns {boolean} <code>true</code> if left and right are within the provided epsilon, <code>false</code> otherwise.
- */
-Cartographic.equalsEpsilon = function (left, right, epsilon) {
-  epsilon = epsilon ?? 0;
-
-  return (
-    left === right ||
-    (defined(left) &&
-      defined(right) &&
-      Math.abs(left.longitude - right.longitude) <= epsilon &&
-      Math.abs(left.latitude - right.latitude) <= epsilon &&
-      Math.abs(left.height - right.height) <= epsilon)
-  );
-};
-
-/**
- * An immutable Cartographic instance initialized to (0.0, 0.0, 0.0).
- *
- * @type {Cartographic}
- * @constant
- */
-Cartographic.ZERO = Object.freeze(new Cartographic(0.0, 0.0, 0.0));
-
-/**
- * Duplicates this instance.
- *
- * @param {Cartographic} [result] The object onto which to store the result.
- * @returns {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided.
- */
-Cartographic.prototype.clone = function (result) {
-  return Cartographic.clone(this, result);
-};
-
-/**
- * Compares the provided against this cartographic componentwise and returns
- * <code>true</code> if they are equal, <code>false</code> otherwise.
- *
- * @param {Cartographic} [right] The second cartographic.
- * @returns {boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
- */
-Cartographic.prototype.equals = function (right) {
-  return Cartographic.equals(this, right);
-};
-
-/**
- * Compares the provided against this cartographic componentwise and returns
- * <code>true</code> if they are within the provided epsilon,
- * <code>false</code> otherwise.
- *
- * @param {Cartographic} [right] The second cartographic.
- * @param {number} [epsilon=0] The epsilon to use for equality testing.
- * @returns {boolean} <code>true</code> if left and right are within the provided epsilon, <code>false</code> otherwise.
- */
-Cartographic.prototype.equalsEpsilon = function (right, epsilon) {
-  return Cartographic.equalsEpsilon(this, right, epsilon);
-};
-
-/**
- * Creates a string representing this cartographic in the format '(longitude, latitude, height)'.
- *
- * @returns {string} A string representing the provided cartographic in the format '(longitude, latitude, height)'.
- */
-Cartographic.prototype.toString = function () {
-  return `(${this.longitude}, ${this.latitude}, ${this.height})`;
-};
 export default Cartographic;

--- a/packages/engine/Source/Core/Cartographic.js
+++ b/packages/engine/Source/Core/Cartographic.js
@@ -14,17 +14,6 @@ import scaleToGeodeticSurface from "./scaleToGeodeticSurface.js";
  * @see Ellipsoid
  */
 class Cartographic {
-  // TODO(DO NOT SUBMIT): Why isn't this a 'static' property in Cesium.d.ts?
-  // Does tsd-jsdoc not support that? Need @static or @readonly tags?
-
-  /**
-   * An immutable Cartographic instance initialized to (0.0, 0.0, 0.0).
-   *
-   * @type {Cartographic}
-   * @constant
-   */
-  static ZERO = Object.freeze(new Cartographic(0.0, 0.0, 0.0));
-
   /**
    * @param {number} [longitude=0.0] The longitude, in radians.
    * @param {number} [latitude=0.0] The latitude, in radians.
@@ -307,6 +296,14 @@ class Cartographic {
 
   static _ellipsoidCenterToleranceSquared = CesiumMath.EPSILON1;
 }
+
+/**
+ * An immutable Cartographic instance initialized to (0.0, 0.0, 0.0).
+ *
+ * @type {Cartographic}
+ * @constant
+ */
+Cartographic.ZERO = Object.freeze(new Cartographic(0.0, 0.0, 0.0));
 
 const cartesianToCartographicN = new Cartesian3();
 const cartesianToCartographicP = new Cartesian3();

--- a/packages/engine/Source/Core/Ellipsoid.js
+++ b/packages/engine/Source/Core/Ellipsoid.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import Cartesian2 from "./Cartesian2.js";
 import Cartesian3 from "./Cartesian3.js";
 import Cartographic from "./Cartographic.js";
@@ -7,6 +9,24 @@ import DeveloperError from "./DeveloperError.js";
 import CesiumMath from "./Math.js";
 import scaleToGeodeticSurface from "./scaleToGeodeticSurface.js";
 
+/** @import Rectangle from "./Rectangle.js"; */
+
+/**
+ * A real valued scalar function.
+ * @callback EllipsoidRealValuedScalarFunction
+ *
+ * @param {number} x The value used to evaluate the function.
+ * @returns {number} The value of the function at x.
+ *
+ * @private
+ */
+
+/**
+ * @param {Ellipsoid} ellipsoid
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ */
 function initialize(ellipsoid, x, y, z) {
   x = x ?? 0.0;
   y = y ?? 0.0;
@@ -59,168 +79,678 @@ function initialize(ellipsoid, x, y, z) {
  *
  * Rather than constructing this object directly, one of the provided
  * constants is normally used.
- * @alias Ellipsoid
- * @constructor
- *
- * @param {number} [x=0] The radius in the x direction.
- * @param {number} [y=0] The radius in the y direction.
- * @param {number} [z=0] The radius in the z direction.
- *
- * @exception {DeveloperError} All radii components must be greater than or equal to zero.
  *
  * @see Ellipsoid.fromCartesian3
  * @see Ellipsoid.WGS84
  * @see Ellipsoid.UNIT_SPHERE
  */
-function Ellipsoid(x, y, z) {
-  this._radii = undefined;
-  this._radiiSquared = undefined;
-  this._radiiToTheFourth = undefined;
-  this._oneOverRadii = undefined;
-  this._oneOverRadiiSquared = undefined;
-  this._minimumRadius = undefined;
-  this._maximumRadius = undefined;
-  this._centerToleranceSquared = undefined;
-  this._squaredXOverSquaredZ = undefined;
+class Ellipsoid {
+  /**
+   * @param {number} [x=0] The radius in the x direction.
+   * @param {number} [y=0] The radius in the y direction.
+   * @param {number} [z=0] The radius in the z direction.
+   *
+   * @exception {DeveloperError} All radii components must be greater than or equal to zero.
+   */
+  constructor(x, y, z) {
+    this._radii = undefined;
+    this._radiiSquared = undefined;
+    this._radiiToTheFourth = undefined;
+    this._oneOverRadii = undefined;
+    this._oneOverRadiiSquared = undefined;
+    this._minimumRadius = undefined;
+    this._maximumRadius = undefined;
+    this._centerToleranceSquared = undefined;
+    this._squaredXOverSquaredZ = undefined;
 
-  initialize(this, x, y, z);
-}
+    initialize(this, x, y, z);
+  }
 
-Object.defineProperties(Ellipsoid.prototype, {
   /**
    * Gets the radii of the ellipsoid.
-   * @memberof Ellipsoid.prototype
    * @type {Cartesian3}
    * @readonly
    */
-  radii: {
-    get: function () {
-      return this._radii;
-    },
-  },
+  get radii() {
+    return this._radii;
+  }
+
   /**
    * Gets the squared radii of the ellipsoid.
-   * @memberof Ellipsoid.prototype
    * @type {Cartesian3}
    * @readonly
    */
-  radiiSquared: {
-    get: function () {
-      return this._radiiSquared;
-    },
-  },
+  get radiiSquared() {
+    return this._radiiSquared;
+  }
+
   /**
    * Gets the radii of the ellipsoid raise to the fourth power.
-   * @memberof Ellipsoid.prototype
    * @type {Cartesian3}
    * @readonly
    */
-  radiiToTheFourth: {
-    get: function () {
-      return this._radiiToTheFourth;
-    },
-  },
+  get radiiToTheFourth() {
+    return this._radiiToTheFourth;
+  }
+
   /**
    * Gets one over the radii of the ellipsoid.
-   * @memberof Ellipsoid.prototype
    * @type {Cartesian3}
    * @readonly
    */
-  oneOverRadii: {
-    get: function () {
-      return this._oneOverRadii;
-    },
-  },
+  get oneOverRadii() {
+    return this._oneOverRadii;
+  }
+
   /**
    * Gets one over the squared radii of the ellipsoid.
-   * @memberof Ellipsoid.prototype
    * @type {Cartesian3}
    * @readonly
    */
-  oneOverRadiiSquared: {
-    get: function () {
-      return this._oneOverRadiiSquared;
-    },
-  },
+  get oneOverRadiiSquared() {
+    return this._oneOverRadiiSquared;
+  }
+
   /**
    * Gets the minimum radius of the ellipsoid.
-   * @memberof Ellipsoid.prototype
    * @type {number}
    * @readonly
    */
-  minimumRadius: {
-    get: function () {
-      return this._minimumRadius;
-    },
-  },
+  get minimumRadius() {
+    return this._minimumRadius;
+  }
+
   /**
    * Gets the maximum radius of the ellipsoid.
-   * @memberof Ellipsoid.prototype
    * @type {number}
    * @readonly
    */
-  maximumRadius: {
-    get: function () {
-      return this._maximumRadius;
-    },
-  },
-});
-
-/**
- * Duplicates an Ellipsoid instance.
- *
- * @param {Ellipsoid} ellipsoid The ellipsoid to duplicate.
- * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
- *                    instance should be created.
- * @returns {Ellipsoid} The cloned Ellipsoid. (Returns undefined if ellipsoid is undefined)
- */
-Ellipsoid.clone = function (ellipsoid, result) {
-  if (!defined(ellipsoid)) {
-    return undefined;
-  }
-  const radii = ellipsoid._radii;
-
-  if (!defined(result)) {
-    return new Ellipsoid(radii.x, radii.y, radii.z);
+  get maximumRadius() {
+    return this._maximumRadius;
   }
 
-  Cartesian3.clone(radii, result._radii);
-  Cartesian3.clone(ellipsoid._radiiSquared, result._radiiSquared);
-  Cartesian3.clone(ellipsoid._radiiToTheFourth, result._radiiToTheFourth);
-  Cartesian3.clone(ellipsoid._oneOverRadii, result._oneOverRadii);
-  Cartesian3.clone(ellipsoid._oneOverRadiiSquared, result._oneOverRadiiSquared);
-  result._minimumRadius = ellipsoid._minimumRadius;
-  result._maximumRadius = ellipsoid._maximumRadius;
-  result._centerToleranceSquared = ellipsoid._centerToleranceSquared;
+  /**
+   * Duplicates an Ellipsoid instance.
+   *
+   * @param {Ellipsoid} ellipsoid The ellipsoid to duplicate.
+   * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
+   *                    instance should be created.
+   * @returns {Ellipsoid} The cloned Ellipsoid. (Returns undefined if ellipsoid is undefined)
+   */
+  static clone(ellipsoid, result) {
+    if (!defined(ellipsoid)) {
+      return undefined;
+    }
+    const radii = ellipsoid._radii;
 
-  return result;
-};
+    if (!defined(result)) {
+      return new Ellipsoid(radii.x, radii.y, radii.z);
+    }
 
-/**
- * Computes an Ellipsoid from a Cartesian specifying the radii in x, y, and z directions.
- *
- * @param {Cartesian3} [cartesian=Cartesian3.ZERO] The ellipsoid's radius in the x, y, and z directions.
- * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
- *                    instance should be created.
- * @returns {Ellipsoid} A new Ellipsoid instance.
- *
- * @exception {DeveloperError} All radii components must be greater than or equal to zero.
- *
- * @see Ellipsoid.WGS84
- * @see Ellipsoid.UNIT_SPHERE
- */
-Ellipsoid.fromCartesian3 = function (cartesian, result) {
-  if (!defined(result)) {
-    result = new Ellipsoid();
-  }
+    Cartesian3.clone(radii, result._radii);
+    Cartesian3.clone(ellipsoid._radiiSquared, result._radiiSquared);
+    Cartesian3.clone(ellipsoid._radiiToTheFourth, result._radiiToTheFourth);
+    Cartesian3.clone(ellipsoid._oneOverRadii, result._oneOverRadii);
+    Cartesian3.clone(
+      ellipsoid._oneOverRadiiSquared,
+      result._oneOverRadiiSquared,
+    );
+    result._minimumRadius = ellipsoid._minimumRadius;
+    result._maximumRadius = ellipsoid._maximumRadius;
+    result._centerToleranceSquared = ellipsoid._centerToleranceSquared;
 
-  if (!defined(cartesian)) {
     return result;
   }
 
-  initialize(result, cartesian.x, cartesian.y, cartesian.z);
-  return result;
-};
+  /**
+   * Computes an Ellipsoid from a Cartesian specifying the radii in x, y, and z directions.
+   *
+   * @param {Cartesian3} [cartesian=Cartesian3.ZERO] The ellipsoid's radius in the x, y, and z directions.
+   * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
+   *                    instance should be created.
+   * @returns {Ellipsoid} A new Ellipsoid instance.
+   *
+   * @exception {DeveloperError} All radii components must be greater than or equal to zero.
+   *
+   * @see Ellipsoid.WGS84
+   * @see Ellipsoid.UNIT_SPHERE
+   */
+  static fromCartesian3(cartesian, result) {
+    if (!defined(result)) {
+      result = new Ellipsoid();
+    }
+
+    if (!defined(cartesian)) {
+      return result;
+    }
+
+    initialize(result, cartesian.x, cartesian.y, cartesian.z);
+    return result;
+  }
+
+  /**
+   * The default ellipsoid used when not otherwise specified.
+   * @memberof Ellipsoid
+   * @type {Ellipsoid}
+   * @example
+   * Cesium.Ellipsoid.default = Cesium.Ellipsoid.MOON;
+   *
+   * // Apollo 11 landing site
+   * const position = Cesium.Cartesian3.fromRadians(
+   *   0.67416,
+   *   23.47315,
+   * );
+   */
+  static get default() {
+    return Ellipsoid._default;
+  }
+
+  static set default(value) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("value", value);
+    //>>includeEnd('debug');
+
+    Ellipsoid._default = value;
+    Cartesian3._ellipsoidRadiiSquared = value.radiiSquared;
+    Cartographic._ellipsoidOneOverRadii = value.oneOverRadii;
+    Cartographic._ellipsoidOneOverRadiiSquared = value.oneOverRadiiSquared;
+    Cartographic._ellipsoidCenterToleranceSquared =
+      value._centerToleranceSquared;
+  }
+
+  /**
+   * Duplicates an Ellipsoid instance.
+   *
+   * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
+   *                    instance should be created.
+   * @returns {Ellipsoid} The cloned Ellipsoid.
+   */
+  clone(result) {
+    return Ellipsoid.clone(this, result);
+  }
+
+  /**
+   * Stores the provided instance into the provided array.
+   *
+   * @param {Ellipsoid} value The value to pack.
+   * @param {number[]} array The array to pack into.
+   * @param {number} [startingIndex=0] The index into the array at which to start packing the elements.
+   *
+   * @returns {number[]} The array that was packed into
+   */
+  static pack(value, array, startingIndex) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("value", value);
+    Check.defined("array", array);
+    //>>includeEnd('debug');
+
+    startingIndex = startingIndex ?? 0;
+
+    Cartesian3.pack(value._radii, array, startingIndex);
+
+    return array;
+  }
+
+  /**
+   * Retrieves an instance from a packed array.
+   *
+   * @param {number[]} array The packed array.
+   * @param {number} [startingIndex=0] The starting index of the element to be unpacked.
+   * @param {Ellipsoid} [result] The object into which to store the result.
+   * @returns {Ellipsoid} The modified result parameter or a new Ellipsoid instance if one was not provided.
+   */
+  static unpack(array, startingIndex, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("array", array);
+    //>>includeEnd('debug');
+
+    startingIndex = startingIndex ?? 0;
+
+    const radii = Cartesian3.unpack(array, startingIndex);
+    return Ellipsoid.fromCartesian3(radii, result);
+  }
+
+  /**
+   * Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
+   *
+   * @param {Cartographic} cartographic The cartographic position for which to to determine the geodetic normal.
+   * @param {Cartesian3} [result] The object onto which to store the result.
+   * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided.
+   */
+  geodeticSurfaceNormalCartographic(cartographic, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("cartographic", cartographic);
+    //>>includeEnd('debug');
+
+    const longitude = cartographic.longitude;
+    const latitude = cartographic.latitude;
+    const cosLatitude = Math.cos(latitude);
+
+    const x = cosLatitude * Math.cos(longitude);
+    const y = cosLatitude * Math.sin(longitude);
+    const z = Math.sin(latitude);
+
+    if (!defined(result)) {
+      result = new Cartesian3();
+    }
+    result.x = x;
+    result.y = y;
+    result.z = z;
+    return Cartesian3.normalize(result, result);
+  }
+
+  /**
+   * Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
+   *
+   * @param {Cartesian3} cartesian The Cartesian position for which to to determine the surface normal.
+   * @param {Cartesian3} [result] The object onto which to store the result.
+   * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided, or undefined if a normal cannot be found.
+   */
+  geodeticSurfaceNormal(cartesian, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("cartesian", cartesian);
+    if (isNaN(cartesian.x) || isNaN(cartesian.y) || isNaN(cartesian.z)) {
+      throw new DeveloperError("cartesian has a NaN component");
+    }
+    //>>includeEnd('debug');
+    if (
+      Cartesian3.equalsEpsilon(cartesian, Cartesian3.ZERO, CesiumMath.EPSILON14)
+    ) {
+      return undefined;
+    }
+    if (!defined(result)) {
+      result = new Cartesian3();
+    }
+    result = Cartesian3.multiplyComponents(
+      cartesian,
+      this._oneOverRadiiSquared,
+      result,
+    );
+    return Cartesian3.normalize(result, result);
+  }
+
+  /**
+   * Converts the provided cartographic to Cartesian representation.
+   *
+   * @param {Cartographic} cartographic The cartographic position.
+   * @param {Cartesian3} [result] The object onto which to store the result.
+   * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided.
+   *
+   * @example
+   * //Create a Cartographic and determine it's Cartesian representation on a WGS84 ellipsoid.
+   * const position = new Cesium.Cartographic(Cesium.Math.toRadians(21), Cesium.Math.toRadians(78), 5000);
+   * const cartesianPosition = Cesium.Ellipsoid.WGS84.cartographicToCartesian(position);
+   */
+  cartographicToCartesian(cartographic, result) {
+    //`cartographic is required` is thrown from geodeticSurfaceNormalCartographic.
+    const n = cartographicToCartesianNormal;
+    const k = cartographicToCartesianK;
+    this.geodeticSurfaceNormalCartographic(cartographic, n);
+    Cartesian3.multiplyComponents(this._radiiSquared, n, k);
+    const gamma = Math.sqrt(Cartesian3.dot(n, k));
+    Cartesian3.divideByScalar(k, gamma, k);
+    Cartesian3.multiplyByScalar(n, cartographic.height, n);
+
+    if (!defined(result)) {
+      result = new Cartesian3();
+    }
+    return Cartesian3.add(k, n, result);
+  }
+
+  /**
+   * Converts the provided array of cartographics to an array of Cartesians.
+   *
+   * @param {Cartographic[]} cartographics An array of cartographic positions.
+   * @param {Cartesian3[]} [result] The object onto which to store the result.
+   * @returns {Cartesian3[]} The modified result parameter or a new Array instance if none was provided.
+   *
+   * @example
+   * //Convert an array of Cartographics and determine their Cartesian representation on a WGS84 ellipsoid.
+   * const positions = [new Cesium.Cartographic(Cesium.Math.toRadians(21), Cesium.Math.toRadians(78), 0),
+   *                  new Cesium.Cartographic(Cesium.Math.toRadians(21.321), Cesium.Math.toRadians(78.123), 100),
+   *                  new Cesium.Cartographic(Cesium.Math.toRadians(21.645), Cesium.Math.toRadians(78.456), 250)];
+   * const cartesianPositions = Cesium.Ellipsoid.WGS84.cartographicArrayToCartesianArray(positions);
+   */
+  cartographicArrayToCartesianArray(cartographics, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("cartographics", cartographics);
+    //>>includeEnd('debug');
+
+    const length = cartographics.length;
+    if (!defined(result)) {
+      result = new Array(length);
+    } else {
+      result.length = length;
+    }
+    for (let i = 0; i < length; i++) {
+      result[i] = this.cartographicToCartesian(cartographics[i], result[i]);
+    }
+    return result;
+  }
+
+  /**
+   * Converts the provided cartesian to cartographic representation.
+   * The cartesian is undefined at the center of the ellipsoid.
+   *
+   * @param {Cartesian3} cartesian The Cartesian position to convert to cartographic representation.
+   * @param {Cartographic} [result] The object onto which to store the result.
+   * @returns {Cartographic} The modified result parameter, new Cartographic instance if none was provided, or undefined if the cartesian is at the center of the ellipsoid.
+   *
+   * @example
+   * //Create a Cartesian and determine it's Cartographic representation on a WGS84 ellipsoid.
+   * const position = new Cesium.Cartesian3(17832.12, 83234.52, 952313.73);
+   * const cartographicPosition = Cesium.Ellipsoid.WGS84.cartesianToCartographic(position);
+   */
+  cartesianToCartographic(cartesian, result) {
+    //`cartesian is required.` is thrown from scaleToGeodeticSurface
+    const p = this.scaleToGeodeticSurface(cartesian, cartesianToCartographicP);
+
+    if (!defined(p)) {
+      return undefined;
+    }
+
+    const n = this.geodeticSurfaceNormal(p, cartesianToCartographicN);
+    const h = Cartesian3.subtract(cartesian, p, cartesianToCartographicH);
+
+    const longitude = Math.atan2(n.y, n.x);
+    const latitude = Math.asin(n.z);
+    const height =
+      CesiumMath.sign(Cartesian3.dot(h, cartesian)) * Cartesian3.magnitude(h);
+
+    if (!defined(result)) {
+      return new Cartographic(longitude, latitude, height);
+    }
+    result.longitude = longitude;
+    result.latitude = latitude;
+    result.height = height;
+    return result;
+  }
+
+  /**
+   * Converts the provided array of cartesians to an array of cartographics.
+   *
+   * @param {Cartesian3[]} cartesians An array of Cartesian positions.
+   * @param {Cartographic[]} [result] The object onto which to store the result.
+   * @returns {Cartographic[]} The modified result parameter or a new Array instance if none was provided.
+   *
+   * @example
+   * //Create an array of Cartesians and determine their Cartographic representation on a WGS84 ellipsoid.
+   * const positions = [new Cesium.Cartesian3(17832.12, 83234.52, 952313.73),
+   *                  new Cesium.Cartesian3(17832.13, 83234.53, 952313.73),
+   *                  new Cesium.Cartesian3(17832.14, 83234.54, 952313.73)]
+   * const cartographicPositions = Cesium.Ellipsoid.WGS84.cartesianArrayToCartographicArray(positions);
+   */
+  cartesianArrayToCartographicArray(cartesians, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("cartesians", cartesians);
+    //>>includeEnd('debug');
+
+    const length = cartesians.length;
+    if (!defined(result)) {
+      result = new Array(length);
+    } else {
+      result.length = length;
+    }
+    for (let i = 0; i < length; ++i) {
+      result[i] = this.cartesianToCartographic(cartesians[i], result[i]);
+    }
+    return result;
+  }
+
+  /**
+   * Scales the provided Cartesian position along the geodetic surface normal
+   * so that it is on the surface of this ellipsoid.  If the position is
+   * at the center of the ellipsoid, this function returns undefined.
+   *
+   * @param {Cartesian3} cartesian The Cartesian position to scale.
+   * @param {Cartesian3} [result] The object onto which to store the result.
+   * @returns {Cartesian3} The modified result parameter, a new Cartesian3 instance if none was provided, or undefined if the position is at the center.
+   */
+  scaleToGeodeticSurface(cartesian, result) {
+    return scaleToGeodeticSurface(
+      cartesian,
+      this._oneOverRadii,
+      this._oneOverRadiiSquared,
+      this._centerToleranceSquared,
+      result,
+    );
+  }
+
+  /**
+   * Scales the provided Cartesian position along the geocentric surface normal
+   * so that it is on the surface of this ellipsoid.
+   *
+   * @param {Cartesian3} cartesian The Cartesian position to scale.
+   * @param {Cartesian3} [result] The object onto which to store the result.
+   * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided.
+   */
+  scaleToGeocentricSurface(cartesian, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("cartesian", cartesian);
+    //>>includeEnd('debug');
+
+    if (!defined(result)) {
+      result = new Cartesian3();
+    }
+
+    const positionX = cartesian.x;
+    const positionY = cartesian.y;
+    const positionZ = cartesian.z;
+    const oneOverRadiiSquared = this._oneOverRadiiSquared;
+
+    const beta =
+      1.0 /
+      Math.sqrt(
+        positionX * positionX * oneOverRadiiSquared.x +
+          positionY * positionY * oneOverRadiiSquared.y +
+          positionZ * positionZ * oneOverRadiiSquared.z,
+      );
+
+    return Cartesian3.multiplyByScalar(cartesian, beta, result);
+  }
+
+  /**
+   * Transforms a Cartesian X, Y, Z position to the ellipsoid-scaled space by multiplying
+   * its components by the result of {@link Ellipsoid#oneOverRadii}.
+   *
+   * @param {Cartesian3} position The position to transform.
+   * @param {Cartesian3} [result] The position to which to copy the result, or undefined to create and
+   *        return a new instance.
+   * @returns {Cartesian3} The position expressed in the scaled space.  The returned instance is the
+   *          one passed as the result parameter if it is not undefined, or a new instance of it is.
+   */
+  transformPositionToScaledSpace(position, result) {
+    if (!defined(result)) {
+      result = new Cartesian3();
+    }
+
+    return Cartesian3.multiplyComponents(position, this._oneOverRadii, result);
+  }
+
+  /**
+   * Transforms a Cartesian X, Y, Z position from the ellipsoid-scaled space by multiplying
+   * its components by the result of {@link Ellipsoid#radii}.
+   *
+   * @param {Cartesian3} position The position to transform.
+   * @param {Cartesian3} [result] The position to which to copy the result, or undefined to create and
+   *        return a new instance.
+   * @returns {Cartesian3} The position expressed in the unscaled space.  The returned instance is the
+   *          one passed as the result parameter if it is not undefined, or a new instance of it is.
+   */
+  transformPositionFromScaledSpace(position, result) {
+    if (!defined(result)) {
+      result = new Cartesian3();
+    }
+
+    return Cartesian3.multiplyComponents(position, this._radii, result);
+  }
+
+  /**
+   * Compares this Ellipsoid against the provided Ellipsoid componentwise and returns
+   * <code>true</code> if they are equal, <code>false</code> otherwise.
+   *
+   * @param {Ellipsoid} [right] The other Ellipsoid.
+   * @returns {boolean} <code>true</code> if they are equal, <code>false</code> otherwise.
+   */
+  equals(right) {
+    return (
+      this === right ||
+      (defined(right) && Cartesian3.equals(this._radii, right._radii))
+    );
+  }
+
+  /**
+   * Creates a string representing this Ellipsoid in the format '(radii.x, radii.y, radii.z)'.
+   *
+   * @returns {string} A string representing this ellipsoid in the format '(radii.x, radii.y, radii.z)'.
+   */
+  toString() {
+    return this._radii.toString();
+  }
+
+  /**
+   * Computes a point which is the intersection of the surface normal with the z-axis.
+   *
+   * @param {Cartesian3} position the position. must be on the surface of the ellipsoid.
+   * @param {number} [buffer = 0.0] A buffer to subtract from the ellipsoid size when checking if the point is inside the ellipsoid.
+   *                                In earth case, with common earth datums, there is no need for this buffer since the intersection point is always (relatively) very close to the center.
+   *                                In WGS84 datum, intersection point is at max z = +-42841.31151331382 (0.673% of z-axis).
+   *                                Intersection point could be outside the ellipsoid if the ratio of MajorAxis / AxisOfRotation is bigger than the square root of 2
+   * @param {Cartesian3} [result] The cartesian to which to copy the result, or undefined to create and
+   *        return a new instance.
+   * @returns {Cartesian3 | undefined} the intersection point if it's inside the ellipsoid, undefined otherwise
+   *
+   * @exception {DeveloperError} position is required.
+   * @exception {DeveloperError} Ellipsoid must be an ellipsoid of revolution (radii.x == radii.y).
+   * @exception {DeveloperError} Ellipsoid.radii.z must be greater than 0.
+   */
+  getSurfaceNormalIntersectionWithZAxis(position, buffer, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("position", position);
+
+    if (
+      !CesiumMath.equalsEpsilon(
+        this._radii.x,
+        this._radii.y,
+        CesiumMath.EPSILON15,
+      )
+    ) {
+      throw new DeveloperError(
+        "Ellipsoid must be an ellipsoid of revolution (radii.x == radii.y)",
+      );
+    }
+
+    Check.typeOf.number.greaterThan("Ellipsoid.radii.z", this._radii.z, 0);
+    //>>includeEnd('debug');
+
+    buffer = buffer ?? 0.0;
+
+    const squaredXOverSquaredZ = this._squaredXOverSquaredZ;
+
+    if (!defined(result)) {
+      result = new Cartesian3();
+    }
+
+    result.x = 0.0;
+    result.y = 0.0;
+    result.z = position.z * (1 - squaredXOverSquaredZ);
+
+    if (Math.abs(result.z) >= this._radii.z - buffer) {
+      return undefined;
+    }
+
+    return result;
+  }
+
+  /**
+   * Computes the ellipsoid curvatures at a given position on the surface.
+   *
+   * @param {Cartesian3} surfacePosition The position on the ellipsoid surface where curvatures will be calculated.
+   * @param {Cartesian2} [result] The cartesian to which to copy the result, or undefined to create and return a new instance.
+   * @returns {Cartesian2} The local curvature of the ellipsoid surface at the provided position, in east and north directions.
+   *
+   * @exception {DeveloperError} position is required.
+   */
+  getLocalCurvature(surfacePosition, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("surfacePosition", surfacePosition);
+    //>>includeEnd('debug');
+
+    if (!defined(result)) {
+      result = new Cartesian2();
+    }
+
+    const primeVerticalEndpoint = this.getSurfaceNormalIntersectionWithZAxis(
+      surfacePosition,
+      0.0,
+      scratchEndpoint,
+    );
+    const primeVerticalRadius = Cartesian3.distance(
+      surfacePosition,
+      primeVerticalEndpoint,
+    );
+    // meridional radius = (1 - e^2) * primeVerticalRadius^3 / a^2
+    // where 1 - e^2 = b^2 / a^2,
+    // so meridional = b^2 * primeVerticalRadius^3 / a^4
+    //   = (b * primeVerticalRadius / a^2)^2 * primeVertical
+    const radiusRatio =
+      (this.minimumRadius * primeVerticalRadius) / this.maximumRadius ** 2;
+    const meridionalRadius = primeVerticalRadius * radiusRatio ** 2;
+
+    return Cartesian2.fromElements(
+      1.0 / primeVerticalRadius,
+      1.0 / meridionalRadius,
+      result,
+    );
+  }
+
+  /**
+   * Computes an approximation of the surface area of a rectangle on the surface of an ellipsoid using
+   * Gauss-Legendre 10th order quadrature.
+   *
+   * @param {Rectangle} rectangle The rectangle used for computing the surface area.
+   * @returns {number} The approximate area of the rectangle on the surface of this ellipsoid.
+   */
+  surfaceArea(rectangle) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.object("rectangle", rectangle);
+    //>>includeEnd('debug');
+    const minLongitude = rectangle.west;
+    let maxLongitude = rectangle.east;
+    const minLatitude = rectangle.south;
+    const maxLatitude = rectangle.north;
+
+    while (maxLongitude < minLongitude) {
+      maxLongitude += CesiumMath.TWO_PI;
+    }
+
+    const radiiSquared = this._radiiSquared;
+    const a2 = radiiSquared.x;
+    const b2 = radiiSquared.y;
+    const c2 = radiiSquared.z;
+    const a2b2 = a2 * b2;
+    return gaussLegendreQuadrature(minLatitude, maxLatitude, function (lat) {
+      // phi represents the angle measured from the north pole
+      // sin(phi) = sin(pi / 2 - lat) = cos(lat), cos(phi) is similar
+      const sinPhi = Math.cos(lat);
+      const cosPhi = Math.sin(lat);
+      return (
+        Math.cos(lat) *
+        gaussLegendreQuadrature(minLongitude, maxLongitude, function (lon) {
+          const cosTheta = Math.cos(lon);
+          const sinTheta = Math.sin(lon);
+          return Math.sqrt(
+            a2b2 * cosPhi * cosPhi +
+              c2 *
+                (b2 * cosTheta * cosTheta + a2 * sinTheta * sinTheta) *
+                sinPhi *
+                sinPhi,
+          );
+        })
+      );
+    });
+  }
+}
 
 /**
  * An Ellipsoid instance initialized to the WGS84 standard.
@@ -264,96 +794,12 @@ Ellipsoid.MOON = Object.freeze(
 Ellipsoid.MARS = Object.freeze(new Ellipsoid(3396190.0, 3396190.0, 3376200.0));
 
 Ellipsoid._default = Ellipsoid.WGS84;
-Object.defineProperties(Ellipsoid, {
-  /**
-   * The default ellipsoid used when not otherwise specified.
-   * @memberof Ellipsoid
-   * @type {Ellipsoid}
-   * @example
-   * Cesium.Ellipsoid.default = Cesium.Ellipsoid.MOON;
-   *
-   * // Apollo 11 landing site
-   * const position = Cesium.Cartesian3.fromRadians(
-   *   0.67416,
-   *   23.47315,
-   * );
-   */
-  default: {
-    get: function () {
-      return Ellipsoid._default;
-    },
-    set: function (value) {
-      //>>includeStart('debug', pragmas.debug);
-      Check.typeOf.object("value", value);
-      //>>includeEnd('debug');
-
-      Ellipsoid._default = value;
-      Cartesian3._ellipsoidRadiiSquared = value.radiiSquared;
-      Cartographic._ellipsoidOneOverRadii = value.oneOverRadii;
-      Cartographic._ellipsoidOneOverRadiiSquared = value.oneOverRadiiSquared;
-      Cartographic._ellipsoidCenterToleranceSquared =
-        value._centerToleranceSquared;
-    },
-  },
-});
-
-/**
- * Duplicates an Ellipsoid instance.
- *
- * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
- *                    instance should be created.
- * @returns {Ellipsoid} The cloned Ellipsoid.
- */
-Ellipsoid.prototype.clone = function (result) {
-  return Ellipsoid.clone(this, result);
-};
 
 /**
  * The number of elements used to pack the object into an array.
  * @type {number}
  */
 Ellipsoid.packedLength = Cartesian3.packedLength;
-
-/**
- * Stores the provided instance into the provided array.
- *
- * @param {Ellipsoid} value The value to pack.
- * @param {number[]} array The array to pack into.
- * @param {number} [startingIndex=0] The index into the array at which to start packing the elements.
- *
- * @returns {number[]} The array that was packed into
- */
-Ellipsoid.pack = function (value, array, startingIndex) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("value", value);
-  Check.defined("array", array);
-  //>>includeEnd('debug');
-
-  startingIndex = startingIndex ?? 0;
-
-  Cartesian3.pack(value._radii, array, startingIndex);
-
-  return array;
-};
-
-/**
- * Retrieves an instance from a packed array.
- *
- * @param {number[]} array The packed array.
- * @param {number} [startingIndex=0] The starting index of the element to be unpacked.
- * @param {Ellipsoid} [result] The object into which to store the result.
- * @returns {Ellipsoid} The modified result parameter or a new Ellipsoid instance if one was not provided.
- */
-Ellipsoid.unpack = function (array, startingIndex, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("array", array);
-  //>>includeEnd('debug');
-
-  startingIndex = startingIndex ?? 0;
-
-  const radii = Cartesian3.unpack(array, startingIndex);
-  return Ellipsoid.fromCartesian3(radii, result);
-};
 
 /**
  * Computes the unit vector directed from the center of this ellipsoid toward the provided Cartesian position.
@@ -365,427 +811,14 @@ Ellipsoid.unpack = function (array, startingIndex, result) {
  */
 Ellipsoid.prototype.geocentricSurfaceNormal = Cartesian3.normalize;
 
-/**
- * Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
- *
- * @param {Cartographic} cartographic The cartographic position for which to to determine the geodetic normal.
- * @param {Cartesian3} [result] The object onto which to store the result.
- * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided.
- */
-Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function (
-  cartographic,
-  result,
-) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("cartographic", cartographic);
-  //>>includeEnd('debug');
-
-  const longitude = cartographic.longitude;
-  const latitude = cartographic.latitude;
-  const cosLatitude = Math.cos(latitude);
-
-  const x = cosLatitude * Math.cos(longitude);
-  const y = cosLatitude * Math.sin(longitude);
-  const z = Math.sin(latitude);
-
-  if (!defined(result)) {
-    result = new Cartesian3();
-  }
-  result.x = x;
-  result.y = y;
-  result.z = z;
-  return Cartesian3.normalize(result, result);
-};
-
-/**
- * Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
- *
- * @param {Cartesian3} cartesian The Cartesian position for which to to determine the surface normal.
- * @param {Cartesian3} [result] The object onto which to store the result.
- * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided, or undefined if a normal cannot be found.
- */
-Ellipsoid.prototype.geodeticSurfaceNormal = function (cartesian, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("cartesian", cartesian);
-  if (isNaN(cartesian.x) || isNaN(cartesian.y) || isNaN(cartesian.z)) {
-    throw new DeveloperError("cartesian has a NaN component");
-  }
-  //>>includeEnd('debug');
-  if (
-    Cartesian3.equalsEpsilon(cartesian, Cartesian3.ZERO, CesiumMath.EPSILON14)
-  ) {
-    return undefined;
-  }
-  if (!defined(result)) {
-    result = new Cartesian3();
-  }
-  result = Cartesian3.multiplyComponents(
-    cartesian,
-    this._oneOverRadiiSquared,
-    result,
-  );
-  return Cartesian3.normalize(result, result);
-};
-
 const cartographicToCartesianNormal = new Cartesian3();
 const cartographicToCartesianK = new Cartesian3();
-
-/**
- * Converts the provided cartographic to Cartesian representation.
- *
- * @param {Cartographic} cartographic The cartographic position.
- * @param {Cartesian3} [result] The object onto which to store the result.
- * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided.
- *
- * @example
- * //Create a Cartographic and determine it's Cartesian representation on a WGS84 ellipsoid.
- * const position = new Cesium.Cartographic(Cesium.Math.toRadians(21), Cesium.Math.toRadians(78), 5000);
- * const cartesianPosition = Cesium.Ellipsoid.WGS84.cartographicToCartesian(position);
- */
-Ellipsoid.prototype.cartographicToCartesian = function (cartographic, result) {
-  //`cartographic is required` is thrown from geodeticSurfaceNormalCartographic.
-  const n = cartographicToCartesianNormal;
-  const k = cartographicToCartesianK;
-  this.geodeticSurfaceNormalCartographic(cartographic, n);
-  Cartesian3.multiplyComponents(this._radiiSquared, n, k);
-  const gamma = Math.sqrt(Cartesian3.dot(n, k));
-  Cartesian3.divideByScalar(k, gamma, k);
-  Cartesian3.multiplyByScalar(n, cartographic.height, n);
-
-  if (!defined(result)) {
-    result = new Cartesian3();
-  }
-  return Cartesian3.add(k, n, result);
-};
-
-/**
- * Converts the provided array of cartographics to an array of Cartesians.
- *
- * @param {Cartographic[]} cartographics An array of cartographic positions.
- * @param {Cartesian3[]} [result] The object onto which to store the result.
- * @returns {Cartesian3[]} The modified result parameter or a new Array instance if none was provided.
- *
- * @example
- * //Convert an array of Cartographics and determine their Cartesian representation on a WGS84 ellipsoid.
- * const positions = [new Cesium.Cartographic(Cesium.Math.toRadians(21), Cesium.Math.toRadians(78), 0),
- *                  new Cesium.Cartographic(Cesium.Math.toRadians(21.321), Cesium.Math.toRadians(78.123), 100),
- *                  new Cesium.Cartographic(Cesium.Math.toRadians(21.645), Cesium.Math.toRadians(78.456), 250)];
- * const cartesianPositions = Cesium.Ellipsoid.WGS84.cartographicArrayToCartesianArray(positions);
- */
-Ellipsoid.prototype.cartographicArrayToCartesianArray = function (
-  cartographics,
-  result,
-) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("cartographics", cartographics);
-  //>>includeEnd('debug');
-
-  const length = cartographics.length;
-  if (!defined(result)) {
-    result = new Array(length);
-  } else {
-    result.length = length;
-  }
-  for (let i = 0; i < length; i++) {
-    result[i] = this.cartographicToCartesian(cartographics[i], result[i]);
-  }
-  return result;
-};
 
 const cartesianToCartographicN = new Cartesian3();
 const cartesianToCartographicP = new Cartesian3();
 const cartesianToCartographicH = new Cartesian3();
 
-/**
- * Converts the provided cartesian to cartographic representation.
- * The cartesian is undefined at the center of the ellipsoid.
- *
- * @param {Cartesian3} cartesian The Cartesian position to convert to cartographic representation.
- * @param {Cartographic} [result] The object onto which to store the result.
- * @returns {Cartographic} The modified result parameter, new Cartographic instance if none was provided, or undefined if the cartesian is at the center of the ellipsoid.
- *
- * @example
- * //Create a Cartesian and determine it's Cartographic representation on a WGS84 ellipsoid.
- * const position = new Cesium.Cartesian3(17832.12, 83234.52, 952313.73);
- * const cartographicPosition = Cesium.Ellipsoid.WGS84.cartesianToCartographic(position);
- */
-Ellipsoid.prototype.cartesianToCartographic = function (cartesian, result) {
-  //`cartesian is required.` is thrown from scaleToGeodeticSurface
-  const p = this.scaleToGeodeticSurface(cartesian, cartesianToCartographicP);
-
-  if (!defined(p)) {
-    return undefined;
-  }
-
-  const n = this.geodeticSurfaceNormal(p, cartesianToCartographicN);
-  const h = Cartesian3.subtract(cartesian, p, cartesianToCartographicH);
-
-  const longitude = Math.atan2(n.y, n.x);
-  const latitude = Math.asin(n.z);
-  const height =
-    CesiumMath.sign(Cartesian3.dot(h, cartesian)) * Cartesian3.magnitude(h);
-
-  if (!defined(result)) {
-    return new Cartographic(longitude, latitude, height);
-  }
-  result.longitude = longitude;
-  result.latitude = latitude;
-  result.height = height;
-  return result;
-};
-
-/**
- * Converts the provided array of cartesians to an array of cartographics.
- *
- * @param {Cartesian3[]} cartesians An array of Cartesian positions.
- * @param {Cartographic[]} [result] The object onto which to store the result.
- * @returns {Cartographic[]} The modified result parameter or a new Array instance if none was provided.
- *
- * @example
- * //Create an array of Cartesians and determine their Cartographic representation on a WGS84 ellipsoid.
- * const positions = [new Cesium.Cartesian3(17832.12, 83234.52, 952313.73),
- *                  new Cesium.Cartesian3(17832.13, 83234.53, 952313.73),
- *                  new Cesium.Cartesian3(17832.14, 83234.54, 952313.73)]
- * const cartographicPositions = Cesium.Ellipsoid.WGS84.cartesianArrayToCartographicArray(positions);
- */
-Ellipsoid.prototype.cartesianArrayToCartographicArray = function (
-  cartesians,
-  result,
-) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("cartesians", cartesians);
-  //>>includeEnd('debug');
-
-  const length = cartesians.length;
-  if (!defined(result)) {
-    result = new Array(length);
-  } else {
-    result.length = length;
-  }
-  for (let i = 0; i < length; ++i) {
-    result[i] = this.cartesianToCartographic(cartesians[i], result[i]);
-  }
-  return result;
-};
-
-/**
- * Scales the provided Cartesian position along the geodetic surface normal
- * so that it is on the surface of this ellipsoid.  If the position is
- * at the center of the ellipsoid, this function returns undefined.
- *
- * @param {Cartesian3} cartesian The Cartesian position to scale.
- * @param {Cartesian3} [result] The object onto which to store the result.
- * @returns {Cartesian3} The modified result parameter, a new Cartesian3 instance if none was provided, or undefined if the position is at the center.
- */
-Ellipsoid.prototype.scaleToGeodeticSurface = function (cartesian, result) {
-  return scaleToGeodeticSurface(
-    cartesian,
-    this._oneOverRadii,
-    this._oneOverRadiiSquared,
-    this._centerToleranceSquared,
-    result,
-  );
-};
-
-/**
- * Scales the provided Cartesian position along the geocentric surface normal
- * so that it is on the surface of this ellipsoid.
- *
- * @param {Cartesian3} cartesian The Cartesian position to scale.
- * @param {Cartesian3} [result] The object onto which to store the result.
- * @returns {Cartesian3} The modified result parameter or a new Cartesian3 instance if none was provided.
- */
-Ellipsoid.prototype.scaleToGeocentricSurface = function (cartesian, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("cartesian", cartesian);
-  //>>includeEnd('debug');
-
-  if (!defined(result)) {
-    result = new Cartesian3();
-  }
-
-  const positionX = cartesian.x;
-  const positionY = cartesian.y;
-  const positionZ = cartesian.z;
-  const oneOverRadiiSquared = this._oneOverRadiiSquared;
-
-  const beta =
-    1.0 /
-    Math.sqrt(
-      positionX * positionX * oneOverRadiiSquared.x +
-        positionY * positionY * oneOverRadiiSquared.y +
-        positionZ * positionZ * oneOverRadiiSquared.z,
-    );
-
-  return Cartesian3.multiplyByScalar(cartesian, beta, result);
-};
-
-/**
- * Transforms a Cartesian X, Y, Z position to the ellipsoid-scaled space by multiplying
- * its components by the result of {@link Ellipsoid#oneOverRadii}.
- *
- * @param {Cartesian3} position The position to transform.
- * @param {Cartesian3} [result] The position to which to copy the result, or undefined to create and
- *        return a new instance.
- * @returns {Cartesian3} The position expressed in the scaled space.  The returned instance is the
- *          one passed as the result parameter if it is not undefined, or a new instance of it is.
- */
-Ellipsoid.prototype.transformPositionToScaledSpace = function (
-  position,
-  result,
-) {
-  if (!defined(result)) {
-    result = new Cartesian3();
-  }
-
-  return Cartesian3.multiplyComponents(position, this._oneOverRadii, result);
-};
-
-/**
- * Transforms a Cartesian X, Y, Z position from the ellipsoid-scaled space by multiplying
- * its components by the result of {@link Ellipsoid#radii}.
- *
- * @param {Cartesian3} position The position to transform.
- * @param {Cartesian3} [result] The position to which to copy the result, or undefined to create and
- *        return a new instance.
- * @returns {Cartesian3} The position expressed in the unscaled space.  The returned instance is the
- *          one passed as the result parameter if it is not undefined, or a new instance of it is.
- */
-Ellipsoid.prototype.transformPositionFromScaledSpace = function (
-  position,
-  result,
-) {
-  if (!defined(result)) {
-    result = new Cartesian3();
-  }
-
-  return Cartesian3.multiplyComponents(position, this._radii, result);
-};
-
-/**
- * Compares this Ellipsoid against the provided Ellipsoid componentwise and returns
- * <code>true</code> if they are equal, <code>false</code> otherwise.
- *
- * @param {Ellipsoid} [right] The other Ellipsoid.
- * @returns {boolean} <code>true</code> if they are equal, <code>false</code> otherwise.
- */
-Ellipsoid.prototype.equals = function (right) {
-  return (
-    this === right ||
-    (defined(right) && Cartesian3.equals(this._radii, right._radii))
-  );
-};
-
-/**
- * Creates a string representing this Ellipsoid in the format '(radii.x, radii.y, radii.z)'.
- *
- * @returns {string} A string representing this ellipsoid in the format '(radii.x, radii.y, radii.z)'.
- */
-Ellipsoid.prototype.toString = function () {
-  return this._radii.toString();
-};
-
-/**
- * Computes a point which is the intersection of the surface normal with the z-axis.
- *
- * @param {Cartesian3} position the position. must be on the surface of the ellipsoid.
- * @param {number} [buffer = 0.0] A buffer to subtract from the ellipsoid size when checking if the point is inside the ellipsoid.
- *                                In earth case, with common earth datums, there is no need for this buffer since the intersection point is always (relatively) very close to the center.
- *                                In WGS84 datum, intersection point is at max z = +-42841.31151331382 (0.673% of z-axis).
- *                                Intersection point could be outside the ellipsoid if the ratio of MajorAxis / AxisOfRotation is bigger than the square root of 2
- * @param {Cartesian3} [result] The cartesian to which to copy the result, or undefined to create and
- *        return a new instance.
- * @returns {Cartesian3 | undefined} the intersection point if it's inside the ellipsoid, undefined otherwise
- *
- * @exception {DeveloperError} position is required.
- * @exception {DeveloperError} Ellipsoid must be an ellipsoid of revolution (radii.x == radii.y).
- * @exception {DeveloperError} Ellipsoid.radii.z must be greater than 0.
- */
-Ellipsoid.prototype.getSurfaceNormalIntersectionWithZAxis = function (
-  position,
-  buffer,
-  result,
-) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("position", position);
-
-  if (
-    !CesiumMath.equalsEpsilon(
-      this._radii.x,
-      this._radii.y,
-      CesiumMath.EPSILON15,
-    )
-  ) {
-    throw new DeveloperError(
-      "Ellipsoid must be an ellipsoid of revolution (radii.x == radii.y)",
-    );
-  }
-
-  Check.typeOf.number.greaterThan("Ellipsoid.radii.z", this._radii.z, 0);
-  //>>includeEnd('debug');
-
-  buffer = buffer ?? 0.0;
-
-  const squaredXOverSquaredZ = this._squaredXOverSquaredZ;
-
-  if (!defined(result)) {
-    result = new Cartesian3();
-  }
-
-  result.x = 0.0;
-  result.y = 0.0;
-  result.z = position.z * (1 - squaredXOverSquaredZ);
-
-  if (Math.abs(result.z) >= this._radii.z - buffer) {
-    return undefined;
-  }
-
-  return result;
-};
-
 const scratchEndpoint = new Cartesian3();
-
-/**
- * Computes the ellipsoid curvatures at a given position on the surface.
- *
- * @param {Cartesian3} surfacePosition The position on the ellipsoid surface where curvatures will be calculated.
- * @param {Cartesian2} [result] The cartesian to which to copy the result, or undefined to create and return a new instance.
- * @returns {Cartesian2} The local curvature of the ellipsoid surface at the provided position, in east and north directions.
- *
- * @exception {DeveloperError} position is required.
- */
-Ellipsoid.prototype.getLocalCurvature = function (surfacePosition, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("surfacePosition", surfacePosition);
-  //>>includeEnd('debug');
-
-  if (!defined(result)) {
-    result = new Cartesian2();
-  }
-
-  const primeVerticalEndpoint = this.getSurfaceNormalIntersectionWithZAxis(
-    surfacePosition,
-    0.0,
-    scratchEndpoint,
-  );
-  const primeVerticalRadius = Cartesian3.distance(
-    surfacePosition,
-    primeVerticalEndpoint,
-  );
-  // meridional radius = (1 - e^2) * primeVerticalRadius^3 / a^2
-  // where 1 - e^2 = b^2 / a^2,
-  // so meridional = b^2 * primeVerticalRadius^3 / a^4
-  //   = (b * primeVerticalRadius / a^2)^2 * primeVertical
-  const radiusRatio =
-    (this.minimumRadius * primeVerticalRadius) / this.maximumRadius ** 2;
-  const meridionalRadius = primeVerticalRadius * radiusRatio ** 2;
-
-  return Cartesian2.fromElements(
-    1.0 / primeVerticalRadius,
-    1.0 / meridionalRadius,
-    result,
-  );
-};
 
 const abscissas = [
   0.14887433898163, 0.43339539412925, 0.67940956829902, 0.86506336668898,
@@ -801,7 +834,7 @@ const weights = [
  *
  * @param {number} a The lower bound for the integration.
  * @param {number} b The upper bound for the integration.
- * @param {Ellipsoid~RealValuedScalarFunction} func The function to integrate.
+ * @param {EllipsoidRealValuedScalarFunction} func The function to integrate.
  * @returns {number} The value of the integral of the given function over the given domain.
  *
  * @private
@@ -828,62 +861,5 @@ function gaussLegendreQuadrature(a, b, func) {
   sum *= xRange;
   return sum;
 }
-
-/**
- * A real valued scalar function.
- * @callback Ellipsoid~RealValuedScalarFunction
- *
- * @param {number} x The value used to evaluate the function.
- * @returns {number} The value of the function at x.
- *
- * @private
- */
-
-/**
- * Computes an approximation of the surface area of a rectangle on the surface of an ellipsoid using
- * Gauss-Legendre 10th order quadrature.
- *
- * @param {Rectangle} rectangle The rectangle used for computing the surface area.
- * @returns {number} The approximate area of the rectangle on the surface of this ellipsoid.
- */
-Ellipsoid.prototype.surfaceArea = function (rectangle) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("rectangle", rectangle);
-  //>>includeEnd('debug');
-  const minLongitude = rectangle.west;
-  let maxLongitude = rectangle.east;
-  const minLatitude = rectangle.south;
-  const maxLatitude = rectangle.north;
-
-  while (maxLongitude < minLongitude) {
-    maxLongitude += CesiumMath.TWO_PI;
-  }
-
-  const radiiSquared = this._radiiSquared;
-  const a2 = radiiSquared.x;
-  const b2 = radiiSquared.y;
-  const c2 = radiiSquared.z;
-  const a2b2 = a2 * b2;
-  return gaussLegendreQuadrature(minLatitude, maxLatitude, function (lat) {
-    // phi represents the angle measured from the north pole
-    // sin(phi) = sin(pi / 2 - lat) = cos(lat), cos(phi) is similar
-    const sinPhi = Math.cos(lat);
-    const cosPhi = Math.sin(lat);
-    return (
-      Math.cos(lat) *
-      gaussLegendreQuadrature(minLongitude, maxLongitude, function (lon) {
-        const cosTheta = Math.cos(lon);
-        const sinTheta = Math.sin(lon);
-        return Math.sqrt(
-          a2b2 * cosPhi * cosPhi +
-            c2 *
-              (b2 * cosTheta * cosTheta + a2 * sinTheta * sinTheta) *
-              sinPhi *
-              sinPhi,
-        );
-      })
-    );
-  });
-};
 
 export default Ellipsoid;

--- a/packages/engine/Source/Core/Ellipsoid.js
+++ b/packages/engine/Source/Core/Ellipsoid.js
@@ -26,6 +26,8 @@ import scaleToGeodeticSurface from "./scaleToGeodeticSurface.js";
  * @param {number} x
  * @param {number} y
  * @param {number} z
+ *
+ * @ignore
  */
 function initialize(ellipsoid, x, y, z) {
   x = x ?? 0.0;

--- a/packages/engine/Source/Core/Ellipsoid.js
+++ b/packages/engine/Source/Core/Ellipsoid.js
@@ -230,7 +230,6 @@ class Ellipsoid {
 
   /**
    * The default ellipsoid used when not otherwise specified.
-   * @memberof Ellipsoid
    * @type {Ellipsoid}
    * @example
    * Cesium.Ellipsoid.default = Cesium.Ellipsoid.MOON;

--- a/packages/engine/Source/Core/GeographicProjection.js
+++ b/packages/engine/Source/Core/GeographicProjection.js
@@ -1,8 +1,12 @@
+// @ts-check
+
 import Cartesian3 from "./Cartesian3.js";
 import Cartographic from "./Cartographic.js";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 import Ellipsoid from "./Ellipsoid.js";
+
+/** @import MapProjection from "./MapProjection.js"; */
 
 /**
  * A simple map projection where longitude and latitude are linearly mapped to X and Y by multiplying
@@ -10,20 +14,20 @@ import Ellipsoid from "./Ellipsoid.js";
  * is commonly known as geographic, equirectangular, equidistant cylindrical, or plate carrée. When using the WGS84 ellipsoid, it
  * is also known as EPSG:4326.
  *
- * @alias GeographicProjection
- * @constructor
- *
- * @param {Ellipsoid} [ellipsoid=Ellipsoid.default] The ellipsoid.
- *
  * @see WebMercatorProjection
+ *
+ * @implements MapProjection
  */
-function GeographicProjection(ellipsoid) {
-  this._ellipsoid = ellipsoid ?? Ellipsoid.default;
-  this._semimajorAxis = this._ellipsoid.maximumRadius;
-  this._oneOverSemimajorAxis = 1.0 / this._semimajorAxis;
-}
+class GeographicProjection {
+  /**
+   * @param {Ellipsoid} [ellipsoid=Ellipsoid.default] The ellipsoid.
+   */
+  constructor(ellipsoid) {
+    this._ellipsoid = ellipsoid ?? Ellipsoid.default;
+    this._semimajorAxis = this._ellipsoid.maximumRadius;
+    this._oneOverSemimajorAxis = 1.0 / this._semimajorAxis;
+  }
 
-Object.defineProperties(GeographicProjection.prototype, {
   /**
    * Gets the {@link Ellipsoid}.
    *
@@ -32,74 +36,72 @@ Object.defineProperties(GeographicProjection.prototype, {
    * @type {Ellipsoid}
    * @readonly
    */
-  ellipsoid: {
-    get: function () {
-      return this._ellipsoid;
-    },
-  },
-});
-
-/**
- * Projects a set of {@link Cartographic} coordinates, in radians, to map coordinates, in meters.
- * X and Y are the longitude and latitude, respectively, multiplied by the maximum radius of the
- * ellipsoid.  Z is the unmodified height.
- *
- * @param {Cartographic} cartographic The coordinates to project.
- * @param {Cartesian3} [result] An instance into which to copy the result.  If this parameter is
- *        undefined, a new instance is created and returned.
- * @returns {Cartesian3} The projected coordinates.  If the result parameter is not undefined, the
- *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
- *          created and returned.
- */
-GeographicProjection.prototype.project = function (cartographic, result) {
-  // Actually this is the special case of equidistant cylindrical called the plate carree
-  const semimajorAxis = this._semimajorAxis;
-  const x = cartographic.longitude * semimajorAxis;
-  const y = cartographic.latitude * semimajorAxis;
-  const z = cartographic.height;
-
-  if (!defined(result)) {
-    return new Cartesian3(x, y, z);
+  get ellipsoid() {
+    return this._ellipsoid;
   }
 
-  result.x = x;
-  result.y = y;
-  result.z = z;
-  return result;
-};
+  /**
+   * Projects a set of {@link Cartographic} coordinates, in radians, to map coordinates, in meters.
+   * X and Y are the longitude and latitude, respectively, multiplied by the maximum radius of the
+   * ellipsoid.  Z is the unmodified height.
+   *
+   * @param {Cartographic} cartographic The coordinates to project.
+   * @param {Cartesian3} [result] An instance into which to copy the result.  If this parameter is
+   *        undefined, a new instance is created and returned.
+   * @returns {Cartesian3} The projected coordinates.  If the result parameter is not undefined, the
+   *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
+   *          created and returned.
+   */
+  project(cartographic, result) {
+    // Actually this is the special case of equidistant cylindrical called the plate carree
+    const semimajorAxis = this._semimajorAxis;
+    const x = cartographic.longitude * semimajorAxis;
+    const y = cartographic.latitude * semimajorAxis;
+    const z = cartographic.height;
 
-/**
- * Unprojects a set of projected {@link Cartesian3} coordinates, in meters, to {@link Cartographic}
- * coordinates, in radians.  Longitude and Latitude are the X and Y coordinates, respectively,
- * divided by the maximum radius of the ellipsoid.  Height is the unmodified Z coordinate.
- *
- * @param {Cartesian3} cartesian The Cartesian position to unproject with height (z) in meters.
- * @param {Cartographic} [result] An instance into which to copy the result.  If this parameter is
- *        undefined, a new instance is created and returned.
- * @returns {Cartographic} The unprojected coordinates.  If the result parameter is not undefined, the
- *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
- *          created and returned.
- */
-GeographicProjection.prototype.unproject = function (cartesian, result) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(cartesian)) {
-    throw new DeveloperError("cartesian is required");
-  }
-  //>>includeEnd('debug');
+    if (!defined(result)) {
+      return new Cartesian3(x, y, z);
+    }
 
-  const oneOverEarthSemimajorAxis = this._oneOverSemimajorAxis;
-  const longitude = cartesian.x * oneOverEarthSemimajorAxis;
-  const latitude = cartesian.y * oneOverEarthSemimajorAxis;
-  const height = cartesian.z;
-
-  if (!defined(result)) {
-    return new Cartographic(longitude, latitude, height);
+    result.x = x;
+    result.y = y;
+    result.z = z;
+    return result;
   }
 
-  result.longitude = longitude;
-  result.latitude = latitude;
-  result.height = height;
-  return result;
-};
+  /**
+   * Unprojects a set of projected {@link Cartesian3} coordinates, in meters, to {@link Cartographic}
+   * coordinates, in radians.  Longitude and Latitude are the X and Y coordinates, respectively,
+   * divided by the maximum radius of the ellipsoid.  Height is the unmodified Z coordinate.
+   *
+   * @param {Cartesian3} cartesian The Cartesian position to unproject with height (z) in meters.
+   * @param {Cartographic} [result] An instance into which to copy the result.  If this parameter is
+   *        undefined, a new instance is created and returned.
+   * @returns {Cartographic} The unprojected coordinates.  If the result parameter is not undefined, the
+   *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
+   *          created and returned.
+   */
+  unproject(cartesian, result) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(cartesian)) {
+      throw new DeveloperError("cartesian is required");
+    }
+    //>>includeEnd('debug');
+
+    const oneOverEarthSemimajorAxis = this._oneOverSemimajorAxis;
+    const longitude = cartesian.x * oneOverEarthSemimajorAxis;
+    const latitude = cartesian.y * oneOverEarthSemimajorAxis;
+    const height = cartesian.z;
+
+    if (!defined(result)) {
+      return new Cartographic(longitude, latitude, height);
+    }
+
+    result.longitude = longitude;
+    result.latitude = latitude;
+    result.height = height;
+    return result;
+  }
+}
 
 export default GeographicProjection;

--- a/packages/engine/Source/Core/GeographicProjection.js
+++ b/packages/engine/Source/Core/GeographicProjection.js
@@ -31,8 +31,6 @@ class GeographicProjection {
   /**
    * Gets the {@link Ellipsoid}.
    *
-   * @memberof GeographicProjection.prototype
-   *
    * @type {Ellipsoid}
    * @readonly
    */

--- a/packages/engine/Source/Core/MapProjection.js
+++ b/packages/engine/Source/Core/MapProjection.js
@@ -1,62 +1,59 @@
+// @ts-check
+
 import DeveloperError from "./DeveloperError.js";
+
+/** @import Cartesian3 from "./Cartesian3.js"; */
+/** @import Cartographic from "./Cartographic.js"; */
+/** @import Ellipsoid from "./Ellipsoid.js"; */
 
 /**
  * Defines how geodetic ellipsoid coordinates ({@link Cartographic}) project to a
  * flat map like Cesium's 2D and Columbus View modes.
  *
- * @alias MapProjection
- * @constructor
  * @abstract
  *
  * @see GeographicProjection
  * @see WebMercatorProjection
+ *
+ * @interface
  */
-function MapProjection() {
-  DeveloperError.throwInstantiationError();
-}
-
-Object.defineProperties(MapProjection.prototype, {
+class MapProjection {
   /**
    * Gets the {@link Ellipsoid}.
-   *
-   * @memberof MapProjection.prototype
    *
    * @type {Ellipsoid}
    * @readonly
    */
-  ellipsoid: {
-    get: DeveloperError.throwInstantiationError,
-  },
-});
+  ellipsoid;
 
-/**
- * Projects {@link Cartographic} coordinates, in radians, to projection-specific map coordinates, in meters.
- *
- * @memberof MapProjection
- * @function
- *
- * @param {Cartographic} cartographic The coordinates to project.
- * @param {Cartesian3} [result] An instance into which to copy the result.  If this parameter is
- *        undefined, a new instance is created and returned.
- * @returns {Cartesian3} The projected coordinates.  If the result parameter is not undefined, the
- *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
- *          created and returned.
- */
-MapProjection.prototype.project = DeveloperError.throwInstantiationError;
+  /**
+   * Projects {@link Cartographic} coordinates, in radians, to projection-specific map coordinates, in meters.
+   *
+   * @param {Cartographic} cartographic The coordinates to project.
+   * @param {Cartesian3} [result] An instance into which to copy the result.  If this parameter is
+   *        undefined, a new instance is created and returned.
+   * @returns {Cartesian3} The projected coordinates.  If the result parameter is not undefined, the
+   *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
+   *          created and returned.
+   */
+  project(cartographic, result) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Unprojects projection-specific map {@link Cartesian3} coordinates, in meters, to {@link Cartographic}
- * coordinates, in radians.
- *
- * @memberof MapProjection
- * @function
- *
- * @param {Cartesian3} cartesian The Cartesian position to unproject with height (z) in meters.
- * @param {Cartographic} [result] An instance into which to copy the result.  If this parameter is
- *        undefined, a new instance is created and returned.
- * @returns {Cartographic} The unprojected coordinates.  If the result parameter is not undefined, the
- *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
- *          created and returned.
- */
-MapProjection.prototype.unproject = DeveloperError.throwInstantiationError;
+  /**
+   * Unprojects projection-specific map {@link Cartesian3} coordinates, in meters, to {@link Cartographic}
+   * coordinates, in radians.
+   *
+   * @param {Cartesian3} cartesian The Cartesian position to unproject with height (z) in meters.
+   * @param {Cartographic} [result] An instance into which to copy the result.  If this parameter is
+   *        undefined, a new instance is created and returned.
+   * @returns {Cartographic} The unprojected coordinates.  If the result parameter is not undefined, the
+   *          coordinates are copied there and that instance is returned.  Otherwise, a new instance is
+   *          created and returned.
+   */
+  unproject(cartesian, result) {
+    DeveloperError.throwInstantiationError();
+  }
+}
+
 export default MapProjection;

--- a/packages/engine/Source/Core/MapProjection.js
+++ b/packages/engine/Source/Core/MapProjection.js
@@ -10,8 +10,6 @@ import DeveloperError from "./DeveloperError.js";
  * Defines how geodetic ellipsoid coordinates ({@link Cartographic}) project to a
  * flat map like Cesium's 2D and Columbus View modes.
  *
- * @abstract
- *
  * @see GeographicProjection
  * @see WebMercatorProjection
  *

--- a/packages/engine/Source/Core/WebMercatorProjection.js
+++ b/packages/engine/Source/Core/WebMercatorProjection.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import Cartesian3 from "./Cartesian3.js";
 import Cartographic from "./Cartographic.js";
 import defined from "./defined.js";
@@ -5,25 +7,27 @@ import DeveloperError from "./DeveloperError.js";
 import Ellipsoid from "./Ellipsoid.js";
 import CesiumMath from "./Math.js";
 
+/** @import MapProjection from "./MapProjection.js"; */
+
 /**
  * The map projection used by Google Maps, Bing Maps, and most of ArcGIS Online, EPSG:3857.  This
  * projection use longitude and latitude expressed with the WGS84 and transforms them to Mercator using
  * the spherical (rather than ellipsoidal) equations.
  *
- * @alias WebMercatorProjection
- * @constructor
- *
- * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid.
- *
  * @see GeographicProjection
+ *
+ * @implements MapProjection
  */
-function WebMercatorProjection(ellipsoid) {
-  this._ellipsoid = ellipsoid ?? Ellipsoid.WGS84;
-  this._semimajorAxis = this._ellipsoid.maximumRadius;
-  this._oneOverSemimajorAxis = 1.0 / this._semimajorAxis;
-}
+class WebMercatorProjection {
+  /**
+   * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid.
+   */
+  constructor(ellipsoid) {
+    this._ellipsoid = ellipsoid ?? Ellipsoid.WGS84;
+    this._semimajorAxis = this._ellipsoid.maximumRadius;
+    this._oneOverSemimajorAxis = 1.0 / this._semimajorAxis;
+  }
 
-Object.defineProperties(WebMercatorProjection.prototype, {
   /**
    * Gets the {@link Ellipsoid}.
    *
@@ -32,43 +36,102 @@ Object.defineProperties(WebMercatorProjection.prototype, {
    * @type {Ellipsoid}
    * @readonly
    */
-  ellipsoid: {
-    get: function () {
-      return this._ellipsoid;
-    },
-  },
-});
-
-/**
- * Converts a Mercator angle, in the range -PI to PI, to a geodetic latitude
- * in the range -PI/2 to PI/2.
- *
- * @param {number} mercatorAngle The angle to convert.
- * @returns {number} The geodetic latitude in radians.
- */
-WebMercatorProjection.mercatorAngleToGeodeticLatitude = function (
-  mercatorAngle,
-) {
-  return CesiumMath.PI_OVER_TWO - 2.0 * Math.atan(Math.exp(-mercatorAngle));
-};
-
-/**
- * Converts a geodetic latitude in radians, in the range -PI/2 to PI/2, to a Mercator
- * angle in the range -PI to PI.
- *
- * @param {number} latitude The geodetic latitude in radians.
- * @returns {number} The Mercator angle.
- */
-WebMercatorProjection.geodeticLatitudeToMercatorAngle = function (latitude) {
-  // Clamp the latitude coordinate to the valid Mercator bounds.
-  if (latitude > WebMercatorProjection.MaximumLatitude) {
-    latitude = WebMercatorProjection.MaximumLatitude;
-  } else if (latitude < -WebMercatorProjection.MaximumLatitude) {
-    latitude = -WebMercatorProjection.MaximumLatitude;
+  get ellipsoid() {
+    return this._ellipsoid;
   }
-  const sinLatitude = Math.sin(latitude);
-  return 0.5 * Math.log((1.0 + sinLatitude) / (1.0 - sinLatitude));
-};
+
+  /**
+   * Converts a Mercator angle, in the range -PI to PI, to a geodetic latitude
+   * in the range -PI/2 to PI/2.
+   *
+   * @param {number} mercatorAngle The angle to convert.
+   * @returns {number} The geodetic latitude in radians.
+   */
+  static mercatorAngleToGeodeticLatitude(mercatorAngle) {
+    return CesiumMath.PI_OVER_TWO - 2.0 * Math.atan(Math.exp(-mercatorAngle));
+  }
+
+  /**
+   * Converts a geodetic latitude in radians, in the range -PI/2 to PI/2, to a Mercator
+   * angle in the range -PI to PI.
+   *
+   * @param {number} latitude The geodetic latitude in radians.
+   * @returns {number} The Mercator angle.
+   */
+  static geodeticLatitudeToMercatorAngle(latitude) {
+    // Clamp the latitude coordinate to the valid Mercator bounds.
+    if (latitude > WebMercatorProjection.MaximumLatitude) {
+      latitude = WebMercatorProjection.MaximumLatitude;
+    } else if (latitude < -WebMercatorProjection.MaximumLatitude) {
+      latitude = -WebMercatorProjection.MaximumLatitude;
+    }
+    const sinLatitude = Math.sin(latitude);
+    return 0.5 * Math.log((1.0 + sinLatitude) / (1.0 - sinLatitude));
+  }
+
+  /**
+   * Converts geodetic ellipsoid coordinates, in radians, to the equivalent Web Mercator
+   * X, Y, Z coordinates expressed in meters and returned in a {@link Cartesian3}.  The height
+   * is copied unmodified to the Z coordinate.
+   *
+   * @param {Cartographic} cartographic The cartographic coordinates in radians.
+   * @param {Cartesian3} [result] The instance to which to copy the result, or undefined if a
+   *        new instance should be created.
+   * @returns {Cartesian3} The equivalent web mercator X, Y, Z coordinates, in meters.
+   */
+  project(cartographic, result) {
+    const semimajorAxis = this._semimajorAxis;
+    const x = cartographic.longitude * semimajorAxis;
+    const y =
+      WebMercatorProjection.geodeticLatitudeToMercatorAngle(
+        cartographic.latitude,
+      ) * semimajorAxis;
+    const z = cartographic.height;
+
+    if (!defined(result)) {
+      return new Cartesian3(x, y, z);
+    }
+
+    result.x = x;
+    result.y = y;
+    result.z = z;
+    return result;
+  }
+
+  /**
+   * Converts Web Mercator X, Y coordinates, expressed in meters, to a {@link Cartographic}
+   * containing geodetic ellipsoid coordinates.  The Z coordinate is copied unmodified to the
+   * height.
+   *
+   * @param {Cartesian3} cartesian The web mercator Cartesian position to unrproject with height (z) in meters.
+   * @param {Cartographic} [result] The instance to which to copy the result, or undefined if a
+   *        new instance should be created.
+   * @returns {Cartographic} The equivalent cartographic coordinates.
+   */
+  unproject(cartesian, result) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(cartesian)) {
+      throw new DeveloperError("cartesian is required");
+    }
+    //>>includeEnd('debug');
+
+    const oneOverEarthSemimajorAxis = this._oneOverSemimajorAxis;
+    const longitude = cartesian.x * oneOverEarthSemimajorAxis;
+    const latitude = WebMercatorProjection.mercatorAngleToGeodeticLatitude(
+      cartesian.y * oneOverEarthSemimajorAxis,
+    );
+    const height = cartesian.z;
+
+    if (!defined(result)) {
+      return new Cartographic(longitude, latitude, height);
+    }
+
+    result.longitude = longitude;
+    result.latitude = latitude;
+    result.height = height;
+    return result;
+  }
+}
 
 /**
  * The maximum latitude (both North and South) supported by a Web Mercator
@@ -87,66 +150,4 @@ WebMercatorProjection.geodeticLatitudeToMercatorAngle = function (latitude) {
 WebMercatorProjection.MaximumLatitude =
   WebMercatorProjection.mercatorAngleToGeodeticLatitude(Math.PI);
 
-/**
- * Converts geodetic ellipsoid coordinates, in radians, to the equivalent Web Mercator
- * X, Y, Z coordinates expressed in meters and returned in a {@link Cartesian3}.  The height
- * is copied unmodified to the Z coordinate.
- *
- * @param {Cartographic} cartographic The cartographic coordinates in radians.
- * @param {Cartesian3} [result] The instance to which to copy the result, or undefined if a
- *        new instance should be created.
- * @returns {Cartesian3} The equivalent web mercator X, Y, Z coordinates, in meters.
- */
-WebMercatorProjection.prototype.project = function (cartographic, result) {
-  const semimajorAxis = this._semimajorAxis;
-  const x = cartographic.longitude * semimajorAxis;
-  const y =
-    WebMercatorProjection.geodeticLatitudeToMercatorAngle(
-      cartographic.latitude,
-    ) * semimajorAxis;
-  const z = cartographic.height;
-
-  if (!defined(result)) {
-    return new Cartesian3(x, y, z);
-  }
-
-  result.x = x;
-  result.y = y;
-  result.z = z;
-  return result;
-};
-
-/**
- * Converts Web Mercator X, Y coordinates, expressed in meters, to a {@link Cartographic}
- * containing geodetic ellipsoid coordinates.  The Z coordinate is copied unmodified to the
- * height.
- *
- * @param {Cartesian3} cartesian The web mercator Cartesian position to unrproject with height (z) in meters.
- * @param {Cartographic} [result] The instance to which to copy the result, or undefined if a
- *        new instance should be created.
- * @returns {Cartographic} The equivalent cartographic coordinates.
- */
-WebMercatorProjection.prototype.unproject = function (cartesian, result) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(cartesian)) {
-    throw new DeveloperError("cartesian is required");
-  }
-  //>>includeEnd('debug');
-
-  const oneOverEarthSemimajorAxis = this._oneOverSemimajorAxis;
-  const longitude = cartesian.x * oneOverEarthSemimajorAxis;
-  const latitude = WebMercatorProjection.mercatorAngleToGeodeticLatitude(
-    cartesian.y * oneOverEarthSemimajorAxis,
-  );
-  const height = cartesian.z;
-
-  if (!defined(result)) {
-    return new Cartographic(longitude, latitude, height);
-  }
-
-  result.longitude = longitude;
-  result.latitude = latitude;
-  result.height = height;
-  return result;
-};
 export default WebMercatorProjection;

--- a/packages/engine/Source/Core/WebMercatorProjection.js
+++ b/packages/engine/Source/Core/WebMercatorProjection.js
@@ -31,8 +31,6 @@ class WebMercatorProjection {
   /**
    * Gets the {@link Ellipsoid}.
    *
-   * @memberof WebMercatorProjection.prototype
-   *
    * @type {Ellipsoid}
    * @readonly
    */


### PR DESCRIPTION
# Description

ES6 class conversions and type checking:

- Cartographic.js
- Ellipsoid.js
- MapProjection.js
- WebMercatorProjection.js
- GeographicProjection.js

I think this is the first example where we're defining and implementing an interface (MapProjection) and enforcing implementation compatibility with that interface using TypeScript, so there are some new-ish pieces in the migration here.

## Issue number and link

- #4434 
- #8359

## Testing plan

- `npm run tsc` should pass
- `npm run build-ts` should pass
- `npm run sg-scan` should pass (pending #13377)
- unit tests should pass
- confirm a few relevant sandcastles work as expected

<details>
<summary>Diff on `Cesium.d.ts`</summary>

```diff
diff --git a/Source/Cesium.main.d.ts b/Source/Cesium.d.ts
index 1b6118d40b..ad9d33e123 100644
--- a/Source/Cesium.main.d.ts
+++ b/Source/Cesium.d.ts
@@ -2685,10 +2685,6 @@ export class Cartographic {
      * @returns <code>true</code> if left and right are within the provided epsilon, <code>false</code> otherwise.
      */
     static equalsEpsilon(left?: Cartographic, right?: Cartographic, epsilon?: number): boolean;
-    /**
-     * An immutable Cartographic instance initialized to (0.0, 0.0, 0.0).
-     */
-    static readonly ZERO: Cartographic;
     /**
      * Duplicates this instance.
      * @param [result] - The object onto which to store the result.
@@ -2716,6 +2712,10 @@ export class Cartographic {
      * @returns A string representing the provided cartographic in the format '(longitude, latitude, height)'.
      */
     toString(): string;
+    /**
+     * An immutable Cartographic instance initialized to (0.0, 0.0, 0.0).
+     */
+    static readonly ZERO: Cartographic;
 }
 
 /**
@@ -6040,23 +6040,6 @@ export class Ellipsoid {
      * @returns A new Ellipsoid instance.
      */
     static fromCartesian3(cartesian?: Cartesian3, result?: Ellipsoid): Ellipsoid;
-    /**
-     * An Ellipsoid instance initialized to the WGS84 standard.
-     */
-    static readonly WGS84: Ellipsoid;
-    /**
-     * An Ellipsoid instance initialized to radii of (1.0, 1.0, 1.0).
-     */
-    static readonly UNIT_SPHERE: Ellipsoid;
-    /**
-     * An Ellipsoid instance initialized to a sphere with the lunar radius.
-     */
-    static readonly MOON: Ellipsoid;
-    /**
-     * An Ellipsoid instance initialized to a sphere with the mean radii of Mars.
-     * Source: https://epsg.io/104905
-     */
-    static readonly MARS: Ellipsoid;
     /**
      * The default ellipsoid used when not otherwise specified.
      * @example
@@ -6076,10 +6059,6 @@ export class Ellipsoid {
      * @returns The cloned Ellipsoid.
      */
     clone(result?: Ellipsoid): Ellipsoid;
-    /**
-     * The number of elements used to pack the object into an array.
-     */
-    static packedLength: number;
     /**
      * Stores the provided instance into the provided array.
      * @param value - The value to pack.
@@ -6096,13 +6075,6 @@ export class Ellipsoid {
      * @returns The modified result parameter or a new Ellipsoid instance if one was not provided.
      */
     static unpack(array: number[], startingIndex?: number, result?: Ellipsoid): Ellipsoid;
-    /**
-     * Computes the unit vector directed from the center of this ellipsoid toward the provided Cartesian position.
-     * @param cartesian - The Cartesian for which to to determine the geocentric normal.
-     * @param [result] - The object onto which to store the result.
-     * @returns The modified result parameter or a new Cartesian3 instance if none was provided.
-     */
-    geocentricSurfaceNormal(cartesian: Cartesian3, result?: Cartesian3): Cartesian3;
     /**
      * Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
      * @param cartographic - The cartographic position for which to to determine the geodetic normal.
@@ -6241,6 +6213,34 @@ export class Ellipsoid {
      * @returns The approximate area of the rectangle on the surface of this ellipsoid.
      */
     surfaceArea(rectangle: Rectangle): number;
+    /**
+     * An Ellipsoid instance initialized to the WGS84 standard.
+     */
+    static readonly WGS84: Ellipsoid;
+    /**
+     * An Ellipsoid instance initialized to radii of (1.0, 1.0, 1.0).
+     */
+    static readonly UNIT_SPHERE: Ellipsoid;
+    /**
+     * An Ellipsoid instance initialized to a sphere with the lunar radius.
+     */
+    static readonly MOON: Ellipsoid;
+    /**
+     * An Ellipsoid instance initialized to a sphere with the mean radii of Mars.
+     * Source: https://epsg.io/104905
+     */
+    static readonly MARS: Ellipsoid;
+    /**
+     * The number of elements used to pack the object into an array.
+     */
+    static packedLength: number;
+    /**
+     * Computes the unit vector directed from the center of this ellipsoid toward the provided Cartesian position.
+     * @param cartesian - The Cartesian for which to to determine the geocentric normal.
+     * @param [result] - The object onto which to store the result.
+     * @returns The modified result parameter or a new Cartesian3 instance if none was provided.
+     */
+    geocentricSurfaceNormal(cartesian: Cartesian3, result?: Cartesian3): Cartesian3;
 }
 
 /**
@@ -7034,6 +7034,9 @@ export class GeocoderService {
     geocode(query: string, type?: GeocodeType): Promise<GeocoderService.Result[]>;
 }
 
+export interface GeographicProjection extends MapProjection {
+}
+
 /**
  * A simple map projection where longitude and latitude are linearly mapped to X and Y by multiplying
  * them by the {@link Ellipsoid#maximumRadius}.  This projection
@@ -7041,7 +7044,7 @@ export class GeocoderService {
  * is also known as EPSG:4326.
  * @param [ellipsoid = Ellipsoid.default] - The ellipsoid.
  */
-export class GeographicProjection {
+export class GeographicProjection implements MapProjection {
     constructor(ellipsoid?: Ellipsoid);
     /**
      * Gets the {@link Ellipsoid}.
@@ -9562,12 +9565,11 @@ export class LinearSpline {
  * Defines how geodetic ellipsoid coordinates ({@link Cartographic}) project to a
  * flat map like Cesium's 2D and Columbus View modes.
  */
-export class MapProjection {
-    constructor();
+export interface MapProjection {
     /**
      * Gets the {@link Ellipsoid}.
      */
-    readonly ellipsoid: Ellipsoid;
+    ellipsoid: Ellipsoid;
     /**
      * Projects {@link Cartographic} coordinates, in radians, to projection-specific map coordinates, in meters.
      * @param cartographic - The coordinates to project.
@@ -18467,13 +18469,16 @@ export class WallOutlineGeometry {
     static createGeometry(wallGeometry: WallOutlineGeometry): Geometry | undefined;
 }
 
+export interface WebMercatorProjection extends MapProjection {
+}
+
 /**
  * The map projection used by Google Maps, Bing Maps, and most of ArcGIS Online, EPSG:3857.  This
  * projection use longitude and latitude expressed with the WGS84 and transforms them to Mercator using
  * the spherical (rather than ellipsoidal) equations.
  * @param [ellipsoid = Ellipsoid.WGS84] - The ellipsoid.
  */
-export class WebMercatorProjection {
+export class WebMercatorProjection implements MapProjection {
     constructor(ellipsoid?: Ellipsoid);
     /**
      * Gets the {@link Ellipsoid}.
@@ -18493,19 +18498,6 @@ export class WebMercatorProjection {
      * @returns The Mercator angle.
      */
     static geodeticLatitudeToMercatorAngle(latitude: number): number;
-    /**
-     * The maximum latitude (both North and South) supported by a Web Mercator
-     * (EPSG:3857) projection.  Technically, the Mercator projection is defined
-     * for any latitude up to (but not including) 90 degrees, but it makes sense
-     * to cut it off sooner because it grows exponentially with increasing latitude.
-     * The logic behind this particular cutoff value, which is the one used by
-     * Google Maps, Bing Maps, and Esri, is that it makes the projection
-     * square.  That is, the rectangle is equal in the X and Y directions.
-     *
-     * The constant value is computed by calling:
-     *    WebMercatorProjection.mercatorAngleToGeodeticLatitude(Math.PI)
-     */
-    static MaximumLatitude: number;
     /**
      * Converts geodetic ellipsoid coordinates, in radians, to the equivalent Web Mercator
      * X, Y, Z coordinates expressed in meters and returned in a {@link Cartesian3}.  The height
@@ -18526,6 +18518,19 @@ export class WebMercatorProjection {
      * @returns The equivalent cartographic coordinates.
      */
     unproject(cartesian: Cartesian3, result?: Cartographic): Cartographic;
+    /**
+     * The maximum latitude (both North and South) supported by a Web Mercator
+     * (EPSG:3857) projection.  Technically, the Mercator projection is defined
+     * for any latitude up to (but not including) 90 degrees, but it makes sense
+     * to cut it off sooner because it grows exponentially with increasing latitude.
+     * The logic behind this particular cutoff value, which is the one used by
+     * Google Maps, Bing Maps, and Esri, is that it makes the projection
+     * square.  That is, the rectangle is equal in the X and Y directions.
+     *
+     * The constant value is computed by calling:
+     *    WebMercatorProjection.mercatorAngleToGeodeticLatitude(Math.PI)
+     */
+    static MaximumLatitude: number;
 }
 
 /**

```

</details>

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [ ] ~~I have updated the inline documentation, and included code examples where relevant~~
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13390** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)