### PR TITLE
Fix #12775: Change default texture to transparent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fix JSDoc for SkyBox.show to correctly declare it as a prototype property for TypeScript compatibility. [#13357](https://github.com/CesiumGS/cesium/pull/13357)
 - Fixed lighting affecting `EquirectangularPanorama`. [#13369](https://github.com/CesiumGS/cesium/pull/13369)
+- Changed default texture and cube map to be transparent instead of white, preventing white flashing during material loading. [#12775](https://github.com/CesiumGS/cesium/issues/12775)
 
 ## 1.140 - 2026-04-01
 

--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -1010,7 +1010,7 @@ Object.defineProperties(Context.prototype, {
   },
 
   /**
-   * A 1x1 RGBA texture initialized to [255, 255, 255, 255].  This can
+   * A 1x1 RGBA texture initialized to [0, 0, 0, 0].  This can
    * be used as a placeholder texture while other textures are downloaded.
    * @memberof Context.prototype
    * @type {Texture}
@@ -1023,7 +1023,7 @@ Object.defineProperties(Context.prototype, {
           source: {
             width: 1,
             height: 1,
-            arrayBufferView: new Uint8Array([255, 255, 255, 255]),
+            arrayBufferView: new Uint8Array([0, 0, 0, 0]),
           },
           flipY: false,
         });
@@ -1086,7 +1086,7 @@ Object.defineProperties(Context.prototype, {
 
   /**
    * A cube map, where each face is a 1x1 RGBA texture initialized to
-   * [255, 255, 255, 255].  This can be used as a placeholder cube map while
+   * [0, 0, 0, 0].  This can be used as a placeholder cube map while
    * other cube maps are downloaded.
    * @memberof Context.prototype
    * @type {CubeMap}
@@ -1097,7 +1097,7 @@ Object.defineProperties(Context.prototype, {
         const face = {
           width: 1,
           height: 1,
-          arrayBufferView: new Uint8Array([255, 255, 255, 255]),
+          arrayBufferView: new Uint8Array([0, 0, 0, 0]),
         };
 
         this._defaultCubeMap = new CubeMap({


### PR DESCRIPTION
## Changes

This PR fixes #12775 by changing the default texture and cube map from white \[255, 255, 255, 255]\ to transparent \[0, 0, 0, 0]\.

### Problem
When constructing a new Material, users may see a white flash during material loading. This is because the Update-loop-based image loading model that Material employs causes a brief period where the white default texture is visible.

### Solution
Make the default texture transparent instead of white. This way, materials won't flash white into existence before loading.

### Files Changed
- \packages/engine/Source/Renderer/Context.js\: Changed defaultTexture and defaultCubeMap from \[255, 255, 255, 255]\ to \[0, 0, 0, 0]\
- \CHANGES.md\: Added entry for this fix

### Testing
- No test changes required as existing tests only check if defaultTexture is used, not its color value
- Manual testing recommended to verify no visual regressions