### PR TITLE
Add 'count' for all point cloud attributes

### DIFF
--- a/packages/engine/Source/Scene/Model/PntsLoader.js
+++ b/packages/engine/Source/Scene/Model/PntsLoader.js
@@ -525,19 +525,23 @@ function makeAttributes(loader, parsedContent, context) {
 
   if (defined(parsedContent.normals)) {
     attribute = makeAttribute(loader, parsedContent.normals, context);
+    attribute.count = parsedContent.pointsLength;
     attributes.push(attribute);
   }
 
   if (defined(parsedContent.colors)) {
     attribute = makeAttribute(loader, parsedContent.colors, context);
+    attribute.count = parsedContent.pointsLength;
     attributes.push(attribute);
   } else {
     attribute = makeAttribute(loader, defaultColorAttribute, context);
+    attribute.count = parsedContent.pointsLength;
     attributes.push(attribute);
   }
 
   if (defined(parsedContent.batchIds)) {
     attribute = makeAttribute(loader, parsedContent.batchIds, context);
+    attribute.count = parsedContent.pointsLength;
     attributes.push(attribute);
   }
 

--- a/packages/engine/Specs/Scene/Model/PntsLoaderSpec.js
+++ b/packages/engine/Specs/Scene/Model/PntsLoaderSpec.js
@@ -169,6 +169,19 @@ describe(
       }
     }
 
+    /**
+     * Expects the `count` property of each of the given attributes
+     * to be the given value.
+     *
+     * @param {Attribute[]} attributes The attributes
+     * @param {number} count The count value
+     */
+    function expectCountsToBe(attributes, count) {
+      for (const attribute of attributes) {
+        expect(attribute.count).toBe(count);
+      }
+    }
+
     function expectPosition(attribute) {
       expect(attribute.name).toBe("POSITION");
       expect(attribute.semantic).toBe(VertexAttributeSemantic.POSITION);
@@ -303,6 +316,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPosition(attributes[0]);
         expectColorRGB(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -317,6 +331,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPosition(attributes[0]);
         expectColorRGBA(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -331,6 +346,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPosition(attributes[0]);
         expectColorRGB565(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -345,6 +361,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPosition(attributes[0]);
         expectDefaultColor(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -359,6 +376,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPosition(attributes[0]);
         expectConstantColor(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -374,6 +392,7 @@ describe(
         expectPosition(attributes[0]);
         expectNormal(attributes[1]);
         expectColorRGB(attributes[2]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -393,6 +412,7 @@ describe(
           false,
         );
         expectColorRGB(attributes[2]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -407,6 +427,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPositionQuantized(attributes[0], ComponentDatatype.UNSIGNED_BYTE);
         expectColorRGB(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -426,6 +447,7 @@ describe(
           false,
         );
         expectColorRGB(attributes[2]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -464,6 +486,7 @@ describe(
           true,
         );
         expectColorRGB(attributes[2]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -498,6 +521,7 @@ describe(
         expectPositionQuantized(attributes[0]);
         expectNormal(attributes[1]);
         expectColorRGB(attributes[2]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -537,6 +561,7 @@ describe(
         );
         expectColorRGB(attributes[2]);
         expectBatchId(attributes[3], ComponentDatatype.UNSIGNED_BYTE);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -563,6 +588,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPosition(attributes[0]);
         expectColorRGB(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -598,6 +624,7 @@ describe(
         expectNormal(attributes[1]);
         expectDefaultColor(attributes[2]);
         expectBatchId(attributes[3], ComponentDatatype.UNSIGNED_BYTE);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -621,6 +648,7 @@ describe(
         expect(attributes.length).toBe(2);
         expectPosition(attributes[0]);
         expectColorRGB(attributes[1]);
+        expectCountsToBe(attributes, 1000);
       });
     });
 
@@ -676,6 +704,7 @@ describe(
           expect(attributes.length).toBe(5);
           expectPosition(attributes[0]);
           expectColorRGB(attributes[1]);
+          expectCountsToBe(attributes, 1000);
         },
       );
     });
@@ -712,6 +741,7 @@ describe(
           expect(attributes.length).toBe(5);
           expectPosition(attributes[0]);
           expectColorRGB(attributes[1]);
+          expectCountsToBe(attributes, 1000);
         },
       );
     });
@@ -732,6 +762,7 @@ describe(
           expect(positionAttribute.typedArray).toBeDefined();
 
           expectColorRGB(attributes[1]);
+          expectCountsToBe(attributes, 1000);
         },
       );
     });
@@ -776,6 +807,7 @@ describe(
             true,
           );
           expectColorRGB(attributes[2]);
+          expectCountsToBe(attributes, 1000);
         },
       );
     });


### PR DESCRIPTION
(Note: This is a trivial fix that could probably be merged at any point in time. The change might then go into https://github.com/CesiumGS/cesium/pull/13330 by merging in `main` there)

# Description

The `PntsLoader` reads several `Attribute` values from the PNTS data (positions, colors, normals...). This is happening at https://github.com/CesiumGS/cesium/blob/13781b131e8a1c63db16479b03303a2bcbc619b6/packages/engine/Source/Scene/Model/PntsLoader.js#L522 

It can be seen there that the `count` value of the attribute was _only_ set for the 'poisition' attribute. It was _not_ set for the other attributes. 

This caused trouble for consumers who wanted to handle these attributes. Specifically, it caused trouble for the functionality that is implemented at https://github.com/CesiumGS/cesium/pull/13330 , for extracting the data for these attributes.

(On top of that, the `count` attribute is documented to be of type `number`, and not of type `number|undefined`, so ... something was wrong there in any case)

This PR changes the `PntsLoader` to set the `count` value for all attributes.

## Issue number and link

**n/a** (came up in https://github.com/CesiumGS/cesium/pull/13330 )

## Testing plan

The `PntsLoaderSpec` has been updated to check for the `count` value in **all** attributes in **each** test.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] **n/a**  I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

