### PR TITLE
Print warning about outlines only when imagery is present

### DIFF
--- a/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
+++ b/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
@@ -214,7 +214,8 @@ ModelRuntimePrimitive.prototype.configurePipeline = function (frameState) {
   // Check whether the model is part of a `Model3DTileContent` that
   // belongs to a tileset that has imagery layers. If this is the
   // case, then the `ImageryPipelineStage` will be required.
-  const hasImageryLayers = defined(model.imageryLayers);
+  const hasImageryLayers =
+    defined(model.imageryLayers) && model.imageryLayers.length > 0;
 
   const hasCustomShader = defined(customShader);
   const hasCustomFragmentShader =


### PR DESCRIPTION
# Description

When loading a tileset that uses outline rendering, then it printed the one-time warning message

> Primitive outlines disable imagery draping

This was printed even when the tileset did not use draping (i.e. when it did not have imagery layers associated with it). The message was emitted [from here](https://github.com/CesiumGS/cesium/blob/e4ee58166a05bbb5a3e578c40ce2bb54e1d9948b/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js#L288) because the `hasImageryLayers` only checked for the _definedness_ of the imagery layers, and not whether they actually had a size > 0. (This was an oversight from the change that was [requested in this review comment](https://github.com/CesiumGS/cesium/pull/12567#discussion_r2054578041)).

The change here simply adds a check for `model.imageryLayers.length > 0;`

## Testing plan

- Open the [OSM Buildings Sandcastle](https://sandcastle.cesium.com/index.html?id=cesium-osm-buildings) that is currently deployed. It will show the message. 
- Open the [CI build of the OSM Buildings Sandcaste](https://ci-builds.cesium.com/cesium/fix-outline-draping-warning/Apps/Sandcastle2/index.html#c=dVFNb9NAEP0rI59c5K6TUqgKbgSEI6gSRPTiy3Y9aUasd6OZcaKA+t9Z2zGkarlYnrfvY98stdvICq/ACixRqGthzbGFOnPDVGfv61AHF4Mo7Aj3yHADAfdHtvkxYPnEX8aglgJynRXwuw4AiswJeTcJVuNs+pi7yL45AvlZUYfHs5O4KO2njnxD4UFW5FFQU7bdW9LJzDFaxdsT4kc5BJf3NuNtjTgMaLZMLSntUIxtmvwF6zH5icjZFtmatT+sYj6UaVCUglWK/wotLWv6s+H10OkzPjCi5OdXl2Y2vy7gcmbeXs8vCrh6M+s7AkQmTGsaXQZfgA3a/jZ/Xb9a3RiN3xJqg+QXRynAltRt/kc7n3iPw7fp+Jgym5abFVklevC46AkfaHz/jn1uTKnYbn1aqJT3nfuJapxIL6rKSVI1tANqbl54b3DeiqSTdef9d/qFdbaoysR/IvNx6Hm7Q/b20FM288WXETTGVGUan6s0Rn9v+cTxDw). It will _not_ show the message
- Open the [CI build of the OSM Buildings Sandcastle **with** an imagery layer](https://ci-builds.cesium.com/cesium/fix-outline-draping-warning/Apps/Sandcastle2/index.html#c=dVJNb9pAEP0rI59MRdaY0Ea0BjWhl0iJUjWovfiy2AMedb2LZtcgt8p/73qNU6rQi+V9fh/zvEP13rCDdyAtrNBSU8OWTQ15VIRTHn3Kda4Lo62DA+ERGRag8Xhii+8Biwf+ymgnSSPn0Rh+5xrAIbNHPg6CdX8WXcwPw6o8AfFonOuX0VmcsfVdQ6okvbNrUmjR+Wx5lOQGs4JROnw6I97aVhdxb5MksAoEcBUC1XKH3IKSrS+xNQx3XgCPcm8hVnKDyoLRqh0N+QG771UPQbQYcs/R0OQrmwOVyH1813tgGn0iD5TAv7W+zX0ZT2dpej1Pu+7dzBcqCzrLskKWZfxmsL5ufz3CFqhR7JlqcnTAXnLB+IKokDWyFFvVrk0cbq9E60hLR+bvDa4kO/8m9XWo8gV3jGjjq5uZmKTzMcwm4sM8nY7h5v2kKwZgmNDvRe8SfAEqlN00r66P0lXCmW8eldrG05MUYE+uqP5Huxp4L+FZNnxKmQzbFI2jzLpW4bIjfKZ+4RtWsRCJw3qv/ILYZNMUP/3PLqztRFkySLKSDkDl4sKCQ6Gktf7LtlHqmX5hHi2zxPP/kSkTej4dkP3mdZQqXT70oBAiS/zxrcoZozaSzxz/AA). It will show the message.
 

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] **n/a** I have updated `CHANGES.md` with a short summary of my change
- [ ] **n/a** I have added or updated unit tests to ensure consistent code coverage
- [ ] **n/a** I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

