### PR TITLE
Draft for external tileset schema handling

### DIFF
--- a/packages/engine/Source/Scene/Cesium3DTile.js
+++ b/packages/engine/Source/Scene/Cesium3DTile.js
@@ -53,12 +53,18 @@ import VerticalExaggeration from "../Core/VerticalExaggeration.js";
  *
  * @alias Cesium3DTile
  * @constructor
- * @param {Cesium3DTileset} tileset The tileset
+ * @param {Cesium3DTileset} tileset The tileset. Now which one? The global
+ * one, or the "external" one that contains this tile? However.
+ * @param {MetadataSchema|undefined} metadataSchema The metadata schema
+ * that contains the definition of the metadata for the tile. This may
+ * be different from the 'tileset.schema', for the case that the tile
+ * is actually contained in an external tileset that defines its own
+ * schema.
  * @param {Resource} baseResource The base resource for the tileset
  * @param {object} header The JSON header for the tile
  * @param {Cesium3DTile} parent The parent tile of the new tile
  */
-function Cesium3DTile(tileset, baseResource, header, parent) {
+function Cesium3DTile(tileset, metadataSchema, baseResource, header, parent) {
   this._tileset = tileset;
   this._header = header;
 
@@ -117,7 +123,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * @private
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
-  this.metadata = findTileMetadata(tileset, header);
+  this.metadata = findTileMetadata(metadataSchema, header);
 
   this._verticalExaggeration = 1.0;
   this._verticalExaggerationRelativeHeight = 0.0;

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -2200,7 +2200,7 @@ Cesium3DTileset.fromUrl = async function (url, options) {
   }
 
   const tilesetJson = await Cesium3DTileset.loadJson(resource);
-  const metadataExtension = await processMetadataExtension(
+  const metadataExtension = await Cesium3DTileset.processMetadataExtension(
     resource,
     tilesetJson,
   );
@@ -2234,7 +2234,11 @@ Cesium3DTileset.fromUrl = async function (url, options) {
   tileset._modelUpAxis = modelUpAxis;
   tileset._modelForwardAxis = modelForwardAxis;
 
-  tileset._root = tileset.loadTileset(resource, tilesetJson);
+  tileset._root = tileset.loadTileset(
+    resource,
+    tilesetJson,
+    metadataExtension?.schema,
+  );
 
   // Save the original, untransformed bounding volume position so we can apply
   // the tile transform and model matrix at run time
@@ -2286,6 +2290,10 @@ Cesium3DTileset.prototype.makeStyleDirty = function () {
 /**
  * Loads the main tileset JSON file or a tileset JSON file referenced from a tile.
  *
+ * @param {MetadataSchema|undefined} containingTilesetMetadataSchema The
+ * MetadataSchema object of the tileset. The metadata of the root
+ * tile will be resolved against this metadata schema
+ * @returns {Cesium3DTile} The root tile
  * @exception {RuntimeError} When the tileset asset version is not 0.0, 1.0, or 1.1,
  * or when the tileset contains a required extension that is not supported.
  *
@@ -2294,6 +2302,7 @@ Cesium3DTileset.prototype.makeStyleDirty = function () {
 Cesium3DTileset.prototype.loadTileset = function (
   resource,
   tilesetJson,
+  containingTilesetMetadataSchema,
   parentTile,
 ) {
   const asset = tilesetJson.asset;
@@ -2326,7 +2335,14 @@ Cesium3DTileset.prototype.loadTileset = function (
 
   // A tileset JSON file referenced from a tile may exist in a different directory than the root tileset.
   // Get the basePath relative to the external tileset.
-  const rootTile = makeTile(this, resource, tilesetJson.root, parentTile);
+  // Now, this comment has nothing to do with the next line, but let's just randomly mention that here.
+  const rootTile = makeTile(
+    this,
+    containingTilesetMetadataSchema,
+    resource,
+    tilesetJson.root,
+    parentTile,
+  );
 
   // If there is a parentTile, add the root of the currently loading tileset
   // to parentTile's children, and update its _depth.
@@ -2347,7 +2363,13 @@ Cesium3DTileset.prototype.loadTileset = function (
     if (defined(children)) {
       for (let i = 0; i < children.length; ++i) {
         const childHeader = children[i];
-        const childTile = makeTile(this, resource, childHeader, tile);
+        const childTile = makeTile(
+          this,
+          containingTilesetMetadataSchema,
+          resource,
+          childHeader,
+          tile,
+        );
         tile.children.push(childTile);
         childTile._depth = tile._depth + 1;
         stack.push(childTile);
@@ -2368,6 +2390,9 @@ Cesium3DTileset.prototype.loadTileset = function (
  * it creates a placeholder tile instead for lazy evaluation of the implicit tileset.
  *
  * @param {Cesium3DTileset} tileset The tileset
+ * @param {MetadataSchema|undefined} metadataSchema The metadata schema that
+ * should be used for the tile. This may be different from the 'tileset.schema'
+ * if the tile is contained in an external tileset that defines its own schema.
  * @param {Resource} baseResource The base resource for the tileset
  * @param {object} tileHeader The JSON header for the tile
  * @param {Cesium3DTile} [parentTile] The parent tile of the new tile
@@ -2375,16 +2400,26 @@ Cesium3DTileset.prototype.loadTileset = function (
  *
  * @private
  */
-function makeTile(tileset, baseResource, tileHeader, parentTile) {
+function makeTile(
+  tileset,
+  metadataSchema,
+  baseResource,
+  tileHeader,
+  parentTile,
+) {
   const hasImplicitTiling =
     defined(tileHeader.implicitTiling) ||
     hasExtension(tileHeader, "3DTILES_implicit_tiling");
 
   if (!hasImplicitTiling) {
-    return new Cesium3DTile(tileset, baseResource, tileHeader, parentTile);
+    return new Cesium3DTile(
+      tileset,
+      metadataSchema,
+      baseResource,
+      tileHeader,
+      parentTile,
+    );
   }
-
-  const metadataSchema = tileset.schema;
 
   const implicitTileset = new ImplicitTileset(
     baseResource,
@@ -2423,7 +2458,13 @@ function makeTile(tileset, baseResource, tileHeader, parentTile) {
   // copy them to the transcoded tiles.
   delete tileJson.extensions;
 
-  const tile = new Cesium3DTile(tileset, baseResource, tileJson, parentTile);
+  const tile = new Cesium3DTile(
+    tileset,
+    metadataSchema,
+    baseResource,
+    tileJson,
+    parentTile,
+  );
   tile.implicitTileset = implicitTileset;
   tile.implicitCoordinates = rootCoordinates;
   return tile;
@@ -2438,7 +2479,10 @@ function makeTile(tileset, baseResource, tileHeader, parentTile) {
  * @return {Promise<Cesium3DTilesetMetadata>} The loaded Cesium3DTilesetMetadata
  * @private
  */
-async function processMetadataExtension(resource, tilesetJson) {
+Cesium3DTileset.processMetadataExtension = async function (
+  resource,
+  tilesetJson,
+) {
   const metadataJson = hasExtension(tilesetJson, "3DTILES_metadata")
     ? tilesetJson.extensions["3DTILES_metadata"]
     : tilesetJson;
@@ -2469,7 +2513,7 @@ async function processMetadataExtension(resource, tilesetJson) {
   ResourceCache.unload(schemaLoader);
 
   return metadataExtension;
-}
+};
 
 const scratchPositionNormal = new Cartesian3();
 const scratchCartographic = new Cartographic();

--- a/packages/engine/Source/Scene/I3SNode.js
+++ b/packages/engine/Source/Scene/I3SNode.js
@@ -192,6 +192,7 @@ I3SNode.prototype.load = async function () {
 
       that._tile = new Cesium3DTile(
         that._layer._tileset,
+        this._layer._tileset.schema,
         that._dataProvider.resource,
         tileDefinition,
         that._parent._tile,

--- a/packages/engine/Source/Scene/Implicit3DTileContent.js
+++ b/packages/engine/Source/Scene/Implicit3DTileContent.js
@@ -1154,7 +1154,13 @@ function makePlaceholderChildSubtree(content, parentTile, childIndex) {
  */
 function makeTile(content, baseResource, tileJson, parentTile) {
   const Cesium3DTile = content._tile.constructor;
-  return new Cesium3DTile(content._tileset, baseResource, tileJson, parentTile);
+  return new Cesium3DTile(
+    content._tileset,
+    content._tileset.schema,
+    baseResource,
+    tileJson,
+    parentTile,
+  );
 }
 
 /**

--- a/packages/engine/Source/Scene/Tileset3DTileContent.js
+++ b/packages/engine/Source/Scene/Tileset3DTileContent.js
@@ -1,4 +1,5 @@
 import destroyObject from "../Core/destroyObject.js";
+import Cesium3DTileset from "./Cesium3DTileset.js";
 
 /**
  * Represents content for a tile in a
@@ -137,9 +138,28 @@ Object.defineProperties(Tileset3DTileContent.prototype, {
  */
 Tileset3DTileContent.fromJson = function (tileset, tile, resource, json) {
   const content = new Tileset3DTileContent(tileset, tile, resource);
-  content._tileset.loadTileset(content._resource, json, content._tile);
-  content._ready = true;
+  const tilesetMetadataPromise = Cesium3DTileset.processMetadataExtension(
+    resource,
+    json,
+  );
+  tilesetMetadataPromise.then((externalTilesetMetadata) => {
+    // XXX_EXTERNAL_SCHEMA
+    {
+      console.log("Loaded metadata for external: ", externalTilesetMetadata);
+      if (tileset.schema) {
+        console.log("Using external one instead of one from the root");
+      }
+    }
 
+    const tilesetMetadata = externalTilesetMetadata?.schema ?? tileset.schema;
+    content._tileset.loadTileset(
+      content._resource,
+      json,
+      tilesetMetadata,
+      content._tile,
+    );
+    content._ready = true;
+  });
   return content;
 };
 

--- a/packages/engine/Source/Scene/findTileMetadata.js
+++ b/packages/engine/Source/Scene/findTileMetadata.js
@@ -8,18 +8,15 @@ import oneTimeWarning from "../Core/oneTimeWarning.js";
  * Check if a tile has metadata, either defined in its metadata field (3D Tiles 1.1)
  * or in the <code>3DTILES_metadata</code> extension. If defined, get the tile metadata
  * with the corresponding class.
- * <p>
- * This assumes that tileset.metadata has been created before any tiles are constructed.
- * </p>
  * @function
  *
- * @param {Cesium3DTileset} tileset The tileset to query for tile metadata
+ * @param {MetadataSchema|undefined} metadataSchema The metadata schema
  * @param {object} tileHeader the JSON header for a {@link Cesium3DTile}
  * @return {TileMetadata} the tile metadata, or <code>undefined</code> if not found
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-function findTileMetadata(tileset, tileHeader) {
+function findTileMetadata(metadataSchema, tileHeader) {
   const metadataJson = hasExtension(tileHeader, "3DTILES_metadata")
     ? tileHeader.extensions["3DTILES_metadata"]
     : tileHeader.metadata;
@@ -28,17 +25,24 @@ function findTileMetadata(tileset, tileHeader) {
     return undefined;
   }
 
-  if (!defined(tileset.schema)) {
+  if (!defined(metadataSchema)) {
     findTileMetadata._oneTimeWarning(
-      "findTileMetadata-missing-root-schema",
-      "Could not find a metadata schema for tile metadata. For tilesets that contain external tilesets, make sure the schema is added to the root tileset.json.",
+      "findTileMetadata-missing-schema",
+      "Could not find a metadata schema for tile metadata.",
     );
     return undefined;
   }
 
-  const classes = tileset.schema.classes ?? Frozen.EMPTY_OBJECT;
+  const classes = metadataSchema.classes ?? Frozen.EMPTY_OBJECT;
   if (defined(metadataJson.class)) {
     const tileClass = classes[metadataJson.class];
+    if (!defined(tileClass)) {
+      findTileMetadata._oneTimeWarning(
+        "findTileMetadata-missing-tile-class",
+        `Could not find a class definition for tile metadata class ${metadataJson.class} in schema:\n${JSON.stringify(metadataSchema, null, 2)}`,
+      );
+      return undefined;
+    }
     return new TileMetadata({
       tile: metadataJson,
       class: tileClass,


### PR DESCRIPTION
# Description

This is a **draft** for resolving https://github.com/CesiumGS/cesium/issues/13407

It changes the mechanism for looking up the metadata schema that is used for tile metadata. The tile metadata will be resolved against the schema that was found in the external tileset that _contained_ the tile. 

The state here right now is that it also tries to resolve it against the schema that was found in the "root" tileset, but as described in the issue: I think that this should **not** be done.

`<!-- Include screenshots if appropriate -->`

Okay...:

<img width="797" height="667" alt="Cesium External Tileset Metadata" src="https://github.com/user-attachments/assets/264de41e-aed4-439e-ab1e-0a297dbf887a" />

Note that it prints an error message for the tile in tileset C, which _intentionally_ contains an _invalid_ metadata class. The point is that (I think that) it should not just bail out with a 
`DeveloperError: Expection options.class to be typeof object, actual typeof was undefined`
which doesn't tell the user anything.


## Issue number and link

https://github.com/CesiumGS/cesium/issues/13407

## Testing plan

Run the sandcastle that is included with the test data set that is attached in the issue

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code
