### PR TITLE
Half edge mesh

### DIFF
--- a/packages/edit/README.md
+++ b/packages/edit/README.md
@@ -8,7 +8,7 @@
 
 [CesiumJS](../../README.md) is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin. It uses WebGL for hardware-accelerated graphics, and is cross-platform, cross-browser, and tuned for dynamic-data visualization.
 
-`@cesium/edit` is the experimental package scaffold for future editing APIs built on top of `@cesium/engine`.
+`@cesium/edit` provides experimental editing APIs built on top of `@cesium/engine`, including interfaces and infrastructure for model-editing workflows.
 
 ---
 
@@ -33,6 +33,12 @@ yarn add @cesium/edit
 ```
 
 ## Usage
+
+Import individual modules to benefit from tree shaking optimizations through most build tools:
+
+```js
+import { EditableMesh } from "@cesium/edit";
+```
 
 The APIs in this package are experimental and are expected to evolve as CesiumJS editing workflows expand.
 

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -25,18 +25,26 @@ class Edge {
   }
 
   /**
-   * Returns the vertices that are incident to this edge.
+   * Returns the vertices that compose this edge.
    * @returns {Vertex[]}
    */
-  lower() {
+  vertices() {
     return [this._halfEdge.vertex, this._halfEdge.next.vertex];
+  }
+
+  /**
+   * MeshComponent method to return the edges that are part of this component. For an edge, this is just itself.
+   * @returns {Edge[]}
+   */
+  edges() {
+    return [this];
   }
 
   /**
    * Returns the faces that are incident to this edge.
    * @returns {Face[]}
    */
-  upper() {
+  faces() {
     const faces = [];
     if (this._halfEdge.face) {
       faces.push(this._halfEdge.face);

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -1,6 +1,6 @@
-/** @import { Cartesian3 } from "@cesium/engine"; */
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
+/** @import Face from "./Face"; */
 /** @import Vertex from "./Vertex"; */
 
 /**
@@ -25,11 +25,26 @@ class Edge {
   }
 
   /**
-   * Returns the vertices that compose this component. For an edge, this is the two vertices at its endpoints.
+   * Returns the vertices that are incident to this edge.
    * @returns {Vertex[]}
    */
-  vertices() {
+  lower() {
     return [this._halfEdge.vertex, this._halfEdge.next.vertex];
+  }
+
+  /**
+   * Returns the faces that are incident to this edge.
+   * @returns {Face[]}
+   */
+  upper() {
+    const faces = [];
+    if (this._halfEdge.face) {
+      faces.push(this._halfEdge.face);
+    }
+    if (this._halfEdge.twin.face) {
+      faces.push(this._halfEdge.twin.face);
+    }
+    return faces;
   }
 }
 

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -29,7 +29,7 @@ class Edge {
    * @returns {Vertex[]}
    */
   vertices() {
-    return [this._halfEdge.vertex, this._halfEdge.twin.vertex];
+    return [this._halfEdge.vertex, this._halfEdge.next.vertex];
   }
 }
 

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -26,33 +26,38 @@ class Edge {
 
   /**
    * Returns the vertices that compose this edge.
+   * @param {Vertex[]} result Destination array.
    * @returns {Vertex[]}
    */
-  vertices() {
-    return [this._halfEdge.vertex, this._halfEdge.next.vertex];
+  vertices(result) {
+    result.push(this._halfEdge.vertex);
+    result.push(this._halfEdge.next.vertex);
+    return result;
   }
 
   /**
    * MeshComponent method to return the edges that are part of this component. For an edge, this is just itself.
+   * @param {Edge[]} result Destination array.
    * @returns {Edge[]}
    */
-  edges() {
-    return [this];
+  edges(result) {
+    result.push(this);
+    return result;
   }
 
   /**
    * Returns the faces that are incident to this edge.
+   * @param {Face[]} result Destination array.
    * @returns {Face[]}
    */
-  faces() {
-    const faces = [];
+  faces(result) {
     if (this._halfEdge.face) {
-      faces.push(this._halfEdge.face);
+      result.push(this._halfEdge.face);
     }
     if (this._halfEdge.twin.face) {
-      faces.push(this._halfEdge.twin.face);
+      result.push(this._halfEdge.twin.face);
     }
-    return faces;
+    return result;
   }
 }
 

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -22,12 +22,6 @@ class Edge {
   get halfEdge() {
     return this._halfEdge;
   }
-
-  /**
-   * Move the edge to a new position.
-   * @param {Cartesian3} newPosition
-   */
-  move(newPosition) {}
 }
 
 export default Edge;

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -1,0 +1,13 @@
+import MeshComponent from "./MeshComponent.js";
+
+/**
+ * Edge record for an EditableMesh.
+ *
+ * @alias Edge
+ * @constructor
+ *
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class Edge extends MeshComponent {}
+
+export default Edge;

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -25,6 +25,26 @@ class Edge {
   }
 
   /**
+   * Returns the endpoint vertices of this edge. Equivalent to
+   * {@link Edge#vertices}.
+   * @param {Vertex[]} result Destination array.
+   * @returns {Vertex[]}
+   */
+  lower(result) {
+    return this.vertices(result);
+  }
+
+  /**
+   * Returns the faces incident to this edge. Equivalent to
+   * {@link Edge#faces}.
+   * @param {Face[]} result Destination array.
+   * @returns {Face[]}
+   */
+  upper(result) {
+    return this.faces(result);
+  }
+
+  /**
    * Returns the vertices that compose this edge.
    * @param {Vertex[]} result Destination array.
    * @returns {Vertex[]}
@@ -32,16 +52,6 @@ class Edge {
   vertices(result) {
     result.push(this._halfEdge.vertex);
     result.push(this._halfEdge.next.vertex);
-    return result;
-  }
-
-  /**
-   * MeshComponent method to return the edges that are part of this component. For an edge, this is just itself.
-   * @param {Edge[]} result Destination array.
-   * @returns {Edge[]}
-   */
-  edges(result) {
-    result.push(this);
     return result;
   }
 

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -1,3 +1,7 @@
+/** @import { Cartesian3 } from "@cesium/engine"; */
+/** @import HalfEdge from "./HalfEdge"; */
+/** @import MeshComponent from "./MeshComponent"; */
+
 /**
  * Edge record for an EditableMesh.
  * Unlike a HalfEdge, an Edge is purely topological - containing data specific to the edge itself, not its relationship to other components.
@@ -7,7 +11,10 @@
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
 class Edge {
-  // Accepts a canonical half-edge from the pair of half-edges that make up this edge.
+  /**
+   * Accepts a canonical half-edge from the pair of half-edges that make up this edge.
+   * @param {HalfEdge} halfEdge
+   */
   constructor(halfEdge) {
     this._halfEdge = halfEdge;
   }
@@ -16,6 +23,10 @@ class Edge {
     return this._halfEdge;
   }
 
+  /**
+   * Move the edge to a new position.
+   * @param {Cartesian3} newPosition
+   */
   move(newPosition) {}
 }
 

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -1,6 +1,7 @@
 /** @import { Cartesian3 } from "@cesium/engine"; */
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
+/** @import Vertex from "./Vertex"; */
 
 /**
  * Edge record for an EditableMesh.
@@ -21,6 +22,14 @@ class Edge {
 
   get halfEdge() {
     return this._halfEdge;
+  }
+
+  /**
+   * Returns the vertices that compose this component. For an edge, this is the two vertices at its endpoints.
+   * @returns {Vertex[]}
+   */
+  vertices() {
+    return [this._halfEdge.vertex, this._halfEdge.twin.vertex];
   }
 }
 

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -1,13 +1,22 @@
-import MeshComponent from "./MeshComponent.js";
-
 /**
  * Edge record for an EditableMesh.
+ * Unlike a HalfEdge, an Edge is purely topological - containing data specific to the edge itself, not its relationship to other components.
+ * For example, an Edge may contain selection state or a crease flag. This pertains to both HalfEdges in the pair, so it makes sense to have a single Edge record for both.
  *
- * @alias Edge
- * @constructor
- *
+ * @implements MeshComponent
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class Edge extends MeshComponent {}
+class Edge {
+  // Accepts a canonical half-edge from the pair of half-edges that make up this edge.
+  constructor(halfEdge) {
+    this._halfEdge = halfEdge;
+  }
+
+  get halfEdge() {
+    return this._halfEdge;
+  }
+
+  move(newPosition) {}
+}
 
 export default Edge;

--- a/packages/edit/Source/Mesh/Edge.js
+++ b/packages/edit/Source/Mesh/Edge.js
@@ -1,22 +1,24 @@
 /** @import HalfEdge from "./HalfEdge"; */
-/** @import MeshComponent from "./MeshComponent"; */
 /** @import Face from "./Face"; */
 /** @import Vertex from "./Vertex"; */
+
+import MeshComponent from "./MeshComponent";
 
 /**
  * Edge record for an EditableMesh.
  * Unlike a HalfEdge, an Edge is purely topological - containing data specific to the edge itself, not its relationship to other components.
  * For example, an Edge may contain selection state or a crease flag. This pertains to both HalfEdges in the pair, so it makes sense to have a single Edge record for both.
  *
- * @implements MeshComponent
+ * @extends MeshComponent
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class Edge {
+class Edge extends MeshComponent {
   /**
    * Accepts a canonical half-edge from the pair of half-edges that make up this edge.
    * @param {HalfEdge} halfEdge
    */
   constructor(halfEdge) {
+    super();
     this._halfEdge = halfEdge;
   }
 

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -4,11 +4,52 @@
  * EditableMesh owns the CPU-side topology with a loose coupling to the render-side geometry
  * via a mapping of topological vertex IDs to render vertex IDs.
  *
- * @alias EditableMesh
- * @constructor
- *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class EditableMesh {}
+class EditableMesh {
+  constructor(geometryAccessor) {
+    this._geometryAccessor = geometryAccessor;
+    this._vertices = [];
+    this._edges = [];
+    this._faces = [];
+    this._halfEdges = [];
+
+    this.#buildMesh(geometryAccessor);
+  }
+
+  get vertices() {
+    return this._vertices;
+  }
+
+  get edges() {
+    return this._edges;
+  }
+
+  get faces() {
+    return this._faces;
+  }
+
+  getVertex(index) {
+    return getElement(this._vertices, index);
+  }
+
+  getEdge(index) {
+    return getElement(this._edges, index);
+  }
+
+  getFace(index) {
+    return getElement(this._faces, index);
+  }
+
+  #buildMesh(geometryAccessor) {}
+}
+
+function getElement(elements, index) {
+  if (index === undefined) {
+    return undefined;
+  }
+
+  return elements[index];
+}
 
 export default EditableMesh;

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -1,3 +1,12 @@
+import { DeveloperError } from "@cesium/engine";
+
+/** @import { GeometryAccessor } from "@cesium/engine"; */
+/** @import Vertex from "./Vertex"; */
+/** @import Edge from "./Edge"; */
+/** @import Face from "./Face"; */
+/** @import HalfEdge from "./HalfEdge"; */
+/** @import MeshComponent from "./MeshComponent"; */
+
 /**
  * Editable half-edge mesh backed by a render-side GeometryAccessor.
  *
@@ -7,11 +16,27 @@
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
 class EditableMesh {
+  /**
+   * @param {GeometryAccessor} geometryAccessor
+   */
   constructor(geometryAccessor) {
     this._geometryAccessor = geometryAccessor;
+
+    /**
+     * @type {Vertex[]}
+     */
     this._vertices = [];
+    /**
+     * @type {Edge[]}
+     */
     this._edges = [];
+    /**
+     * @type {Face[]}
+     */
     this._faces = [];
+    /**
+     * @type {HalfEdge[]}
+     */
     this._halfEdges = [];
 
     this.#buildMesh(geometryAccessor);
@@ -29,25 +54,54 @@ class EditableMesh {
     return this._faces;
   }
 
+  /**
+   * Get a vertex by index.
+   * @param {Number} index
+   * @returns {Vertex}
+   */
   getVertex(index) {
     return getElement(this._vertices, index);
   }
 
+  /**
+   * Get an edge by index.
+   * @param {Number} index
+   * @returns {Edge}
+   */
   getEdge(index) {
     return getElement(this._edges, index);
   }
 
+  /**
+   * Get a face by index.
+   * @param {Number} index
+   * @returns {Face}
+   */
   getFace(index) {
     return getElement(this._faces, index);
   }
 
+  /**
+   * Build the mesh topology from the geometry accessor.
+   * @param {GeometryAccessor} geometryAccessor
+   */
   #buildMesh(geometryAccessor) {}
 }
 
+/**
+ * @template {MeshComponent} T
+ * @param {T[]} elements
+ * @param {Number} index
+ * @returns {T}
+ */
 function getElement(elements, index) {
-  if (index === undefined) {
-    return undefined;
+  //>>includeStart('debug', pragmas.debug);
+  if (index < 0 || index >= elements.length) {
+    throw new DeveloperError(
+      `Index ${index} is out of bounds for elements array of length ${elements.length}.`,
+    );
   }
+  //>>includeEnd('debug');
 
   return elements[index];
 }

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -56,7 +56,7 @@ class EditableMesh {
 
   /**
    * Get a vertex by index.
-   * @param {Number} index
+   * @param {number} index
    * @returns {Vertex}
    */
   getVertex(index) {
@@ -65,7 +65,7 @@ class EditableMesh {
 
   /**
    * Get an edge by index.
-   * @param {Number} index
+   * @param {number} index
    * @returns {Edge}
    */
   getEdge(index) {
@@ -74,7 +74,7 @@ class EditableMesh {
 
   /**
    * Get a face by index.
-   * @param {Number} index
+   * @param {number} index
    * @returns {Face}
    */
   getFace(index) {
@@ -91,8 +91,9 @@ class EditableMesh {
 /**
  * @template {MeshComponent} T
  * @param {T[]} elements
- * @param {Number} index
+ * @param {number} index
  * @returns {T}
+ * @private
  */
 function getElement(elements, index) {
   //>>includeStart('debug', pragmas.debug);

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -6,7 +6,6 @@ import { DeveloperError } from "@cesium/engine";
 /** @import Face from "./Face"; */
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
-/** @import { Cartesian3 } from "@cesium/engine"; */
 
 /**
  * Editable half-edge mesh backed by a render-side GeometryAccessor.
@@ -106,16 +105,6 @@ class EditableMesh {
    * Closes an edit session opened by openEditSession(). If there are no open edit sessions, this method does nothing.
    */
   closeEditSession() {}
-
-  /**
-   * Move a mesh component by a given translation. For edges and faces, all connected vertices move by the translation.
-   *
-   * @param {MeshComponent} component
-   * @param {Cartesian3} translation
-   */
-  translateMeshComponent(component, translation) {
-    component.move(translation);
-  }
 
   /**
    * Build the mesh topology from the geometry accessor.

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -1,0 +1,14 @@
+/**
+ * Editable half-edge mesh backed by a render-side GeometryAccessor.
+ *
+ * EditableMesh owns the CPU-side topology with a loose coupling to the render-side geometry
+ * via a mapping of topological vertex IDs to render vertex IDs.
+ *
+ * @alias EditableMesh
+ * @constructor
+ *
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class EditableMesh {}
+
+export default EditableMesh;

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -1,6 +1,6 @@
 import { DeveloperError } from "@cesium/engine";
 
-/** @import { GeometryAccessor, GeometryAccessSession } from "@cesium/engine"; */
+/** @import { Editable, GeometryAccessor, GeometryAccessSession } from "@cesium/engine"; */
 /** @import Vertex from "./Vertex"; */
 /** @import Edge from "./Edge"; */
 /** @import Face from "./Face"; */
@@ -19,13 +19,14 @@ import { DeveloperError } from "@cesium/engine";
  */
 class EditableMesh {
   /**
-   * @param {GeometryAccessor} geometryAccessor
+   * @param {Editable} editable An object implementing the {@link Editable} interface.
+   * Supplies the underlying {@link GeometryAccessor} and world-space model matrix.
    */
-  constructor(geometryAccessor) {
-    this._geometryAccessor = geometryAccessor;
+  constructor(editable) {
+    this._editable = editable;
+
     /** @type {GeometryAccessSession|null} */
     this._editSession = null;
-
     /**
      * @type {Vertex[]}
      */
@@ -43,7 +44,7 @@ class EditableMesh {
      */
     this._halfEdges = [];
 
-    this.#buildMesh(geometryAccessor);
+    this.#buildMesh(this._editable.geometryAccessor);
   }
 
   get vertices() {

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -6,6 +6,7 @@ import { DeveloperError } from "@cesium/engine";
 /** @import Face from "./Face"; */
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
+/** @import { Cartesian3 } from "@cesium/engine"; */
 
 /**
  * Editable half-edge mesh backed by a render-side GeometryAccessor.
@@ -105,6 +106,16 @@ class EditableMesh {
    * Closes an edit session opened by openEditSession(). If there are no open edit sessions, this method does nothing.
    */
   closeEditSession() {}
+
+  /**
+   * Move a mesh component by a given translation. For edges and faces, all connected vertices move by the translation.
+   *
+   * @param {MeshComponent} component
+   * @param {Cartesian3} translation
+   */
+  translateMeshComponent(component, translation) {
+    component.move(translation);
+  }
 
   /**
    * Build the mesh topology from the geometry accessor.

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -11,7 +11,9 @@ import { DeveloperError } from "@cesium/engine";
  * Editable half-edge mesh backed by a render-side GeometryAccessor.
  *
  * EditableMesh owns the CPU-side topology and communicates changes to the render-side geometry via the GeometryAccessor.
- * This class exposes higher level operations for editing the mesh, such as splitting edges, collapsing edges, and extruding faces.
+ * This class exposes higher level operations for editing the mesh, such as splitting edges, collapsing edges, and extruding faces. These
+ * operations only affect the internal data structures and are not reflected in the render layer until commit() is called, which gives flexibility to batch multiple edits together before syncing with the GPU.
+ * For even more flexibility, openEditSession() and closeEditSession() can be used to keep resources alive across multiple commits, which is especially useful for asynchronous edit operations such as user interactions.
  *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -1,6 +1,6 @@
 import { DeveloperError } from "@cesium/engine";
 
-/** @import { GeometryAccessor } from "@cesium/engine"; */
+/** @import { GeometryAccessor, GeometryAccessSession } from "@cesium/engine"; */
 /** @import Vertex from "./Vertex"; */
 /** @import Edge from "./Edge"; */
 /** @import Face from "./Face"; */
@@ -10,8 +10,8 @@ import { DeveloperError } from "@cesium/engine";
 /**
  * Editable half-edge mesh backed by a render-side GeometryAccessor.
  *
- * EditableMesh owns the CPU-side topology with a loose coupling to the render-side geometry
- * via a mapping of topological vertex IDs to render vertex IDs.
+ * EditableMesh owns the CPU-side topology and communicates changes to the render-side geometry via the GeometryAccessor.
+ * This class exposes higher level operations for editing the mesh, such as splitting edges, collapsing edges, and extruding faces.
  *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
@@ -21,6 +21,8 @@ class EditableMesh {
    */
   constructor(geometryAccessor) {
     this._geometryAccessor = geometryAccessor;
+    /** @type {GeometryAccessSession|null} */
+    this._editSession = null;
 
     /**
      * @type {Vertex[]}
@@ -80,6 +82,27 @@ class EditableMesh {
   getFace(index) {
     return getElement(this._faces, index);
   }
+
+  /**
+   * Commit any mesh changes to the underlying render layer, without closing the edit session.
+   * This method must be called in order for changes to be reflected on screen.
+   *
+   * If there is no active edit session, this method will create one automatically and destroy it after.
+   */
+  commit() {}
+
+  /**
+   * Opens an edit session which persists until closed. This is most useful for asynchronous edit operations (e.g. user interactions)
+   * where it is desirable to keep certain resources alive across multiple commits as performance optimization.
+   *
+   * If you just want to batch many changes synchronously, just call commit() after making all your changes.
+   */
+  openEditSession() {}
+
+  /**
+   * Closes an edit session opened by openEditSession(). If there are no open edit sessions, this method does nothing.
+   */
+  closeEditSession() {}
 
   /**
    * Build the mesh topology from the geometry accessor.

--- a/packages/edit/Source/Mesh/EditableMesh.js
+++ b/packages/edit/Source/Mesh/EditableMesh.js
@@ -11,9 +11,7 @@ import { DeveloperError } from "@cesium/engine";
  * Editable half-edge mesh backed by a render-side GeometryAccessor.
  *
  * EditableMesh owns the CPU-side topology and communicates changes to the render-side geometry via the GeometryAccessor.
- * This class exposes higher level operations for editing the mesh, such as splitting edges, collapsing edges, and extruding faces. These
- * operations only affect the internal data structures and are not reflected in the render layer until commit() is called, which gives flexibility to batch multiple edits together before syncing with the GPU.
- * For even more flexibility, openEditSession() and closeEditSession() can be used to keep resources alive across multiple commits, which is especially useful for asynchronous edit operations such as user interactions.
+ * This class exposes higher level operations for editing the mesh, such as splitting edges, collapsing edges, and extruding faces.
  *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
@@ -25,8 +23,23 @@ class EditableMesh {
   constructor(editable) {
     this._editable = editable;
 
-    /** @type {GeometryAccessSession|null} */
-    this._editSession = null;
+    const geometryAccessor = editable.geometryAccessor;
+    const availableAttributes = new Set(
+      geometryAccessor.getAvailableAttributes(),
+    );
+    const scopes = {
+      read: {
+        attributes: availableAttributes,
+        topology: true,
+      },
+      write: {
+        attributes: availableAttributes,
+        topology: true,
+      },
+    };
+
+    /** @type {GeometryAccessSession} */
+    this._editSession = geometryAccessor.openSession(scopes);
     /**
      * @type {Vertex[]}
      */
@@ -39,10 +52,6 @@ class EditableMesh {
      * @type {Face[]}
      */
     this._faces = [];
-    /**
-     * @type {HalfEdge[]}
-     */
-    this._halfEdges = [];
 
     this.#buildMesh(this._editable.geometryAccessor);
   }
@@ -85,27 +94,6 @@ class EditableMesh {
   getFace(index) {
     return getElement(this._faces, index);
   }
-
-  /**
-   * Commit any mesh changes to the underlying render layer, without closing the edit session.
-   * This method must be called in order for changes to be reflected on screen.
-   *
-   * If there is no active edit session, this method will create one automatically and destroy it after.
-   */
-  commit() {}
-
-  /**
-   * Opens an edit session which persists until closed. This is most useful for asynchronous edit operations (e.g. user interactions)
-   * where it is desirable to keep certain resources alive across multiple commits as performance optimization.
-   *
-   * If you just want to batch many changes synchronously, just call commit() after making all your changes.
-   */
-  openEditSession() {}
-
-  /**
-   * Closes an edit session opened by openEditSession(). If there are no open edit sessions, this method does nothing.
-   */
-  closeEditSession() {}
 
   /**
    * Build the mesh topology from the geometry accessor.

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -1,13 +1,23 @@
-import MeshComponent from "./MeshComponent.js";
-
 /**
  * Face record for an EditableMesh.
  *
- * @alias Face
- * @constructor
- *
+ * @implements MeshComponent
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class Face extends MeshComponent {}
+class Face {
+  constructor() {
+    this._halfEdge = undefined;
+  }
+
+  get halfEdge() {
+    return this._halfEdge;
+  }
+
+  set halfEdge(halfEdge) {
+    this._halfEdge = halfEdge;
+  }
+
+  move(newPosition) {}
+}
 
 export default Face;

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -28,6 +28,26 @@ class Face {
   }
 
   /**
+   * Returns the boundary edges of this face. Equivalent to
+   * {@link Face#edges}.
+   * @param {Edge[]} result Destination array.
+   * @returns {Edge[]}
+   */
+  lower(result) {
+    return this.edges(result);
+  }
+
+  /**
+   * Faces have no super-components; <code>result</code> is returned
+   * unchanged.
+   * @param {MeshComponent[]} result Destination array.
+   * @returns {MeshComponent[]}
+   */
+  upper(result) {
+    return result;
+  }
+
+  /**
    * Returns the vertices that compose this face.
    * @param {Vertex[]} [result] Destination array.
    * @returns {Vertex[]}
@@ -66,16 +86,6 @@ class Face {
       currentHalfEdge = currentHalfEdge.next;
     } while (currentHalfEdge !== this._halfEdge);
 
-    return result;
-  }
-
-  /**
-   * MeshComponent method to return the faces that are part of this component. For a face, this is just itself.
-   * @param {Face[]} [result] Destination array.
-   * @returns {Face[]}
-   */
-  faces(result) {
-    result.push(this);
     return result;
   }
 }

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -1,0 +1,13 @@
+import MeshComponent from "./MeshComponent.js";
+
+/**
+ * Face record for an EditableMesh.
+ *
+ * @alias Face
+ * @constructor
+ *
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class Face extends MeshComponent {}
+
+export default Face;

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -29,54 +29,54 @@ class Face {
 
   /**
    * Returns the vertices that compose this face.
+   * @param {Vertex[]} [result] Destination array.
    * @returns {Vertex[]}
    */
-  vertices() {
+  vertices(result) {
     //>>includeStart('debug', pragmas.debug);
     if (!defined(this._halfEdge)) {
       throw new DeveloperError("Face must have a half-edge.");
     }
     //>>includeEnd('debug');
 
-    const vertices = [];
     let currentHalfEdge = this._halfEdge;
-
     do {
-      vertices.push(currentHalfEdge.vertex);
+      result.push(currentHalfEdge.vertex);
       currentHalfEdge = currentHalfEdge.next;
     } while (currentHalfEdge !== this._halfEdge);
 
-    return vertices;
+    return result;
   }
 
   /**
    * Returns the edges that compose this face.
+   * @param {Edge[]} [result] Destination array.
    * @returns {Edge[]}
    */
-  edges() {
+  edges(result) {
     //>>includeStart('debug', pragmas.debug);
     if (!defined(this._halfEdge)) {
       throw new DeveloperError("Face must have a half-edge.");
     }
     //>>includeEnd('debug');
 
-    const edges = [];
     let currentHalfEdge = this._halfEdge;
-
     do {
-      edges.push(currentHalfEdge.edge);
+      result.push(currentHalfEdge.edge);
       currentHalfEdge = currentHalfEdge.next;
     } while (currentHalfEdge !== this._halfEdge);
 
-    return edges;
+    return result;
   }
 
   /**
    * MeshComponent method to return the faces that are part of this component. For a face, this is just itself.
+   * @param {Face[]} [result] Destination array.
    * @returns {Face[]}
    */
-  faces() {
-    return [this];
+  faces(result) {
+    result.push(this);
+    return result;
   }
 }
 

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -1,6 +1,6 @@
-/** @import { Cartesian3 } from "@cesium/engine"; */
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
+/** @import Vertex from "./Vertex"; */
 
 /**
  * Face record for an EditableMesh.
@@ -22,6 +22,33 @@ class Face {
 
   set halfEdge(halfEdge) {
     this._halfEdge = halfEdge;
+  }
+
+  /**
+   * Iterates over each vertex of the face and executes a callback function.
+   * @param {function(Vertex): void} callback - The function to execute for each vertex.
+   */
+  forEachVertex(callback) {
+    let halfEdge = this._halfEdge;
+    if (!halfEdge) {
+      return;
+    }
+
+    do {
+      callback(halfEdge.vertex);
+      halfEdge = halfEdge.next;
+    } while (halfEdge !== this._halfEdge);
+  }
+
+  /**
+   * Returns the vertices that compose this component. For a face, this is all vertices that make up the face.
+   * @returns {Vertex[]}
+   */
+  vertices() {
+    /** @type {Vertex[]} */
+    const vertices = [];
+    this.forEachVertex((vertex) => vertices.push(vertex));
+    return vertices;
   }
 }
 

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -23,12 +23,6 @@ class Face {
   set halfEdge(halfEdge) {
     this._halfEdge = halfEdge;
   }
-
-  /**
-   * Move the face to a new position.
-   * @param {Cartesian3} newPosition
-   */
-  move(newPosition) {}
 }
 
 export default Face;

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -1,3 +1,7 @@
+/** @import { Cartesian3 } from "@cesium/engine"; */
+/** @import HalfEdge from "./HalfEdge"; */
+/** @import MeshComponent from "./MeshComponent"; */
+
 /**
  * Face record for an EditableMesh.
  *
@@ -6,6 +10,9 @@
  */
 class Face {
   constructor() {
+    /**
+     * @type {HalfEdge | undefined}
+     */
     this._halfEdge = undefined;
   }
 
@@ -17,6 +24,10 @@ class Face {
     this._halfEdge = halfEdge;
   }
 
+  /**
+   * Move the face to a new position.
+   * @param {Cartesian3} newPosition
+   */
   move(newPosition) {}
 }
 

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -1,6 +1,7 @@
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
 /** @import Edge from "./Edge"; */
+/** @import Vertex from "./Vertex"; */
 
 import { defined, DeveloperError } from "@cesium/engine";
 
@@ -27,10 +28,32 @@ class Face {
   }
 
   /**
+   * Returns the vertices that compose this face.
+   * @returns {Vertex[]}
+   */
+  vertices() {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(this._halfEdge)) {
+      throw new DeveloperError("Face must have a half-edge.");
+    }
+    //>>includeEnd('debug');
+
+    const vertices = [];
+    let currentHalfEdge = this._halfEdge;
+
+    do {
+      vertices.push(currentHalfEdge.vertex);
+      currentHalfEdge = currentHalfEdge.next;
+    } while (currentHalfEdge !== this._halfEdge);
+
+    return vertices;
+  }
+
+  /**
    * Returns the edges that compose this face.
    * @returns {Edge[]}
    */
-  lower() {
+  edges() {
     //>>includeStart('debug', pragmas.debug);
     if (!defined(this._halfEdge)) {
       throw new DeveloperError("Face must have a half-edge.");
@@ -49,11 +72,11 @@ class Face {
   }
 
   /**
-   * Returns the components that this one participates in. For faces, this is empty.
-   * @returns {MeshComponent[]}
+   * MeshComponent method to return the faces that are part of this component. For a face, this is just itself.
+   * @returns {Face[]}
    */
-  upper() {
-    return [];
+  faces() {
+    return [this];
   }
 }
 

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -1,6 +1,8 @@
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
-/** @import Vertex from "./Vertex"; */
+/** @import Edge from "./Edge"; */
+
+import { defined, DeveloperError } from "@cesium/engine";
 
 /**
  * Face record for an EditableMesh.
@@ -25,30 +27,33 @@ class Face {
   }
 
   /**
-   * Iterates over each vertex of the face and executes a callback function.
-   * @param {function(Vertex): void} callback - The function to execute for each vertex.
+   * Returns the edges that compose this face.
+   * @returns {Edge[]}
    */
-  forEachVertex(callback) {
-    let halfEdge = this._halfEdge;
-    if (!halfEdge) {
-      return;
+  lower() {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(this._halfEdge)) {
+      throw new DeveloperError("Face must have a half-edge.");
     }
+    //>>includeEnd('debug');
+
+    const edges = [];
+    let currentHalfEdge = this._halfEdge;
 
     do {
-      callback(halfEdge.vertex);
-      halfEdge = halfEdge.next;
-    } while (halfEdge !== this._halfEdge);
+      edges.push(currentHalfEdge.edge);
+      currentHalfEdge = currentHalfEdge.next;
+    } while (currentHalfEdge !== this._halfEdge);
+
+    return edges;
   }
 
   /**
-   * Returns the vertices that compose this component. For a face, this is all vertices that make up the face.
-   * @returns {Vertex[]}
+   * Returns the components that this one participates in. For faces, this is empty.
+   * @returns {MeshComponent[]}
    */
-  vertices() {
-    /** @type {Vertex[]} */
-    const vertices = [];
-    this.forEachVertex((vertex) => vertices.push(vertex));
-    return vertices;
+  upper() {
+    return [];
   }
 }
 

--- a/packages/edit/Source/Mesh/Face.js
+++ b/packages/edit/Source/Mesh/Face.js
@@ -1,18 +1,20 @@
 /** @import HalfEdge from "./HalfEdge"; */
-/** @import MeshComponent from "./MeshComponent"; */
 /** @import Edge from "./Edge"; */
 /** @import Vertex from "./Vertex"; */
 
+import MeshComponent from "./MeshComponent";
 import { defined, DeveloperError } from "@cesium/engine";
 
 /**
  * Face record for an EditableMesh.
  *
- * @implements MeshComponent
+ * @extends MeshComponent
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class Face {
+class Face extends MeshComponent {
   constructor() {
+    super();
+
     /**
      * @type {HalfEdge | undefined}
      */

--- a/packages/edit/Source/Mesh/HalfEdge.js
+++ b/packages/edit/Source/Mesh/HalfEdge.js
@@ -1,13 +1,32 @@
+/** @import Vertex from "./Vertex"; */
+/** @import Face from "./Face"; */
+
 /**
  * Half-edge record for an EditableMesh.
  *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
 class HalfEdge {
+  /**
+   * @param {Vertex} vertex
+   * @param {Face} face
+   */
   constructor(vertex, face) {
+    /**
+     * @type {Vertex}
+     */
     this._vertex = vertex;
+    /**
+     * @type {Face}
+     */
     this._face = face;
+    /**
+     * @type {HalfEdge | undefined}
+     */
     this._next = undefined;
+    /**
+     * @type {HalfEdge | undefined}
+     */
     this._twin = undefined;
   }
 

--- a/packages/edit/Source/Mesh/HalfEdge.js
+++ b/packages/edit/Source/Mesh/HalfEdge.js
@@ -1,5 +1,6 @@
 /** @import Vertex from "./Vertex"; */
 /** @import Face from "./Face"; */
+/** @import Edge from "./Edge"; */
 
 /**
  * Half-edge record for an EditableMesh.
@@ -28,6 +29,10 @@ class HalfEdge {
      * @type {HalfEdge | undefined}
      */
     this._twin = undefined;
+    /**
+     * @type {Edge | undefined}
+     */
+    this._edge = undefined;
   }
 
   get next() {
@@ -52,6 +57,14 @@ class HalfEdge {
 
   get face() {
     return this._face;
+  }
+
+  get edge() {
+    return this._edge;
+  }
+
+  set edge(edge) {
+    this._edge = edge;
   }
 }
 

--- a/packages/edit/Source/Mesh/HalfEdge.js
+++ b/packages/edit/Source/Mesh/HalfEdge.js
@@ -1,11 +1,39 @@
 /**
  * Half-edge record for an EditableMesh.
  *
- * @alias HalfEdge
- * @constructor
- *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class HalfEdge {}
+class HalfEdge {
+  constructor(vertex, face) {
+    this._vertex = vertex;
+    this._face = face;
+    this._next = undefined;
+    this._twin = undefined;
+  }
+
+  get next() {
+    return this._next;
+  }
+
+  set next(halfEdge) {
+    this._next = halfEdge;
+  }
+
+  get twin() {
+    return this._twin;
+  }
+
+  set twin(halfEdge) {
+    this._twin = halfEdge;
+  }
+
+  get vertex() {
+    return this._vertex;
+  }
+
+  get face() {
+    return this._face;
+  }
+}
 
 export default HalfEdge;

--- a/packages/edit/Source/Mesh/HalfEdge.js
+++ b/packages/edit/Source/Mesh/HalfEdge.js
@@ -1,0 +1,11 @@
+/**
+ * Half-edge record for an EditableMesh.
+ *
+ * @alias HalfEdge
+ * @constructor
+ *
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class HalfEdge {}
+
+export default HalfEdge;

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -9,20 +9,23 @@ import { DeveloperError } from "@cesium/engine";
  */
 class MeshComponent {
   /**
-   * Returns the components that this one is composed of.
-   * For a vertex, this is empty. For an edge, this is its two endpoint vertices. For a face, this is the edge loop that composes its boundary.
-   * @returns {MeshComponent[]}
+   * Implemented by subclasses to return the vertices that compose this component (for edges and faces, or the vertex itself for vertices).
    */
-  lower() {
+  vertices() {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Returns the components that this one participates in.
-   * For a vertex, this is the edges that are incident to it. For an edge, this is the faces that are incident to it. For a face, this is empty.
-   * @returns {MeshComponent[]}
+   * Implemented by subclasses to return the edges that compose or are incident to this component (for faces and vertices, or the edge itself for edges).
    */
-  upper() {
+  edges() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Implemented by subclasses to return the faces that are incident to this component (for vertices and edges, or the face itself for faces).
+   */
+  faces() {
     DeveloperError.throwInstantiationError();
   }
 }

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -1,11 +1,20 @@
+import { DeveloperError } from "@cesium/engine";
+
 /**
  * Base class for mesh elements owned by an EditableMesh.
  *
- * @alias MeshComponent
- * @constructor
- *
+ * @interface
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class MeshComponent {}
+class MeshComponent {
+  /**
+   * Move a mesh component to a new position in model space.
+   *
+   * @param {Cartesian3} newPosition
+   */
+  move(newPosition) {
+    DeveloperError.throwInstantiationError();
+  }
+}
 
 export default MeshComponent;

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -1,4 +1,5 @@
 import { DeveloperError } from "@cesium/engine";
+/** @import { Cartesian3 } from "@cesium/engine"; */
 
 /**
  * Base class for mesh elements owned by an EditableMesh.

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -1,9 +1,20 @@
+import { DeveloperError } from "@cesium/engine";
+/** @import Vertex from "./Vertex"; */
+
 /**
  * Base class for mesh elements owned by an EditableMesh.
  *
  * @interface
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class MeshComponent {}
+class MeshComponent {
+  /**
+   * Get the vertices that compose this component. For a Vertex, this is just the vertex itself. For an Edge, this is the two vertices at its endpoints. For a Face, this is all vertices that make up the face.
+   * @returns {Vertex[]}
+   */
+  vertices() {
+    DeveloperError.throwInstantiationError();
+  }
+}
 
 export default MeshComponent;

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -9,11 +9,11 @@ import { DeveloperError } from "@cesium/engine";
  */
 class MeshComponent {
   /**
-   * Move a mesh component to a new position in model space.
+   * Move a mesh component by a given translation in model space.
    *
-   * @param {Cartesian3} newPosition
+   * @param {Cartesian3} translation
    */
-  move(newPosition) {
+  move(translation) {
     DeveloperError.throwInstantiationError();
   }
 }

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -9,10 +9,20 @@ import { DeveloperError } from "@cesium/engine";
  */
 class MeshComponent {
   /**
-   * Get the vertices that compose this component. For a Vertex, this is just the vertex itself. For an Edge, this is the two vertices at its endpoints. For a Face, this is all vertices that make up the face.
-   * @returns {Vertex[]}
+   * Returns the components that this one is composed of.
+   * For a vertex, this is empty. For an edge, this is its two endpoint vertices. For a face, this is the edge loop that composes its boundary.
+   * @returns {MeshComponent[]}
    */
-  vertices() {
+  lower() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Returns the components that this one participates in.
+   * For a vertex, this is the edges that are incident to it. For an edge, this is the faces that are incident to it. For a face, this is empty.
+   * @returns {MeshComponent[]}
+   */
+  upper() {
     DeveloperError.throwInstantiationError();
   }
 }

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -1,0 +1,11 @@
+/**
+ * Base class for mesh elements owned by an EditableMesh.
+ *
+ * @alias MeshComponent
+ * @constructor
+ *
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class MeshComponent {}
+
+export default MeshComponent;

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -11,32 +11,24 @@ import { DeveloperError } from "@cesium/engine";
  */
 class MeshComponent {
   /**
-   * Returns the vertices that compose this component (for edges and faces),
-   * or the vertex itself (for vertices).
-   * @param {Vertex[]} result Destination array.
-   * @returns {Vertex[]}
+   * Returns the components one level below this one that compose it: the
+   * boundary edges of a face, the endpoint vertices of an edge, or
+   * nothing for a vertex.
+   * @param {MeshComponent[]} result Destination array.
+   * @returns {MeshComponent[]}
    */
-  vertices(result) {
+  lower(result) {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Returns the edges that compose this component (for faces) or are
-   * incident to it (for vertices), or the edge itself (for edges).
-   * @param {Edge[]} result Destination array.
-   * @returns {Edge[]}
+   * Returns the components one level above this one that this is
+   * incident to: the incident edges of a vertex, the incident faces of
+   * an edge, or nothing for a face.
+   * @param {MeshComponent[]} result Destination array.
+   * @returns {MeshComponent[]}
    */
-  edges(result) {
-    DeveloperError.throwInstantiationError();
-  }
-
-  /**
-   * Returns the faces incident to this component (for vertices and edges),
-   * or the face itself (for faces).
-   * @param {Face[]} result Destination array.
-   * @returns {Face[]}
-   */
-  faces(result) {
+  upper(result) {
     DeveloperError.throwInstantiationError();
   }
 }

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -1,4 +1,6 @@
 import { DeveloperError } from "@cesium/engine";
+/** @import Face from "./Face"; */
+/** @import Edge from "./Edge"; */
 /** @import Vertex from "./Vertex"; */
 
 /**
@@ -9,23 +11,32 @@ import { DeveloperError } from "@cesium/engine";
  */
 class MeshComponent {
   /**
-   * Implemented by subclasses to return the vertices that compose this component (for edges and faces, or the vertex itself for vertices).
+   * Returns the vertices that compose this component (for edges and faces),
+   * or the vertex itself (for vertices).
+   * @param {Vertex[]} result Destination array.
+   * @returns {Vertex[]}
    */
-  vertices() {
+  vertices(result) {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Implemented by subclasses to return the edges that compose or are incident to this component (for faces and vertices, or the edge itself for edges).
+   * Returns the edges that compose this component (for faces) or are
+   * incident to it (for vertices), or the edge itself (for edges).
+   * @param {Edge[]} result Destination array.
+   * @returns {Edge[]}
    */
-  edges() {
+  edges(result) {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Implemented by subclasses to return the faces that are incident to this component (for vertices and edges, or the face itself for faces).
+   * Returns the faces incident to this component (for vertices and edges),
+   * or the face itself (for faces).
+   * @param {Face[]} result Destination array.
+   * @returns {Face[]}
    */
-  faces() {
+  faces(result) {
     DeveloperError.throwInstantiationError();
   }
 }

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -1,21 +1,9 @@
-import { DeveloperError } from "@cesium/engine";
-/** @import { Cartesian3 } from "@cesium/engine"; */
-
 /**
  * Base class for mesh elements owned by an EditableMesh.
  *
  * @interface
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class MeshComponent {
-  /**
-   * Move a mesh component by a given translation in model space.
-   *
-   * @param {Cartesian3} translation
-   */
-  move(translation) {
-    DeveloperError.throwInstantiationError();
-  }
-}
+class MeshComponent {}
 
 export default MeshComponent;

--- a/packages/edit/Source/Mesh/MeshComponent.js
+++ b/packages/edit/Source/Mesh/MeshComponent.js
@@ -1,12 +1,9 @@
-import { DeveloperError } from "@cesium/engine";
-/** @import Face from "./Face"; */
-/** @import Edge from "./Edge"; */
-/** @import Vertex from "./Vertex"; */
+import { defined, DeveloperError } from "@cesium/engine";
 
 /**
  * Base class for mesh elements owned by an EditableMesh.
  *
- * @interface
+ * @abstract
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
 class MeshComponent {
@@ -18,7 +15,7 @@ class MeshComponent {
    * @returns {MeshComponent[]}
    */
   lower(result) {
-    DeveloperError.throwInstantiationError();
+    return [];
   }
 
   /**
@@ -29,7 +26,58 @@ class MeshComponent {
    * @returns {MeshComponent[]}
    */
   upper(result) {
-    DeveloperError.throwInstantiationError();
+    return [];
+  }
+
+  /**
+   * Associates blind data with this component under the given key.
+   * @param {string} key
+   * @param {*} value
+   */
+  setUserData(key, value) {
+    //>>includeStart('debug', pragmas.debug);
+    if (typeof key !== "string") {
+      throw new DeveloperError("key must be a string.");
+    }
+    //>>includeEnd('debug');
+
+    // Lazily allocate so components that never carry user data pay nothing.
+    if (!defined(this._userData)) {
+      this._userData = new Map();
+    }
+    this._userData.set(key, value);
+  }
+
+  /**
+   * Returns the value previously stored under the given key, or undefined.
+   * @param {string} key
+   * @returns {*}
+   */
+  getUserData(key) {
+    if (!defined(this._userData)) {
+      return undefined;
+    }
+    return this._userData.get(key);
+  }
+
+  /**
+   * @param {string} key
+   * @returns {boolean}
+   */
+  hasUserData(key) {
+    return defined(this._userData) && this._userData.has(key);
+  }
+
+  /**
+   * Removes the value stored under the given key.
+   * @param {string} key
+   * @returns {boolean} True if a value was removed.
+   */
+  deleteUserData(key) {
+    if (!defined(this._userData)) {
+      return false;
+    }
+    return this._userData.delete(key);
   }
 }
 

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -41,10 +41,10 @@ class Vertex {
   }
 
   /**
-   * Move the vertex to a new position.
-   * @param {Cartesian3} newPosition
+   * Move the vertex by a given translation.
+   * @param {Cartesian3} translation
    */
-  move(newPosition) {}
+  move(translation) {}
 }
 
 export default Vertex;

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -46,56 +46,54 @@ class Vertex {
 
   /**
    * MeshComponent method to return the vertices that are part of this component. For a vertex, this is just itself.
-   * @returns {Vertex[]} This vertex
+   * @param {Vertex[]} result Destination array.
+   * @returns {Vertex[]}
    */
-  vertices() {
-    return [this];
+  vertices(result) {
+    result.push(this);
+    return result;
   }
 
   /**
    * Returns the edges that are incident to this vertex.
+   * @param {Edge[]} result Destination array.
    * @returns {Edge[]}
    */
-  edges() {
+  edges(result) {
     //>>includeStart('debug', pragmas.debug);
     if (!defined(this._halfEdge)) {
       throw new DeveloperError("Vertex must have a half-edge.");
     }
     //>>includeEnd('debug');
 
-    /** @type {Edge[]} */
-    const edges = [];
-
     let currentHalfEdge = this._halfEdge;
     do {
-      edges.push(currentHalfEdge.edge);
+      result.push(currentHalfEdge.edge);
       currentHalfEdge = currentHalfEdge.twin.next;
     } while (currentHalfEdge !== this._halfEdge);
 
-    return edges;
+    return result;
   }
 
   /**
    * Returns the faces that are incident to this vertex.
+   * @param {Face[]} result Destination array.
    * @returns {Face[]}
    */
-  faces() {
+  faces(result) {
     //>>includeStart('debug', pragmas.debug);
     if (!defined(this._halfEdge)) {
       throw new DeveloperError("Vertex must have a half-edge.");
     }
     //>>includeEnd('debug');
 
-    /** @type {Face[]} */
-    const faces = [];
-
     let currentHalfEdge = this._halfEdge;
     do {
-      faces.push(currentHalfEdge.face);
+      result.push(currentHalfEdge.face);
       currentHalfEdge = currentHalfEdge.twin.next;
     } while (currentHalfEdge !== this._halfEdge);
 
-    return faces;
+    return result;
   }
 
   /**

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -1,3 +1,7 @@
+/** @import { Cartesian3 } from "@cesium/engine"; */
+/** @import HalfEdge from "./HalfEdge"; */
+/** @import MeshComponent from "./MeshComponent"; */
+
 /**
  * Vertex record for an EditableMesh.
  *
@@ -5,8 +9,18 @@
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
 class Vertex {
+  /**
+   * @param {Cartesian3} position
+   */
   constructor(position) {
+    /**
+     * @type {HalfEdge | undefined}
+     */
     this._halfEdge = undefined;
+
+    /**
+     * @type {Cartesian3}
+     */
     this._position = position;
   }
 
@@ -26,6 +40,10 @@ class Vertex {
     this._position = position;
   }
 
+  /**
+   * Move the vertex to a new position.
+   * @param {Cartesian3} newPosition
+   */
   move(newPosition) {}
 }
 

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -1,13 +1,32 @@
-import MeshComponent from "./MeshComponent.js";
-
 /**
  * Vertex record for an EditableMesh.
  *
- * @alias Vertex
- * @constructor
- *
+ * @implements MeshComponent
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class Vertex extends MeshComponent {}
+class Vertex {
+  constructor(position) {
+    this._halfEdge = undefined;
+    this._position = position;
+  }
+
+  get halfEdge() {
+    return this._halfEdge;
+  }
+
+  set halfEdge(halfEdge) {
+    this._halfEdge = halfEdge;
+  }
+
+  get position() {
+    return this._position;
+  }
+
+  set position(position) {
+    this._position = position;
+  }
+
+  move(newPosition) {}
+}
 
 export default Vertex;

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -1,6 +1,9 @@
 /** @import { Cartesian3 } from "@cesium/engine"; */
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
+/** @import Edge from "./Edge"; */
+
+import { defined, DeveloperError } from "@cesium/engine";
 
 /**
  * Vertex record for an EditableMesh.
@@ -41,11 +44,34 @@ class Vertex {
   }
 
   /**
-   * Returns the vertices that compose this component. For a vertex, this is just itself.
-   * @returns {Vertex[]}
+   * Returns the constituent MeshComponents that compose this component. For a vertex, this is empty.
+   * @returns {MeshComponent[]}
    */
-  vertices() {
-    return [this];
+  lower() {
+    return [];
+  }
+
+  /**
+   * Returns the edges that are incident to this vertex.
+   * @returns {Edge[]}
+   */
+  upper() {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(this._halfEdge)) {
+      throw new DeveloperError("Vertex must have a half-edge.");
+    }
+    //>>includeEnd('debug');
+
+    /** @type {Edge[]} */
+    const edges = [];
+
+    let currentHalfEdge = this._halfEdge;
+    do {
+      edges.push(currentHalfEdge.edge);
+      currentHalfEdge = currentHalfEdge.twin.next;
+    } while (currentHalfEdge !== this._halfEdge);
+
+    return edges;
   }
 
   /**

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -2,6 +2,7 @@
 /** @import HalfEdge from "./HalfEdge"; */
 /** @import MeshComponent from "./MeshComponent"; */
 /** @import Edge from "./Edge"; */
+/** @import Face from "./Face"; */
 
 import { defined, DeveloperError } from "@cesium/engine";
 
@@ -44,18 +45,18 @@ class Vertex {
   }
 
   /**
-   * Returns the constituent MeshComponents that compose this component. For a vertex, this is empty.
-   * @returns {MeshComponent[]}
+   * MeshComponent method to return the vertices that are part of this component. For a vertex, this is just itself.
+   * @returns {Vertex[]} This vertex
    */
-  lower() {
-    return [];
+  vertices() {
+    return [this];
   }
 
   /**
    * Returns the edges that are incident to this vertex.
    * @returns {Edge[]}
    */
-  upper() {
+  edges() {
     //>>includeStart('debug', pragmas.debug);
     if (!defined(this._halfEdge)) {
       throw new DeveloperError("Vertex must have a half-edge.");
@@ -72,6 +73,29 @@ class Vertex {
     } while (currentHalfEdge !== this._halfEdge);
 
     return edges;
+  }
+
+  /**
+   * Returns the faces that are incident to this vertex.
+   * @returns {Face[]}
+   */
+  faces() {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(this._halfEdge)) {
+      throw new DeveloperError("Vertex must have a half-edge.");
+    }
+    //>>includeEnd('debug');
+
+    /** @type {Face[]} */
+    const faces = [];
+
+    let currentHalfEdge = this._halfEdge;
+    do {
+      faces.push(currentHalfEdge.face);
+      currentHalfEdge = currentHalfEdge.twin.next;
+    } while (currentHalfEdge !== this._halfEdge);
+
+    return faces;
   }
 
   /**

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -45,13 +45,23 @@ class Vertex {
   }
 
   /**
-   * MeshComponent method to return the vertices that are part of this component. For a vertex, this is just itself.
-   * @param {Vertex[]} result Destination array.
-   * @returns {Vertex[]}
+   * Vertices have no sub-components; <code>result</code> is returned
+   * unchanged.
+   * @param {MeshComponent[]} result Destination array.
+   * @returns {MeshComponent[]}
    */
-  vertices(result) {
-    result.push(this);
+  lower(result) {
     return result;
+  }
+
+  /**
+   * Returns the edges incident to this vertex. Equivalent to
+   * {@link Vertex#edges}.
+   * @param {Edge[]} result Destination array.
+   * @returns {Edge[]}
+   */
+  upper(result) {
+    return this.edges(result);
   }
 
   /**

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -1,0 +1,13 @@
+import MeshComponent from "./MeshComponent.js";
+
+/**
+ * Vertex record for an EditableMesh.
+ *
+ * @alias Vertex
+ * @constructor
+ *
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class Vertex extends MeshComponent {}
+
+export default Vertex;

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -41,6 +41,14 @@ class Vertex {
   }
 
   /**
+   * Returns the vertices that compose this component. For a vertex, this is just itself.
+   * @returns {Vertex[]}
+   */
+  vertices() {
+    return [this];
+  }
+
+  /**
    * Move the vertex by a given translation.
    * @param {Cartesian3} translation
    */

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -23,11 +23,6 @@ class Vertex extends MeshComponent {
      * @type {HalfEdge | undefined}
      */
     this._halfEdge = undefined;
-
-    /**
-     * @type {Cartesian3}
-     */
-    this._position = position;
   }
 
   get halfEdge() {
@@ -36,14 +31,6 @@ class Vertex extends MeshComponent {
 
   set halfEdge(halfEdge) {
     this._halfEdge = halfEdge;
-  }
-
-  get position() {
-    return this._position;
-  }
-
-  set position(position) {
-    this._position = position;
   }
 
   /**
@@ -128,12 +115,6 @@ class Vertex extends MeshComponent {
 
     return result;
   }
-
-  /**
-   * Move the vertex by a given translation.
-   * @param {Cartesian3} translation
-   */
-  move(translation) {}
 }
 
 export default Vertex;

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -107,6 +107,27 @@ class Vertex {
   }
 
   /**
+   * Returns the vertices that are connected to this vertex by an edge.
+   * @param {Vertex[]} result Destination array
+   * @returns {Vertex[]} The vertices that are connected to this vertex by an edge.
+   */
+  neighbors(result) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(this._halfEdge)) {
+      throw new DeveloperError("Vertex must have a half-edge.");
+    }
+    //>>includeEnd('debug');
+
+    let currentHalfEdge = this._halfEdge;
+    do {
+      result.push(currentHalfEdge.twin.vertex);
+      currentHalfEdge = currentHalfEdge.twin.next;
+    } while (currentHalfEdge !== this._halfEdge);
+
+    return result;
+  }
+
+  /**
    * Move the vertex by a given translation.
    * @param {Cartesian3} translation
    */

--- a/packages/edit/Source/Mesh/Vertex.js
+++ b/packages/edit/Source/Mesh/Vertex.js
@@ -1,22 +1,24 @@
 /** @import { Cartesian3 } from "@cesium/engine"; */
 /** @import HalfEdge from "./HalfEdge"; */
-/** @import MeshComponent from "./MeshComponent"; */
 /** @import Edge from "./Edge"; */
 /** @import Face from "./Face"; */
 
+import MeshComponent from "./MeshComponent";
 import { defined, DeveloperError } from "@cesium/engine";
 
 /**
  * Vertex record for an EditableMesh.
  *
- * @implements MeshComponent
+ * @extends MeshComponent
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-class Vertex {
+class Vertex extends MeshComponent {
   /**
    * @param {Cartesian3} position
    */
   constructor(position) {
+    super();
+
     /**
      * @type {HalfEdge | undefined}
      */

--- a/packages/edit/Specs/Mesh/EditableMeshSpec.js
+++ b/packages/edit/Specs/Mesh/EditableMeshSpec.js
@@ -1,0 +1,23 @@
+describe("Mesh/EditableMesh", function () {
+  describe("topology validation", function () {
+    it("creates an empty mesh when the accessor provides no primitives", function () {});
+
+    it("constructs the expected vertex, edge, face, and half-edge counts for simple meshes", function () {});
+
+    it("builds a closed topological loop for each face", function () {});
+
+    it("preserves winding order of vertices in each face", function () {});
+
+    it("creates twin half-edges and a single topological edge for shared face boundaries", function () {});
+
+    it("leaves boundary half-edges untwinned when an edge belongs to only one face", function () {});
+
+    it("assigns correct half-edges to each constructed vertex, edge, and face", function () {});
+
+    it("deduplicates render vertices that represent the same topological vertex", function () {});
+
+    it("builds the same topological mesh even when render vertices appear in a different order", function () {});
+
+    it("rejects non-manifold geometry", function () {});
+  });
+});

--- a/packages/edit/Specs/Mesh/EditableMeshSpec.js
+++ b/packages/edit/Specs/Mesh/EditableMeshSpec.js
@@ -18,4 +18,8 @@ describe("Mesh/EditableMesh", function () {
 
     it("rejects non-manifold geometry", function () {});
   });
+
+  describe("edit operations", function () {
+    it("translates components correctly", function () {});
+  });
 });

--- a/packages/edit/Specs/Mesh/EditableMeshSpec.js
+++ b/packages/edit/Specs/Mesh/EditableMeshSpec.js
@@ -14,8 +14,6 @@ describe("Mesh/EditableMesh", function () {
 
     it("assigns correct half-edges to each constructed vertex, edge, and face", function () {});
 
-    it("deduplicates render vertices that represent the same topological vertex", function () {});
-
     it("builds the same topological mesh even when render vertices appear in a different order", function () {});
 
     it("rejects non-manifold geometry", function () {});

--- a/packages/engine/Source/Scene/Editable.js
+++ b/packages/engine/Source/Scene/Editable.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+import DeveloperError from "../Core/DeveloperError.js";
+import defined from "../Core/defined.js";
+
+/** @import Event from "../Core/Event.js"; */
+/** @import Matrix4 from "../Core/Matrix4.js"; */
+/** @import GeometryAccessor from "./GeometryAccessor.js"; */
+
+/**
+ * Interface for objects that expose mesh-editable geometry, used to construct an {@link EditableMesh}.
+ *
+ * Implementers should set `this[Editable.symbol] = true;` so {@link Editable.isEditable} returns true.
+ *
+ * @interface
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class Editable {
+  /** @type {GeometryAccessor} */
+  geometryAccessor;
+
+  /**
+   * World-space model matrix the geometry is drawn under. Treat as read-only.
+   * @type {Matrix4}
+   */
+  modelMatrix;
+
+  /**
+   * Raised when {@link Editable#modelMatrix} changes.
+   * @type {Event<Matrix4>}
+   */
+  modelMatrixChanged;
+
+  constructor() {
+    //>>includeStart('debug', pragmas.debug);
+    DeveloperError.throwInstantiationError();
+    //>>includeEnd('debug');
+  }
+
+  /**
+   * Brand symbol. Implementers set `this[Editable.symbol] = true`.
+   * @type {symbol}
+   */
+  static symbol = Symbol("Editable");
+
+  /**
+   * @param {*} obj
+   * @returns {boolean} True if `obj` is branded as an Editable.
+   */
+  static isEditable(obj) {
+    return defined(obj) && obj[Editable.symbol] === true;
+  }
+}
+export default Editable;

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -1,13 +1,101 @@
 // @ts-check
 
+import DeveloperError from "../Core/DeveloperError.js";
+
+/** @import Cartesian3 from "../Core/Cartesian3.js"; */
+
 /**
  * Interface for reading and updating mesh geometry, agnostic of the underlying rendering representation.
  * Must be implemented by render-side geometry classes to be compatible with EditableMesh.
  *
- * @abstract
- *
- * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ * @interface
+ * @private
  */
-class GeometryAccessor {}
+class GeometryAccessor {
+  /**
+   * Begins a geometry read session.
+   * Implementations may use this to set up temporary state, lock resources, etc.
+   */
+  beginRead() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Ends a geometry read session.
+   * Implementations may use this to tear down temporary state, unlock resources, etc., set up by {@link GeometryAccessor#beginRead}.
+   */
+  endRead() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Begins a geometry write session.
+   * Implementations may use this to set up temporary state, lock resources, etc., in preparation for geometry updates.
+   */
+  beginWrite() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Ends a geometry write session.
+   * Implementations may use this to tear down temporary state, unlock resources, etc., set up by {@link GeometryAccessor#beginWrite}.
+   */
+  endWrite() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the number of faces in the geometry.
+   *
+   * @returns {number}
+   */
+  getFaceCount() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the number of render vertices in a given face.
+   *
+   * @param {number} faceIndex The face index.
+   * @returns {number}
+   */
+  getFaceVertexCount(faceIndex) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the render vertex index for a face corner.
+   * Vertices must be returned in winding order around the face.
+   *
+   * @param {number} faceIndex The face index.
+   * @param {number} vertexIndex The vertex index within the face.
+   * @returns {number}
+   */
+  getFaceVertexIndex(faceIndex, vertexIndex) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the model-space position of a render vertex.
+   * Accessors may assume this is only called between beginRead and endRead.
+   *
+   * @param {number} vertexIndex The render vertex index.
+   * @returns {Cartesian3}
+   */
+  getVertexPosition(vertexIndex) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Updates the model-space position of a render vertex.
+   * Accessors may assume this is only called between beginWrite and endWrite.
+   *
+   * @param {number} vertexIndex The render vertex index.
+   * @param {Cartesian3} position The new position for the vertex.
+   */
+  setVertexPosition(vertexIndex, position) {
+    DeveloperError.throwInstantiationError();
+  }
+}
 
 export default GeometryAccessor;

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -50,7 +50,7 @@ import VertexAttributeSemantic from "./VertexAttributeSemantic.js";
  */
 
 /**
- * @typedef {"getTriangleCount" | "getTriangleVertexIndex" | "setTriangleVertexIndex"} GeometryAccessorFunctionName
+ * @typedef {"vertexCount" | "addVertex" | "removeVertex" | "primitiveVertexCount" | "primitiveCount" | "getPrimitive" | "setPrimitive" | "addPrimitive" | "removePrimitive" } GeometryAccessorFunctionName
  */
 
 /**
@@ -180,11 +180,19 @@ class GeometryAccessSession {
 
     /** @type {GeometryAccessorFunctionName[]} */
     const readTopologyFunctions = [
-      "getTriangleCount",
-      "getTriangleVertexIndex",
+      "vertexCount",
+      "primitiveVertexCount",
+      "primitiveCount",
+      "getPrimitive",
     ];
     /** @type {GeometryAccessorFunctionName[]} */
-    const writeTopologyFunctions = ["setTriangleVertexIndex"];
+    const writeTopologyFunctions = [
+      "setPrimitive",
+      "addPrimitive",
+      "removePrimitive",
+      "addVertex",
+      "removeVertex",
+    ];
 
     if (!canReadTopology) {
       this.#bindErrorFunctions(readTopologyFunctions);

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -143,7 +143,9 @@ class GeometryAccessor {
    * @returns {GeometryAttributeDescriptor[]} The available vertex attribute descriptors.
    */
   getAvailableAttributes() {
-    return this._geometrySessionClass.getAvailableAttributes();
+    return this._geometrySessionClass.getAvailableAttributes(
+      this._accessSessionOptions,
+    );
   }
 }
 
@@ -226,9 +228,10 @@ class GeometryAccessSession {
    * Returns the list of vertex attribute descriptors available on geometry handled by this session class.
    * Subclasses must override this to advertise the attributes they support.
    *
+   * @param {object} [accessSessionOptions] The options that would be passed to a new session of this class.
    * @returns {GeometryAttributeDescriptor[]} The available vertex attribute descriptors.
    */
-  static getAvailableAttributes() {
+  static getAvailableAttributes(accessSessionOptions) {
     DeveloperError.throwInstantiationError();
   }
 

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -4,28 +4,52 @@ import DeveloperError from "../Core/DeveloperError.js";
 import oneTimeWarning from "../Core/oneTimeWarning.js";
 
 /**
- *
- * @import VertexAttributeSemantic from "./VertexAttributeSemantic.js"
- *
+ * @typedef {object} GeometryAttributeDescriptor
+ * @property {string} semantic The attribute semantic.
+ * @property {number} [setIndex] The attribute set index.
+ */
+
+/**
  * @typedef {object} GeometryAccessScope
  * @property {GeometryAttributeDescriptor[]} [attributes] The attributes allowed in this access scope.
  * @property {boolean} [topology=false] Whether topology operations are allowed in this access scope.
- *
+ */
+
+/**
  * @typedef {object} GeometryAccessScopes
  * @property {GeometryAccessScope} [read] The requested read access.
  * @property {GeometryAccessScope} [write] The requested write access.
- *
- * @typedef {object} GeometryAttributeDescriptor
- * @property {VertexAttributeSemantic} semantic
- * @property {number} [setIndex]
- *
+ */
+
+/**
+ * @callback GeometryAccessSessionCallback
+ * @param {GeometryAccessSession} accessSession The active access session.
+ */
+
+/**
+ * @callback GeometryAttributeReader
+ * @param {number} vertexIndex The vertex index to read.
+ * @returns {*} The vertex attribute value.
+ */
+
+/**
+ * @callback GeometryAttributeWriter
+ * @param {number} vertexIndex The vertex index to write.
+ * @param {*} value The vertex attribute value.
+ */
+
+/**
+ * @typedef {object} GeometryAttributeAccessors
+ * @property {GeometryAttributeReader} [get] Reads a vertex attribute value.
+ * @property {GeometryAttributeWriter} [set] Writes a vertex attribute value.
+ */
+
+/**
+ * @typedef {*} GeometryAccessSessionConstructor
+ */
+
+/**
  * @typedef {"getTriangleCount" | "getTriangleVertexIndex" | "setTriangleVertexIndex"} GeometryAccessorFunctionName
- *
- * @typedef {new (
- *  accessor: GeometryAccessor,
- *  scopes: GeometryAccessScopes,
- *  options: any
- * ) => GeometryAccessSession} GeometryAccessSessionConstructor
  */
 
 /**
@@ -82,7 +106,7 @@ class GeometryAccessor {
    * For best performance, only request the access level and attributes needed.
    *
    * @param {GeometryAccessScopes} scopes The requested access scopes for this session.
-   * @param {(accessor: GeometryAccessSession) => void} callback The callback to run.
+   * @param {GeometryAccessSessionCallback} callback The callback to run.
    */
   withSession(scopes, callback) {
     const accessSession = new this._geometrySessionClass(
@@ -152,7 +176,7 @@ class GeometryAccessSession {
   /**
    * Creates a function for reading from a vertex attribute defined by a vertex attribute descriptor (semantic and set index).
    * @param {GeometryAttributeDescriptor} descriptor
-   * @returns {(vertexIndex: number) => *}
+   * @returns {GeometryAttributeReader}
    * @protected
    */
   _createVertexAttributeReader(descriptor) {
@@ -162,7 +186,7 @@ class GeometryAccessSession {
   /**
    * Creates a function for writing to a vertex attribute defined by a vertex attribute descriptor (semantic and set index).
    * @param {GeometryAttributeDescriptor} descriptor
-   * @returns {(vertexIndex: number, value: *) => void}
+   * @returns {GeometryAttributeWriter}
    * @protected
    */
   _createVertexAttributeWriter(descriptor) {
@@ -173,7 +197,7 @@ class GeometryAccessSession {
    * Get accessors for a vertex attribute defined by a vertex attribute descriptor (semantic and set index).
    * If the requested attribute is not included in the session scopes, the accessors log a warning when called.
    * @param {GeometryAttributeDescriptor} descriptor
-   * @returns {{ get?: (vertexIndex: number) => *, set?: (vertexIndex: number, value: *) => void }}
+   * @returns {GeometryAttributeAccessors}
    *
    * @example
    * const positionAccess = session.vertexAttributeAccessors({ semantic: VertexAttributeSemantic.POSITION });
@@ -182,7 +206,7 @@ class GeometryAccessSession {
    * positionAccess.set(0, position); // Write updated position back to geometry
    */
   vertexAttributeAccessors(descriptor) {
-    /** @type {{ get?: (vertexIndex: number) => *, set?: (vertexIndex: number, value: *) => void }} */
+    /** @type {GeometryAttributeAccessors} */
     const accessors = {
       get: (vertexIndex) =>
         oneTimeWarning(
@@ -196,10 +220,13 @@ class GeometryAccessSession {
         ),
     };
 
+    /** @type {GeometryAttributeDescriptor[]} */
     const readAttributes =
       this._scopes.read && this._scopes.read.attributes
         ? this._scopes.read.attributes
         : [];
+
+    /** @type {GeometryAttributeDescriptor[]} */
     const writeAttributes =
       this._scopes.write && this._scopes.write.attributes
         ? this._scopes.write.attributes

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -30,13 +30,14 @@ import VertexAttributeSemantic from "./VertexAttributeSemantic.js";
 /**
  * @callback GeometryAttributeReader
  * @param {number} vertexIndex The vertex index to read.
- * @returns {*} The vertex attribute value.
+ * @param {number[]} results Array to store the vertex attribute value.
+ * @returns {number[]} The vertex attribute value.
  */
 
 /**
  * @callback GeometryAttributeWriter
  * @param {number} vertexIndex The vertex index to write.
- * @param {*} value The vertex attribute value.
+ * @param {number[]} value The vertex attribute value.
  */
 
 /**
@@ -256,11 +257,13 @@ class GeometryAccessSession {
 
     /** @type {GeometryAttributeAccessors} */
     const accessors = {
-      get: (vertexIndex) =>
+      get: (vertexIndex, results) => {
         oneTimeWarning(
           descriptorVariableName,
           `Attempting to read vertex attribute ${descriptor.semantic} (set ${descriptor.setIndex}) without proper access scope.`,
-        ),
+        );
+        return results;
+      },
       set: (vertexIndex, value) =>
         oneTimeWarning(
           descriptorVariableName,

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -2,16 +2,17 @@
 
 import DeveloperError from "../Core/DeveloperError.js";
 import oneTimeWarning from "../Core/oneTimeWarning.js";
+import VertexAttributeSemantic from "./VertexAttributeSemantic.js";
 
 /**
  * @typedef {object} GeometryAttributeDescriptor
- * @property {string} semantic The attribute semantic.
+ * @property {VertexAttributeSemantic} semantic The attribute semantic.
  * @property {number} [setIndex] The attribute set index.
  */
 
 /**
  * @typedef {object} GeometryAccessScope
- * @property {GeometryAttributeDescriptor[]} [attributes] The attributes allowed in this access scope.
+ * @property {Set<GeometryAttributeDescriptor>} [attributes] The attributes allowed in this access scope.
  * @property {boolean} [topology=false] Whether topology operations are allowed in this access scope.
  */
 
@@ -68,9 +69,9 @@ import oneTimeWarning from "../Core/oneTimeWarning.js";
  * ```
  * const sessionScopes = {
  *  read: {
- *    attributes: [
+ *    attributes: new Set([
  *      { semantic: VertexAttributeSemantic.POSITION }
- *    ],
+ *    ]),
  *    topology: true,
  *  },
  * };
@@ -103,7 +104,8 @@ class GeometryAccessor {
   /**
    * Executes a callback in a context that provides the requested resources.
    * This function gives the implementation the chance to acquire resources and ensure they are released after the callback completes.
-   * For best performance, only request the access level and attributes needed.
+   *
+   * Note: the scope just helps the implementation figure out the minimum resources it needs to fetch, for performance.
    *
    * @param {GeometryAccessScopes} scopes The requested access scopes for this session.
    * @param {GeometryAccessSessionCallback} callback The callback to run.
@@ -138,6 +140,30 @@ class GeometryAccessSession {
   constructor(accessor, scopes) {
     this._accessor = accessor;
     this._scopes = scopes;
+    this._readAttributeKeys = new Set();
+    this._writeAttributeKeys = new Set();
+
+    if (scopes.read && scopes.read.attributes) {
+      for (const descriptor of scopes.read.attributes) {
+        this._readAttributeKeys.add(
+          /** @type {any} */ (VertexAttributeSemantic).getVariableName(
+            descriptor.semantic,
+            descriptor.setIndex,
+          ),
+        );
+      }
+    }
+
+    if (scopes.write && scopes.write.attributes) {
+      for (const descriptor of scopes.write.attributes) {
+        this._writeAttributeKeys.add(
+          /** @type {any} */ (VertexAttributeSemantic).getVariableName(
+            descriptor.semantic,
+            descriptor.setIndex,
+          ),
+        );
+      }
+    }
 
     const canReadTopology = !!(scopes.read && scopes.read.topology);
     const canWriteTopology = !!(scopes.write && scopes.write.topology);
@@ -206,49 +232,29 @@ class GeometryAccessSession {
    * positionAccess.set(0, position); // Write updated position back to geometry
    */
   vertexAttributeAccessors(descriptor) {
+    const descriptorVariableName = /** @type {any} */ (
+      VertexAttributeSemantic
+    ).getVariableName(descriptor.semantic, descriptor.setIndex);
+
     /** @type {GeometryAttributeAccessors} */
     const accessors = {
       get: (vertexIndex) =>
         oneTimeWarning(
-          `${descriptor.semantic}_${descriptor.setIndex}`,
+          descriptorVariableName,
           `Attempting to read vertex attribute ${descriptor.semantic} (set ${descriptor.setIndex}) without proper access scope.`,
         ),
       set: (vertexIndex, value) =>
         oneTimeWarning(
-          `${descriptor.semantic}_${descriptor.setIndex}`,
+          descriptorVariableName,
           `Attempting to write vertex attribute ${descriptor.semantic} (set ${descriptor.setIndex}) without proper access scope.`,
         ),
     };
 
-    /** @type {GeometryAttributeDescriptor[]} */
-    const readAttributes =
-      this._scopes.read && this._scopes.read.attributes
-        ? this._scopes.read.attributes
-        : [];
-
-    /** @type {GeometryAttributeDescriptor[]} */
-    const writeAttributes =
-      this._scopes.write && this._scopes.write.attributes
-        ? this._scopes.write.attributes
-        : [];
-
-    if (
-      readAttributes.some(
-        (attr) =>
-          attr.semantic === descriptor.semantic &&
-          attr.setIndex === descriptor.setIndex,
-      )
-    ) {
+    if (this._readAttributeKeys.has(descriptorVariableName)) {
       accessors.get = this._createVertexAttributeReader(descriptor);
     }
 
-    if (
-      writeAttributes.some(
-        (attr) =>
-          attr.semantic === descriptor.semantic &&
-          attr.setIndex === descriptor.setIndex,
-      )
-    ) {
+    if (this._writeAttributeKeys.has(descriptorVariableName)) {
       accessors.set = this._createVertexAttributeWriter(descriptor);
     }
 
@@ -256,34 +262,88 @@ class GeometryAccessSession {
   }
 
   /**
-   * Gets the number of triangles in the geometry.
+   * Gets the number of vertices in the geometry.
    *
-   * @returns {number}
+   * @returns {number} Vertex count of geometry.
    */
-  getTriangleCount() {
+  vertexCount() {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Gets the render vertex index for a triangle corner.
-   * Vertices should be returned in winding order around the triangle.
+   * Adds a new vertex to the geometry and returns its index.
    *
-   * @param {number} triangleIndex The triangle index.
-   * @param {number} vertexIndex The vertex index within the triangle (0, 1, or 2).
-   * @returns {number}
+   * @returns {number} The index of the new vertex.
    */
-  getTriangleVertexIndex(triangleIndex, vertexIndex) {
+  addVertex() {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Updates the render vertex index for a triangle corner.
+   * Removes a vertex from the geometry.
    *
-   * @param {number} triangleIndex The triangle index.
-   * @param {number} vertexIndex The vertex index within the triangle (0, 1, or 2).
-   * @param {number} renderVertexIndex The new render vertex index.
+   * @param {number} vertexIndex The index of the vertex to remove.
    */
-  setTriangleVertexIndex(triangleIndex, vertexIndex, renderVertexIndex) {
+  removeVertex(vertexIndex) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the number of vertices per primitive (e.g. 3 for triangles).
+   *
+   * @returns {number} The number of vertices per primitive.
+   */
+  primitiveVertexCount() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the number of primitives in the geometry.
+   *
+   * @returns {number} Primitive count of geometry.
+   */
+  primitiveCount() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the vertex indices of the vertices that compose a given primitive.
+   * Note: for non-indexed primitives, the primitive index and vertex index are the same and this function should return the primitiveIndex.
+   *
+   * @param {number} primitiveIndex
+   * @param {number[]} results Array of the primitive's vertex indices
+   *
+   * @returns {number[]} The vertex indices for the primitive at the provided index.
+   */
+  getPrimitive(primitiveIndex, results) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Sets the vertex indices of the vertices that compose a given primitive.
+   * Note: for non-indexed primitives, this function should be a no-op.
+   *
+   * @param {number} primitiveIndex
+   * @param {number[]} vertexIndices
+   */
+  setPrimitive(primitiveIndex, vertexIndices) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Adds a new primitive to the geometry with the provided vertex indices.
+   *
+   * @param {number[]} vertexIndices The vertex indices that compose the new primitive.
+   */
+  addPrimitive(vertexIndices) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Removes a primitive from the geometry.
+   * @param {number} primitiveIndex The index of the primitive to remove.
+   */
+  removePrimitive(primitiveIndex) {
     DeveloperError.throwInstantiationError();
   }
 

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -5,42 +5,93 @@ import DeveloperError from "../Core/DeveloperError.js";
 /** @import Cartesian3 from "../Core/Cartesian3.js"; */
 
 /**
- * Interface for reading and updating mesh geometry, agnostic of the underlying rendering representation.
+ * Abstract class for reading and writing mesh geometry, agnostic of the underlying rendering representation.
  * Must be implemented by render-side geometry classes to be compatible with EditableMesh.
  *
- * @interface
+ * Callers must access geometry through {@link GeometryAccessor#withReadAccess}
+ * or {@link GeometryAccessor#withWriteAccess}. These methods allow the
+ * implementation to create short-lived reader and writer objects that own any
+ * staged resources required for the duration of the callback.
+ *
+ * Generally speaking, assume acquiring read or write access is slow and should only be called sparingly (i.e. not for each element read / written).
+ * Callbacks are expected to complete synchronously.
+ *
+ * Enforcing whether nested contexts are allowed is up to the implementation.
+ *
+ * @abstract
  * @private
  */
 class GeometryAccessor {
   /**
-   * Begins a geometry read session.
-   * Implementations may use this to set up temporary state, lock resources, etc.
+   * Executes a function in a context that provides geometry read access.
+   *
+   * @template T
+   * @param {(reader: GeometryReader) => T} callback The callback to run.
+   * @returns {T} The callback result.
    */
-  beginRead() {
+  withReadAccess(callback) {
+    const reader = this._createReader();
+    try {
+      return callback(reader);
+    } finally {
+      reader.destroy();
+    }
+  }
+
+  /**
+   * Executes a function in a context that provides geometry write access.
+   *
+   * @template T
+   * @param {(writer: GeometryWriter) => T} callback The callback to run.
+   * @returns {T} The callback result.
+   */
+  withWriteAccess(callback) {
+    const writer = this._createWriter();
+    try {
+      return callback(writer);
+    } finally {
+      writer.destroy();
+    }
+  }
+
+  /**
+   * Creates a reader for a geometry read session.
+   * Implementations may use this to stage data, allocate temporary state, and
+   * acquire any resources needed by the returned reader.
+   *
+   * @protected
+   * @returns {GeometryReader}
+   */
+  _createReader() {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Ends a geometry read session.
-   * Implementations may use this to tear down temporary state, unlock resources, etc., set up by {@link GeometryAccessor#beginRead}.
+   * Creates a writer for a geometry write session.
+   * Implementations may use this to stage mutable data, allocate temporary
+   * state, and acquire any resources needed by the returned writer.
+   *
+   * @protected
+   * @returns {GeometryWriter}
    */
-  endRead() {
+  _createWriter() {
     DeveloperError.throwInstantiationError();
   }
+}
 
+/**
+ * Abstract base class for a scoped geometry read session.
+ * Implementations own any resources required to read geometry and must release
+ * them when {@link GeometryReader#destroy} is called.
+ *
+ * @abstract
+ * @private
+ */
+class GeometryReader {
   /**
-   * Begins a geometry write session.
-   * Implementations may use this to set up temporary state, lock resources, etc., in preparation for geometry updates.
+   * Releases resources acquired for this read session.
    */
-  beginWrite() {
-    DeveloperError.throwInstantiationError();
-  }
-
-  /**
-   * Ends a geometry write session.
-   * Implementations may use this to tear down temporary state, unlock resources, etc., set up by {@link GeometryAccessor#beginWrite}.
-   */
-  endWrite() {
+  destroy() {
     DeveloperError.throwInstantiationError();
   }
 
@@ -77,7 +128,6 @@ class GeometryAccessor {
 
   /**
    * Gets the model-space position of a render vertex.
-   * Accessors may assume this is only called between beginRead and endRead.
    *
    * @param {number} vertexIndex The render vertex index.
    * @returns {Cartesian3}
@@ -85,10 +135,19 @@ class GeometryAccessor {
   getVertexPosition(vertexIndex) {
     DeveloperError.throwInstantiationError();
   }
+}
 
+/**
+ * Abstract base class for a scoped geometry write session.
+ * A writer also supports all read operations exposed by
+ * {@link GeometryReader}.
+ *
+ * @abstract
+ * @private
+ */
+class GeometryWriter extends GeometryReader {
   /**
    * Updates the model-space position of a render vertex.
-   * Accessors may assume this is only called between beginWrite and endWrite.
    *
    * @param {number} vertexIndex The render vertex index.
    * @param {Cartesian3} position The new position for the vertex.
@@ -98,4 +157,5 @@ class GeometryAccessor {
   }
 }
 
+export { GeometryReader, GeometryWriter };
 export default GeometryAccessor;

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -134,6 +134,17 @@ class GeometryAccessor {
       accessSession.destroy();
     }
   }
+
+  /**
+   * Gets the list of vertex attribute descriptors that this accessor's session class supports.
+   * Useful for consumers that need to enumerate available attributes without opening a session
+   * (e.g. to pre-allocate dirty-tracking state).
+   *
+   * @returns {GeometryAttributeDescriptor[]} The available vertex attribute descriptors.
+   */
+  getAvailableAttributes() {
+    return this._geometrySessionClass.getAvailableAttributes();
+  }
 }
 
 /**
@@ -208,6 +219,16 @@ class GeometryAccessSession {
    * Releases any resources acquired for the current resource scope.
    */
   destroy() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Returns the list of vertex attribute descriptors available on geometry handled by this session class.
+   * Subclasses must override this to advertise the attributes they support.
+   *
+   * @returns {GeometryAttributeDescriptor[]} The available vertex attribute descriptors.
+   */
+  static getAvailableAttributes() {
     DeveloperError.throwInstantiationError();
   }
 

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -42,8 +42,8 @@ import VertexAttributeSemantic from "./VertexAttributeSemantic.js";
 
 /**
  * @typedef {object} GeometryAttributeAccessors
- * @property {GeometryAttributeReader} [get] Reads a vertex attribute value.
- * @property {GeometryAttributeWriter} [set] Writes a vertex attribute value.
+ * @property {GeometryAttributeReader} get Reads a vertex attribute value.
+ * @property {GeometryAttributeWriter} set Writes a vertex attribute value.
  */
 
 /**

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -1,161 +1,288 @@
 // @ts-check
 
 import DeveloperError from "../Core/DeveloperError.js";
-
-/** @import Cartesian3 from "../Core/Cartesian3.js"; */
+import oneTimeWarning from "../Core/oneTimeWarning.js";
 
 /**
- * Abstract class for reading and writing mesh geometry, agnostic of the underlying rendering representation.
- * Must be implemented by render-side geometry classes to be compatible with EditableMesh.
  *
- * Callers must access geometry through {@link GeometryAccessor#withReadAccess}
- * or {@link GeometryAccessor#withWriteAccess}. These methods allow the
- * implementation to create short-lived reader and writer objects that own any
- * staged resources required for the duration of the callback.
+ * @import VertexAttributeSemantic from "./VertexAttributeSemantic.js"
  *
- * Generally speaking, assume acquiring read or write access is slow and should only be called sparingly (i.e. not for each element read / written).
- * Callbacks are expected to complete synchronously.
+ * @typedef {object} GeometryAccessScope
+ * @property {GeometryAttributeDescriptor[]} [attributes] The attributes allowed in this access scope.
+ * @property {boolean} [topology=false] Whether topology operations are allowed in this access scope.
  *
- * Enforcing whether nested contexts are allowed is up to the implementation.
+ * @typedef {object} GeometryAccessScopes
+ * @property {GeometryAccessScope} [read] The requested read access.
+ * @property {GeometryAccessScope} [write] The requested write access.
  *
- * @abstract
- * @private
+ * @typedef {object} GeometryAttributeDescriptor
+ * @property {VertexAttributeSemantic} semantic
+ * @property {number} [setIndex]
+ *
+ * @typedef {"getTriangleCount" | "getTriangleVertexIndex" | "setTriangleVertexIndex"} GeometryAccessorFunctionName
+ *
+ * @typedef {new (
+ *  accessor: GeometryAccessor,
+ *  scopes: GeometryAccessScopes,
+ *  options: any
+ * ) => GeometryAccessSession} GeometryAccessSessionConstructor
+ */
+
+/**
+ * Factory class that creates sessions for reading and writing mesh vertex attributes and topology.
+ * Geometry-owning classes must implement a GeometryAccessSession, and provide it to this class's constructor.
+ *
+ * The method {@link GeometryAccessor#withSession} creates an instance of the provided access session with methods wired up based on the requested access.
+ *
+ * Notes:
+ *   - Generally speaking, assume creating and closing a session is slow (e.g. copies data from a GPU buffer to the CPU or vice versa)
+ *     and should only be used for bulk operations when possible.
+ *   - Callbacks are expected to be completed synchronously.
+ *   - Nothing prevents a consumer from creating multiple sessions at once. Be careful as doing this may result in overwrites or reading stale data.
+ *
+ * @example
+ * ```
+ * const sessionScopes = {
+ *  read: {
+ *    attributes: [
+ *      { semantic: VertexAttributeSemantic.POSITION }
+ *    ],
+ *    topology: true,
+ *  },
+ * };
+ *
+ * myPrimitive.geometryAccessor.withSession(sessionScopes, (session) => {
+ *   const triangleCount = session.getTriangleCount();
+ *   const positionAccessors = session.vertexAttributeAccessors({ semantic: VertexAttributeSemantic.POSITION });
+ *
+ *   for (let i = 0; i < 3 * triangleCount; ++i) {
+ *     const position = positionAccessors.get(i);
+ *     // Do something with vertex position...
+ *   }
+ * });
+ * ```
  */
 class GeometryAccessor {
   /**
-   * Executes a function in a context that provides geometry read access.
-   *
-   * @template T
-   * @param {(reader: GeometryReader) => T} callback The callback to run.
-   * @returns {T} The callback result.
+   * @param {GeometryAccessSessionConstructor} accessSessionClass The class that implements GeometryAccessSession for this accessor.
+   * @param {object} [accessSessionOptions] Options to pass to created GeometryAccessSessions.
    */
-  withReadAccess(callback) {
-    const reader = this._createReader();
-    try {
-      return callback(reader);
-    } finally {
-      reader.destroy();
+  constructor(accessSessionClass, accessSessionOptions) {
+    if (!(accessSessionClass.prototype instanceof GeometryAccessSession)) {
+      DeveloperError.throwInstantiationError();
     }
+
+    this._geometrySessionClass = accessSessionClass;
+    this._accessSessionOptions = accessSessionOptions;
   }
 
   /**
-   * Executes a function in a context that provides geometry write access.
+   * Executes a callback in a context that provides the requested resources.
+   * This function gives the implementation the chance to acquire resources and ensure they are released after the callback completes.
+   * For best performance, only request the access level and attributes needed.
    *
-   * @template T
-   * @param {(writer: GeometryWriter) => T} callback The callback to run.
-   * @returns {T} The callback result.
+   * @param {GeometryAccessScopes} scopes The requested access scopes for this session.
+   * @param {(accessor: GeometryAccessSession) => void} callback The callback to run.
    */
-  withWriteAccess(callback) {
-    const writer = this._createWriter();
+  withSession(scopes, callback) {
+    const accessSession = new this._geometrySessionClass(
+      this,
+      scopes,
+      this._accessSessionOptions,
+    );
+
     try {
-      return callback(writer);
+      callback(accessSession);
     } finally {
-      writer.destroy();
+      accessSession.destroy();
     }
-  }
-
-  /**
-   * Creates a reader for a geometry read session.
-   * Implementations may use this to stage data, allocate temporary state, and
-   * acquire any resources needed by the returned reader.
-   *
-   * @protected
-   * @returns {GeometryReader}
-   */
-  _createReader() {
-    DeveloperError.throwInstantiationError();
-  }
-
-  /**
-   * Creates a writer for a geometry write session.
-   * Implementations may use this to stage mutable data, allocate temporary
-   * state, and acquire any resources needed by the returned writer.
-   *
-   * @protected
-   * @returns {GeometryWriter}
-   */
-  _createWriter() {
-    DeveloperError.throwInstantiationError();
   }
 }
 
 /**
- * Abstract base class for a scoped geometry read session.
- * Implementations own any resources required to read geometry and must release
- * them when {@link GeometryReader#destroy} is called.
- *
+ * Session in a GeometryAccessor that (lightly) enforces access to only the operations allowed for the requested scopes.
+ * An implementation should define a constructor with any options necessary for resource acquisition.
  * @abstract
- * @private
  */
-class GeometryReader {
+class GeometryAccessSession {
   /**
-   * Releases resources acquired for this read session.
+   * Acquires any resources needed for the requested resource scope.
+   * Subclasses that override this should call the base implementation to enforce access scope restrictions.
+   * @param {GeometryAccessor} accessor The parent accessor for this session.
+   * @param {GeometryAccessScopes} scopes The requested resources.
+   */
+  constructor(accessor, scopes) {
+    this._accessor = accessor;
+    this._scopes = scopes;
+
+    const canReadTopology = !!(scopes.read && scopes.read.topology);
+    const canWriteTopology = !!(scopes.write && scopes.write.topology);
+
+    /** @type {GeometryAccessorFunctionName[]} */
+    const readTopologyFunctions = [
+      "getTriangleCount",
+      "getTriangleVertexIndex",
+    ];
+    /** @type {GeometryAccessorFunctionName[]} */
+    const writeTopologyFunctions = ["setTriangleVertexIndex"];
+
+    if (!canReadTopology) {
+      this.#bindErrorFunctions(readTopologyFunctions);
+    }
+
+    if (!canWriteTopology) {
+      this.#bindErrorFunctions(writeTopologyFunctions);
+    }
+  }
+
+  /**
+   * Releases any resources acquired for the current resource scope.
    */
   destroy() {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Gets the number of faces in the geometry.
-   *
-   * @returns {number}
+   * Commit changes to underlying geometry without ending the session.
    */
-  getFaceCount() {
+  commit() {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Gets the number of render vertices in a given face.
-   *
-   * @param {number} faceIndex The face index.
-   * @returns {number}
+   * Creates a function for reading from a vertex attribute defined by a vertex attribute descriptor (semantic and set index).
+   * @param {GeometryAttributeDescriptor} descriptor
+   * @returns {(vertexIndex: number) => *}
+   * @protected
    */
-  getFaceVertexCount(faceIndex) {
+  _createVertexAttributeReader(descriptor) {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Gets the render vertex index for a face corner.
-   * Vertices must be returned in winding order around the face.
-   *
-   * @param {number} faceIndex The face index.
-   * @param {number} vertexIndex The vertex index within the face.
-   * @returns {number}
+   * Creates a function for writing to a vertex attribute defined by a vertex attribute descriptor (semantic and set index).
+   * @param {GeometryAttributeDescriptor} descriptor
+   * @returns {(vertexIndex: number, value: *) => void}
+   * @protected
    */
-  getFaceVertexIndex(faceIndex, vertexIndex) {
+  _createVertexAttributeWriter(descriptor) {
     DeveloperError.throwInstantiationError();
   }
 
   /**
-   * Gets the model-space position of a render vertex.
+   * Get accessors for a vertex attribute defined by a vertex attribute descriptor (semantic and set index).
+   * If the requested attribute is not included in the session scopes, the accessors log a warning when called.
+   * @param {GeometryAttributeDescriptor} descriptor
+   * @returns {{ get?: (vertexIndex: number) => *, set?: (vertexIndex: number, value: *) => void }}
    *
-   * @param {number} vertexIndex The render vertex index.
-   * @returns {Cartesian3}
+   * @example
+   * const positionAccess = session.vertexAttributeAccessors({ semantic: VertexAttributeSemantic.POSITION });
+   * const position = positionAccess.get(0); // Get position of first vertex
+   * position[0] += 1.0; // Move vertex 1 unit in x direction
+   * positionAccess.set(0, position); // Write updated position back to geometry
    */
-  getVertexPosition(vertexIndex) {
+  vertexAttributeAccessors(descriptor) {
+    /** @type {{ get?: (vertexIndex: number) => *, set?: (vertexIndex: number, value: *) => void }} */
+    const accessors = {
+      get: (vertexIndex) =>
+        oneTimeWarning(
+          `${descriptor.semantic}_${descriptor.setIndex}`,
+          `Attempting to read vertex attribute ${descriptor.semantic} (set ${descriptor.setIndex}) without proper access scope.`,
+        ),
+      set: (vertexIndex, value) =>
+        oneTimeWarning(
+          `${descriptor.semantic}_${descriptor.setIndex}`,
+          `Attempting to write vertex attribute ${descriptor.semantic} (set ${descriptor.setIndex}) without proper access scope.`,
+        ),
+    };
+
+    const readAttributes =
+      this._scopes.read && this._scopes.read.attributes
+        ? this._scopes.read.attributes
+        : [];
+    const writeAttributes =
+      this._scopes.write && this._scopes.write.attributes
+        ? this._scopes.write.attributes
+        : [];
+
+    if (
+      readAttributes.some(
+        (attr) =>
+          attr.semantic === descriptor.semantic &&
+          attr.setIndex === descriptor.setIndex,
+      )
+    ) {
+      accessors.get = this._createVertexAttributeReader(descriptor);
+    }
+
+    if (
+      writeAttributes.some(
+        (attr) =>
+          attr.semantic === descriptor.semantic &&
+          attr.setIndex === descriptor.setIndex,
+      )
+    ) {
+      accessors.set = this._createVertexAttributeWriter(descriptor);
+    }
+
+    return accessors;
+  }
+
+  /**
+   * Gets the number of triangles in the geometry.
+   *
+   * @returns {number}
+   */
+  getTriangleCount() {
     DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Gets the render vertex index for a triangle corner.
+   * Vertices should be returned in winding order around the triangle.
+   *
+   * @param {number} triangleIndex The triangle index.
+   * @param {number} vertexIndex The vertex index within the triangle (0, 1, or 2).
+   * @returns {number}
+   */
+  getTriangleVertexIndex(triangleIndex, vertexIndex) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Updates the render vertex index for a triangle corner.
+   *
+   * @param {number} triangleIndex The triangle index.
+   * @param {number} vertexIndex The vertex index within the triangle (0, 1, or 2).
+   * @param {number} renderVertexIndex The new render vertex index.
+   */
+  setTriangleVertexIndex(triangleIndex, vertexIndex, renderVertexIndex) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * @param {GeometryAccessorFunctionName[]} functionNames
+   */
+  #bindErrorFunctions(functionNames) {
+    const session = /** @type {any} */ (this);
+    for (let i = 0; i < functionNames.length; ++i) {
+      const functionName = functionNames[i];
+      session[functionName] = createAccessErrorFunction(functionName);
+    }
   }
 }
 
 /**
- * Abstract base class for a scoped geometry write session.
- * A writer also supports all read operations exposed by
- * {@link GeometryReader}.
- *
- * @abstract
- * @private
+ * @param {string} methodName The method name.
+ * @returns {Function}
  */
-class GeometryWriter extends GeometryReader {
-  /**
-   * Updates the model-space position of a render vertex.
-   *
-   * @param {number} vertexIndex The render vertex index.
-   * @param {Cartesian3} position The new position for the vertex.
-   */
-  setVertexPosition(vertexIndex, position) {
-    DeveloperError.throwInstantiationError();
-  }
+function createAccessErrorFunction(methodName) {
+  return function () {
+    throw new DeveloperError(
+      `${methodName} is not available for the provided access scopes.`,
+    );
+  };
 }
 
-export { GeometryReader, GeometryWriter };
 export default GeometryAccessor;
+export { GeometryAccessSession };

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -1,9 +1,9 @@
+// @ts-check
+
 /**
  * Interface for reading and updating mesh geometry, agnostic of the underlying rendering representation.
  * Must be implemented by render-side geometry classes to be compatible with EditableMesh.
  *
- * @alias GeometryAccessor
- * @constructor
  * @abstract
  *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -1,0 +1,13 @@
+/**
+ * Interface for reading and updating mesh geometry, agnostic of the underlying rendering representation.
+ * Must be implemented by render-side geometry classes to be compatible with EditableMesh.
+ *
+ * @alias GeometryAccessor
+ * @constructor
+ * @abstract
+ *
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class GeometryAccessor {}
+
+export default GeometryAccessor;

--- a/packages/engine/Source/Scene/GeometryAccessor.js
+++ b/packages/engine/Source/Scene/GeometryAccessor.js
@@ -102,6 +102,20 @@ class GeometryAccessor {
   }
 
   /**
+   * Creates and returns a session for accessing geometry with methods wired up based on the requested access scopes.
+   * Consumers must call the {@link GeometryAccessSession#destroy} method when they are finished with it to release any resources acquired for the session.
+   *
+   * This is less safe than using {@link GeometryAccessor#withSession}, but gives consumers the ability to hold a long-running session.
+   *
+   * @param {GeometryAccessScopes} scopes The requested access scopes for this session.
+   * @returns {GeometryAccessSession} An access session with methods wired up based on the requested access.
+   */
+  openSession(scopes) {
+    const GeometrySessionClass = this._geometrySessionClass;
+    return new GeometrySessionClass(this, scopes, this._accessSessionOptions);
+  }
+
+  /**
    * Executes a callback in a context that provides the requested resources.
    * This function gives the implementation the chance to acquire resources and ensure they are released after the callback completes.
    *
@@ -111,11 +125,7 @@ class GeometryAccessor {
    * @param {GeometryAccessSessionCallback} callback The callback to run.
    */
   withSession(scopes, callback) {
-    const accessSession = new this._geometrySessionClass(
-      this,
-      scopes,
-      this._accessSessionOptions,
-    );
+    const accessSession = this.openSession(scopes);
 
     try {
       callback(accessSession);
@@ -271,7 +281,7 @@ class GeometryAccessSession {
   }
 
   /**
-   * Adds a new vertex to the geometry and returns its index.
+   * Adds a new vertex to the geometry, with default values, and returns its index.
    *
    * @returns {number} The index of the new vertex.
    */

--- a/packages/engine/Source/Scene/Highlightable.js
+++ b/packages/engine/Source/Scene/Highlightable.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+import DeveloperError from "../Core/DeveloperError.js";
+import defined from "../Core/defined.js";
+
+/** @import Color from "../Core/Color.js"; */
+
+/**
+ * Interface for objects that can render a visual highlight (e.g. for hover or selection).
+ * Implementers choose how the highlight is rendered (silhouette, outline, tint - in the future, maybe the
+ * highlight type becomes a part of this interface).
+ *
+ * Implementers should set `this[Highlightable.symbol] = true;` so {@link Highlightable.isHighlightable} returns true.
+ *
+ * @interface
+ * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+class Highlightable {
+  constructor() {
+    //>>includeStart('debug', pragmas.debug);
+    DeveloperError.throwInstantiationError();
+    //>>includeEnd('debug');
+  }
+
+  /**
+   * @param {Color|undefined} color Highlight color, or `undefined` to clear.
+   * @param {number|undefined} intensity Highlight intensity, or `undefined` to use default.
+   */
+  setHighlight(color, intensity) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Brand symbol. Implementers set `this[Highlightable.symbol] = true`.
+   * @type {symbol}
+   */
+  static symbol = Symbol("Highlightable");
+
+  /**
+   * @param {*} obj
+   * @returns {boolean} True if `obj` is branded as a Highlightable.
+   */
+  static isHighlightable(obj) {
+    return defined(obj) && obj[Highlightable.symbol] === true;
+  }
+}
+
+export default Highlightable;

--- a/packages/engine/Specs/Scene/GeometryAccessorSpec.js
+++ b/packages/engine/Specs/Scene/GeometryAccessorSpec.js
@@ -1,0 +1,27 @@
+describe("Scene/GeometryAccessor", function () {
+  describe("session lifecycle", function () {
+    it("acquires resources on construction of a session", function () {});
+
+    it("destroys the session after a successful callback", function () {});
+
+    it("destroys the session and rethrows when the callback throws", function () {});
+  });
+
+  describe("topology access control", function () {
+    it("rejects topology reads when read topology access was not requested", function () {});
+
+    it("rejects topology writes when write topology access was not requested", function () {});
+
+    it("allows topology reads when read topology access was requested", function () {});
+
+    it("allows topology writes when write topology access was requested", function () {});
+  });
+
+  describe("vertex attribute access control", function () {
+    it("grants attribute read access only for an exact descriptor match", function () {});
+
+    it("grants attribute write access only for an exact descriptor match", function () {});
+
+    it("warns and leaves geometry unchanged for unauthorized attribute access", function () {});
+  });
+});

--- a/scripts/buildSandcastle.js
+++ b/scripts/buildSandcastle.js
@@ -140,6 +140,10 @@ export async function buildSandcastleApp({
           path: "../../../packages/edit/Build/Unminified/index.js",
           typesPath: "../../../packages/edit/index.d.ts",
         },
+        "@cesium/edit": {
+          path: "../../../packages/edit/Build/Unminified/index.js",
+          typesPath: "../../../packages/edit/index.d.ts",
+        },
         "@cesium/widgets": {
           path: "../../../packages/widgets/Build/Unminified/index.js",
           typesPath: "../../packages/widgets/index.d.ts",


### PR DESCRIPTION
# Description

=== DO NOT MERGE ===
Preceded by #13397

Introduces a half-edge mesh data structure for a CPU-side mesh editing representation. This data structure strikes a good balance between memory size and speed (for operations requiring adjacency information).

Also introduces a new interface `GeometryAccessor`. Any class that implements a `GeometryAccessSession` subclass can expose a `GeometryAccessor` that can create access sessions scoped to certain resources (read/write vertex attributes and topology). This is intended to be a new, very cross-compatible, general way to access low-level geometry data. See the comment [here](https://github.com/CesiumGS/cesium/pull/13400#discussion_r3113059178) for a discussion of its design.

Note: this PR outlines the new APIs. The implementations will follow in the next PR. This is mostly as a design practice (quasi-TDD), and to make review easier.

## Issue number and link

#13398

## Testing plan

No testing plan - this is just a scaffold for the implementation in the next PR.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
