### PR TITLE
Fix: edge visibility bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Fix JSDoc for SkyBox.show to correctly declare it as a prototype property for TypeScript compatibility. [#13357](https://github.com/CesiumGS/cesium/pull/13357)
 - Fixed lighting affecting `EquirectangularPanorama`. [#13369](https://github.com/CesiumGS/cesium/pull/13369)
+- Fixed a `DeveloperError` thrown when loading 3D tiles containing degenerate (zero-area) triangles with edge visibility data. [#13421](https://github.com/CesiumGS/cesium/pull/13421)
 
 ## 1.140 - 2026-04-01
 

--- a/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
@@ -367,7 +367,11 @@ function buildTriangleAdjacency(primitive) {
       continue;
     }
 
-    Cartesian3.normalize(scratchCross, scratchCross);
+    Cartesian3.multiplyByScalar(
+      scratchCross,
+      1.0 / Math.sqrt(crossMagnitudeSquared),
+      scratchCross,
+    );
 
     faceNormals[base] = scratchCross.x;
     faceNormals[base + 1] = scratchCross.y;

--- a/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
@@ -5,9 +5,7 @@ import defined from "../../Core/defined.js";
 import IndexDatatype from "../../Core/IndexDatatype.js";
 import ComponentDatatype from "../../Core/ComponentDatatype.js";
 import PrimitiveType from "../../Core/PrimitiveType.js";
-import Cartesian2 from "../../Core/Cartesian2.js";
 import Cartesian3 from "../../Core/Cartesian3.js";
-import AttributeCompression from "../../Core/AttributeCompression.js";
 import Pass from "../../Renderer/Pass.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 import EdgeVisibilityStageFS from "../../Shaders/Model/EdgeVisibilityStageFS.js";
@@ -358,6 +356,14 @@ function buildTriangleAdjacency(primitive) {
     Cartesian3.subtract(scratchP1, scratchP0, scratchE1);
     Cartesian3.subtract(scratchP2, scratchP0, scratchE2);
     Cartesian3.cross(scratchE1, scratchE2, scratchCross);
+
+    // Skip degenerate triangles (zero-area): their cross product is the zero
+    // vector, which cannot be normalized and would produce NaN face normals.
+    const crossMagnitudeSquared = Cartesian3.magnitudeSquared(scratchCross);
+    if (crossMagnitudeSquared === 0.0) {
+      continue;
+    }
+
     Cartesian3.normalize(scratchCross, scratchCross);
 
     faceNormals[base] = scratchCross.x;
@@ -397,58 +403,32 @@ function generateEdgeFaceNormals(
 
   const hasGLBSilhouetteNormals =
     defined(edgeVisibility) && defined(edgeVisibility.silhouetteNormals);
-  let silhouetteNormalsUint32 = null;
-  const scratchDecodedA = new Cartesian3();
-  const scratchDecodedB = new Cartesian3();
+
+  // Decode GLB silhouette normals from signed-byte VEC3 to plain float Cartesian3 once,
+  // so each edge lookup is a direct array read with no further conversion.
+  let silhouetteNormalsFloat = null;
 
   if (hasGLBSilhouetteNormals) {
-    // GLB stores VEC3 BYTE as normalized normal vectors (signed bytes).
-    // Decode from signed bytes to normalized vectors, then re-encode to 16-bit octahedral format.
-    const decodeSignedByte = (val) => 2 * ((val + 128) / 255) - 1;
-
-    // Re-encode each VEC3 BYTE to 16-bit oct-encoded normal using AttributeCompression
-    const uint16Normals = new Uint16Array(
-      edgeVisibility.silhouetteNormals.length,
-    );
+    const raw = edgeVisibility.silhouetteNormals;
+    silhouetteNormalsFloat = new Array(raw.length);
     const scratchNormal = new Cartesian3();
-    const scratchEncoded = new Cartesian2();
 
-    for (let i = 0; i < edgeVisibility.silhouetteNormals.length; i++) {
-      const vec3 = edgeVisibility.silhouetteNormals[i];
+    for (let i = 0; i < raw.length; i++) {
+      const vec3 = raw[i];
+      // Signed byte → float: map [0,255] → [-1,1]
+      scratchNormal.x = 2 * ((vec3.x + 128) / 255) - 1;
+      scratchNormal.y = 2 * ((vec3.y + 128) / 255) - 1;
+      scratchNormal.z = 2 * ((vec3.z + 128) / 255) - 1;
 
-      // Decode from signed byte to normal vector
-      scratchNormal.x = decodeSignedByte(vec3.x);
-      scratchNormal.y = decodeSignedByte(vec3.y);
-      scratchNormal.z = decodeSignedByte(vec3.z);
-
-      // Normalize to unit vector
-      const magnitude = Cartesian3.magnitude(scratchNormal);
-      if (magnitude > 0) {
+      if (Cartesian3.magnitudeSquared(scratchNormal) > 0) {
         Cartesian3.normalize(scratchNormal, scratchNormal);
       } else {
-        // Handle zero vector - use default up vector
         scratchNormal.x = 0;
         scratchNormal.y = 0;
         scratchNormal.z = 1;
       }
 
-      // Use Cesium's octahedral encoding (returns 0-255 integers)
-      AttributeCompression.octEncodeInRange(scratchNormal, 255, scratchEncoded);
-
-      // Convert to 16-bit integer: (y << 8) | x
-      const byteX = scratchEncoded.x & 0xff;
-      const byteY = scratchEncoded.y & 0xff;
-      uint16Normals[i] = (byteY << 8) | byteX;
-    }
-
-    // Pack pairs into Uint32Array (little-endian: normalA|normalB<<16)
-    const numPairs = Math.floor(uint16Normals.length / 2);
-    silhouetteNormalsUint32 = new Uint32Array(numPairs);
-
-    for (let i = 0; i < numPairs; i++) {
-      const normalA = uint16Normals[i * 2];
-      const normalB = uint16Normals[i * 2 + 1];
-      silhouetteNormalsUint32[i] = normalA | (normalB << 16);
+      silhouetteNormalsFloat[i] = Cartesian3.clone(scratchNormal);
     }
   }
 
@@ -466,37 +446,25 @@ function generateEdgeFaceNormals(
     // Use GLB silhouetteNormals for type=1 (SILHOUETTE) edges if available
     if (
       hasGLBSilhouetteNormals &&
-      silhouetteNormalsUint32 &&
+      silhouetteNormalsFloat &&
       edgeType === 1 &&
       mateVertexIndex >= 0
     ) {
-      // Each OctEncodedNormalPair is stored as one Uint32 value
-      // Uint32 contains 4 bytes: [byte0, byte1, byte2, byte3]
-      // normalA = byte0 | (byte1 << 8)  - little endian
-      // normalB = byte2 | (byte3 << 8)  - little endian
+      const pairBase = mateVertexIndex * 2;
+      if (
+        pairBase + 1 < silhouetteNormalsFloat.length &&
+        defined(silhouetteNormalsFloat[pairBase]) &&
+        defined(silhouetteNormalsFloat[pairBase + 1])
+      ) {
+        const nA = silhouetteNormalsFloat[pairBase];
+        const nB = silhouetteNormalsFloat[pairBase + 1];
 
-      if (mateVertexIndex < silhouetteNormalsUint32.length) {
-        const uint32Value = silhouetteNormalsUint32[mateVertexIndex];
-
-        // Uint32 contains 4 bytes: [xA, yA, xB, yB]
-        // Extract and decode using octDecode (rangeMax=255)
-        AttributeCompression.octDecode(
-          uint32Value & 0xff, // xA
-          (uint32Value >> 8) & 0xff, // yA
-          scratchDecodedA,
-        );
-        AttributeCompression.octDecode(
-          (uint32Value >> 16) & 0xff, // xB
-          (uint32Value >> 24) & 0xff, // yB
-          scratchDecodedB,
-        );
-
-        nAx = scratchDecodedA.x;
-        nAy = scratchDecodedA.y;
-        nAz = scratchDecodedA.z;
-        nBx = scratchDecodedB.x;
-        nBy = scratchDecodedB.y;
-        nBz = scratchDecodedB.z;
+        nAx = nA.x;
+        nAy = nA.y;
+        nAz = nA.z;
+        nBx = nB.x;
+        nBy = nB.y;
+        nBz = nB.z;
 
         usedGLBNormals = true;
       }

--- a/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
@@ -357,10 +357,13 @@ function buildTriangleAdjacency(primitive) {
     Cartesian3.subtract(scratchP2, scratchP0, scratchE2);
     Cartesian3.cross(scratchE1, scratchE2, scratchCross);
 
-    // Skip degenerate triangles (zero-area): their cross product is the zero
-    // vector, which cannot be normalized and would produce NaN face normals.
+    // Skip degenerate triangles: a zero or non-finite cross product cannot be
+    // safely normalized and would produce invalid face normals.
     const crossMagnitudeSquared = Cartesian3.magnitudeSquared(scratchCross);
-    if (crossMagnitudeSquared === 0.0) {
+    if (
+      crossMagnitudeSquared === 0.0 ||
+      !Number.isFinite(crossMagnitudeSquared)
+    ) {
       continue;
     }
 
@@ -404,18 +407,18 @@ function generateEdgeFaceNormals(
   const hasGLBSilhouetteNormals =
     defined(edgeVisibility) && defined(edgeVisibility.silhouetteNormals);
 
-  // Decode GLB silhouette normals from signed-byte VEC3 to plain float Cartesian3 once,
-  // so each edge lookup is a direct array read with no further conversion.
+  // Decode GLB silhouette normals from signed-byte VEC3 to a flat Float32Array
+  // (3 floats per normal) to avoid per-normal object allocation and GC pressure.
   let silhouetteNormalsFloat = null;
 
   if (hasGLBSilhouetteNormals) {
     const raw = edgeVisibility.silhouetteNormals;
-    silhouetteNormalsFloat = new Array(raw.length);
+    silhouetteNormalsFloat = new Float32Array(raw.length * 3);
     const scratchNormal = new Cartesian3();
 
     for (let i = 0; i < raw.length; i++) {
       const vec3 = raw[i];
-      // Signed byte → float: map [0,255] → [-1,1]
+      // Signed byte → float: map [-128,127] → [-1,1] via [0,255]
       scratchNormal.x = 2 * ((vec3.x + 128) / 255) - 1;
       scratchNormal.y = 2 * ((vec3.y + 128) / 255) - 1;
       scratchNormal.z = 2 * ((vec3.z + 128) / 255) - 1;
@@ -428,7 +431,9 @@ function generateEdgeFaceNormals(
         scratchNormal.z = 1;
       }
 
-      silhouetteNormalsFloat[i] = Cartesian3.clone(scratchNormal);
+      silhouetteNormalsFloat[i * 3] = scratchNormal.x;
+      silhouetteNormalsFloat[i * 3 + 1] = scratchNormal.y;
+      silhouetteNormalsFloat[i * 3 + 2] = scratchNormal.z;
     }
   }
 
@@ -451,20 +456,16 @@ function generateEdgeFaceNormals(
       mateVertexIndex >= 0
     ) {
       const pairBase = mateVertexIndex * 2;
-      if (
-        pairBase + 1 < silhouetteNormalsFloat.length &&
-        defined(silhouetteNormalsFloat[pairBase]) &&
-        defined(silhouetteNormalsFloat[pairBase + 1])
-      ) {
-        const nA = silhouetteNormalsFloat[pairBase];
-        const nB = silhouetteNormalsFloat[pairBase + 1];
+      if ((pairBase + 1) * 3 + 2 < silhouetteNormalsFloat.length) {
+        const baseA = pairBase * 3;
+        const baseB = (pairBase + 1) * 3;
 
-        nAx = nA.x;
-        nAy = nA.y;
-        nAz = nA.z;
-        nBx = nB.x;
-        nBy = nB.y;
-        nBz = nB.z;
+        nAx = silhouetteNormalsFloat[baseA];
+        nAy = silhouetteNormalsFloat[baseA + 1];
+        nAz = silhouetteNormalsFloat[baseA + 2];
+        nBx = silhouetteNormalsFloat[baseB];
+        nBy = silhouetteNormalsFloat[baseB + 1];
+        nBz = silhouetteNormalsFloat[baseB + 2];
 
         usedGLBNormals = true;
       }

--- a/packages/engine/Specs/Scene/Model/EdgeVisibilityPipelineStageDecodingSpec.js
+++ b/packages/engine/Specs/Scene/Model/EdgeVisibilityPipelineStageDecodingSpec.js
@@ -563,6 +563,66 @@ describe("Scene/Model/EdgeVisibilityPipelineStage", function () {
     expect(positionBuffer.sizeInBytes).toBe(12 * 3 * 4);
   });
 
+  it("does not throw for degenerate (zero-area) triangles", function () {
+    // A degenerate triangle has two identical vertices, so its cross product is
+    // the zero vector. Normalizing it used to throw a DeveloperError.
+    const positions = new Float32Array([
+      0.0,
+      0.0,
+      0.0, // vertex 0
+      1.0,
+      0.0,
+      0.0, // vertex 1
+      1.0,
+      0.0,
+      0.0, // vertex 2 == vertex 1 (degenerate)
+    ]);
+    const indices = new Uint16Array([0, 1, 2]);
+    const visibilityBuffer = new Uint8Array([0b00101010]); // 3 HARD edges
+
+    const primitive = {
+      attributes: [
+        {
+          semantic: VertexAttributeSemantic.POSITION,
+          componentDatatype: ComponentDatatype.FLOAT,
+          count: 3,
+          typedArray: positions,
+          buffer: Buffer.createVertexBuffer({
+            context: context,
+            typedArray: positions,
+            usage: BufferUsage.STATIC_DRAW,
+          }),
+          strideInBytes: 12,
+          offsetInBytes: 0,
+        },
+      ],
+      indices: {
+        indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        count: 3,
+        typedArray: indices,
+        buffer: Buffer.createIndexBuffer({
+          context: context,
+          typedArray: indices,
+          usage: BufferUsage.STATIC_DRAW,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        }),
+      },
+      mode: PrimitiveType.TRIANGLES,
+      edgeVisibility: { visibility: visibilityBuffer },
+    };
+
+    const renderResources = createMockRenderResources(primitive);
+    const frameState = createMockFrameState();
+
+    expect(function () {
+      EdgeVisibilityPipelineStage.process(
+        renderResources,
+        primitive,
+        frameState,
+      );
+    }).not.toThrow();
+  });
+
   it("validates BENTLEY_materials_line_style support", function () {
     const primitive = createTestPrimitive();
     const renderResources = createMockRenderResources(primitive);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Problem:
1. GLB files produced by TilesetPublisher contain degenerate triangles — triangles where two or more vertices share the same position, giving them zero area. In buildTriangleAdjacency, the cross product of the two edge vectors for such a triangle is the zero vector. Calling Cartesian3.normalize on it throws:
`Error: normalized result is not a number`

These have always existed in the data, but previously went unnoticed because face normal computation was done in the GPU shader, where normalize(vec3(0)) silently returns vec3(0).

https://github.com/CesiumGS/cesium/pull/13110 moved face normal computation to the CPU, introducing the first JS call to `Cartesian3.normalize` on per-triangle cross products. Unlike the GPU, `Cartesian3.normalize` throws a `DeveloperError` when given the zero vector, causing the tile to fail to load entirely.

This fix makes Cesium defensively skip degenerate triangles, restoring the previous tolerance for imperfect mesh data regardless of its origin.


2. Cleanup and simplify silhouette normal decoding

The previous implementation decoded GLB signed-byte normals, then immediately re-encoded them to 16-bit oct format, packed two into a Uint32, and later unpacked and decoded them back to floats before writing into the Float32Array vertex buffer. This round-trip (signed byte → oct16 → Uint32 → oct16 → float) introduced quantization loss and unnecessary complexity.

The normals are now decoded once — signed byte → normalized Cartesian3 — and stored directly in a plain JS array. Each edge lookup reads directly from this array. The final vertex buffer (Float32Array) is unchanged. The unused Cartesian2 and `AttributeCompression` imports are removed.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link
https://github.com/CesiumGS/tilers/issues/2156
<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):
GitHub Copilot
<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):
Claude 4.6 Sonnect
<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
