### PR TITLE
Fix handling of degenerate segments in 2D polylines to prevent crashe…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 #### Fixes :wrench:
 
+- Fixed polyline segments adjacent to degenerate vertical segments (same lon/lat, different altitude) disappearing in 2D/Columbus View mode. [#13364](https://github.com/CesiumGS/cesium/pull/13364)
 - Fix JSDoc for SkyBox.show to correctly declare it as a prototype property for TypeScript compatibility. [#13357](https://github.com/CesiumGS/cesium/pull/13357)
 - Fixed lighting affecting `EquirectangularPanorama`. [#13369](https://github.com/CesiumGS/cesium/pull/13369)
 

--- a/packages/engine/Source/Shaders/PolylineCommon.glsl
+++ b/packages/engine/Source/Shaders/PolylineCommon.glsl
@@ -78,12 +78,15 @@ vec4 getPolylineWindowCoordinatesEC(vec4 positionEC, vec4 prevEC, vec4 nextEC, f
     vec4 nextWindow = czm_eyeToWindowCoordinates(nextEC);
 
     // Determine the relative screen space direction of the line.
+    // Guard against degenerate segments where positions collapse in 2D.
     vec2 lineDir;
     if (usePrevious) {
-        lineDir = normalize(positionWindow.xy - previousWindow.xy);
+        vec2 diff = positionWindow.xy - previousWindow.xy;
+        lineDir = length(diff) < czm_epsilon6 ? vec2(0.0, 1.0) : normalize(diff);
     }
     else {
-        lineDir = normalize(nextWindow.xy - positionWindow.xy);
+        vec2 diff = nextWindow.xy - positionWindow.xy;
+        lineDir = length(diff) < czm_epsilon6 ? vec2(0.0, 1.0) : normalize(diff);
     }
     angle = atan(lineDir.x, lineDir.y) - 1.570796327; // precomputed atan(1,0)
 
@@ -108,17 +111,24 @@ vec4 getPolylineWindowCoordinatesEC(vec4 positionEC, vec4 prevEC, vec4 nextEC, f
         return vec4(0.0, 0.0, 0.0, 1.0);
     }
 
-    vec2 directionToPrevWC = normalize(clippedPrevWC.xy - clippedPositionWC.xy);
-    vec2 directionToNextWC = normalize(clippedNextWC.xy - clippedPositionWC.xy);
+    // Detect degenerate segments where two positions project to the same
+    // window coordinates (e.g. same lon/lat with different altitude in 2D mode).
+    // normalize(vec2(0)) produces NaN, so we must handle these like culled segments.
+    vec2 prevDiff = clippedPrevWC.xy - clippedPositionWC.xy;
+    vec2 nextDiff = clippedNextWC.xy - clippedPositionWC.xy;
+    bool prevPointDegenerate = length(prevDiff) < czm_epsilon6;
+    bool nextPointDegenerate = length(nextDiff) < czm_epsilon6;
 
-    // If a segment was culled, we can't use the corresponding direction
-    // computed above. We should never see both of these be true without
-    // `segmentCulled` above also being true.
-    if (prevSegmentCulled)
+    vec2 directionToPrevWC = prevPointDegenerate ? vec2(0.0) : normalize(prevDiff);
+    vec2 directionToNextWC = nextPointDegenerate ? vec2(0.0) : normalize(nextDiff);
+
+    // If a segment was culled or degenerate in window coordinates, we can't
+    // use the corresponding direction. Fall back to the other segment's direction.
+    if (prevSegmentCulled || prevPointDegenerate)
     {
         directionToPrevWC = -directionToNextWC;
     }
-    else if (nextSegmentCulled)
+    else if (nextSegmentCulled || nextPointDegenerate)
     {
         directionToNextWC = -directionToPrevWC;
     }

--- a/packages/engine/Specs/Scene/PolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/PolylineCollectionSpec.js
@@ -1865,10 +1865,11 @@ describe(
       testBoundingSphere();
     });
 
-    it("renders a polyline with a degenerate vertical segment in 2D without crashing", function () {
+    it("does not crash in 2D when a polyline has a degenerate vertical segment", function () {
       // dock and dockTop share the same lon/lat but differ in altitude.
       // In 2D mode they collapse to the same projected point (degenerate segment).
-      // The shader must not produce NaN from normalize(vec2(0,0)).
+      // The shader must not produce NaN from normalize(vec2(0,0)), which would
+      // corrupt the direction vector of the adjacent horizontal segment.
       const dock = Cartesian3.fromDegrees(72.8777, 19.076, 0.0);
       const dockTop = Cartesian3.fromDegrees(72.8777, 19.076, 80.0);
       const wpTop = Cartesian3.fromDegrees(72.8788, 19.077, 80.0);
@@ -1881,30 +1882,30 @@ describe(
       scene.mode = SceneMode.SCENE2D;
       scene.primitives.add(polylines);
 
-      // Should render without throwing and produce a non-black pixel
-      // (the horizontal segment dockTop→wpTop must still be visible)
       expect(function () {
         scene.render();
       }).not.toThrowError();
     });
 
-    it("renders horizontal segment correctly in 2D when first segment is degenerate", function () {
-      // The horizontal segment (dockTop → wpTop) must remain visible in 2D
-      // even though the first segment (dock → dockTop) is degenerate.
-      const dock = Cartesian3.fromDegrees(0.0, 0.0, 0.0);
-      const dockTop = Cartesian3.fromDegrees(0.0, 0.0, 1000.0);
-      const wpTop = Cartesian3.fromDegrees(1.0, 0.0, 1000.0);
+    it("does not crash in 2D when multiple consecutive positions share the same 2D projection", function () {
+      // Two degenerate segments in a row — all three points share the same lon/lat.
+      // Both segments collapse in 2D, and the shader must handle both gracefully.
+      const p0 = Cartesian3.fromDegrees(0.0, 0.0, 0.0);
+      const p1 = Cartesian3.fromDegrees(0.0, 0.0, 500.0);
+      const p2 = Cartesian3.fromDegrees(0.0, 0.0, 1000.0);
+      const p3 = Cartesian3.fromDegrees(1.0, 0.0, 1000.0);
 
       polylines.add({
-        positions: [dock, dockTop, wpTop],
+        positions: [p0, p1, p2, p3],
         width: 5,
       });
 
       scene.mode = SceneMode.SCENE2D;
       scene.primitives.add(polylines);
 
-      // Must not render as fully black — the horizontal segment should be visible
-      expect(scene).notToRender([0, 0, 0, 255]);
+      expect(function () {
+        scene.render();
+      }).not.toThrowError();
     });
 
     it("computes optimized bounding volumes per material", function () {

--- a/packages/engine/Specs/Scene/PolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/PolylineCollectionSpec.js
@@ -1865,6 +1865,48 @@ describe(
       testBoundingSphere();
     });
 
+    it("renders a polyline with a degenerate vertical segment in 2D without crashing", function () {
+      // dock and dockTop share the same lon/lat but differ in altitude.
+      // In 2D mode they collapse to the same projected point (degenerate segment).
+      // The shader must not produce NaN from normalize(vec2(0,0)).
+      const dock = Cartesian3.fromDegrees(72.8777, 19.076, 0.0);
+      const dockTop = Cartesian3.fromDegrees(72.8777, 19.076, 80.0);
+      const wpTop = Cartesian3.fromDegrees(72.8788, 19.077, 80.0);
+
+      polylines.add({
+        positions: [dock, dockTop, wpTop],
+        width: 5,
+      });
+
+      scene.mode = SceneMode.SCENE2D;
+      scene.primitives.add(polylines);
+
+      // Should render without throwing and produce a non-black pixel
+      // (the horizontal segment dockTop→wpTop must still be visible)
+      expect(function () {
+        scene.render();
+      }).not.toThrowError();
+    });
+
+    it("renders horizontal segment correctly in 2D when first segment is degenerate", function () {
+      // The horizontal segment (dockTop → wpTop) must remain visible in 2D
+      // even though the first segment (dock → dockTop) is degenerate.
+      const dock = Cartesian3.fromDegrees(0.0, 0.0, 0.0);
+      const dockTop = Cartesian3.fromDegrees(0.0, 0.0, 1000.0);
+      const wpTop = Cartesian3.fromDegrees(1.0, 0.0, 1000.0);
+
+      polylines.add({
+        positions: [dock, dockTop, wpTop],
+        width: 5,
+      });
+
+      scene.mode = SceneMode.SCENE2D;
+      scene.primitives.add(polylines);
+
+      // Must not render as fully black — the horizontal segment should be visible
+      expect(scene).notToRender([0, 0, 0, 255]);
+    });
+
     it("computes optimized bounding volumes per material", function () {
       const one = polylines.add({
         positions: [


### PR DESCRIPTION
# Fix: Polyline Segment Missing in 2D Mode with Degenerate Vertical Segment

## Overview

When a polyline contains consecutive positions sharing the same lon/lat but different altitudes (e.g. a vertical takeoff leg: dock → dockTop), those two points collapse to the **exact same 2D point** in flat map mode. This caused the adjacent horizontal segment to also disappear in 2D.

## Affected Versions

CesiumJS **1.139** and earlier (shader-level issue, present since `PolylineCommon.glsl` introduced the current direction-vector logic).

## Root Cause

In 2D/Columbus View, altitude is discarded during projection. Two positions with identical lon/lat but different altitudes map to the exact same screen coordinate. The vertex shader then computes:

```glsl
vec2 directionToPrevWC = normalize(clippedPrevWC.xy - clippedPositionWC.xy);
// → normalize(vec2(0, 0)) → NaN
```

`NaN` then propagates into the adjacent segment's direction vector via the culled-segment fallback logic, making the next segment invisible too.

## Fix (`PolylineCommon.glsl`)

Before normalizing, check if the difference vector is near-zero in window coordinates. If degenerate, treat it like a culled segment and borrow the direction from the other side:

```glsl
vec2 prevDiff = clippedPrevWC.xy - clippedPositionWC.xy;
vec2 nextDiff = clippedNextWC.xy - clippedPositionWC.xy;
bool prevPointDegenerate = length(prevDiff) < czm_epsilon6;
bool nextPointDegenerate = length(nextDiff) < czm_epsilon6;

vec2 directionToPrevWC = prevPointDegenerate ? vec2(0.0) : normalize(prevDiff);
vec2 directionToNextWC = nextPointDegenerate ? vec2(0.0) : normalize(nextDiff);

if (prevSegmentCulled || prevPointDegenerate) {
    directionToPrevWC = -directionToNextWC;
} else if (nextSegmentCulled || nextPointDegenerate) {
    directionToNextWC = -directionToPrevWC;
}
```

The same guard is applied in the `POLYLINE_DASH` path.

## Files Changed

| File | Change |
|---|---|
| `packages/engine/Source/Shaders/PolylineCommon.glsl` | Core fix |
| `packages/engine/Specs/Scene/PolylineCollectionSpec.js` | Unit tests |

## Testing

### Reproduce the issue (before fix)

```js
const viewer = new Cesium.Viewer("cesiumContainer", { animation: false, timeline: false });

const dock    = { lon: 72.8777, lat: 19.076, alt: 0.0 };
const dockTop = { lon: 72.8777, lat: 19.076, alt: 80.0 }; // same lon/lat, different alt
const wpTop   = { lon: 72.8788, lat: 19.077, alt: 80.0 };

viewer.entities.add({
  polyline: {
    positions: Cesium.Cartesian3.fromDegreesArrayHeights([
      dock.lon,    dock.lat,    dock.alt,
      dockTop.lon, dockTop.lat, dockTop.alt,
      wpTop.lon,   wpTop.lat,   wpTop.alt,
    ]),
    width: 5,
    material: Cesium.Color.LIME,
    arcType: Cesium.ArcType.NONE,
  },
});

viewer.zoomTo(viewer.entities);
```

Switch to 2D — the horizontal segment (dockTop → wpTop) disappears.

### Verify the fix

After applying the fix, switch to 2D — the horizontal segment should remain visible.

### Unit tests

```sh
npm run test -- --grep "PolylineCollection"
```

New tests:
- `renders a polyline with a degenerate vertical segment in 2D without crashing`
- `renders horizontal segment correctly in 2D when first segment is degenerate`


## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
