### PR TITLE
Fix `Unhandled promise rejection: undefined thrown` in CI

### DIFF
--- a/packages/engine/Source/Core/Iau2006XysData.js
+++ b/packages/engine/Source/Core/Iau2006XysData.js
@@ -253,7 +253,8 @@ async function requestXysChunkJson(resource, index, xysData) {
     const chunk = await resource.fetchJson();
     xysData._updateChunkData(index, chunk);
   } catch (e) {
-    // TODO: Retry?
+    // Swallow the error. Proper error handling was not initially implemented
+    // for this class, and upstream systems all have fallbacks.
   }
 }
 

--- a/packages/engine/Source/Core/Iau2006XysData.js
+++ b/packages/engine/Source/Core/Iau2006XysData.js
@@ -142,7 +142,7 @@ Iau2006XysData.prototype.preload = function (
  *                 the Terrestrial Time (TT) time standard.
  * @param {Iau2006XysSample} [result] The instance to which to copy the interpolated result.  If this parameter
  *                           is undefined, a new instance is allocated and returned.
- * @returns {Iau2006XysSample} The interpolated XYS values, or undefined if the required data for this
+ * @returns {Iau2006XysSample|undefined} The interpolated XYS values, or undefined if the required data for this
  *                             computation has not yet been downloaded.
  *
  * @see Iau2006XysData#preload
@@ -237,8 +237,28 @@ Iau2006XysData.prototype.computeXysRadians = function (
   return result;
 };
 
+Iau2006XysData.prototype._updateChunkData = function (index, { samples }) {
+  this._chunkDownloadsInProgress[index] = undefined;
+
+  const samplesPerFile = this._samplesPerXysFile;
+  const startIndex = index * samplesPerFile * 3;
+
+  for (let i = 0; i < samples.length; ++i) {
+    this._samples[startIndex + i] = samples[i];
+  }
+};
+
+async function requestXysChunkJson(resource, index, xysData) {
+  try {
+    const chunk = await resource.fetchJson();
+    xysData._updateChunkData(index, chunk);
+  } catch (e) {
+    // TODO: Retry?
+  }
+}
+
 function requestXysChunk(xysData, chunkIndex) {
-  if (xysData._chunkDownloadsInProgress[chunkIndex]) {
+  if (defined(xysData._chunkDownloadsInProgress[chunkIndex])) {
     // Chunk has already been requested.
     return xysData._chunkDownloadsInProgress[chunkIndex];
   }
@@ -257,17 +277,7 @@ function requestXysChunk(xysData, chunkIndex) {
     });
   }
 
-  const promise = chunkUrl.fetchJson().then(function (chunk) {
-    xysData._chunkDownloadsInProgress[chunkIndex] = false;
-
-    const samples = xysData._samples;
-    const newSamples = chunk.samples;
-    const startIndex = chunkIndex * xysData._samplesPerXysFile * 3;
-
-    for (let i = 0, len = newSamples.length; i < len; ++i) {
-      samples[startIndex + i] = newSamples[i];
-    }
-  });
+  const promise = requestXysChunkJson(chunkUrl, chunkIndex, xysData);
   xysData._chunkDownloadsInProgress[chunkIndex] = promise;
 
   return promise;

--- a/packages/engine/Source/Core/RequestScheduler.js
+++ b/packages/engine/Source/Core/RequestScheduler.js
@@ -7,6 +7,7 @@ import Heap from "./Heap.js";
 import isBlobUri from "./isBlobUri.js";
 import isDataUri from "./isDataUri.js";
 import RequestState from "./RequestState.js";
+import RuntimeError from "./RuntimeError.js";
 
 function sortRequests(a, b) {
   return a.priority - b.priority;
@@ -219,6 +220,7 @@ function getRequestReceivedFunction(request) {
 function getRequestFailedFunction(request) {
   return function (error) {
     if (request.state === RequestState.CANCELLED) {
+      // The error is handled in cancelRequest()
       // If the data request comes back but the request is cancelled, ignore it.
       return;
     }
@@ -249,12 +251,15 @@ function cancelRequest(request) {
   const active = request.state === RequestState.ACTIVE;
   request.state = RequestState.CANCELLED;
   ++statistics.numberOfCancelledRequests;
-  // check that deferred has not been cleared since cancelRequest can be called
-  // on a finished request, e.g. by clearForSpecs during tests
+  // If the request has resolved, request.deferred should now be undefined
+  // If it's in progress, fail the promise immediately and discard it, but ensure the failure is handled so the failure does not bubble up, e.g. by clearForSpecs during tests
   if (defined(request.deferred)) {
     const deferred = request.deferred;
+    deferred.promise.catch(() => {
+      // noop fallback handler
+    });
     request.deferred = undefined;
-    deferred.reject();
+    deferred.reject(new RuntimeError("Request cancelled"));
   }
 
   if (active) {

--- a/packages/engine/Source/Core/RequestScheduler.js
+++ b/packages/engine/Source/Core/RequestScheduler.js
@@ -259,7 +259,7 @@ function cancelRequest(request) {
       // noop fallback handler
     });
     request.deferred = undefined;
-    deferred.reject(new RuntimeError("Request cancelled"));
+    deferred.reject(new RuntimeError(`Request cancelled: "${request.url}"`));
   }
 
   if (active) {

--- a/packages/engine/Specs/Core/RequestSchedulerSpec.js
+++ b/packages/engine/Specs/Core/RequestSchedulerSpec.js
@@ -239,7 +239,7 @@ describe("Core/RequestScheduler", function () {
       function (error) {
         // Request will be cancelled
         expect(error).toBeDefined();
-        expect(error.message).toEqual("Request cancelled");
+        expect(error.message).toContain("Request cancelled");
       },
     );
     expect(promise).toBeDefined();
@@ -1011,7 +1011,7 @@ describe("Core/RequestScheduler", function () {
       .catch(function (error) {
         // Request will be cancelled
         expect(error).toBeDefined();
-        expect(error.message).toEqual("Request cancelled");
+        expect(error.message).toContain("Request cancelled");
       });
   });
 

--- a/packages/engine/Specs/Core/RequestSchedulerSpec.js
+++ b/packages/engine/Specs/Core/RequestSchedulerSpec.js
@@ -238,7 +238,8 @@ describe("Core/RequestScheduler", function () {
     const promise = RequestScheduler.request(firstRequest).catch(
       function (error) {
         // Request will be cancelled
-        expect(error).toBeUndefined();
+        expect(error).toBeDefined();
+        expect(error.message).toEqual("Request cancelled");
       },
     );
     expect(promise).toBeDefined();
@@ -418,6 +419,44 @@ describe("Core/RequestScheduler", function () {
       .catch(function (error) {
         expect(request.state).toBe(RequestState.CANCELLED);
       });
+  });
+
+  it("does not emit an unhandled rejection when a cancelled request's promise is discarded", async function () {
+    const originalHandler = window.onunhandledrejection;
+    let unhandledRejection = false;
+    window.onunhandledrejection = function (event) {
+      unhandledRejection = true;
+      event.preventDefault();
+    };
+
+    let deferred;
+    let cancelled = false;
+    const request = new Request({
+      throttle: true,
+      url: "https://test.invalid/1",
+      requestFunction: function () {
+        // Simulate a request failing
+        deferred = defer();
+        return deferred.promise;
+      },
+      cancelFunction: function () {
+        cancelled = true;
+      },
+    });
+
+    RequestScheduler.request(request);
+    RequestScheduler.update();
+
+    request.cancel();
+    RequestScheduler.update();
+
+    deferred.reject("fail request");
+
+    await expectAsync(deferred.promise).toBeRejected();
+
+    expect(cancelled).toBeTrue();
+    expect(unhandledRejection).toBeFalse();
+    window.onunhandledrejection = originalHandler;
   });
 
   it("handles request failure", function () {
@@ -970,7 +1009,9 @@ describe("Core/RequestScheduler", function () {
         fail();
       })
       .catch(function (error) {
-        expect(error).toBeUndefined();
+        // Request will be cancelled
+        expect(error).toBeDefined();
+        expect(error.message).toEqual("Request cancelled");
       });
   });
 


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

I'm really hoping this addresses the root of the sporadic failures we've been seeing in CI. 🤞 

With some brute-force help from copilot, I tracked down where `RequestScheduler` was rejecting with with `undefined`. 

1. Since `undefined` is not very helpful in isolation, I changed it to be a slightly more descriptive `RuntimeError` which should also help by providing a stack trace if or when it is unhandled.
2. Added a fallback `catch` block to cancelled requests to ensure any rejections are handled once the reference to the original promise is lost.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/11958

## Testing plan

1. CI should pass
2. In `main`, the original issue can be reproduced with `npm run test -- --webgl-stub`. In this branch, multiple runs of the same command should consistently pass.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~I have updated `CHANGES.md` with a short summary of my change~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code

## AI acknowledgment

_No content was generated by AI, but I used GitHub Copilot to trace down the source of the rejection._

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
