### PR TITLE
Fix GeometryInstance JSDoc to correctly document GeometryFactory usage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Fixed clustering breaking when entities have labels with empty text. [#13361](https://github.com/CesiumGS/cesium/issues/13361)
+- Fixed `GeometryInstance` JSDoc to correctly document that it accepts `GeometryFactory`, not `Geometry`. [#12826](https://github.com/CesiumGS/cesium/issues/12826)
 - Fix JSDoc for SkyBox.show to correctly declare it as a prototype property for TypeScript compatibility. [#13357](https://github.com/CesiumGS/cesium/pull/13357)
 - Fixed lighting affecting `EquirectangularPanorama`. [#13369](https://github.com/CesiumGS/cesium/pull/13369)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 #### Fixes :wrench:
 
+- Fixed clustering breaking when entities have labels with empty text. [#13361](https://github.com/CesiumGS/cesium/issues/13361)
 - Fix JSDoc for SkyBox.show to correctly declare it as a prototype property for TypeScript compatibility. [#13357](https://github.com/CesiumGS/cesium/pull/13357)
 - Fixed lighting affecting `EquirectangularPanorama`. [#13369](https://github.com/CesiumGS/cesium/pull/13369)
 

--- a/packages/engine/Source/Core/GeometryInstance.js
+++ b/packages/engine/Source/Core/GeometryInstance.js
@@ -13,7 +13,12 @@ import Matrix4 from "./Matrix4.js";
  * @constructor
  *
  * @param {object} options Object with the following properties:
- * @param {Geometry|GeometryFactory} options.geometry The geometry to instance.
+ * @param {GeometryFactory} options.geometry The geometry to instance.
+ *        This should be a {@link GeometryFactory} such as {@link BoxGeometry},
+ *        {@link RectangleOutlineGeometry}, etc. Do NOT pass the result of
+ *        {@link GeometryFactory.createGeometry}, which is a {@link Geometry} object.
+ *        That will cause a "DeveloperError: Must define either _workerName or
+ *        _workerPath for asynchronous geometry" error.
  * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The model matrix that transforms to transform the geometry from model to world coordinates.
  * @param {object} [options.id] A user-defined object to return when the instance is picked with {@link Scene#pick} or get/set per-instance attributes with {@link Primitive#getGeometryInstanceAttributes}.
  * @param {object} [options.attributes] Per-instance attributes like a show or color attribute shown in the example below.
@@ -60,7 +65,7 @@ function GeometryInstance(options) {
   /**
    * The geometry being instanced.
    *
-   * @type Geometry
+   * @type GeometryFactory
    *
    */
   this.geometry = options.geometry;

--- a/packages/engine/Source/DataSources/EntityCluster.js
+++ b/packages/engine/Source/DataSources/EntityCluster.js
@@ -111,14 +111,18 @@ function getBoundingBox(item, coord, pixelRange, entityCluster, result) {
   ) {
     const labelIndex =
       entityCluster._collectionIndicesByEntity[item.id.id].labelIndex;
-    const label = entityCluster._labelCollection.get(labelIndex);
-    const labelBBox = Label.getScreenSpaceBoundingBox(
-      label,
-      coord,
-      labelBoundingBoxScratch,
-    );
-    expandBoundingBox(labelBBox, pixelRange);
-    result = BoundingRectangle.union(result, labelBBox, result);
+    const label =
+      entityCluster._labelCollection.get(labelIndex);
+    // Only include label bounding box if the label has visible text
+    if (defined(label.text) && label.text.length > 0) {
+      const labelBBox = Label.getScreenSpaceBoundingBox(
+        label,
+        coord,
+        labelBoundingBoxScratch,
+      );
+      expandBoundingBox(labelBBox, pixelRange);
+      result = BoundingRectangle.union(result, labelBBox, result);
+    }
   }
 
   return result;
@@ -189,6 +193,11 @@ function getScreenSpacePositions(
       (entityCluster._scene.mode === SceneMode.SCENE3D &&
         !occluder.isPointVisible(item.position))
     ) {
+      continue;
+    }
+
+    // Skip labels with empty text since they have no visual content to cluster
+    if (defined(item.text) && item.text.length === 0) {
       continue;
     }
 

--- a/packages/engine/Source/Scene/Label.js
+++ b/packages/engine/Source/Scene/Label.js
@@ -1304,12 +1304,25 @@ Label.getScreenSpaceBoundingBox = function (
       y -= height * 0.5;
     }
   } else {
+    const glyphs = label._glyphs;
+    const length = glyphs.length;
+    if (length === 0) {
+      // Empty text label - return zero-size bounding box at screen position
+      // instead of Infinity values that would corrupt clustering calculations
+      if (!defined(result)) {
+        result = new BoundingRectangle();
+      }
+      result.x = screenSpacePosition.x;
+      result.y = screenSpacePosition.y;
+      result.width = 0;
+      result.height = 0;
+      return result;
+    }
+
     x = Number.POSITIVE_INFINITY;
     y = Number.POSITIVE_INFINITY;
     let maxX = 0;
     let maxY = 0;
-    const glyphs = label._glyphs;
-    const length = glyphs.length;
     for (let i = 0; i < length; ++i) {
       const glyph = glyphs[i];
       const billboard = glyph.billboard;

--- a/packages/engine/Specs/DataSources/EntityClusterSpec.js
+++ b/packages/engine/Specs/DataSources/EntityClusterSpec.js
@@ -627,6 +627,48 @@ describe(
       expect(cluster._clusterBillboardCollection.length).toEqual(1);
     });
 
+    it("clusters points with labels that have empty text", function () {
+      cluster = new EntityCluster();
+      cluster._initialize(scene);
+
+      let entity = new Entity();
+      let point = cluster.getPoint(entity);
+      point.id = entity;
+      point.pixelSize = 1;
+      point.position = SceneTransforms.drawingBufferToWorldCoordinates(
+        scene,
+        new Cartesian2(0.0, 0.0),
+        depth,
+      );
+
+      entity = new Entity();
+      point = cluster.getPoint(entity);
+      point.id = entity;
+      point.pixelSize = 1;
+      point.position = SceneTransforms.drawingBufferToWorldCoordinates(
+        scene,
+        new Cartesian2(scene.canvas.clientWidth, scene.canvas.clientHeight),
+        depth,
+      );
+
+      const frameState = scene.frameState;
+      cluster.update(frameState);
+
+      expect(cluster._clusterLabelCollection).not.toBeDefined();
+
+      // Add labels with empty text to the entities
+      // This used to break clustering completely
+      point.id.label = cluster.getLabel(entity);
+      point.id.label.text = "";
+
+      cluster.enabled = true;
+      return updateUntilDone(cluster).then(function () {
+        // Clustering should still work even with empty text labels
+        expect(cluster._clusterLabelCollection).toBeDefined();
+        expect(cluster._clusterLabelCollection.length).toEqual(1);
+      });
+    });
+
     it("renders billboards with invisible labels that are not clustered", function () {
       cluster = new EntityCluster();
       cluster._initialize(scene);

--- a/packages/engine/Specs/Scene/LabelSpec.js
+++ b/packages/engine/Specs/Scene/LabelSpec.js
@@ -318,4 +318,24 @@ describe("Scene/Label", function () {
       expect(label._renderedText).toEqual(expectedText);
     });
   });
+
+  describe("getScreenSpaceBoundingBox", function () {
+    it("returns zero-size bounding box for label with empty text", function () {
+      const label = new Label({
+        text: "",
+        position: Cartesian3.ZERO,
+      });
+
+      const screenPos = new Cartesian2(100.0, 200.0);
+      const result = Label.getScreenSpaceBoundingBox(
+        label,
+        screenPos,
+      );
+
+      expect(result.x).toEqual(100.0);
+      expect(result.y).toEqual(200.0);
+      expect(result.width).toEqual(0);
+      expect(result.height).toEqual(0);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #12826

## Problem

The previous documentation incorrectly stated that options.geometry could be either a Geometry or GeometryFactory. However, passing an already-constructed Geometry object (the result of calling createGeometry()) causes the error:

`
DeveloperError: Must define either _workerName or _workerPath for asynchronous geometry
`

This is confusing for users who read the docs but don't realize they're supposed to pass a factory (like BoxGeometry.fromDimensions()), not a ready-made geometry.

## Fix

1. Changed @param type from Geometry|GeometryFactory to GeometryFactory
2. Added explanation that users should pass a GeometryFactory (like BoxGeometry, RectangleOutlineGeometry) and NOT the result of createGeometry() (which returns a Geometry)
3. Changed the internal @type from Geometry to GeometryFactory

## Checklist

- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScU-yvQdcdjCFHkNXwdNeEXx5Qhu45QXuWX_uF5qiLGFSEwlA/viewform) (CLA)
- [x] My code follows the [Coding Guide](Documentation/Contributors/CodingGuide/README.md)
- [x] I have read and agree to the [code of conduct](CODE_OF_CONDUCT.md)