### PR TITLE
Types: Enable type-checking on all enums without attached functions

### DIFF
--- a/Tools/ast-grep/rules/no-export-object-freeze.yml
+++ b/Tools/ast-grep/rules/no-export-object-freeze.yml
@@ -1,0 +1,26 @@
+id: no-export-object-freeze
+message: >
+  Exporting the result of Object.freeze(...) will lose type information
+  associated with the enum. Instead, freeze the object one one line and export
+  the original (now frozen) enum on the next.
+severity: error
+language: JavaScript
+files:
+  - packages/engine/Source/**/*.js
+rule:
+  pattern:
+    selector: export_statement
+    context: export default Object.freeze($A)
+  # Require the export statement to _immediately_ follow the enum declaration,
+  # which exempts enums with attached utility functions from this rule. In the
+  # future, when utility functions are moved or type checking conflicts
+  # resolved, this 'follows' block can include all preceeding declarations.
+  # See: https://github.com/CesiumGS/cesium/issues/13420
+  follows:
+    kind: lexical_declaration
+    has:
+      pattern: $A
+      stopBy: end
+    follows:
+      kind: comment
+      regex: "@enum \\{.*\\}"

--- a/Tools/ast-grep/rules/no-export-object-freeze.yml
+++ b/Tools/ast-grep/rules/no-export-object-freeze.yml
@@ -1,7 +1,7 @@
 id: no-export-object-freeze
 message: >
   Exporting the result of Object.freeze(...) will lose type information
-  associated with the enum. Instead, freeze the object one one line and export
+  associated with the enum. Instead, freeze the enum on one line and export
   the original (now frozen) enum on the next.
 severity: error
 language: JavaScript

--- a/Tools/ast-grep/tests/__snapshots__/no-export-object-freeze-snapshot.yml
+++ b/Tools/ast-grep/tests/__snapshots__/no-export-object-freeze-snapshot.yml
@@ -1,0 +1,21 @@
+id: no-export-object-freeze
+snapshots:
+  ? |
+    /** @enum {number} */ const MyInteger = { ONE: 1, TWO: 2 }; export default Object.freeze(MyInteger);
+  : labels:
+    - source: export default Object.freeze(MyInteger);
+      style: primary
+      start: 60
+      end: 100
+    - source: MyInteger
+      style: secondary
+      start: 28
+      end: 37
+    - source: /** @enum {number} */
+      style: secondary
+      start: 0
+      end: 21
+    - source: 'const MyInteger = { ONE: 1, TWO: 2 };'
+      style: secondary
+      start: 22
+      end: 59

--- a/Tools/ast-grep/tests/no-export-object-freeze.test.yml
+++ b/Tools/ast-grep/tests/no-export-object-freeze.test.yml
@@ -1,0 +1,17 @@
+id: no-export-object-freeze
+valid:
+  - >
+    /** @enum {number} */
+    const MyInteger = { ONE: 1, TWO: 2 };
+    Object.freeze(MyInteger);
+    export default MyInteger;
+  - >
+    /** @enum {number} */
+    const MyInteger = { ONE: 1, TWO: 2 };
+    MyInteger.validate = () => {};
+    export Object.freeze(MyInteger);
+invalid:
+  - >
+    /** @enum {number} */
+    const MyInteger = { ONE: 1, TWO: 2 };
+    export default Object.freeze(MyInteger);

--- a/packages/engine/Source/Core/ArcType.js
+++ b/packages/engine/Source/Core/ArcType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * ArcType defines the path that should be taken connecting vertices.
  *
@@ -28,4 +30,7 @@ const ArcType = {
    */
   RHUMB: 2,
 };
-export default Object.freeze(ArcType);
+
+Object.freeze(ArcType);
+
+export default ArcType;

--- a/packages/engine/Source/Core/ArticulationStageType.js
+++ b/packages/engine/Source/Core/ArticulationStageType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum describing the type of motion that is defined by an articulation stage
  * in the AGI_articulations extension.
@@ -20,4 +22,6 @@ const ArticulationStageType = {
   UNIFORMSCALE: "uniformScale",
 };
 
-export default Object.freeze(ArticulationStageType);
+Object.freeze(ArticulationStageType);
+
+export default ArticulationStageType;

--- a/packages/engine/Source/Core/BoundingSphere.js
+++ b/packages/engine/Source/Core/BoundingSphere.js
@@ -1063,14 +1063,11 @@ class BoundingSphere {
 
     if (distanceToPlane < -radius) {
       // The center point is negative side of the plane normal
-      // @ts-expect-error Requires type-checking on Intersect.js.
       return Intersect.OUTSIDE;
     } else if (distanceToPlane < radius) {
       // The center point is positive side of the plane, but radius extends beyond it; partial overlap
-      // @ts-expect-error Requires type-checking on Intersect.js.
       return Intersect.INTERSECTING;
     }
-    // @ts-expect-error Requires type-checking on Intersect.js.
     return Intersect.INSIDE;
   }
 

--- a/packages/engine/Source/Core/ClockRange.js
+++ b/packages/engine/Source/Core/ClockRange.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Constants used by {@link Clock#tick} to determine behavior
  * when {@link Clock#startTime} or {@link Clock#stopTime} is reached.
@@ -36,4 +38,7 @@ const ClockRange = {
    */
   LOOP_STOP: 2,
 };
-export default Object.freeze(ClockRange);
+
+Object.freeze(ClockRange);
+
+export default ClockRange;

--- a/packages/engine/Source/Core/ClockStep.js
+++ b/packages/engine/Source/Core/ClockStep.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Constants to determine how much time advances with each call
  * to {@link Clock#tick}.
@@ -35,4 +37,7 @@ const ClockStep = {
    */
   SYSTEM_CLOCK: 2,
 };
-export default Object.freeze(ClockStep);
+
+Object.freeze(ClockStep);
+
+export default ClockStep;

--- a/packages/engine/Source/Core/CornerType.js
+++ b/packages/engine/Source/Core/CornerType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Style options for corners.
  *
@@ -34,4 +36,7 @@ const CornerType = {
    */
   BEVELED: 2,
 };
-export default Object.freeze(CornerType);
+
+Object.freeze(CornerType);
+
+export default CornerType;

--- a/packages/engine/Source/Core/ExtrapolationType.js
+++ b/packages/engine/Source/Core/ExtrapolationType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Constants to determine how an interpolated value is extrapolated
  * when querying outside the bounds of available data.
@@ -31,4 +33,7 @@ const ExtrapolationType = {
    */
   EXTRAPOLATE: 2,
 };
-export default Object.freeze(ExtrapolationType);
+
+Object.freeze(ExtrapolationType);
+
+export default ExtrapolationType;

--- a/packages/engine/Source/Core/GeocodeType.js
+++ b/packages/engine/Source/Core/GeocodeType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The type of geocoding to be performed by a {@link GeocoderService}.
  * @enum {number}
@@ -21,4 +23,7 @@ const GeocodeType = {
    */
   AUTOCOMPLETE: 1,
 };
-export default Object.freeze(GeocodeType);
+
+Object.freeze(GeocodeType);
+
+export default GeocodeType;

--- a/packages/engine/Source/Core/GeometryOffsetAttribute.js
+++ b/packages/engine/Source/Core/GeometryOffsetAttribute.js
@@ -1,5 +1,8 @@
+// @ts-check
+
 /**
  * Represents which vertices should have a value of `true` for the `applyOffset` attribute
+ * @enum {number}
  * @private
  */
 const GeometryOffsetAttribute = {
@@ -7,4 +10,7 @@ const GeometryOffsetAttribute = {
   TOP: 1,
   ALL: 2,
 };
-export default Object.freeze(GeometryOffsetAttribute);
+
+Object.freeze(GeometryOffsetAttribute);
+
+export default GeometryOffsetAttribute;

--- a/packages/engine/Source/Core/GeometryType.js
+++ b/packages/engine/Source/Core/GeometryType.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 /**
+ * @enum {number}
  * @private
  */
 const GeometryType = {

--- a/packages/engine/Source/Core/GeometryType.js
+++ b/packages/engine/Source/Core/GeometryType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * @private
  */
@@ -7,4 +9,7 @@ const GeometryType = {
   LINES: 2,
   POLYLINES: 3,
 };
-export default Object.freeze(GeometryType);
+
+Object.freeze(GeometryType);
+
+export default GeometryType;

--- a/packages/engine/Source/Core/HeightmapEncoding.js
+++ b/packages/engine/Source/Core/HeightmapEncoding.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The encoding that is used for a heightmap
  *
@@ -22,4 +24,7 @@ const HeightmapEncoding = {
    */
   LERC: 1,
 };
-export default Object.freeze(HeightmapEncoding);
+
+Object.freeze(HeightmapEncoding);
+
+export default HeightmapEncoding;

--- a/packages/engine/Source/Core/InterpolationType.js
+++ b/packages/engine/Source/Core/InterpolationType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum describing the type of interpolation used in a glTF animation.
  *
@@ -11,4 +13,6 @@ const InterpolationType = {
   CUBICSPLINE: 2,
 };
 
-export default Object.freeze(InterpolationType);
+Object.freeze(InterpolationType);
+
+export default InterpolationType;

--- a/packages/engine/Source/Core/Intersect.js
+++ b/packages/engine/Source/Core/Intersect.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * This enumerated type is used in determining where, relative to the frustum, an
  * object is located. The object can either be fully contained within the frustum (INSIDE),
@@ -31,4 +33,7 @@ const Intersect = {
    */
   INSIDE: 1,
 };
-export default Object.freeze(Intersect);
+
+Object.freeze(Intersect);
+
+export default Intersect;

--- a/packages/engine/Source/Core/IonGeocodeProviderType.js
+++ b/packages/engine/Source/Core/IonGeocodeProviderType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Underlying geocoding services that can be used via Cesium ion.
  *
@@ -30,4 +32,6 @@ const IonGeocodeProviderType = {
   DEFAULT: "DEFAULT",
 };
 
-export default Object.freeze(IonGeocodeProviderType);
+Object.freeze(IonGeocodeProviderType);
+
+export default IonGeocodeProviderType;

--- a/packages/engine/Source/Core/KeyboardEventModifier.js
+++ b/packages/engine/Source/Core/KeyboardEventModifier.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * This enumerated type is for representing keyboard modifiers. These are keys
  * that are held down in addition to other event types.
@@ -29,4 +31,7 @@ const KeyboardEventModifier = {
    */
   ALT: 2,
 };
-export default Object.freeze(KeyboardEventModifier);
+
+Object.freeze(KeyboardEventModifier);
+
+export default KeyboardEventModifier;

--- a/packages/engine/Source/Core/ReferenceFrame.js
+++ b/packages/engine/Source/Core/ReferenceFrame.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Constants for identifying well-known reference frames.
  *
@@ -20,4 +22,7 @@ const ReferenceFrame = {
    */
   INERTIAL: 1,
 };
-export default Object.freeze(ReferenceFrame);
+
+Object.freeze(ReferenceFrame);
+
+export default ReferenceFrame;

--- a/packages/engine/Source/Core/RequestState.js
+++ b/packages/engine/Source/Core/RequestState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * State of the request.
  *
@@ -52,4 +54,7 @@ const RequestState = {
    */
   FAILED: 5,
 };
-export default Object.freeze(RequestState);
+
+Object.freeze(RequestState);
+
+export default RequestState;

--- a/packages/engine/Source/Core/RequestType.js
+++ b/packages/engine/Source/Core/RequestType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum identifying the type of request. Used for finer grained logging and priority sorting.
  *
@@ -36,4 +38,7 @@ const RequestType = {
    */
   OTHER: 3,
 };
-export default Object.freeze(RequestType);
+
+Object.freeze(RequestType);
+
+export default RequestType;

--- a/packages/engine/Source/Core/ScreenSpaceEventType.js
+++ b/packages/engine/Source/Core/ScreenSpaceEventType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * This enumerated type is for classifying mouse events: down, up, click, double click, move and move while a button is held down.
  *
@@ -124,4 +126,7 @@ const ScreenSpaceEventType = {
    */
   PINCH_MOVE: 19,
 };
-export default Object.freeze(ScreenSpaceEventType);
+
+Object.freeze(ScreenSpaceEventType);
+
+export default ScreenSpaceEventType;

--- a/packages/engine/Source/Core/TerrainQuantization.js
+++ b/packages/engine/Source/Core/TerrainQuantization.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * This enumerated type is used to determine how the vertices of the terrain mesh are compressed.
  *
@@ -22,4 +24,7 @@ const TerrainQuantization = {
    */
   BITS12: 1,
 };
-export default Object.freeze(TerrainQuantization);
+
+Object.freeze(TerrainQuantization);
+
+export default TerrainQuantization;

--- a/packages/engine/Source/Core/TimeConstants.js
+++ b/packages/engine/Source/Core/TimeConstants.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Constants for time conversions like those done by {@link JulianDate}.
  *
@@ -80,4 +82,7 @@ const TimeConstants = {
    */
   MODIFIED_JULIAN_DATE_DIFFERENCE: 2400000.5,
 };
-export default Object.freeze(TimeConstants);
+
+Object.freeze(TimeConstants);
+
+export default TimeConstants;

--- a/packages/engine/Source/Core/TimeStandard.js
+++ b/packages/engine/Source/Core/TimeStandard.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Provides the type of time standards which JulianDate can take as input.
  *
@@ -27,4 +29,7 @@ const TimeStandard = {
    */
   TAI: 1,
 };
-export default Object.freeze(TimeStandard);
+
+Object.freeze(TimeStandard);
+
+export default TimeStandard;

--- a/packages/engine/Source/Core/TrackingReferenceFrame.js
+++ b/packages/engine/Source/Core/TrackingReferenceFrame.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Constants for identifying well-known tracking reference frames.
  *
@@ -42,4 +44,7 @@ const TrackingReferenceFrame = {
    */
   VELOCITY: 3,
 };
-export default Object.freeze(TrackingReferenceFrame);
+
+Object.freeze(TrackingReferenceFrame);
+
+export default TrackingReferenceFrame;

--- a/packages/engine/Source/Core/Visibility.js
+++ b/packages/engine/Source/Core/Visibility.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * This enumerated type is used in determining to what extent an object, the occludee,
  * is visible during horizon culling. An occluder may fully block an occludee, in which case
@@ -31,4 +33,7 @@ const Visibility = {
    */
   FULL: 1,
 };
-export default Object.freeze(Visibility);
+
+Object.freeze(Visibility);
+
+export default Visibility;

--- a/packages/engine/Source/Core/VulkanConstants.js
+++ b/packages/engine/Source/Core/VulkanConstants.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Enum containing Vulkan Constant values by name.
  *
@@ -283,4 +285,7 @@ const VulkanConstants = {
   VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR: 1000156032,
   VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR: 1000156033,
 };
-export default Object.freeze(VulkanConstants);
+
+Object.freeze(VulkanConstants);
+
+export default VulkanConstants;

--- a/packages/engine/Source/Core/WebGLConstants.js
+++ b/packages/engine/Source/Core/WebGLConstants.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Enum containing WebGL Constant values by name.
  * for use without an active WebGL context, or in cases where certain constants are unavailable using the WebGL context
@@ -611,4 +613,7 @@ const WebGLConstants = {
   // Extensions
   MAX_TEXTURE_MAX_ANISOTROPY_EXT: 0x84ff,
 };
-export default Object.freeze(WebGLConstants);
+
+Object.freeze(WebGLConstants);
+
+export default WebGLConstants;

--- a/packages/engine/Source/DataSources/StripeOrientation.js
+++ b/packages/engine/Source/DataSources/StripeOrientation.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Defined the orientation of stripes in {@link StripeMaterialProperty}.
  *
@@ -16,4 +18,7 @@ const StripeOrientation = {
    */
   VERTICAL: 1,
 };
-export default Object.freeze(StripeOrientation);
+
+Object.freeze(StripeOrientation);
+
+export default StripeOrientation;

--- a/packages/engine/Source/Renderer/Pass.js
+++ b/packages/engine/Source/Renderer/Pass.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The render pass for a command.
  *
@@ -26,4 +28,7 @@ const Pass = {
   OVERLAY: 12,
   NUMBER_OF_PASSES: 13,
 };
-export default Object.freeze(Pass);
+
+Object.freeze(Pass);
+
+export default Pass;

--- a/packages/engine/Source/Scene/AlphaMode.js
+++ b/packages/engine/Source/Scene/AlphaMode.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The alpha rendering mode of the material.
  *
@@ -30,4 +32,6 @@ const AlphaMode = {
   BLEND: "BLEND",
 };
 
-export default Object.freeze(AlphaMode);
+Object.freeze(AlphaMode);
+
+export default AlphaMode;

--- a/packages/engine/Source/Scene/ArcGisBaseMapType.js
+++ b/packages/engine/Source/Scene/ArcGisBaseMapType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * ArcGisBaseMapType enumerates the ArcGIS image tile layers that are supported by default.
  *
@@ -9,4 +11,7 @@ const ArcGisBaseMapType = {
   OCEANS: 2,
   HILLSHADE: 3,
 };
-export default Object.freeze(ArcGisBaseMapType);
+
+Object.freeze(ArcGisBaseMapType);
+
+export default ArcGisBaseMapType;

--- a/packages/engine/Source/Scene/BingMapsStyle.js
+++ b/packages/engine/Source/Scene/BingMapsStyle.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The types of imagery provided by Bing Maps.
  *
@@ -90,4 +92,7 @@ const BingMapsStyle = {
    */
   COLLINS_BART: "CollinsBart",
 };
-export default Object.freeze(BingMapsStyle);
+
+Object.freeze(BingMapsStyle);
+
+export default BingMapsStyle;

--- a/packages/engine/Source/Scene/BlendEquation.js
+++ b/packages/engine/Source/Scene/BlendEquation.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
@@ -50,4 +52,7 @@ const BlendEquation = {
    */
   MAX: WebGLConstants.MAX,
 };
-export default Object.freeze(BlendEquation);
+
+Object.freeze(BlendEquation);
+
+export default BlendEquation;

--- a/packages/engine/Source/Scene/BlendFunction.js
+++ b/packages/engine/Source/Scene/BlendFunction.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
@@ -126,4 +128,7 @@ const BlendFunction = {
    */
   SOURCE_ALPHA_SATURATE: WebGLConstants.SRC_ALPHA_SATURATE,
 };
-export default Object.freeze(BlendFunction);
+
+Object.freeze(BlendFunction);
+
+export default BlendFunction;

--- a/packages/engine/Source/Scene/BlendOption.js
+++ b/packages/engine/Source/Scene/BlendOption.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Determines how opaque and translucent parts of billboards, points, and labels are blended with the scene.
  *
@@ -25,4 +27,7 @@ const BlendOption = {
    */
   OPAQUE_AND_TRANSLUCENT: 2,
 };
-export default Object.freeze(BlendOption);
+
+Object.freeze(BlendOption);
+
+export default BlendOption;

--- a/packages/engine/Source/Scene/BlendingState.js
+++ b/packages/engine/Source/Scene/BlendingState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import BlendEquation from "./BlendEquation.js";
 import BlendFunction from "./BlendFunction.js";
 
@@ -70,4 +72,7 @@ const BlendingState = {
     functionDestinationAlpha: BlendFunction.ONE,
   }),
 };
-export default Object.freeze(BlendingState);
+
+Object.freeze(BlendingState);
+
+export default BlendingState;

--- a/packages/engine/Source/Scene/CameraEventType.js
+++ b/packages/engine/Source/Scene/CameraEventType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Enumerates the available input for interacting with the camera.
  *
@@ -44,4 +46,7 @@ const CameraEventType = {
    */
   PINCH: 4,
 };
-export default Object.freeze(CameraEventType);
+
+Object.freeze(CameraEventType);
+
+export default CameraEventType;

--- a/packages/engine/Source/Scene/Cesium3DTileColorBlendMode.js
+++ b/packages/engine/Source/Scene/Cesium3DTileColorBlendMode.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Defines how per-feature colors set from the Cesium API or declarative styling blend with the source colors from
  * the original feature, e.g. glTF material or per-point color in the tile.
@@ -49,4 +51,7 @@ const Cesium3DTileColorBlendMode = {
    */
   MIX: 2,
 };
-export default Object.freeze(Cesium3DTileColorBlendMode);
+
+Object.freeze(Cesium3DTileColorBlendMode);
+
+export default Cesium3DTileColorBlendMode;

--- a/packages/engine/Source/Scene/Cesium3DTileContentState.js
+++ b/packages/engine/Source/Scene/Cesium3DTileContentState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * @private
  */
@@ -9,4 +11,7 @@ const Cesium3DTileContentState = {
   EXPIRED: 4, // Is expired and will be unloaded once new content is loaded.
   FAILED: 5, // Request failed.
 };
-export default Object.freeze(Cesium3DTileContentState);
+
+Object.freeze(Cesium3DTileContentState);
+
+export default Cesium3DTileContentState;

--- a/packages/engine/Source/Scene/Cesium3DTileOptimizationHint.js
+++ b/packages/engine/Source/Scene/Cesium3DTileOptimizationHint.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Hint defining optimization support for a 3D tile
  *
@@ -10,4 +12,7 @@ const Cesium3DTileOptimizationHint = {
   USE_OPTIMIZATION: 1,
   SKIP_OPTIMIZATION: 0,
 };
-export default Object.freeze(Cesium3DTileOptimizationHint);
+
+Object.freeze(Cesium3DTileOptimizationHint);
+
+export default Cesium3DTileOptimizationHint;

--- a/packages/engine/Source/Scene/Cesium3DTileRefine.js
+++ b/packages/engine/Source/Scene/Cesium3DTileRefine.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The refinement approach for a tile.
  * <p>
@@ -26,4 +28,7 @@ const Cesium3DTileRefine = {
    */
   REPLACE: 1,
 };
-export default Object.freeze(Cesium3DTileRefine);
+
+Object.freeze(Cesium3DTileRefine);
+
+export default Cesium3DTileRefine;

--- a/packages/engine/Source/Scene/CullFace.js
+++ b/packages/engine/Source/Scene/CullFace.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
@@ -30,4 +32,7 @@ const CullFace = {
    */
   FRONT_AND_BACK: WebGLConstants.FRONT_AND_BACK,
 };
-export default Object.freeze(CullFace);
+
+Object.freeze(CullFace);
+
+export default CullFace;

--- a/packages/engine/Source/Scene/DepthFunction.js
+++ b/packages/engine/Source/Scene/DepthFunction.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
@@ -70,4 +72,7 @@ const DepthFunction = {
    */
   ALWAYS: WebGLConstants.ALWAYS,
 };
-export default Object.freeze(DepthFunction);
+
+Object.freeze(DepthFunction);
+
+export default DepthFunction;

--- a/packages/engine/Source/Scene/ExpressionNodeType.js
+++ b/packages/engine/Source/Scene/ExpressionNodeType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * @private
  */
@@ -22,4 +24,7 @@ const ExpressionNodeType = {
   LITERAL_UNDEFINED: 17,
   BUILTIN_VARIABLE: 18,
 };
-export default Object.freeze(ExpressionNodeType);
+
+Object.freeze(ExpressionNodeType);
+
+export default ExpressionNodeType;

--- a/packages/engine/Source/Scene/HeightReference.js
+++ b/packages/engine/Source/Scene/HeightReference.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Represents the position relative to the terrain.
  *
@@ -54,7 +56,9 @@ const HeightReference = {
   RELATIVE_TO_3D_TILE: 6,
 };
 
-export default Object.freeze(HeightReference);
+Object.freeze(HeightReference);
+
+export default HeightReference;
 
 /**
  * Returns true if the height should be clamped to the surface

--- a/packages/engine/Source/Scene/HorizontalOrigin.js
+++ b/packages/engine/Source/Scene/HorizontalOrigin.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The horizontal location of an origin relative to an object, e.g., a {@link Billboard}
  * or {@link Label}.  For example, setting the horizontal origin to <code>LEFT</code>
@@ -38,4 +40,7 @@ const HorizontalOrigin = {
    */
   RIGHT: -1,
 };
-export default Object.freeze(HorizontalOrigin);
+
+Object.freeze(HorizontalOrigin);
+
+export default HorizontalOrigin;

--- a/packages/engine/Source/Scene/ImageryState.js
+++ b/packages/engine/Source/Scene/ImageryState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * @private
  */
@@ -11,4 +13,7 @@ const ImageryState = {
   INVALID: 6,
   PLACEHOLDER: 7,
 };
-export default Object.freeze(ImageryState);
+
+Object.freeze(ImageryState);
+
+export default ImageryState;

--- a/packages/engine/Source/Scene/IonWorldImageryStyle.js
+++ b/packages/engine/Source/Scene/IonWorldImageryStyle.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Note, these values map directly to ion asset ids.
 
 /**
@@ -30,4 +32,7 @@ const IonWorldImageryStyle = {
    */
   ROAD: 4,
 };
-export default Object.freeze(IonWorldImageryStyle);
+
+Object.freeze(IonWorldImageryStyle);
+
+export default IonWorldImageryStyle;

--- a/packages/engine/Source/Scene/JobType.js
+++ b/packages/engine/Source/Scene/JobType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * @private
  */
@@ -7,4 +9,7 @@ const JobType = {
   BUFFER: 2,
   NUMBER_OF_JOB_TYPES: 3,
 };
-export default Object.freeze(JobType);
+
+Object.freeze(JobType);
+
+export default JobType;

--- a/packages/engine/Source/Scene/LabelStyle.js
+++ b/packages/engine/Source/Scene/LabelStyle.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Describes how to draw a label.
  *
@@ -30,4 +32,7 @@ const LabelStyle = {
    */
   FILL_AND_OUTLINE: 2,
 };
-export default Object.freeze(LabelStyle);
+
+Object.freeze(LabelStyle);
+
+export default LabelStyle;

--- a/packages/engine/Source/Scene/MapMode2D.js
+++ b/packages/engine/Source/Scene/MapMode2D.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Describes how the map will operate in 2D.
  *
@@ -20,4 +22,7 @@ const MapMode2D = {
    */
   INFINITE_SCROLL: 1,
 };
-export default Object.freeze(MapMode2D);
+
+Object.freeze(MapMode2D);
+
+export default MapMode2D;

--- a/packages/engine/Source/Scene/MetadataSemantic.js
+++ b/packages/engine/Source/Scene/MetadataSemantic.js
@@ -1,7 +1,9 @@
+// @ts-check
+
 /**
  * An enum of built-in semantics.
  *
- * @enum MetadataSemantic
+ * @enum {string}
  *
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -150,4 +152,6 @@ const MetadataSemantic = {
   CONTENT_HORIZON_OCCLUSION_POINT: "CONTENT_HORIZON_OCCLUSION_POINT",
 };
 
-export default Object.freeze(MetadataSemantic);
+Object.freeze(MetadataSemantic);
+
+export default MetadataSemantic;

--- a/packages/engine/Source/Scene/Model/CustomShaderTranslucencyMode.js
+++ b/packages/engine/Source/Scene/Model/CustomShaderTranslucencyMode.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum for controling how {@link CustomShader} handles translucency compared with the original
  * primitive.
@@ -32,4 +34,6 @@ const CustomShaderTranslucencyMode = {
   TRANSLUCENT: 2,
 };
 
-export default Object.freeze(CustomShaderTranslucencyMode);
+Object.freeze(CustomShaderTranslucencyMode);
+
+export default CustomShaderTranslucencyMode;

--- a/packages/engine/Source/Scene/Model/Extensions/Gpm/PpeSource.js
+++ b/packages/engine/Source/Scene/Model/Extensions/Gpm/PpeSource.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum of per-point error sources.
  *
@@ -72,4 +74,6 @@ const PpeSource = {
   SIGR: "VARZ",
 };
 
-export default Object.freeze(PpeSource);
+Object.freeze(PpeSource);
+
+export default PpeSource;

--- a/packages/engine/Source/Scene/Model/Extensions/Gpm/StorageType.js
+++ b/packages/engine/Source/Scene/Model/Extensions/Gpm/StorageType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum of storage types for covariance information.
  *
@@ -27,4 +29,6 @@ const StorageType = {
   Indirect: "Indirect",
 };
 
-export default Object.freeze(StorageType);
+Object.freeze(StorageType);
+
+export default StorageType;

--- a/packages/engine/Source/Scene/Model/LightingModel.js
+++ b/packages/engine/Source/Scene/Model/LightingModel.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The lighting model to use for lighting a {@link Model}.
  *
@@ -27,4 +29,6 @@ const LightingModel = {
   PBR: 1,
 };
 
-export default Object.freeze(LightingModel);
+Object.freeze(LightingModel);
+
+export default LightingModel;

--- a/packages/engine/Source/Scene/Model/UniformType.js
+++ b/packages/engine/Source/Scene/Model/UniformType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum of the basic GLSL uniform types. These can be used with
  * {@link CustomShader} to declare user-defined uniforms.
@@ -121,4 +123,6 @@ const UniformType = {
   SAMPLER_CUBE: "samplerCube",
 };
 
-export default Object.freeze(UniformType);
+Object.freeze(UniformType);
+
+export default UniformType;

--- a/packages/engine/Source/Scene/Model/VaryingType.js
+++ b/packages/engine/Source/Scene/Model/VaryingType.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * An enum for the GLSL varying types. These can be used for declaring varyings
  * in {@link CustomShader}
@@ -58,4 +60,6 @@ const VaryingType = {
   MAT4: "mat4",
 };
 
-export default Object.freeze(VaryingType);
+Object.freeze(VaryingType);
+
+export default VaryingType;

--- a/packages/engine/Source/Scene/ModelAnimationLoop.js
+++ b/packages/engine/Source/Scene/ModelAnimationLoop.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Determines if and how a glTF animation is looped.
  *
@@ -30,4 +32,7 @@ const ModelAnimationLoop = {
    */
   MIRRORED_REPEAT: 2,
 };
-export default Object.freeze(ModelAnimationLoop);
+
+Object.freeze(ModelAnimationLoop);
+
+export default ModelAnimationLoop;

--- a/packages/engine/Source/Scene/ModelAnimationState.js
+++ b/packages/engine/Source/Scene/ModelAnimationState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * @private
  */
@@ -6,4 +8,6 @@ const ModelAnimationState = {
   ANIMATING: 1,
 };
 
-export default Object.freeze(ModelAnimationState);
+Object.freeze(ModelAnimationState);
+
+export default ModelAnimationState;

--- a/packages/engine/Source/Scene/ModelAnimationState.js
+++ b/packages/engine/Source/Scene/ModelAnimationState.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 /**
+ * @enum {number}
  * @private
  */
 const ModelAnimationState = {

--- a/packages/engine/Source/Scene/ModelComponents.js
+++ b/packages/engine/Source/Scene/ModelComponents.js
@@ -1661,7 +1661,6 @@ export class Material {
      * @default AlphaMode.OPAQUE
      * @ignore
      */
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
     this.alphaMode = AlphaMode.OPAQUE;
 
     /**

--- a/packages/engine/Source/Scene/PrimitiveState.js
+++ b/packages/engine/Source/Scene/PrimitiveState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The states that describe the lifecycle of a <code>Primitive</code>, as
  * represented by the <code>primitive._state</code>.
@@ -7,6 +9,7 @@
  * <code>asynchronous</code> flag of the primitive was set to
  * <code>true</code>.
  *
+ * @enum {number}
  * @private
  */
 const PrimitiveState = {
@@ -133,4 +136,7 @@ const PrimitiveState = {
    */
   FAILED: 6,
 };
-export default Object.freeze(PrimitiveState);
+
+Object.freeze(PrimitiveState);
+
+export default PrimitiveState;

--- a/packages/engine/Source/Scene/QuadtreeTileLoadState.js
+++ b/packages/engine/Source/Scene/QuadtreeTileLoadState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The state of a {@link QuadtreeTile} in the tile load pipeline.
  * @enum {number}
@@ -36,4 +38,7 @@ const QuadtreeTileLoadState = {
    */
   FAILED: 3,
 };
-export default Object.freeze(QuadtreeTileLoadState);
+
+Object.freeze(QuadtreeTileLoadState);
+
+export default QuadtreeTileLoadState;

--- a/packages/engine/Source/Scene/ResourceLoaderState.js
+++ b/packages/engine/Source/Scene/ResourceLoaderState.js
@@ -1,6 +1,9 @@
+// @ts-check
+
 /**
  * The {@link ResourceLoader} state.
  *
+ * @enum {number}
  * @private
  */
 const ResourceLoaderState = {
@@ -53,4 +56,7 @@ const ResourceLoaderState = {
    */
   FAILED: 5,
 };
-export default Object.freeze(ResourceLoaderState);
+
+Object.freeze(ResourceLoaderState);
+
+export default ResourceLoaderState;

--- a/packages/engine/Source/Scene/SplitDirection.js
+++ b/packages/engine/Source/Scene/SplitDirection.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The direction to display a primitive or ImageryLayer relative to the {@link Scene#splitPosition}.
  *
@@ -31,4 +33,7 @@ const SplitDirection = {
    */
   RIGHT: 1.0,
 };
-export default Object.freeze(SplitDirection);
+
+Object.freeze(SplitDirection);
+
+export default SplitDirection;

--- a/packages/engine/Source/Scene/StencilFunction.js
+++ b/packages/engine/Source/Scene/StencilFunction.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
@@ -70,4 +72,7 @@ const StencilFunction = {
    */
   ALWAYS: WebGLConstants.ALWAYS,
 };
-export default Object.freeze(StencilFunction);
+
+Object.freeze(StencilFunction);
+
+export default StencilFunction;

--- a/packages/engine/Source/Scene/StencilOperation.js
+++ b/packages/engine/Source/Scene/StencilOperation.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
@@ -70,4 +72,7 @@ const StencilOperation = {
    */
   DECREMENT_WRAP: WebGLConstants.DECR_WRAP,
 };
-export default Object.freeze(StencilOperation);
+
+Object.freeze(StencilOperation);
+
+export default StencilOperation;

--- a/packages/engine/Source/Scene/TerrainState.js
+++ b/packages/engine/Source/Scene/TerrainState.js
@@ -1,4 +1,7 @@
+// @ts-check
+
 /**
+ * @enum {number}
  * @private
  */
 const TerrainState = {
@@ -10,4 +13,7 @@ const TerrainState = {
   TRANSFORMED: 5,
   READY: 6,
 };
-export default Object.freeze(TerrainState);
+
+Object.freeze(TerrainState);
+
+export default TerrainState;

--- a/packages/engine/Source/Scene/TileState.js
+++ b/packages/engine/Source/Scene/TileState.js
@@ -1,4 +1,7 @@
+// @ts-check
+
 /**
+ * @enum {number}
  * @private
  */
 const TileState = {
@@ -7,4 +10,7 @@ const TileState = {
   READY: 2,
   UPSAMPLED_ONLY: 3,
 };
-export default Object.freeze(TileState);
+
+Object.freeze(TileState);
+
+export default TileState;

--- a/packages/engine/Source/Scene/Tonemapper.js
+++ b/packages/engine/Source/Scene/Tonemapper.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * A tonemapping algorithm when rendering with high dynamic range.
  *
@@ -61,4 +63,6 @@ export function validateTonemapper(tonemapper) {
   );
 }
 
-export default Object.freeze(Tonemapper);
+Object.freeze(Tonemapper);
+
+export default Tonemapper;

--- a/packages/engine/Source/Scene/VerticalOrigin.js
+++ b/packages/engine/Source/Scene/VerticalOrigin.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The vertical location of an origin relative to an object, e.g., a {@link Billboard}
  * or {@link Label}.  For example, setting the vertical origin to <code>TOP</code>
@@ -46,4 +48,7 @@ const VerticalOrigin = {
    */
   TOP: -1,
 };
-export default Object.freeze(VerticalOrigin);
+
+Object.freeze(VerticalOrigin);
+
+export default VerticalOrigin;

--- a/packages/engine/Source/Scene/VoxelMetadataOrder.js
+++ b/packages/engine/Source/Scene/VoxelMetadataOrder.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Metadata ordering for voxel content.
  * In all cases, x data is contiguous in strides along the y axis,
@@ -21,4 +23,7 @@ const VoxelMetadataOrder = {
    */
   Y_UP: 1,
 };
-export default Object.freeze(VoxelMetadataOrder);
+
+Object.freeze(VoxelMetadataOrder);
+
+export default VoxelMetadataOrder;


### PR DESCRIPTION
# Description

Enables type-checking for enum comparisons on all enum types _without_ attached utility functions. See issue below.

Adds a new test to the `sg scan` lint routine, checking that new enums follow this pattern in the future.

## Issue number and link

- #13420
- #4434 

## Testing plan

No functional changes. Unit tests and `npm run tsc` should pass. The `sg scan` lint step (with a new check for this issue) should pass.

I ran diff-types.sh (from #13372) and confirmed that exported type definitions are unchanged.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] ~~I have updated the inline documentation, and included code examples where relevant~~
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] Yes
- [ ] No
- [x] No, but I probably should have