### PR TITLE
Types: TilingScheme and QuadtreeTile type checking

### DIFF
--- a/packages/engine/Source/Core/GeographicTilingScheme.js
+++ b/packages/engine/Source/Core/GeographicTilingScheme.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import Cartesian2 from "./Cartesian2.js";
 import Check from "./Check.js";
 import Frozen from "./Frozen.js";
@@ -7,239 +9,218 @@ import GeographicProjection from "./GeographicProjection.js";
 import CesiumMath from "./Math.js";
 import Rectangle from "./Rectangle.js";
 
+/** @import Cartographic from "./Cartographic.js"; */
+/** @import MapProjection from "./MapProjection.js"; */
+/** @import TilingScheme from "./TilingScheme.js"; */
+
 /**
  * A tiling scheme for geometry referenced to a simple {@link GeographicProjection} where
  * longitude and latitude are directly mapped to X and Y.  This projection is commonly
  * known as geographic, equirectangular, equidistant cylindrical, or plate carrée.
  *
- * @alias GeographicTilingScheme
- * @constructor
- *
- * @param {object} [options] Object with the following properties:
- * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.default] The ellipsoid whose surface is being tiled. Defaults to
- * the default ellipsoid.
- * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle, in radians, covered by the tiling scheme.
- * @param {number} [options.numberOfLevelZeroTilesX=2] The number of tiles in the X direction at level zero of
- * the tile tree.
- * @param {number} [options.numberOfLevelZeroTilesY=1] The number of tiles in the Y direction at level zero of
- * the tile tree.
+ * @implements {TilingScheme}
  */
-function GeographicTilingScheme(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class GeographicTilingScheme {
+  /**
+   * @param {object} [options] Object with the following properties:
+   * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.default] The ellipsoid whose surface is being tiled. Defaults to
+   * the default ellipsoid.
+   * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle, in radians, covered by the tiling scheme.
+   * @param {number} [options.numberOfLevelZeroTilesX=2] The number of tiles in the X direction at level zero of
+   * the tile tree.
+   * @param {number} [options.numberOfLevelZeroTilesY=1] The number of tiles in the Y direction at level zero of
+   * the tile tree.
+   */
+  constructor(options) {
+    options = options ?? Frozen.EMPTY_OBJECT;
 
-  this._ellipsoid = options.ellipsoid ?? Ellipsoid.default;
-  this._rectangle = options.rectangle ?? Rectangle.MAX_VALUE;
-  this._projection = new GeographicProjection(this._ellipsoid);
-  this._numberOfLevelZeroTilesX = options.numberOfLevelZeroTilesX ?? 2;
-  this._numberOfLevelZeroTilesY = options.numberOfLevelZeroTilesY ?? 1;
-}
+    this._ellipsoid = options.ellipsoid ?? Ellipsoid.default;
+    this._rectangle = options.rectangle ?? Rectangle.MAX_VALUE;
+    this._projection = new GeographicProjection(this._ellipsoid);
+    this._numberOfLevelZeroTilesX = options.numberOfLevelZeroTilesX ?? 2;
+    this._numberOfLevelZeroTilesY = options.numberOfLevelZeroTilesY ?? 1;
+  }
 
-Object.defineProperties(GeographicTilingScheme.prototype, {
   /**
    * Gets the ellipsoid that is tiled by this tiling scheme.
-   * @memberof GeographicTilingScheme.prototype
    * @type {Ellipsoid}
    */
-  ellipsoid: {
-    get: function () {
-      return this._ellipsoid;
-    },
-  },
+  get ellipsoid() {
+    return this._ellipsoid;
+  }
 
   /**
    * Gets the rectangle, in radians, covered by this tiling scheme.
-   * @memberof GeographicTilingScheme.prototype
    * @type {Rectangle}
    */
-  rectangle: {
-    get: function () {
-      return this._rectangle;
-    },
-  },
+  get rectangle() {
+    return this._rectangle;
+  }
 
   /**
    * Gets the map projection used by this tiling scheme.
-   * @memberof GeographicTilingScheme.prototype
    * @type {MapProjection}
    */
-  projection: {
-    get: function () {
-      return this._projection;
-    },
-  },
-});
-
-/**
- * Gets the total number of tiles in the X direction at a specified level-of-detail.
- *
- * @param {number} level The level-of-detail.
- * @returns {number} The number of tiles in the X direction at the given level.
- */
-GeographicTilingScheme.prototype.getNumberOfXTilesAtLevel = function (level) {
-  return this._numberOfLevelZeroTilesX << level;
-};
-
-/**
- * Gets the total number of tiles in the Y direction at a specified level-of-detail.
- *
- * @param {number} level The level-of-detail.
- * @returns {number} The number of tiles in the Y direction at the given level.
- */
-GeographicTilingScheme.prototype.getNumberOfYTilesAtLevel = function (level) {
-  return this._numberOfLevelZeroTilesY << level;
-};
-
-/**
- * Transforms a rectangle specified in geodetic radians to the native coordinate system
- * of this tiling scheme.
- *
- * @param {Rectangle} rectangle The rectangle to transform.
- * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the native rectangle if 'result'
- *          is undefined.
- */
-GeographicTilingScheme.prototype.rectangleToNativeRectangle = function (
-  rectangle,
-  result,
-) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("rectangle", rectangle);
-  //>>includeEnd('debug');
-
-  const west = CesiumMath.toDegrees(rectangle.west);
-  const south = CesiumMath.toDegrees(rectangle.south);
-  const east = CesiumMath.toDegrees(rectangle.east);
-  const north = CesiumMath.toDegrees(rectangle.north);
-
-  if (!defined(result)) {
-    return new Rectangle(west, south, east, north);
+  get projection() {
+    return this._projection;
   }
 
-  result.west = west;
-  result.south = south;
-  result.east = east;
-  result.north = north;
-  return result;
-};
-
-/**
- * Converts tile x, y coordinates and level to a rectangle expressed in the native coordinates
- * of the tiling scheme.
- *
- * @param {number} x The integer x coordinate of the tile.
- * @param {number} y The integer y coordinate of the tile.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
- *          if 'result' is undefined.
- */
-GeographicTilingScheme.prototype.tileXYToNativeRectangle = function (
-  x,
-  y,
-  level,
-  result,
-) {
-  const rectangleRadians = this.tileXYToRectangle(x, y, level, result);
-  rectangleRadians.west = CesiumMath.toDegrees(rectangleRadians.west);
-  rectangleRadians.south = CesiumMath.toDegrees(rectangleRadians.south);
-  rectangleRadians.east = CesiumMath.toDegrees(rectangleRadians.east);
-  rectangleRadians.north = CesiumMath.toDegrees(rectangleRadians.north);
-  return rectangleRadians;
-};
-
-/**
- * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
- *
- * @param {number} x The integer x coordinate of the tile.
- * @param {number} y The integer y coordinate of the tile.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
- *          if 'result' is undefined.
- */
-GeographicTilingScheme.prototype.tileXYToRectangle = function (
-  x,
-  y,
-  level,
-  result,
-) {
-  const rectangle = this._rectangle;
-
-  const xTiles = this.getNumberOfXTilesAtLevel(level);
-  const yTiles = this.getNumberOfYTilesAtLevel(level);
-
-  const xTileWidth = rectangle.width / xTiles;
-  const west = x * xTileWidth + rectangle.west;
-  const east = (x + 1) * xTileWidth + rectangle.west;
-
-  const yTileHeight = rectangle.height / yTiles;
-  const north = rectangle.north - y * yTileHeight;
-  const south = rectangle.north - (y + 1) * yTileHeight;
-
-  if (!defined(result)) {
-    result = new Rectangle(west, south, east, north);
+  /**
+   * Gets the total number of tiles in the X direction at a specified level-of-detail.
+   *
+   * @param {number} level The level-of-detail.
+   * @returns {number} The number of tiles in the X direction at the given level.
+   */
+  getNumberOfXTilesAtLevel(level) {
+    return this._numberOfLevelZeroTilesX << level;
   }
 
-  result.west = west;
-  result.south = south;
-  result.east = east;
-  result.north = north;
-  return result;
-};
-
-/**
- * Calculates the tile x, y coordinates of the tile containing
- * a given cartographic position.
- *
- * @param {Cartographic} position The position.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {Cartesian2} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Cartesian2} The specified 'result', or a new object containing the tile x, y coordinates
- *          if 'result' is undefined.
- */
-GeographicTilingScheme.prototype.positionToTileXY = function (
-  position,
-  level,
-  result,
-) {
-  const rectangle = this._rectangle;
-  if (!Rectangle.contains(rectangle, position)) {
-    // outside the bounds of the tiling scheme
-    return undefined;
+  /**
+   * Gets the total number of tiles in the Y direction at a specified level-of-detail.
+   *
+   * @param {number} level The level-of-detail.
+   * @returns {number} The number of tiles in the Y direction at the given level.
+   */
+  getNumberOfYTilesAtLevel(level) {
+    return this._numberOfLevelZeroTilesY << level;
   }
 
-  const xTiles = this.getNumberOfXTilesAtLevel(level);
-  const yTiles = this.getNumberOfYTilesAtLevel(level);
+  /**
+   * Transforms a rectangle specified in geodetic radians to the native coordinate system
+   * of this tiling scheme.
+   *
+   * @param {Rectangle} rectangle The rectangle to transform.
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the native rectangle if 'result'
+   *          is undefined.
+   */
+  rectangleToNativeRectangle(rectangle, result) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("rectangle", rectangle);
+    //>>includeEnd('debug');
 
-  const xTileWidth = rectangle.width / xTiles;
-  const yTileHeight = rectangle.height / yTiles;
+    const west = CesiumMath.toDegrees(rectangle.west);
+    const south = CesiumMath.toDegrees(rectangle.south);
+    const east = CesiumMath.toDegrees(rectangle.east);
+    const north = CesiumMath.toDegrees(rectangle.north);
 
-  let longitude = position.longitude;
-  if (rectangle.east < rectangle.west) {
-    longitude += CesiumMath.TWO_PI;
+    if (!defined(result)) {
+      return new Rectangle(west, south, east, north);
+    }
+
+    result.west = west;
+    result.south = south;
+    result.east = east;
+    result.north = north;
+    return result;
   }
 
-  let xTileCoordinate = ((longitude - rectangle.west) / xTileWidth) | 0;
-  if (xTileCoordinate >= xTiles) {
-    xTileCoordinate = xTiles - 1;
+  /**
+   * Converts tile x, y coordinates and level to a rectangle expressed in the native coordinates
+   * of the tiling scheme.
+   *
+   * @param {number} x The integer x coordinate of the tile.
+   * @param {number} y The integer y coordinate of the tile.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
+   *          if 'result' is undefined.
+   */
+  tileXYToNativeRectangle(x, y, level, result) {
+    const rectangleRadians = this.tileXYToRectangle(x, y, level, result);
+    rectangleRadians.west = CesiumMath.toDegrees(rectangleRadians.west);
+    rectangleRadians.south = CesiumMath.toDegrees(rectangleRadians.south);
+    rectangleRadians.east = CesiumMath.toDegrees(rectangleRadians.east);
+    rectangleRadians.north = CesiumMath.toDegrees(rectangleRadians.north);
+    return rectangleRadians;
   }
 
-  let yTileCoordinate =
-    ((rectangle.north - position.latitude) / yTileHeight) | 0;
-  if (yTileCoordinate >= yTiles) {
-    yTileCoordinate = yTiles - 1;
+  /**
+   * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
+   *
+   * @param {number} x The integer x coordinate of the tile.
+   * @param {number} y The integer y coordinate of the tile.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
+   *          if 'result' is undefined.
+   */
+  tileXYToRectangle(x, y, level, result) {
+    const rectangle = this._rectangle;
+
+    const xTiles = this.getNumberOfXTilesAtLevel(level);
+    const yTiles = this.getNumberOfYTilesAtLevel(level);
+
+    const xTileWidth = rectangle.width / xTiles;
+    const west = x * xTileWidth + rectangle.west;
+    const east = (x + 1) * xTileWidth + rectangle.west;
+
+    const yTileHeight = rectangle.height / yTiles;
+    const north = rectangle.north - y * yTileHeight;
+    const south = rectangle.north - (y + 1) * yTileHeight;
+
+    if (!defined(result)) {
+      result = new Rectangle(west, south, east, north);
+    }
+
+    result.west = west;
+    result.south = south;
+    result.east = east;
+    result.north = north;
+    return result;
   }
 
-  if (!defined(result)) {
-    return new Cartesian2(xTileCoordinate, yTileCoordinate);
-  }
+  /**
+   * Calculates the tile x, y coordinates of the tile containing
+   * a given cartographic position.
+   *
+   * @param {Cartographic} position The position.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {Cartesian2} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Cartesian2} The specified 'result', or a new object containing the tile x, y coordinates
+   *          if 'result' is undefined.
+   */
+  positionToTileXY(position, level, result) {
+    const rectangle = this._rectangle;
+    if (!Rectangle.contains(rectangle, position)) {
+      // outside the bounds of the tiling scheme
+      return undefined;
+    }
 
-  result.x = xTileCoordinate;
-  result.y = yTileCoordinate;
-  return result;
-};
+    const xTiles = this.getNumberOfXTilesAtLevel(level);
+    const yTiles = this.getNumberOfYTilesAtLevel(level);
+
+    const xTileWidth = rectangle.width / xTiles;
+    const yTileHeight = rectangle.height / yTiles;
+
+    let longitude = position.longitude;
+    if (rectangle.east < rectangle.west) {
+      longitude += CesiumMath.TWO_PI;
+    }
+
+    let xTileCoordinate = ((longitude - rectangle.west) / xTileWidth) | 0;
+    if (xTileCoordinate >= xTiles) {
+      xTileCoordinate = xTiles - 1;
+    }
+
+    let yTileCoordinate =
+      ((rectangle.north - position.latitude) / yTileHeight) | 0;
+    if (yTileCoordinate >= yTiles) {
+      yTileCoordinate = yTiles - 1;
+    }
+
+    if (!defined(result)) {
+      return new Cartesian2(xTileCoordinate, yTileCoordinate);
+    }
+
+    result.x = xTileCoordinate;
+    result.y = yTileCoordinate;
+    return result;
+  }
+}
+
 export default GeographicTilingScheme;

--- a/packages/engine/Source/Core/TilingScheme.js
+++ b/packages/engine/Source/Core/TilingScheme.js
@@ -91,7 +91,7 @@ class TilingScheme {
    * @param {number} x The integer x coordinate of the tile.
    * @param {number} y The integer y coordinate of the tile.
    * @param {number} level The tile level-of-detail.  Zero is the least detailed.
-   * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
    *        should be created.
    * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
    *          if 'result' is undefined.
@@ -106,7 +106,7 @@ class TilingScheme {
    * @param {number} x The integer x coordinate of the tile.
    * @param {number} y The integer y coordinate of the tile.
    * @param {number} level The tile level-of-detail.  Zero is the least detailed.
-   * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
    *        should be created.
    * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
    *          if 'result' is undefined.

--- a/packages/engine/Source/Core/TilingScheme.js
+++ b/packages/engine/Source/Core/TilingScheme.js
@@ -1,4 +1,12 @@
+// @ts-check
+
 import DeveloperError from "./DeveloperError.js";
+
+/** @import Cartesian2 from "./Cartesian2.js"; */
+/** @import Cartographic from "./Cartographic.js"; */
+/** @import Ellipsoid from "./Ellipsoid.js"; */
+/** @import MapProjection from "./MapProjection.js"; */
+/** @import Rectangle from "./Rectangle.js"; */
 
 /**
  * A tiling scheme for geometry or imagery on the surface of an ellipsoid.  At level-of-detail zero,
@@ -7,126 +15,120 @@ import DeveloperError from "./DeveloperError.js";
  * At level of detail two, each of the level one tiles has four children, two in each direction.
  * This continues for as many levels as are present in the geometry or imagery source.
  *
- * @alias TilingScheme
- * @constructor
+ * @interface
  *
  * @see WebMercatorTilingScheme
  * @see GeographicTilingScheme
  */
-function TilingScheme(options) {
-  //>>includeStart('debug', pragmas.debug);
-  throw new DeveloperError(
-    "This type should not be instantiated directly.  Instead, use WebMercatorTilingScheme or GeographicTilingScheme.",
-  );
-  //>>includeEnd('debug');
-}
-
-Object.defineProperties(TilingScheme.prototype, {
+class TilingScheme {
   /**
    * Gets the ellipsoid that is tiled by the tiling scheme.
-   * @memberof TilingScheme.prototype
    * @type {Ellipsoid}
    */
-  ellipsoid: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  ellipsoid;
 
   /**
    * Gets the rectangle, in radians, covered by this tiling scheme.
-   * @memberof TilingScheme.prototype
    * @type {Rectangle}
    */
-  rectangle: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  rectangle;
 
   /**
    * Gets the map projection used by the tiling scheme.
-   * @memberof TilingScheme.prototype
    * @type {MapProjection}
    */
-  projection: {
-    get: DeveloperError.throwInstantiationError,
-  },
-});
+  projection;
 
-/**
- * Gets the total number of tiles in the X direction at a specified level-of-detail.
- * @function
- *
- * @param {number} level The level-of-detail.
- * @returns {number} The number of tiles in the X direction at the given level.
- */
-TilingScheme.prototype.getNumberOfXTilesAtLevel =
-  DeveloperError.throwInstantiationError;
+  /**
+   * @param {object} options
+   */
+  constructor(options) {
+    //>>includeStart('debug', pragmas.debug);
+    throw new DeveloperError(
+      "This type should not be instantiated directly.  Instead, use WebMercatorTilingScheme or GeographicTilingScheme.",
+    );
+    //>>includeEnd('debug');
+  }
 
-/**
- * Gets the total number of tiles in the Y direction at a specified level-of-detail.
- * @function
- *
- * @param {number} level The level-of-detail.
- * @returns {number} The number of tiles in the Y direction at the given level.
- */
-TilingScheme.prototype.getNumberOfYTilesAtLevel =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Gets the total number of tiles in the X direction at a specified level-of-detail.
+   *
+   * @param {number} level The level-of-detail.
+   * @returns {number} The number of tiles in the X direction at the given level.
+   */
+  getNumberOfXTilesAtLevel(level) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Transforms a rectangle specified in geodetic radians to the native coordinate system
- * of this tiling scheme.
- * @function
- *
- * @param {Rectangle} rectangle The rectangle to transform.
- * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the native rectangle if 'result'
- *          is undefined.
- */
-TilingScheme.prototype.rectangleToNativeRectangle =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Gets the total number of tiles in the Y direction at a specified level-of-detail.
+   *
+   * @param {number} level The level-of-detail.
+   * @returns {number} The number of tiles in the Y direction at the given level.
+   */
+  getNumberOfYTilesAtLevel(level) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Converts tile x, y coordinates and level to a rectangle expressed in the native coordinates
- * of the tiling scheme.
- * @function
- *
- * @param {number} x The integer x coordinate of the tile.
- * @param {number} y The integer y coordinate of the tile.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
- *          if 'result' is undefined.
- */
-TilingScheme.prototype.tileXYToNativeRectangle =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Transforms a rectangle specified in geodetic radians to the native coordinate system
+   * of this tiling scheme.
+   *
+   * @param {Rectangle} rectangle The rectangle to transform.
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the native rectangle if 'result'
+   *          is undefined.
+   */
+  rectangleToNativeRectangle(rectangle, result) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
- * @function
- *
- * @param {number} x The integer x coordinate of the tile.
- * @param {number} y The integer y coordinate of the tile.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
- *          if 'result' is undefined.
- */
-TilingScheme.prototype.tileXYToRectangle =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Converts tile x, y coordinates and level to a rectangle expressed in the native coordinates
+   * of the tiling scheme.
+   *
+   * @param {number} x The integer x coordinate of the tile.
+   * @param {number} y The integer y coordinate of the tile.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
+   *          if 'result' is undefined.
+   */
+  tileXYToNativeRectangle(x, y, level, result) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Calculates the tile x, y coordinates of the tile containing
- * a given cartographic position.
- * @function
- *
- * @param {Cartographic} position The position.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {Cartesian2} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Cartesian2} The specified 'result', or a new object containing the tile x, y coordinates
- *          if 'result' is undefined.
- */
-TilingScheme.prototype.positionToTileXY =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
+   *
+   * @param {number} x The integer x coordinate of the tile.
+   * @param {number} y The integer y coordinate of the tile.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
+   *          if 'result' is undefined.
+   */
+  tileXYToRectangle(x, y, level, result) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Calculates the tile x, y coordinates of the tile containing
+   * a given cartographic position.
+   *
+   * @param {Cartographic} position The position.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {Cartesian2} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Cartesian2} The specified 'result', or a new object containing the tile x, y coordinates
+   *          if 'result' is undefined.
+   */
+  positionToTileXY(position, level, result) {
+    DeveloperError.throwInstantiationError();
+  }
+}
+
 export default TilingScheme;

--- a/packages/engine/Source/Core/WebMercatorTilingScheme.js
+++ b/packages/engine/Source/Core/WebMercatorTilingScheme.js
@@ -1,12 +1,12 @@
 // @ts-check
 
 import Cartesian2 from "./Cartesian2.js";
+import Cartesian3 from "./Cartesian3.js";
 import Frozen from "./Frozen.js";
 import defined from "./defined.js";
 import Ellipsoid from "./Ellipsoid.js";
 import Rectangle from "./Rectangle.js";
 import WebMercatorProjection from "./WebMercatorProjection.js";
-import Cartesian3 from "./Cartesian3.js";
 
 /** @import Cartographic from "./Cartographic.js"; */
 /** @import MapProjection from "./MapProjection.js"; */
@@ -20,13 +20,13 @@ import Cartesian3 from "./Cartesian3.js";
  */
 class WebMercatorTilingScheme {
   /**
-   * @type {Cartesian3}
+   * @type {Cartesian2}
    * @private
    */
   _rectangleSouthwestInMeters;
 
   /**
-   * @type {Cartesian3}
+   * @type {Cartesian2}
    * @private
    */
   _rectangleNortheastInMeters;
@@ -61,14 +61,8 @@ class WebMercatorTilingScheme {
       defined(options.rectangleSouthwestInMeters) &&
       defined(options.rectangleNortheastInMeters)
     ) {
-      this._rectangleSouthwestInMeters = new Cartesian3(
-        options.rectangleSouthwestInMeters.x,
-        options.rectangleSouthwestInMeters.y,
-      );
-      this._rectangleNortheastInMeters = new Cartesian3(
-        options.rectangleNortheastInMeters.x,
-        options.rectangleNortheastInMeters.y,
-      );
+      this._rectangleSouthwestInMeters = options.rectangleSouthwestInMeters;
+      this._rectangleNortheastInMeters = options.rectangleNortheastInMeters;
     } else {
       const semimajorAxisTimesPi = this._ellipsoid.maximumRadius * Math.PI;
       this._rectangleSouthwestInMeters = new Cartesian3(
@@ -82,10 +76,16 @@ class WebMercatorTilingScheme {
     }
 
     const southwest = this._projection.unproject(
-      this._rectangleSouthwestInMeters,
+      new Cartesian3(
+        this._rectangleSouthwestInMeters.x,
+        this._rectangleSouthwestInMeters.y,
+      ),
     );
     const northeast = this._projection.unproject(
-      this._rectangleNortheastInMeters,
+      new Cartesian3(
+        this._rectangleNortheastInMeters.x,
+        this._rectangleNortheastInMeters.y,
+      ),
     );
     this._rectangle = new Rectangle(
       southwest.longitude,

--- a/packages/engine/Source/Core/WebMercatorTilingScheme.js
+++ b/packages/engine/Source/Core/WebMercatorTilingScheme.js
@@ -2,15 +2,21 @@
 
 import Cartesian2 from "./Cartesian2.js";
 import Cartesian3 from "./Cartesian3.js";
+import Cartographic from "./Cartographic.js";
 import Frozen from "./Frozen.js";
 import defined from "./defined.js";
 import Ellipsoid from "./Ellipsoid.js";
 import Rectangle from "./Rectangle.js";
 import WebMercatorProjection from "./WebMercatorProjection.js";
 
-/** @import Cartographic from "./Cartographic.js"; */
 /** @import MapProjection from "./MapProjection.js"; */
 /** @import TilingScheme from "./TilingScheme.js"; */
+
+const southwestScratch = new Cartographic();
+const northeastScratch = new Cartographic();
+
+const southwestCartesianScratch = new Cartesian3();
+const northeastCartesianScratch = new Cartesian3();
 
 /**
  * A tiling scheme for geometry referenced to a {@link WebMercatorProjection}, EPSG:3857.  This is
@@ -65,33 +71,29 @@ class WebMercatorTilingScheme {
       this._rectangleNortheastInMeters = options.rectangleNortheastInMeters;
     } else {
       const semimajorAxisTimesPi = this._ellipsoid.maximumRadius * Math.PI;
-      this._rectangleSouthwestInMeters = new Cartesian3(
+      this._rectangleSouthwestInMeters = new Cartesian2(
         -semimajorAxisTimesPi,
         -semimajorAxisTimesPi,
       );
-      this._rectangleNortheastInMeters = new Cartesian3(
+      this._rectangleNortheastInMeters = new Cartesian2(
         semimajorAxisTimesPi,
         semimajorAxisTimesPi,
       );
     }
 
-    const southwest = this._projection.unproject(
-      new Cartesian3(
-        this._rectangleSouthwestInMeters.x,
-        this._rectangleSouthwestInMeters.y,
-      ),
-    );
-    const northeast = this._projection.unproject(
-      new Cartesian3(
-        this._rectangleNortheastInMeters.x,
-        this._rectangleNortheastInMeters.y,
-      ),
-    );
+    let { x, y } = this._rectangleSouthwestInMeters;
+    Cartesian3.fromElements(x, y, 0, southwestCartesianScratch);
+    this._projection.unproject(southwestCartesianScratch, southwestScratch);
+
+    ({ x, y } = this._rectangleNortheastInMeters);
+    Cartesian3.fromElements(x, y, 0, northeastCartesianScratch);
+    this._projection.unproject(northeastCartesianScratch, northeastScratch);
+
     this._rectangle = new Rectangle(
-      southwest.longitude,
-      southwest.latitude,
-      northeast.longitude,
-      northeast.latitude,
+      southwestScratch.longitude,
+      southwestScratch.latitude,
+      northeastScratch.longitude,
+      northeastScratch.latitude,
     );
   }
 

--- a/packages/engine/Source/Core/WebMercatorTilingScheme.js
+++ b/packages/engine/Source/Core/WebMercatorTilingScheme.js
@@ -1,291 +1,293 @@
+// @ts-check
+
 import Cartesian2 from "./Cartesian2.js";
 import Frozen from "./Frozen.js";
 import defined from "./defined.js";
 import Ellipsoid from "./Ellipsoid.js";
 import Rectangle from "./Rectangle.js";
 import WebMercatorProjection from "./WebMercatorProjection.js";
+import Cartesian3 from "./Cartesian3.js";
+
+/** @import Cartographic from "./Cartographic.js"; */
+/** @import MapProjection from "./MapProjection.js"; */
+/** @import TilingScheme from "./TilingScheme.js"; */
 
 /**
  * A tiling scheme for geometry referenced to a {@link WebMercatorProjection}, EPSG:3857.  This is
  * the tiling scheme used by Google Maps, Microsoft Bing Maps, and most of ESRI ArcGIS Online.
  *
- * @alias WebMercatorTilingScheme
- * @constructor
- *
- * @param {object} [options] Object with the following properties:
- * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.default] The ellipsoid whose surface is being tiled. Defaults to
- * the default ellipsoid.
- * @param {number} [options.numberOfLevelZeroTilesX=1] The number of tiles in the X direction at level zero of
- *        the tile tree.
- * @param {number} [options.numberOfLevelZeroTilesY=1] The number of tiles in the Y direction at level zero of
- *        the tile tree.
- * @param {Cartesian2} [options.rectangleSouthwestInMeters] The southwest corner of the rectangle covered by the
- *        tiling scheme, in meters.  If this parameter or rectangleNortheastInMeters is not specified, the entire
- *        globe is covered in the longitude direction and an equal distance is covered in the latitude
- *        direction, resulting in a square projection.
- * @param {Cartesian2} [options.rectangleNortheastInMeters] The northeast corner of the rectangle covered by the
- *        tiling scheme, in meters.  If this parameter or rectangleSouthwestInMeters is not specified, the entire
- *        globe is covered in the longitude direction and an equal distance is covered in the latitude
- *        direction, resulting in a square projection.
+ * @implements {TilingScheme}
  */
-function WebMercatorTilingScheme(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class WebMercatorTilingScheme {
+  /**
+   * @type {Cartesian3}
+   * @private
+   */
+  _rectangleSouthwestInMeters;
 
-  this._ellipsoid = options.ellipsoid ?? Ellipsoid.default;
-  this._numberOfLevelZeroTilesX = options.numberOfLevelZeroTilesX ?? 1;
-  this._numberOfLevelZeroTilesY = options.numberOfLevelZeroTilesY ?? 1;
+  /**
+   * @type {Cartesian3}
+   * @private
+   */
+  _rectangleNortheastInMeters;
 
-  this._projection = new WebMercatorProjection(this._ellipsoid);
+  /**
+   * @param {object} [options] Object with the following properties:
+   * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.default] The ellipsoid whose surface is being tiled. Defaults to
+   * the default ellipsoid.
+   * @param {number} [options.numberOfLevelZeroTilesX=1] The number of tiles in the X direction at level zero of
+   *        the tile tree.
+   * @param {number} [options.numberOfLevelZeroTilesY=1] The number of tiles in the Y direction at level zero of
+   *        the tile tree.
+   * @param {Cartesian2} [options.rectangleSouthwestInMeters] The southwest corner of the rectangle covered by the
+   *        tiling scheme, in meters.  If this parameter or rectangleNortheastInMeters is not specified, the entire
+   *        globe is covered in the longitude direction and an equal distance is covered in the latitude
+   *        direction, resulting in a square projection.
+   * @param {Cartesian2} [options.rectangleNortheastInMeters] The northeast corner of the rectangle covered by the
+   *        tiling scheme, in meters.  If this parameter or rectangleSouthwestInMeters is not specified, the entire
+   *        globe is covered in the longitude direction and an equal distance is covered in the latitude
+   *        direction, resulting in a square projection.
+   */
+  constructor(options) {
+    options = options ?? Frozen.EMPTY_OBJECT;
 
-  if (
-    defined(options.rectangleSouthwestInMeters) &&
-    defined(options.rectangleNortheastInMeters)
-  ) {
-    this._rectangleSouthwestInMeters = options.rectangleSouthwestInMeters;
-    this._rectangleNortheastInMeters = options.rectangleNortheastInMeters;
-  } else {
-    const semimajorAxisTimesPi = this._ellipsoid.maximumRadius * Math.PI;
-    this._rectangleSouthwestInMeters = new Cartesian2(
-      -semimajorAxisTimesPi,
-      -semimajorAxisTimesPi,
+    this._ellipsoid = options.ellipsoid ?? Ellipsoid.default;
+    this._numberOfLevelZeroTilesX = options.numberOfLevelZeroTilesX ?? 1;
+    this._numberOfLevelZeroTilesY = options.numberOfLevelZeroTilesY ?? 1;
+
+    this._projection = new WebMercatorProjection(this._ellipsoid);
+
+    if (
+      defined(options.rectangleSouthwestInMeters) &&
+      defined(options.rectangleNortheastInMeters)
+    ) {
+      this._rectangleSouthwestInMeters = new Cartesian3(
+        options.rectangleSouthwestInMeters.x,
+        options.rectangleSouthwestInMeters.y,
+      );
+      this._rectangleNortheastInMeters = new Cartesian3(
+        options.rectangleNortheastInMeters.x,
+        options.rectangleNortheastInMeters.y,
+      );
+    } else {
+      const semimajorAxisTimesPi = this._ellipsoid.maximumRadius * Math.PI;
+      this._rectangleSouthwestInMeters = new Cartesian3(
+        -semimajorAxisTimesPi,
+        -semimajorAxisTimesPi,
+      );
+      this._rectangleNortheastInMeters = new Cartesian3(
+        semimajorAxisTimesPi,
+        semimajorAxisTimesPi,
+      );
+    }
+
+    const southwest = this._projection.unproject(
+      this._rectangleSouthwestInMeters,
     );
-    this._rectangleNortheastInMeters = new Cartesian2(
-      semimajorAxisTimesPi,
-      semimajorAxisTimesPi,
+    const northeast = this._projection.unproject(
+      this._rectangleNortheastInMeters,
+    );
+    this._rectangle = new Rectangle(
+      southwest.longitude,
+      southwest.latitude,
+      northeast.longitude,
+      northeast.latitude,
     );
   }
 
-  const southwest = this._projection.unproject(
-    this._rectangleSouthwestInMeters,
-  );
-  const northeast = this._projection.unproject(
-    this._rectangleNortheastInMeters,
-  );
-  this._rectangle = new Rectangle(
-    southwest.longitude,
-    southwest.latitude,
-    northeast.longitude,
-    northeast.latitude,
-  );
-}
-
-Object.defineProperties(WebMercatorTilingScheme.prototype, {
   /**
    * Gets the ellipsoid that is tiled by this tiling scheme.
-   * @memberof WebMercatorTilingScheme.prototype
    * @type {Ellipsoid}
    */
-  ellipsoid: {
-    get: function () {
-      return this._ellipsoid;
-    },
-  },
+  get ellipsoid() {
+    return this._ellipsoid;
+  }
 
   /**
    * Gets the rectangle, in radians, covered by this tiling scheme.
-   * @memberof WebMercatorTilingScheme.prototype
    * @type {Rectangle}
    */
-  rectangle: {
-    get: function () {
-      return this._rectangle;
-    },
-  },
+  get rectangle() {
+    return this._rectangle;
+  }
 
   /**
    * Gets the map projection used by this tiling scheme.
-   * @memberof WebMercatorTilingScheme.prototype
    * @type {MapProjection}
    */
-  projection: {
-    get: function () {
-      return this._projection;
-    },
-  },
-});
-
-/**
- * Gets the total number of tiles in the X direction at a specified level-of-detail.
- *
- * @param {number} level The level-of-detail.
- * @returns {number} The number of tiles in the X direction at the given level.
- */
-WebMercatorTilingScheme.prototype.getNumberOfXTilesAtLevel = function (level) {
-  return this._numberOfLevelZeroTilesX << level;
-};
-
-/**
- * Gets the total number of tiles in the Y direction at a specified level-of-detail.
- *
- * @param {number} level The level-of-detail.
- * @returns {number} The number of tiles in the Y direction at the given level.
- */
-WebMercatorTilingScheme.prototype.getNumberOfYTilesAtLevel = function (level) {
-  return this._numberOfLevelZeroTilesY << level;
-};
-
-/**
- * Transforms a rectangle specified in geodetic radians to the native coordinate system
- * of this tiling scheme.
- *
- * @param {Rectangle} rectangle The rectangle to transform.
- * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the native rectangle if 'result'
- *          is undefined.
- */
-WebMercatorTilingScheme.prototype.rectangleToNativeRectangle = function (
-  rectangle,
-  result,
-) {
-  const projection = this._projection;
-  const southwest = projection.project(Rectangle.southwest(rectangle));
-  const northeast = projection.project(Rectangle.northeast(rectangle));
-
-  if (!defined(result)) {
-    return new Rectangle(southwest.x, southwest.y, northeast.x, northeast.y);
+  get projection() {
+    return this._projection;
   }
 
-  result.west = southwest.x;
-  result.south = southwest.y;
-  result.east = northeast.x;
-  result.north = northeast.y;
-  return result;
-};
-
-/**
- * Converts tile x, y coordinates and level to a rectangle expressed in the native coordinates
- * of the tiling scheme.
- *
- * @param {number} x The integer x coordinate of the tile.
- * @param {number} y The integer y coordinate of the tile.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
- *          if 'result' is undefined.
- */
-WebMercatorTilingScheme.prototype.tileXYToNativeRectangle = function (
-  x,
-  y,
-  level,
-  result,
-) {
-  const xTiles = this.getNumberOfXTilesAtLevel(level);
-  const yTiles = this.getNumberOfYTilesAtLevel(level);
-
-  const xTileWidth =
-    (this._rectangleNortheastInMeters.x - this._rectangleSouthwestInMeters.x) /
-    xTiles;
-  const west = this._rectangleSouthwestInMeters.x + x * xTileWidth;
-  const east = this._rectangleSouthwestInMeters.x + (x + 1) * xTileWidth;
-
-  const yTileHeight =
-    (this._rectangleNortheastInMeters.y - this._rectangleSouthwestInMeters.y) /
-    yTiles;
-  const north = this._rectangleNortheastInMeters.y - y * yTileHeight;
-  const south = this._rectangleNortheastInMeters.y - (y + 1) * yTileHeight;
-
-  if (!defined(result)) {
-    return new Rectangle(west, south, east, north);
+  /**
+   * Gets the total number of tiles in the X direction at a specified level-of-detail.
+   *
+   * @param {number} level The level-of-detail.
+   * @returns {number} The number of tiles in the X direction at the given level.
+   */
+  getNumberOfXTilesAtLevel(level) {
+    return this._numberOfLevelZeroTilesX << level;
   }
 
-  result.west = west;
-  result.south = south;
-  result.east = east;
-  result.north = north;
-  return result;
-};
-
-/**
- * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
- *
- * @param {number} x The integer x coordinate of the tile.
- * @param {number} y The integer y coordinate of the tile.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {object} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
- *          if 'result' is undefined.
- */
-WebMercatorTilingScheme.prototype.tileXYToRectangle = function (
-  x,
-  y,
-  level,
-  result,
-) {
-  const nativeRectangle = this.tileXYToNativeRectangle(x, y, level, result);
-
-  const projection = this._projection;
-  const southwest = projection.unproject(
-    new Cartesian2(nativeRectangle.west, nativeRectangle.south),
-  );
-  const northeast = projection.unproject(
-    new Cartesian2(nativeRectangle.east, nativeRectangle.north),
-  );
-
-  nativeRectangle.west = southwest.longitude;
-  nativeRectangle.south = southwest.latitude;
-  nativeRectangle.east = northeast.longitude;
-  nativeRectangle.north = northeast.latitude;
-  return nativeRectangle;
-};
-
-/**
- * Calculates the tile x, y coordinates of the tile containing
- * a given cartographic position.
- *
- * @param {Cartographic} position The position.
- * @param {number} level The tile level-of-detail.  Zero is the least detailed.
- * @param {Cartesian2} [result] The instance to which to copy the result, or undefined if a new instance
- *        should be created.
- * @returns {Cartesian2} The specified 'result', or a new object containing the tile x, y coordinates
- *          if 'result' is undefined.
- */
-WebMercatorTilingScheme.prototype.positionToTileXY = function (
-  position,
-  level,
-  result,
-) {
-  const rectangle = this._rectangle;
-  if (!Rectangle.contains(rectangle, position)) {
-    // outside the bounds of the tiling scheme
-    return undefined;
+  /**
+   * Gets the total number of tiles in the Y direction at a specified level-of-detail.
+   *
+   * @param {number} level The level-of-detail.
+   * @returns {number} The number of tiles in the Y direction at the given level.
+   */
+  getNumberOfYTilesAtLevel(level) {
+    return this._numberOfLevelZeroTilesY << level;
   }
 
-  const xTiles = this.getNumberOfXTilesAtLevel(level);
-  const yTiles = this.getNumberOfYTilesAtLevel(level);
+  /**
+   * Transforms a rectangle specified in geodetic radians to the native coordinate system
+   * of this tiling scheme.
+   *
+   * @param {Rectangle} rectangle The rectangle to transform.
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the native rectangle if 'result'
+   *          is undefined.
+   */
+  rectangleToNativeRectangle(rectangle, result) {
+    const projection = this._projection;
+    const southwest = projection.project(Rectangle.southwest(rectangle));
+    const northeast = projection.project(Rectangle.northeast(rectangle));
 
-  const overallWidth =
-    this._rectangleNortheastInMeters.x - this._rectangleSouthwestInMeters.x;
-  const xTileWidth = overallWidth / xTiles;
-  const overallHeight =
-    this._rectangleNortheastInMeters.y - this._rectangleSouthwestInMeters.y;
-  const yTileHeight = overallHeight / yTiles;
+    if (!defined(result)) {
+      return new Rectangle(southwest.x, southwest.y, northeast.x, northeast.y);
+    }
 
-  const projection = this._projection;
-
-  const webMercatorPosition = projection.project(position);
-  const distanceFromWest =
-    webMercatorPosition.x - this._rectangleSouthwestInMeters.x;
-  const distanceFromNorth =
-    this._rectangleNortheastInMeters.y - webMercatorPosition.y;
-
-  let xTileCoordinate = (distanceFromWest / xTileWidth) | 0;
-  if (xTileCoordinate >= xTiles) {
-    xTileCoordinate = xTiles - 1;
-  }
-  let yTileCoordinate = (distanceFromNorth / yTileHeight) | 0;
-  if (yTileCoordinate >= yTiles) {
-    yTileCoordinate = yTiles - 1;
-  }
-
-  if (!defined(result)) {
-    return new Cartesian2(xTileCoordinate, yTileCoordinate);
+    result.west = southwest.x;
+    result.south = southwest.y;
+    result.east = northeast.x;
+    result.north = northeast.y;
+    return result;
   }
 
-  result.x = xTileCoordinate;
-  result.y = yTileCoordinate;
-  return result;
-};
+  /**
+   * Converts tile x, y coordinates and level to a rectangle expressed in the native coordinates
+   * of the tiling scheme.
+   *
+   * @param {number} x The integer x coordinate of the tile.
+   * @param {number} y The integer y coordinate of the tile.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
+   *          if 'result' is undefined.
+   */
+  tileXYToNativeRectangle(x, y, level, result) {
+    const xTiles = this.getNumberOfXTilesAtLevel(level);
+    const yTiles = this.getNumberOfYTilesAtLevel(level);
+
+    const xTileWidth =
+      (this._rectangleNortheastInMeters.x -
+        this._rectangleSouthwestInMeters.x) /
+      xTiles;
+    const west = this._rectangleSouthwestInMeters.x + x * xTileWidth;
+    const east = this._rectangleSouthwestInMeters.x + (x + 1) * xTileWidth;
+
+    const yTileHeight =
+      (this._rectangleNortheastInMeters.y -
+        this._rectangleSouthwestInMeters.y) /
+      yTiles;
+    const north = this._rectangleNortheastInMeters.y - y * yTileHeight;
+    const south = this._rectangleNortheastInMeters.y - (y + 1) * yTileHeight;
+
+    if (!defined(result)) {
+      return new Rectangle(west, south, east, north);
+    }
+
+    result.west = west;
+    result.south = south;
+    result.east = east;
+    result.north = north;
+    return result;
+  }
+
+  /**
+   * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
+   *
+   * @param {number} x The integer x coordinate of the tile.
+   * @param {number} y The integer y coordinate of the tile.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {Rectangle} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Rectangle} The specified 'result', or a new object containing the rectangle
+   *          if 'result' is undefined.
+   */
+  tileXYToRectangle(x, y, level, result) {
+    const nativeRectangle = this.tileXYToNativeRectangle(x, y, level, result);
+
+    const projection = this._projection;
+    const southwest = projection.unproject(
+      new Cartesian3(nativeRectangle.west, nativeRectangle.south),
+    );
+    const northeast = projection.unproject(
+      new Cartesian3(nativeRectangle.east, nativeRectangle.north),
+    );
+
+    nativeRectangle.west = southwest.longitude;
+    nativeRectangle.south = southwest.latitude;
+    nativeRectangle.east = northeast.longitude;
+    nativeRectangle.north = northeast.latitude;
+    return nativeRectangle;
+  }
+
+  /**
+   * Calculates the tile x, y coordinates of the tile containing
+   * a given cartographic position.
+   *
+   * @param {Cartographic} position The position.
+   * @param {number} level The tile level-of-detail.  Zero is the least detailed.
+   * @param {Cartesian2} [result] The instance to which to copy the result, or undefined if a new instance
+   *        should be created.
+   * @returns {Cartesian2} The specified 'result', or a new object containing the tile x, y coordinates
+   *          if 'result' is undefined.
+   */
+  positionToTileXY(position, level, result) {
+    const rectangle = this._rectangle;
+    if (!Rectangle.contains(rectangle, position)) {
+      // outside the bounds of the tiling scheme
+      return undefined;
+    }
+
+    const xTiles = this.getNumberOfXTilesAtLevel(level);
+    const yTiles = this.getNumberOfYTilesAtLevel(level);
+
+    const overallWidth =
+      this._rectangleNortheastInMeters.x - this._rectangleSouthwestInMeters.x;
+    const xTileWidth = overallWidth / xTiles;
+    const overallHeight =
+      this._rectangleNortheastInMeters.y - this._rectangleSouthwestInMeters.y;
+    const yTileHeight = overallHeight / yTiles;
+
+    const projection = this._projection;
+
+    const webMercatorPosition = projection.project(position);
+    const distanceFromWest =
+      webMercatorPosition.x - this._rectangleSouthwestInMeters.x;
+    const distanceFromNorth =
+      this._rectangleNortheastInMeters.y - webMercatorPosition.y;
+
+    let xTileCoordinate = (distanceFromWest / xTileWidth) | 0;
+    if (xTileCoordinate >= xTiles) {
+      xTileCoordinate = xTiles - 1;
+    }
+    let yTileCoordinate = (distanceFromNorth / yTileHeight) | 0;
+    if (yTileCoordinate >= yTiles) {
+      yTileCoordinate = yTiles - 1;
+    }
+
+    if (!defined(result)) {
+      return new Cartesian2(xTileCoordinate, yTileCoordinate);
+    }
+
+    result.x = xTileCoordinate;
+    result.y = yTileCoordinate;
+    return result;
+  }
+}
+
 export default WebMercatorTilingScheme;

--- a/packages/engine/Source/Scene/QuadtreeOccluders.js
+++ b/packages/engine/Source/Scene/QuadtreeOccluders.js
@@ -1,30 +1,35 @@
+// @ts-check
+
 import Cartesian3 from "../Core/Cartesian3.js";
 import EllipsoidalOccluder from "../Core/EllipsoidalOccluder.js";
+
+/** @import Ellipsoid from "../Core/Ellipsoid.js"; */
 
 /**
  * A set of occluders that can be used to test quadtree tiles for occlusion.
  *
- * @alias QuadtreeOccluders
- * @constructor
  * @private
- *
- * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid that potentially occludes tiles.
  */
-function QuadtreeOccluders(options) {
-  this._ellipsoid = new EllipsoidalOccluder(options.ellipsoid, Cartesian3.ZERO);
-}
+class QuadtreeOccluders {
+  /**
+   * @param {object} [options]
+   * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid that potentially occludes tiles.
+   */
+  constructor(options) {
+    this._ellipsoid = new EllipsoidalOccluder(
+      options.ellipsoid,
+      Cartesian3.ZERO,
+    );
+  }
 
-Object.defineProperties(QuadtreeOccluders.prototype, {
   /**
    * Gets the {@link EllipsoidalOccluder} that can be used to determine if a point is
    * occluded by an {@link Ellipsoid}.
    * @type {EllipsoidalOccluder}
-   * @memberof QuadtreeOccluders.prototype
    */
-  ellipsoid: {
-    get: function () {
-      return this._ellipsoid;
-    },
-  },
-});
+  get ellipsoid() {
+    return this._ellipsoid;
+  }
+}
+
 export default QuadtreeOccluders;

--- a/packages/engine/Source/Scene/QuadtreeTile.js
+++ b/packages/engine/Source/Scene/QuadtreeTile.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Rectangle from "../Core/Rectangle.js";
@@ -5,15 +7,24 @@ import Cartographic from "../Core/Cartographic.js";
 import QuadtreeTileLoadState from "./QuadtreeTileLoadState.js";
 import TileSelectionResult from "./TileSelectionResult.js";
 
+/** @import TilingScheme from "../Core/TilingScheme.js"; */
+
 /**
  * A simple Least Recently Used (LRU) cache implementation.
+ *
+ * @private
  */
 class LRUCache {
+  /** @param {number} maxSize */
   constructor(maxSize) {
     this.maxSize = maxSize;
     this.cache = new Map();
   }
 
+  /**
+   * @param {unknown} key
+   * @returns {unknown}
+   */
   get(key) {
     if (!this.cache.has(key)) {
       return undefined;
@@ -25,6 +36,10 @@ class LRUCache {
     return value;
   }
 
+  /**
+   * @param {unknown} key
+   * @param {unknown} value
+   */
   set(key, value) {
     if (this.cache.has(key)) {
       this.cache.delete(key);
@@ -34,6 +49,14 @@ class LRUCache {
       this.cache.delete(firstKey);
     }
     this.cache.set(key, value);
+  }
+
+  /**
+   * @type {number}
+   * @readonly
+   */
+  get size() {
+    return this.cache.size;
   }
 
   clear() {
@@ -47,146 +70,566 @@ const MAX_CACHE_ENTRIES = 1000;
 /**
  * A single tile in a {@link QuadtreePrimitive}.
  *
- * @alias QuadtreeTile
- * @constructor
  * @private
- *
- * @param {number} options.level The level of the tile in the quadtree.
- * @param {number} options.x The X coordinate of the tile in the quadtree.  0 is the westernmost tile.
- * @param {number} options.y The Y coordinate of the tile in the quadtree.  0 is the northernmost tile.
- * @param {TilingScheme} options.tilingScheme The tiling scheme in which this tile exists.
- * @param {QuadtreeTile} [options.parent] This tile's parent, or undefined if this is a root tile.
  */
-function QuadtreeTile(options) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(options)) {
-    throw new DeveloperError("options is required.");
+class QuadtreeTile {
+  /**
+   * @param {object} options
+   * @param {number} options.level The level of the tile in the quadtree.
+   * @param {number} options.x The X coordinate of the tile in the quadtree.  0 is the westernmost tile.
+   * @param {number} options.y The Y coordinate of the tile in the quadtree.  0 is the northernmost tile.
+   * @param {TilingScheme} options.tilingScheme The tiling scheme in which this tile exists.
+   * @param {QuadtreeTile} [options.parent] This tile's parent, or undefined if this is a root tile.
+   */
+  constructor(options) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(options)) {
+      throw new DeveloperError("options is required.");
+    }
+    if (!defined(options.x)) {
+      throw new DeveloperError("options.x is required.");
+    } else if (!defined(options.y)) {
+      throw new DeveloperError("options.y is required.");
+    } else if (options.x < 0 || options.y < 0) {
+      throw new DeveloperError(
+        "options.x and options.y must be greater than or equal to zero.",
+      );
+    }
+    if (!defined(options.level)) {
+      throw new DeveloperError(
+        "options.level is required and must be greater than or equal to zero.",
+      );
+    }
+    if (!defined(options.tilingScheme)) {
+      throw new DeveloperError("options.tilingScheme is required.");
+    }
+    //>>includeEnd('debug');
+
+    this._tilingScheme = options.tilingScheme;
+    this._x = options.x;
+    this._y = options.y;
+    this._level = options.level;
+    this._parent = options.parent;
+
+    /** @type {Rectangle} */
+    this._rectangle = this._tilingScheme.tileXYToRectangle(
+      this._x,
+      this._y,
+      this._level,
+    );
+
+    this._southwestChild = undefined;
+    this._southeastChild = undefined;
+    this._northwestChild = undefined;
+    this._northeastChild = undefined;
+
+    // TileReplacementQueue gets/sets these private properties.
+    this.replacementPrevious = undefined;
+    this.replacementNext = undefined;
+
+    // The distance from the camera to this tile, updated when the tile is selected
+    // for rendering.  We can get rid of this if we have a better way to sort by
+    // distance - for example, by using the natural ordering of a quadtree.
+    // QuadtreePrimitive gets/sets this private property.
+    this._distance = 0.0;
+    this._loadPriority = 0.0;
+
+    this._customData = new Set();
+    this._customDataIterator = undefined;
+    /** @type {unknown[]} */
+    this._addedCustomData = [];
+    /** @type {unknown[]} */
+    this._removedCustomData = [];
+    this._lastSelectionResult = TileSelectionResult.NONE;
+    this._lastSelectionResultFrame = undefined;
+    this._loadedCallbacks = {};
+
+    // Cache for storing computed position values per tile to avoid redundant calculations
+    this._positionCache = new LRUCache(MAX_CACHE_ENTRIES);
+
+    /**
+     * Gets or sets the current state of the tile in the tile load pipeline.
+     * @type {QuadtreeTileLoadState}
+     * @default {@link QuadtreeTileLoadState.START}
+     */
+    this.state = QuadtreeTileLoadState.START;
+
+    /**
+     * Gets or sets a value indicating whether or not the tile is currently renderable.
+     * @type {boolean}
+     * @default false
+     */
+    this.renderable = false;
+
+    /**
+     * Gets or set a value indicating whether or not the tile was entirely upsampled from its
+     * parent tile.  If all four children of a parent tile were upsampled from the parent,
+     * we will render the parent instead of the children even if the LOD indicates that
+     * the children would be preferable.
+     * @type {boolean}
+     * @default false
+     */
+    this.upsampledFromParent = false;
+
+    /**
+     * Gets or sets the additional data associated with this tile.  The exact content is specific to the
+     * {@link QuadtreeTileProvider}.
+     * @type {object}
+     * @default undefined
+     */
+    this.data = undefined;
   }
-  if (!defined(options.x)) {
-    throw new DeveloperError("options.x is required.");
-  } else if (!defined(options.y)) {
-    throw new DeveloperError("options.y is required.");
-  } else if (options.x < 0 || options.y < 0) {
-    throw new DeveloperError(
-      "options.x and options.y must be greater than or equal to zero.",
+
+  /**
+   * Creates a rectangular set of tiles for level of detail zero, the coarsest, least detailed level.
+   *
+   *
+   * @param {TilingScheme} tilingScheme The tiling scheme for which the tiles are to be created.
+   * @returns {QuadtreeTile[]} An array containing the tiles at level of detail zero, starting with the
+   * tile in the northwest corner and followed by the tile (if any) to its east.
+   */
+  static createLevelZeroTiles(tilingScheme) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(tilingScheme)) {
+      throw new DeveloperError("tilingScheme is required.");
+    }
+    //>>includeEnd('debug');
+
+    const numberOfLevelZeroTilesX = tilingScheme.getNumberOfXTilesAtLevel(0);
+    const numberOfLevelZeroTilesY = tilingScheme.getNumberOfYTilesAtLevel(0);
+
+    const result = new Array(numberOfLevelZeroTilesX * numberOfLevelZeroTilesY);
+
+    let index = 0;
+    for (let y = 0; y < numberOfLevelZeroTilesY; ++y) {
+      for (let x = 0; x < numberOfLevelZeroTilesX; ++x) {
+        result[index++] = new QuadtreeTile({
+          tilingScheme: tilingScheme,
+          x: x,
+          y: y,
+          level: 0,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Generates a unique cache key for a given cartographic position.
+   *
+   * @param {Cartographic} cartographic The cartographic coordinates.
+   * @param {number} maximumScreenSpaceError The maximum screen-space error, in pixels, that is allowed.
+   *        A higher maximum error will render fewer tiles and improve performance, while a lower
+   *        value will improve visual quality.
+   * @returns {string} A string representing the spatial hash key.
+   */
+  _getCacheKey(cartographic, maximumScreenSpaceError) {
+    return createSpatialHashKey(
+      cartographic.longitude,
+      cartographic.latitude,
+      this._rectangle,
+      maximumScreenSpaceError,
     );
   }
-  if (!defined(options.level)) {
-    throw new DeveloperError(
-      "options.level is required and must be greater than or equal to zero.",
+
+  /**
+   * Retrieves a cached position for the specified cartographic position.
+   *
+   *
+   * @param {Cartographic} cartographic - The cartographic coordinates.
+   * @param {number} maximumScreenSpaceError The maximum screen-space error, in pixels, that is allowed.
+   *        A higher maximum error will render fewer tiles and improve performance, while a lower
+   *        value will improve visual quality.
+   * @returns {object|undefined} The cached position data or undefined if not found.
+   */
+  getPositionCacheEntry(cartographic, maximumScreenSpaceError) {
+    const result = this._positionCache.get(
+      this._getCacheKey(cartographic, maximumScreenSpaceError),
+    );
+    return /** @type {object|undefined} */ (result);
+  }
+
+  /**
+   * Sets a position on the cache for this tile.
+   *
+   *
+   * @param {Cartographic} cartographic - The cartographic coordinates.
+   * @param {number} maximumScreenSpaceError The maximum screen-space error, in pixels, that is allowed.
+   *        A higher maximum error will render fewer tiles and improve performance, while a lower
+   *        value will improve visual quality.
+   * @param {object} value - The object to be cached.
+   */
+  setPositionCacheEntry(cartographic, maximumScreenSpaceError, value) {
+    this._positionCache.set(
+      this._getCacheKey(cartographic, maximumScreenSpaceError),
+      value,
     );
   }
-  if (!defined(options.tilingScheme)) {
-    throw new DeveloperError("options.tilingScheme is required.");
-  }
-  //>>includeEnd('debug');
-
-  this._tilingScheme = options.tilingScheme;
-  this._x = options.x;
-  this._y = options.y;
-  this._level = options.level;
-  this._parent = options.parent;
-  this._rectangle = this._tilingScheme.tileXYToRectangle(
-    this._x,
-    this._y,
-    this._level,
-  );
-
-  this._southwestChild = undefined;
-  this._southeastChild = undefined;
-  this._northwestChild = undefined;
-  this._northeastChild = undefined;
-
-  // TileReplacementQueue gets/sets these private properties.
-  this.replacementPrevious = undefined;
-  this.replacementNext = undefined;
-
-  // The distance from the camera to this tile, updated when the tile is selected
-  // for rendering.  We can get rid of this if we have a better way to sort by
-  // distance - for example, by using the natural ordering of a quadtree.
-  // QuadtreePrimitive gets/sets this private property.
-  this._distance = 0.0;
-  this._loadPriority = 0.0;
-
-  this._customData = new Set();
-  this._customDataIterator = undefined;
-  this._addedCustomData = [];
-  this._removedCustomData = [];
-  this._lastSelectionResult = TileSelectionResult.NONE;
-  this._lastSelectionResultFrame = undefined;
-  this._loadedCallbacks = {};
-
-  // Cache for storing computed position values per tile to avoid redundant calculations
-  this._positionCache = new LRUCache(MAX_CACHE_ENTRIES);
 
   /**
-   * Gets or sets the current state of the tile in the tile load pipeline.
-   * @type {QuadtreeTileLoadState}
-   * @default {@link QuadtreeTileLoadState.START}
+   * Clears the position cache for this tile.
+   * This function removes all cached positions that were previously stored
+   * to optimize height computations.
+   *
    */
-  this.state = QuadtreeTileLoadState.START;
-
-  /**
-   * Gets or sets a value indicating whether or not the tile is currently renderable.
-   * @type {boolean}
-   * @default false
-   */
-  this.renderable = false;
-
-  /**
-   * Gets or set a value indicating whether or not the tile was entirely upsampled from its
-   * parent tile.  If all four children of a parent tile were upsampled from the parent,
-   * we will render the parent instead of the children even if the LOD indicates that
-   * the children would be preferable.
-   * @type {boolean}
-   * @default false
-   */
-  this.upsampledFromParent = false;
-
-  /**
-   * Gets or sets the additional data associated with this tile.  The exact content is specific to the
-   * {@link QuadtreeTileProvider}.
-   * @type {object}
-   * @default undefined
-   */
-  this.data = undefined;
-}
-
-/**
- * Creates a rectangular set of tiles for level of detail zero, the coarsest, least detailed level.
- *
- * @memberof QuadtreeTile
- *
- * @param {TilingScheme} tilingScheme The tiling scheme for which the tiles are to be created.
- * @returns {QuadtreeTile[]} An array containing the tiles at level of detail zero, starting with the
- * tile in the northwest corner and followed by the tile (if any) to its east.
- */
-QuadtreeTile.createLevelZeroTiles = function (tilingScheme) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(tilingScheme)) {
-    throw new DeveloperError("tilingScheme is required.");
-  }
-  //>>includeEnd('debug');
-
-  const numberOfLevelZeroTilesX = tilingScheme.getNumberOfXTilesAtLevel(0);
-  const numberOfLevelZeroTilesY = tilingScheme.getNumberOfYTilesAtLevel(0);
-
-  const result = new Array(numberOfLevelZeroTilesX * numberOfLevelZeroTilesY);
-
-  let index = 0;
-  for (let y = 0; y < numberOfLevelZeroTilesY; ++y) {
-    for (let x = 0; x < numberOfLevelZeroTilesX; ++x) {
-      result[index++] = new QuadtreeTile({
-        tilingScheme: tilingScheme,
-        x: x,
-        y: y,
-        level: 0,
-      });
+  clearPositionCache() {
+    if (this._positionCache.size > 0) {
+      this._positionCache.clear();
     }
   }
 
-  return result;
-};
+  updateCustomData() {
+    const added = this._addedCustomData;
+    const removed = this._removedCustomData;
+    if (added.length === 0 && removed.length === 0) {
+      return;
+    }
+
+    const customData = this.customData;
+    for (let i = 0; i < added.length; ++i) {
+      const data = /** @type {*} */ (added[i]);
+      customData.add(data);
+
+      const child = childTileAtPosition(this, data.positionCartographic);
+      child._addedCustomData.push(data);
+    }
+    this._addedCustomData.length = 0;
+
+    for (let i = 0; i < removed.length; ++i) {
+      const data = /** @type {*} */ (removed[i]);
+      if (customData.has(data)) {
+        customData.delete(data);
+      }
+
+      const child = childTileAtPosition(this, data.positionCartographic);
+      child._removedCustomData.push(data);
+    }
+    this._removedCustomData.length = 0;
+  }
+
+  /**
+   * Gets the tiling scheme used to tile the surface.
+   * @type {TilingScheme}
+   */
+  get tilingScheme() {
+    return this._tilingScheme;
+  }
+
+  /**
+   * Gets the tile X coordinate.
+   * @type {number}
+   */
+  get x() {
+    return this._x;
+  }
+
+  /**
+   * Gets the tile Y coordinate.
+   * @type {number}
+   */
+  get y() {
+    return this._y;
+  }
+
+  /**
+   * Gets the level-of-detail, where zero is the coarsest, least-detailed.
+   * @type {number}
+   */
+  get level() {
+    return this._level;
+  }
+
+  /**
+   * Gets the parent tile of this tile.
+   * @type {QuadtreeTile}
+   */
+  get parent() {
+    return this._parent;
+  }
+
+  /**
+   * Gets the cartographic rectangle of the tile, with north, south, east and
+   * west properties in radians.
+   * @type {Rectangle}
+   */
+  get rectangle() {
+    return this._rectangle;
+  }
+
+  /**
+   * An array of tiles that is at the next level of the tile tree.
+   * @type {QuadtreeTile[]}
+   */
+  get children() {
+    return [
+      this.northwestChild,
+      this.northeastChild,
+      this.southwestChild,
+      this.southeastChild,
+    ];
+  }
+
+  /**
+   * Gets the southwest child tile.
+   * @type {QuadtreeTile}
+   */
+  get southwestChild() {
+    if (!defined(this._southwestChild)) {
+      this._southwestChild = new QuadtreeTile({
+        tilingScheme: this.tilingScheme,
+        x: this.x * 2,
+        y: this.y * 2 + 1,
+        level: this.level + 1,
+        parent: this,
+      });
+    }
+    return this._southwestChild;
+  }
+
+  /**
+   * Gets the southeast child tile.
+   * @type {QuadtreeTile}
+   */
+  get southeastChild() {
+    if (!defined(this._southeastChild)) {
+      this._southeastChild = new QuadtreeTile({
+        tilingScheme: this.tilingScheme,
+        x: this.x * 2 + 1,
+        y: this.y * 2 + 1,
+        level: this.level + 1,
+        parent: this,
+      });
+    }
+    return this._southeastChild;
+  }
+
+  /**
+   * Gets the northwest child tile.
+   * @type {QuadtreeTile}
+   */
+  get northwestChild() {
+    if (!defined(this._northwestChild)) {
+      this._northwestChild = new QuadtreeTile({
+        tilingScheme: this.tilingScheme,
+        x: this.x * 2,
+        y: this.y * 2,
+        level: this.level + 1,
+        parent: this,
+      });
+    }
+    return this._northwestChild;
+  }
+
+  /**
+   * Gets the northeast child tile.
+   * @type {QuadtreeTile}
+   */
+  get northeastChild() {
+    if (!defined(this._northeastChild)) {
+      this._northeastChild = new QuadtreeTile({
+        tilingScheme: this.tilingScheme,
+        x: this.x * 2 + 1,
+        y: this.y * 2,
+        level: this.level + 1,
+        parent: this,
+      });
+    }
+    return this._northeastChild;
+  }
+
+  /**
+   * A set of objects associated with this tile.
+   * @type {Set<*>}
+   */
+  get customData() {
+    return this._customData;
+  }
+
+  /**
+   * Gets a value indicating whether or not this tile needs further loading.
+   * This property will return true if the {@link QuadtreeTile#state} is
+   * <code>START</code> or <code>LOADING</code>.
+   * @type {boolean}
+   */
+  get needsLoading() {
+    return this.state < QuadtreeTileLoadState.DONE;
+  }
+
+  /**
+   * Gets a value indicating whether or not this tile is eligible to be unloaded.
+   * Typically, a tile is ineligible to be unloaded while an asynchronous operation,
+   * such as a request for data, is in progress on it.  A tile will never be
+   * unloaded while it is needed for rendering, regardless of the value of this
+   * property.  If {@link QuadtreeTile#data} is defined and has an
+   * <code>eligibleForUnloading</code> property, the value of that property is returned.
+   * Otherwise, this property returns true.
+   * @type {boolean}
+   */
+  get eligibleForUnloading() {
+    let result = true;
+
+    if (defined(this.data)) {
+      result = /** @type {*} */ (this.data).eligibleForUnloading;
+      if (!defined(result)) {
+        result = true;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * @param {QuadtreeTile[]} levelZeroTiles
+   * @param {number} x
+   * @param {number} y
+   * @returns {QuadtreeTile}
+   */
+  findLevelZeroTile(levelZeroTiles, x, y) {
+    const xTiles = this.tilingScheme.getNumberOfXTilesAtLevel(0);
+    if (x < 0) {
+      x += xTiles;
+    } else if (x >= xTiles) {
+      x -= xTiles;
+    }
+
+    if (y < 0 || y >= this.tilingScheme.getNumberOfYTilesAtLevel(0)) {
+      return undefined;
+    }
+
+    return levelZeroTiles.filter(function (tile) {
+      return tile.x === x && tile.y === y;
+    })[0];
+  }
+
+  /**
+   * @param {QuadtreeTile[]} levelZeroTiles
+   * @returns {QuadtreeTile|undefined}
+   */
+  findTileToWest(levelZeroTiles) {
+    const parent = this.parent;
+    if (parent === undefined) {
+      return this.findLevelZeroTile(levelZeroTiles, this.x - 1, this.y);
+    }
+
+    if (parent.southeastChild === this) {
+      return parent.southwestChild;
+    } else if (parent.northeastChild === this) {
+      return parent.northwestChild;
+    }
+
+    const westOfParent = parent.findTileToWest(levelZeroTiles);
+    if (westOfParent === undefined) {
+      return undefined;
+    } else if (parent.southwestChild === this) {
+      return westOfParent.southeastChild;
+    }
+    return westOfParent.northeastChild;
+  }
+
+  /**
+   * @param {QuadtreeTile[]} levelZeroTiles
+   * @returns {QuadtreeTile|undefined}
+   */
+  findTileToEast(levelZeroTiles) {
+    const parent = this.parent;
+    if (parent === undefined) {
+      return this.findLevelZeroTile(levelZeroTiles, this.x + 1, this.y);
+    }
+
+    if (parent.southwestChild === this) {
+      return parent.southeastChild;
+    } else if (parent.northwestChild === this) {
+      return parent.northeastChild;
+    }
+
+    const eastOfParent = parent.findTileToEast(levelZeroTiles);
+    if (eastOfParent === undefined) {
+      return undefined;
+    } else if (parent.southeastChild === this) {
+      return eastOfParent.southwestChild;
+    }
+    return eastOfParent.northwestChild;
+  }
+
+  /**
+   * @param {QuadtreeTile[]} levelZeroTiles
+   * @returns {QuadtreeTile|undefined}
+   */
+  findTileToSouth(levelZeroTiles) {
+    const parent = this.parent;
+    if (parent === undefined) {
+      return this.findLevelZeroTile(levelZeroTiles, this.x, this.y + 1);
+    }
+
+    if (parent.northwestChild === this) {
+      return parent.southwestChild;
+    } else if (parent.northeastChild === this) {
+      return parent.southeastChild;
+    }
+
+    const southOfParent = parent.findTileToSouth(levelZeroTiles);
+    if (southOfParent === undefined) {
+      return undefined;
+    } else if (parent.southwestChild === this) {
+      return southOfParent.northwestChild;
+    }
+    return southOfParent.northeastChild;
+  }
+
+  /**
+   * @param {QuadtreeTile[]} levelZeroTiles
+   * @returns {QuadtreeTile|undefined}
+   */
+  findTileToNorth(levelZeroTiles) {
+    const parent = this.parent;
+    if (parent === undefined) {
+      return this.findLevelZeroTile(levelZeroTiles, this.x, this.y - 1);
+    }
+
+    if (parent.southwestChild === this) {
+      return parent.northwestChild;
+    } else if (parent.southeastChild === this) {
+      return parent.northeastChild;
+    }
+
+    const northOfParent = parent.findTileToNorth(levelZeroTiles);
+    if (northOfParent === undefined) {
+      return undefined;
+    } else if (parent.northwestChild === this) {
+      return northOfParent.southwestChild;
+    }
+    return northOfParent.southeastChild;
+  }
+
+  /**
+   * Frees the resources associated with this tile and returns it to the <code>START</code>
+   * {@link QuadtreeTileLoadState}.  If the {@link QuadtreeTile#data} property is defined and it
+   * has a <code>freeResources</code> method, the method will be invoked.
+   *
+   */
+  freeResources() {
+    // Clears cached heights when the tile is freed
+    this.clearPositionCache();
+    this.state = QuadtreeTileLoadState.START;
+    this.renderable = false;
+    this.upsampledFromParent = false;
+
+    const data = /** @type {*} */ (this.data);
+    if (defined(data) && defined(data.freeResources)) {
+      data.freeResources();
+    }
+
+    freeTile(this._southwestChild);
+    this._southwestChild = undefined;
+    freeTile(this._southeastChild);
+    this._southeastChild = undefined;
+    freeTile(this._northwestChild);
+    this._northwestChild = undefined;
+    freeTile(this._northeastChild);
+    this._northeastChild = undefined;
+  }
+}
 
 /**
  * Creates a spatial hash key for the given longitude, latitude, and tile level.
@@ -223,6 +666,14 @@ QuadtreeTile.createLevelZeroTiles = function (tilingScheme) {
  */
 const TILE_SIZE = 256;
 
+/**
+ * @param {number} longitude
+ * @param {number} latitude
+ * @param {Rectangle} rectangle
+ * @param {number} maximumScreenSpaceError
+ * @returns {string}
+ * @ignore
+ */
 function createSpatialHashKey(
   longitude,
   latitude,
@@ -236,112 +687,6 @@ function createSpatialHashKey(
   const latGrid = Math.floor(latitude / maxError) * maxError;
   return `${lonGrid.toFixed(10)},${latGrid.toFixed(10)}`;
 }
-
-/**
- * Generates a unique cache key for a given cartographic position.
- * @memberof QuadtreeTile
- *
- * @param {Cartographic} cartographic The cartographic coordinates.
- * @param {number} maximumScreenSpaceError The maximum screen-space error, in pixels, that is allowed.
- *        A higher maximum error will render fewer tiles and improve performance, while a lower
- *        value will improve visual quality.
- * @returns {string} A string representing the spatial hash key.
- */
-QuadtreeTile.prototype._getCacheKey = function (
-  cartographic,
-  maximumScreenSpaceError,
-) {
-  return createSpatialHashKey(
-    cartographic.longitude,
-    cartographic.latitude,
-    this._rectangle,
-    maximumScreenSpaceError,
-  );
-};
-
-/**
- * Retrieves a cached position for the specified cartographic position.
- *
- * @memberof QuadtreeTile
- *
- * @param {Cartographic} cartographic - The cartographic coordinates.
- * @param {number} maximumScreenSpaceError The maximum screen-space error, in pixels, that is allowed.
- *        A higher maximum error will render fewer tiles and improve performance, while a lower
- *        value will improve visual quality.
- * @returns {object|undefined} The cached position data or undefined if not found.
- */
-QuadtreeTile.prototype.getPositionCacheEntry = function (
-  cartographic,
-  maximumScreenSpaceError,
-) {
-  return this._positionCache.get(
-    this._getCacheKey(cartographic, maximumScreenSpaceError),
-  );
-};
-
-/**
- * Sets a position on the cache for this tile.
- *
- * @memberof QuadtreeTile
- *
- * @param {Cartographic} cartographic - The cartographic coordinates.
- * @param {number} maximumScreenSpaceError The maximum screen-space error, in pixels, that is allowed.
- *        A higher maximum error will render fewer tiles and improve performance, while a lower
- *        value will improve visual quality.
- * @param {object} value - The object to be cached.
- */
-QuadtreeTile.prototype.setPositionCacheEntry = function (
-  cartographic,
-  maximumScreenSpaceError,
-  value,
-) {
-  this._positionCache.set(
-    this._getCacheKey(cartographic, maximumScreenSpaceError),
-    value,
-  );
-};
-
-/**
- * Clears the position cache for this tile.
- * This function removes all cached positions that were previously stored
- * to optimize height computations.
- *
- * @memberof QuadtreeTile
- */
-QuadtreeTile.prototype.clearPositionCache = function () {
-  if (this._positionCache.size > 0) {
-    this._positionCache.clear();
-  }
-};
-
-QuadtreeTile.prototype.updateCustomData = function () {
-  const added = this._addedCustomData;
-  const removed = this._removedCustomData;
-  if (added.length === 0 && removed.length === 0) {
-    return;
-  }
-
-  const customData = this.customData;
-  for (let i = 0; i < added.length; ++i) {
-    const data = added[i];
-    customData.add(data);
-
-    const child = childTileAtPosition(this, data.positionCartographic);
-    child._addedCustomData.push(data);
-  }
-  this._addedCustomData.length = 0;
-
-  for (let i = 0; i < removed.length; ++i) {
-    const data = removed[i];
-    if (customData.has(data)) {
-      customData.delete(data);
-    }
-
-    const child = childTileAtPosition(this, data.positionCartographic);
-    child._removedCustomData.push(data);
-  }
-  this._removedCustomData.length = 0;
-};
 
 const splitPointScratch = new Cartographic();
 
@@ -377,353 +722,14 @@ function childTileAtPosition(tile, positionCartographic) {
   }
 }
 
-Object.defineProperties(QuadtreeTile.prototype, {
-  /**
-   * Gets the tiling scheme used to tile the surface.
-   * @memberof QuadtreeTile.prototype
-   * @type {TilingScheme}
-   */
-  tilingScheme: {
-    get: function () {
-      return this._tilingScheme;
-    },
-  },
-
-  /**
-   * Gets the tile X coordinate.
-   * @memberof QuadtreeTile.prototype
-   * @type {number}
-   */
-  x: {
-    get: function () {
-      return this._x;
-    },
-  },
-
-  /**
-   * Gets the tile Y coordinate.
-   * @memberof QuadtreeTile.prototype
-   * @type {number}
-   */
-  y: {
-    get: function () {
-      return this._y;
-    },
-  },
-
-  /**
-   * Gets the level-of-detail, where zero is the coarsest, least-detailed.
-   * @memberof QuadtreeTile.prototype
-   * @type {number}
-   */
-  level: {
-    get: function () {
-      return this._level;
-    },
-  },
-
-  /**
-   * Gets the parent tile of this tile.
-   * @memberof QuadtreeTile.prototype
-   * @type {QuadtreeTile}
-   */
-  parent: {
-    get: function () {
-      return this._parent;
-    },
-  },
-
-  /**
-   * Gets the cartographic rectangle of the tile, with north, south, east and
-   * west properties in radians.
-   * @memberof QuadtreeTile.prototype
-   * @type {Rectangle}
-   */
-  rectangle: {
-    get: function () {
-      return this._rectangle;
-    },
-  },
-
-  /**
-   * An array of tiles that is at the next level of the tile tree.
-   * @memberof QuadtreeTile.prototype
-   * @type {QuadtreeTile[]}
-   */
-  children: {
-    get: function () {
-      return [
-        this.northwestChild,
-        this.northeastChild,
-        this.southwestChild,
-        this.southeastChild,
-      ];
-    },
-  },
-
-  /**
-   * Gets the southwest child tile.
-   * @memberof QuadtreeTile.prototype
-   * @type {QuadtreeTile}
-   */
-  southwestChild: {
-    get: function () {
-      if (!defined(this._southwestChild)) {
-        this._southwestChild = new QuadtreeTile({
-          tilingScheme: this.tilingScheme,
-          x: this.x * 2,
-          y: this.y * 2 + 1,
-          level: this.level + 1,
-          parent: this,
-        });
-      }
-      return this._southwestChild;
-    },
-  },
-
-  /**
-   * Gets the southeast child tile.
-   * @memberof QuadtreeTile.prototype
-   * @type {QuadtreeTile}
-   */
-  southeastChild: {
-    get: function () {
-      if (!defined(this._southeastChild)) {
-        this._southeastChild = new QuadtreeTile({
-          tilingScheme: this.tilingScheme,
-          x: this.x * 2 + 1,
-          y: this.y * 2 + 1,
-          level: this.level + 1,
-          parent: this,
-        });
-      }
-      return this._southeastChild;
-    },
-  },
-
-  /**
-   * Gets the northwest child tile.
-   * @memberof QuadtreeTile.prototype
-   * @type {QuadtreeTile}
-   */
-  northwestChild: {
-    get: function () {
-      if (!defined(this._northwestChild)) {
-        this._northwestChild = new QuadtreeTile({
-          tilingScheme: this.tilingScheme,
-          x: this.x * 2,
-          y: this.y * 2,
-          level: this.level + 1,
-          parent: this,
-        });
-      }
-      return this._northwestChild;
-    },
-  },
-
-  /**
-   * Gets the northeast child tile.
-   * @memberof QuadtreeTile.prototype
-   * @type {QuadtreeTile}
-   */
-  northeastChild: {
-    get: function () {
-      if (!defined(this._northeastChild)) {
-        this._northeastChild = new QuadtreeTile({
-          tilingScheme: this.tilingScheme,
-          x: this.x * 2 + 1,
-          y: this.y * 2,
-          level: this.level + 1,
-          parent: this,
-        });
-      }
-      return this._northeastChild;
-    },
-  },
-
-  /**
-   * A set of objects associated with this tile.
-   * @memberof QuadtreeTile.prototype
-   * @type {Set}
-   */
-  customData: {
-    get: function () {
-      return this._customData;
-    },
-  },
-
-  /**
-   * Gets a value indicating whether or not this tile needs further loading.
-   * This property will return true if the {@link QuadtreeTile#state} is
-   * <code>START</code> or <code>LOADING</code>.
-   * @memberof QuadtreeTile.prototype
-   * @type {boolean}
-   */
-  needsLoading: {
-    get: function () {
-      return this.state < QuadtreeTileLoadState.DONE;
-    },
-  },
-
-  /**
-   * Gets a value indicating whether or not this tile is eligible to be unloaded.
-   * Typically, a tile is ineligible to be unloaded while an asynchronous operation,
-   * such as a request for data, is in progress on it.  A tile will never be
-   * unloaded while it is needed for rendering, regardless of the value of this
-   * property.  If {@link QuadtreeTile#data} is defined and has an
-   * <code>eligibleForUnloading</code> property, the value of that property is returned.
-   * Otherwise, this property returns true.
-   * @memberof QuadtreeTile.prototype
-   * @type {boolean}
-   */
-  eligibleForUnloading: {
-    get: function () {
-      let result = true;
-
-      if (defined(this.data)) {
-        result = this.data.eligibleForUnloading;
-        if (!defined(result)) {
-          result = true;
-        }
-      }
-
-      return result;
-    },
-  },
-});
-
-QuadtreeTile.prototype.findLevelZeroTile = function (levelZeroTiles, x, y) {
-  const xTiles = this.tilingScheme.getNumberOfXTilesAtLevel(0);
-  if (x < 0) {
-    x += xTiles;
-  } else if (x >= xTiles) {
-    x -= xTiles;
-  }
-
-  if (y < 0 || y >= this.tilingScheme.getNumberOfYTilesAtLevel(0)) {
-    return undefined;
-  }
-
-  return levelZeroTiles.filter(function (tile) {
-    return tile.x === x && tile.y === y;
-  })[0];
-};
-
-QuadtreeTile.prototype.findTileToWest = function (levelZeroTiles) {
-  const parent = this.parent;
-  if (parent === undefined) {
-    return this.findLevelZeroTile(levelZeroTiles, this.x - 1, this.y);
-  }
-
-  if (parent.southeastChild === this) {
-    return parent.southwestChild;
-  } else if (parent.northeastChild === this) {
-    return parent.northwestChild;
-  }
-
-  const westOfParent = parent.findTileToWest(levelZeroTiles);
-  if (westOfParent === undefined) {
-    return undefined;
-  } else if (parent.southwestChild === this) {
-    return westOfParent.southeastChild;
-  }
-  return westOfParent.northeastChild;
-};
-
-QuadtreeTile.prototype.findTileToEast = function (levelZeroTiles) {
-  const parent = this.parent;
-  if (parent === undefined) {
-    return this.findLevelZeroTile(levelZeroTiles, this.x + 1, this.y);
-  }
-
-  if (parent.southwestChild === this) {
-    return parent.southeastChild;
-  } else if (parent.northwestChild === this) {
-    return parent.northeastChild;
-  }
-
-  const eastOfParent = parent.findTileToEast(levelZeroTiles);
-  if (eastOfParent === undefined) {
-    return undefined;
-  } else if (parent.southeastChild === this) {
-    return eastOfParent.southwestChild;
-  }
-  return eastOfParent.northwestChild;
-};
-
-QuadtreeTile.prototype.findTileToSouth = function (levelZeroTiles) {
-  const parent = this.parent;
-  if (parent === undefined) {
-    return this.findLevelZeroTile(levelZeroTiles, this.x, this.y + 1);
-  }
-
-  if (parent.northwestChild === this) {
-    return parent.southwestChild;
-  } else if (parent.northeastChild === this) {
-    return parent.southeastChild;
-  }
-
-  const southOfParent = parent.findTileToSouth(levelZeroTiles);
-  if (southOfParent === undefined) {
-    return undefined;
-  } else if (parent.southwestChild === this) {
-    return southOfParent.northwestChild;
-  }
-  return southOfParent.northeastChild;
-};
-
-QuadtreeTile.prototype.findTileToNorth = function (levelZeroTiles) {
-  const parent = this.parent;
-  if (parent === undefined) {
-    return this.findLevelZeroTile(levelZeroTiles, this.x, this.y - 1);
-  }
-
-  if (parent.southwestChild === this) {
-    return parent.northwestChild;
-  } else if (parent.southeastChild === this) {
-    return parent.northeastChild;
-  }
-
-  const northOfParent = parent.findTileToNorth(levelZeroTiles);
-  if (northOfParent === undefined) {
-    return undefined;
-  } else if (parent.northwestChild === this) {
-    return northOfParent.southwestChild;
-  }
-  return northOfParent.southeastChild;
-};
-
 /**
- * Frees the resources associated with this tile and returns it to the <code>START</code>
- * {@link QuadtreeTileLoadState}.  If the {@link QuadtreeTile#data} property is defined and it
- * has a <code>freeResources</code> method, the method will be invoked.
- *
- * @memberof QuadtreeTile
+ * @param {QuadtreeTile} tile
+ * @ignore
  */
-QuadtreeTile.prototype.freeResources = function () {
-  // Clears cached heights when the tile is freed
-  this.clearPositionCache();
-  this.state = QuadtreeTileLoadState.START;
-  this.renderable = false;
-  this.upsampledFromParent = false;
-
-  if (defined(this.data) && defined(this.data.freeResources)) {
-    this.data.freeResources();
-  }
-
-  freeTile(this._southwestChild);
-  this._southwestChild = undefined;
-  freeTile(this._southeastChild);
-  this._southeastChild = undefined;
-  freeTile(this._northwestChild);
-  this._northwestChild = undefined;
-  freeTile(this._northeastChild);
-  this._northeastChild = undefined;
-};
-
 function freeTile(tile) {
   if (defined(tile)) {
     tile.freeResources();
   }
 }
+
 export default QuadtreeTile;

--- a/packages/engine/Source/Scene/QuadtreeTileLoadState.js
+++ b/packages/engine/Source/Scene/QuadtreeTileLoadState.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * The state of a {@link QuadtreeTile} in the tile load pipeline.
  * @enum {number}
@@ -36,4 +38,7 @@ const QuadtreeTileLoadState = {
    */
   FAILED: 3,
 };
-export default Object.freeze(QuadtreeTileLoadState);
+
+Object.freeze(QuadtreeTileLoadState);
+
+export default QuadtreeTileLoadState;

--- a/packages/engine/Source/Scene/QuadtreeTileProvider.js
+++ b/packages/engine/Source/Scene/QuadtreeTileProvider.js
@@ -1,212 +1,196 @@
+// @ts-check
+
 import DeveloperError from "../Core/DeveloperError.js";
+
+/** @import Context from "../Renderer/Context.js"; */
+/** @import DrawCommand from "../Renderer/DrawCommand.js"; */
+/** @import FrameState from "./FrameState.js"; */
+/** @import QuadtreeOccluders from "./QuadtreeOccluders.js"; */
+/** @import QuadtreePrimitive from "./QuadtreePrimitive.js"; */
+/** @import QuadtreeTile from "./QuadtreeTile.js"; */
+/** @import TilingScheme from "../Core/TilingScheme.js"; */
+/** @import Visibility from "../Core/Visibility.js"; */
 
 /**
  * Provides general quadtree tiles to be displayed on or near the surface of an ellipsoid.  It is intended to be
  * used with the {@link QuadtreePrimitive}.  This type describes an interface and is not intended to be
  * instantiated directly.
  *
- * @alias QuadtreeTileProvider
- * @constructor
+ * @interface
  * @private
  */
-function QuadtreeTileProvider() {
-  DeveloperError.throwInstantiationError();
-}
-
-/**
- * Computes the default geometric error for level zero of the quadtree.
- *
- * @memberof QuadtreeTileProvider
- *
- * @param {TilingScheme} tilingScheme The tiling scheme for which to compute the geometric error.
- * @returns {number} The maximum geometric error at level zero, in meters.
- */
-QuadtreeTileProvider.computeDefaultLevelZeroMaximumGeometricError = function (
-  tilingScheme,
-) {
-  return (
-    (tilingScheme.ellipsoid.maximumRadius * 2 * Math.PI * 0.25) /
-    (65 * tilingScheme.getNumberOfXTilesAtLevel(0))
-  );
-};
-
-Object.defineProperties(QuadtreeTileProvider.prototype, {
+class QuadtreeTileProvider {
   /**
    * Gets or sets the {@link QuadtreePrimitive} for which this provider is
    * providing tiles.
-   * @memberof QuadtreeTileProvider.prototype
    * @type {QuadtreePrimitive}
    */
-  quadtree: {
-    get: DeveloperError.throwInstantiationError,
-    set: DeveloperError.throwInstantiationError,
-  },
+  quadtree;
 
   /**
    * Gets the tiling scheme used by the provider.
-   * @memberof QuadtreeTileProvider.prototype
    * @type {TilingScheme}
    */
-  tilingScheme: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  tilingScheme;
 
   /**
    * Gets an event that is raised when the geometry provider encounters an asynchronous error.  By subscribing
    * to the event, you will be notified of the error and can potentially recover from it.  Event listeners
    * are passed an instance of {@link TileProviderError}.
-   * @memberof QuadtreeTileProvider.prototype
    * @type {Event}
    */
-  errorEvent: {
-    get: DeveloperError.throwInstantiationError,
-  },
-});
+  errorEvent;
 
-/**
- * Called at the beginning of the update cycle, regardless of id a new frame is being rendered, before {@link QuadtreeTileProvider#beginUpdate}
- * @memberof QuadtreeTileProvider
- * @function
- *
- * @param {Context} context The rendering context.
- * @param {FrameState} frameState The frame state.
- */
-QuadtreeTileProvider.prototype.update = DeveloperError.throwInstantiationError;
+  constructor() {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Called at the beginning of the update cycle for each render frame, before {@link QuadtreeTileProvider#showTileThisFrame}
- * or any other functions.
- * @memberof QuadtreeTileProvider
- * @function
- *
- * @param {Context} context The rendering context.
- * @param {FrameState} frameState The frame state.
- * @param {DrawCommand[]} commandList An array of rendering commands.  This method may push
- *        commands into this array.
- */
-QuadtreeTileProvider.prototype.beginUpdate =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Computes the default geometric error for level zero of the quadtree.
+   *
+   * @param {TilingScheme} tilingScheme The tiling scheme for which to compute the geometric error.
+   * @returns {number} The maximum geometric error at level zero, in meters.
+   */
+  static computeDefaultLevelZeroMaximumGeometricError(tilingScheme) {
+    return (
+      (tilingScheme.ellipsoid.maximumRadius * 2 * Math.PI * 0.25) /
+      (65 * tilingScheme.getNumberOfXTilesAtLevel(0))
+    );
+  }
 
-/**
- * Called at the end of the update cycle for each render frame, after {@link QuadtreeTileProvider#showTileThisFrame}
- * and any other functions.
- * @memberof QuadtreeTileProvider
- * @function
- *
- * @param {Context} context The rendering context.
- * @param {FrameState} frameState The frame state.
- * @param {DrawCommand[]} commandList An array of rendering commands.  This method may push
- *        commands into this array.
- */
-QuadtreeTileProvider.prototype.endUpdate =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Called at the beginning of the update cycle, regardless of id a new frame is being rendered, before {@link QuadtreeTileProvider#beginUpdate}
+   *
+   * @param {Context} context The rendering context.
+   * @param {FrameState} frameState The frame state.
+   */
+  update(context, frameState) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Gets the maximum geometric error allowed in a tile at a given level, in meters.
- *
- * @see QuadtreeTileProvider#computeDefaultLevelZeroMaximumGeometricError
- *
- * @memberof QuadtreeTileProvider
- * @function
- *
- * @param {number} level The tile level for which to get the maximum geometric error.
- * @returns {number} The maximum geometric error in meters.
- */
-QuadtreeTileProvider.prototype.getLevelMaximumGeometricError =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Called at the beginning of the update cycle for each render frame, before {@link QuadtreeTileProvider#showTileThisFrame}
+   * or any other functions.
+   *
+   * @param {Context} context The rendering context.
+   * @param {FrameState} frameState The frame state.
+   * @param {DrawCommand[]} commandList An array of rendering commands.  This method may push
+   *        commands into this array.
+   */
+  beginUpdate(context, frameState, commandList) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Loads, or continues loading, a given tile.  This function will continue to be called
- * until {@link QuadtreeTile#state} is no longer {@link QuadtreeTileLoadState#LOADING}.
- *
- * @memberof QuadtreeTileProvider
- * @function
- *
- * @param {Context} context The rendering context.
- * @param {FrameState} frameState The frame state.
- * @param {QuadtreeTile} tile The tile to load.
- */
-QuadtreeTileProvider.prototype.loadTile =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Called at the end of the update cycle for each render frame, after {@link QuadtreeTileProvider#showTileThisFrame}
+   * and any other functions.
+   *
+   * @param {Context} context The rendering context.
+   * @param {FrameState} frameState The frame state.
+   * @param {DrawCommand[]} commandList An array of rendering commands.  This method may push
+   *        commands into this array.
+   */
+  endUpdate(context, frameState, commandList) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Determines the visibility of a given tile.  The tile may be fully visible, partially visible, or not
- * visible at all.  Tiles that are renderable and are at least partially visible will be shown by a call
- * to {@link QuadtreeTileProvider#showTileThisFrame}.
- *
- * @memberof QuadtreeTileProvider
- *
- * @param {QuadtreeTile} tile The tile instance.
- * @param {FrameState} frameState The state information about the current frame.
- * @param {QuadtreeOccluders} occluders The objects that may occlude this tile.
- *
- * @returns {Visibility} The visibility of the tile.
- */
-QuadtreeTileProvider.prototype.computeTileVisibility =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Gets the maximum geometric error allowed in a tile at a given level, in meters.
+   *
+   * @see QuadtreeTileProvider#computeDefaultLevelZeroMaximumGeometricError
+   *
+   * @param {number} level The tile level for which to get the maximum geometric error.
+   * @returns {number} The maximum geometric error in meters.
+   */
+  getLevelMaximumGeometricError(level) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Shows a specified tile in this frame.  The provider can cause the tile to be shown by adding
- * render commands to the commandList, or use any other method as appropriate.  The tile is not
- * expected to be visible next frame as well, unless this method is call next frame, too.
- *
- * @memberof QuadtreeTileProvider
- * @function
- *
- * @param {QuadtreeTile} tile The tile instance.
- * @param {Context} context The rendering context.
- * @param {FrameState} frameState The state information of the current rendering frame.
- * @param {DrawCommand[]} commandList The list of rendering commands.  This method may add additional commands to this list.
- */
-QuadtreeTileProvider.prototype.showTileThisFrame =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Loads, or continues loading, a given tile.  This function will continue to be called
+   * until {@link QuadtreeTile#state} is no longer {@link QuadtreeTileLoadState#LOADING}.
+   *
+   * @param {Context} context The rendering context.
+   * @param {FrameState} frameState The frame state.
+   * @param {QuadtreeTile} tile The tile to load.
+   */
+  loadTile(context, frameState, tile) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Gets the distance from the camera to the closest point on the tile.  This is used for level-of-detail selection.
- *
- * @memberof QuadtreeTileProvider
- * @function
- *
- * @param {QuadtreeTile} tile The tile instance.
- * @param {FrameState} frameState The state information of the current rendering frame.
- *
- * @returns {number} The distance from the camera to the closest point on the tile, in meters.
- */
-QuadtreeTileProvider.prototype.computeDistanceToTile =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Determines the visibility of a given tile.  The tile may be fully visible, partially visible, or not
+   * visible at all.  Tiles that are renderable and are at least partially visible will be shown by a call
+   * to {@link QuadtreeTileProvider#showTileThisFrame}.
+   *
+   * @param {QuadtreeTile} tile The tile instance.
+   * @param {FrameState} frameState The state information about the current frame.
+   * @param {QuadtreeOccluders} occluders The objects that may occlude this tile.
+   *
+   * @returns {Visibility} The visibility of the tile.
+   */
+  computeTileVisibility(tile, frameState, occluders) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Returns true if this object was destroyed; otherwise, false.
- * <br /><br />
- * If this object was destroyed, it should not be used; calling any function other than
- * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.
- *
- * @memberof QuadtreeTileProvider
- *
- * @returns {boolean} True if this object was destroyed; otherwise, false.
- *
- * @see QuadtreeTileProvider#destroy
- */
-QuadtreeTileProvider.prototype.isDestroyed =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Shows a specified tile in this frame.  The provider can cause the tile to be shown by adding
+   * render commands to the commandList, or use any other method as appropriate.  The tile is not
+   * expected to be visible next frame as well, unless this method is call next frame, too.
+   *
+   * @param {QuadtreeTile} tile The tile instance.
+   * @param {Context} context The rendering context.
+   * @param {FrameState} frameState The state information of the current rendering frame.
+   * @param {DrawCommand[]} commandList The list of rendering commands.  This method may add additional commands to this list.
+   */
+  showTileThisFrame(tile, context, frameState, commandList) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Destroys the WebGL resources held by this object.  Destroying an object allows for deterministic
- * release of WebGL resources, instead of relying on the garbage collector to destroy this object.
- * <br /><br />
- * Once an object is destroyed, it should not be used; calling any function other than
- * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.  Therefore,
- * assign the return value (<code>undefined</code>) to the object as done in the example.
- *
- * @memberof QuadtreeTileProvider
- *
- * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
- *
- *
- * @example
- * provider = provider && provider();
- *
- * @see QuadtreeTileProvider#isDestroyed
- */
-QuadtreeTileProvider.prototype.destroy = DeveloperError.throwInstantiationError;
+  /**
+   * Gets the distance from the camera to the closest point on the tile.  This is used for level-of-detail selection.
+   *
+   * @param {QuadtreeTile} tile The tile instance.
+   * @param {FrameState} frameState The state information of the current rendering frame.
+   *
+   * @returns {number} The distance from the camera to the closest point on the tile, in meters.
+   */
+  computeDistanceToTile(tile, frameState) {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Returns true if this object was destroyed; otherwise, false.
+   * <br /><br />
+   * If this object was destroyed, it should not be used; calling any function other than
+   * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.
+   *
+   * @returns {boolean} True if this object was destroyed; otherwise, false.
+   *
+   * @see QuadtreeTileProvider#destroy
+   */
+  isDestroyed() {
+    DeveloperError.throwInstantiationError();
+  }
+
+  /**
+   * Destroys the WebGL resources held by this object.  Destroying an object allows for deterministic
+   * release of WebGL resources, instead of relying on the garbage collector to destroy this object.
+   * <br /><br />
+   * Once an object is destroyed, it should not be used; calling any function other than
+   * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.  Therefore,
+   * assign the return value (<code>undefined</code>) to the object as done in the example.
+   *
+   * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+   *
+   * @example
+   * provider = provider && provider();
+   *
+   * @see QuadtreeTileProvider#isDestroyed
+   */
+  destroy() {
+    DeveloperError.throwInstantiationError();
+  }
+}
+
 export default QuadtreeTileProvider;


### PR DESCRIPTION
# Description

Preliminary work for upcoming changes. The GPU Lookup rendering path for vectors will require changes within the GlobeSurfaceTile code, and I'd like to have type checking in place before making those changes. These files are important dependencies.


## Issue number and link

- #4434 

## Testing plan

Unit tests, `npm run tsc`, and `sg scan` should pass.

<details>
<summary>Diff on `Cesium.d.ts` before/after:</summary>

```diff
diff --git a/Source/Cesium.main.d.ts b/Source/Cesium.d.ts
index e31dd1180f..d4e875972f 100644
--- a/Source/Cesium.main.d.ts
+++ b/Source/Cesium.d.ts
@@ -7076,6 +7076,9 @@ export class GeographicProjection implements MapProjection {
     unproject(cartesian: Cartesian3, result?: Cartographic): Cartographic;
 }
 
+export interface GeographicTilingScheme extends TilingScheme {
+}
+
 /**
  * A tiling scheme for geometry referenced to a simple {@link GeographicProjection} where
  * longitude and latitude are directly mapped to X and Y.  This projection is commonly
@@ -7089,7 +7092,7 @@ export class GeographicProjection implements MapProjection {
  * @param [options.numberOfLevelZeroTilesY = 1] - The number of tiles in the Y direction at level zero of
  * the tile tree.
  */
-export class GeographicTilingScheme {
+export class GeographicTilingScheme implements TilingScheme {
     constructor(options?: {
         ellipsoid?: Ellipsoid;
         rectangle?: Rectangle;
@@ -7141,7 +7144,7 @@ export class GeographicTilingScheme {
      * @returns The specified 'result', or a new object containing the rectangle
      *          if 'result' is undefined.
      */
-    tileXYToNativeRectangle(x: number, y: number, level: number, result?: any): Rectangle;
+    tileXYToNativeRectangle(x: number, y: number, level: number, result?: Rectangle): Rectangle;
     /**
      * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
      * @param x - The integer x coordinate of the tile.
@@ -7152,7 +7155,7 @@ export class GeographicTilingScheme {
      * @returns The specified 'result', or a new object containing the rectangle
      *          if 'result' is undefined.
      */
-    tileXYToRectangle(x: number, y: number, level: number, result?: any): Rectangle;
+    tileXYToRectangle(x: number, y: number, level: number, result?: Rectangle): Rectangle;
     /**
      * Calculates the tile x, y coordinates of the tile containing
      * a given cartographic position.
@@ -17068,8 +17071,7 @@ export namespace TileProviderError {
  * At level of detail two, each of the level one tiles has four children, two in each direction.
  * This continues for as many levels as are present in the geometry or imagery source.
  */
-export class TilingScheme {
-    constructor();
+export interface TilingScheme {
     /**
      * Gets the ellipsoid that is tiled by the tiling scheme.
      */
@@ -18533,6 +18535,9 @@ export class WebMercatorProjection implements MapProjection {
     static MaximumLatitude: number;
 }
 
+export interface WebMercatorTilingScheme extends TilingScheme {
+}
+
 /**
  * A tiling scheme for geometry referenced to a {@link WebMercatorProjection}, EPSG:3857.  This is
  * the tiling scheme used by Google Maps, Microsoft Bing Maps, and most of ESRI ArcGIS Online.
@@ -18552,7 +18557,7 @@ export class WebMercatorProjection implements MapProjection {
  *        globe is covered in the longitude direction and an equal distance is covered in the latitude
  *        direction, resulting in a square projection.
  */
-export class WebMercatorTilingScheme {
+export class WebMercatorTilingScheme implements TilingScheme {
     constructor(options?: {
         ellipsoid?: Ellipsoid;
         numberOfLevelZeroTilesX?: number;
@@ -18605,7 +18610,7 @@ export class WebMercatorTilingScheme {
      * @returns The specified 'result', or a new object containing the rectangle
      *          if 'result' is undefined.
      */
-    tileXYToNativeRectangle(x: number, y: number, level: number, result?: any): Rectangle;
+    tileXYToNativeRectangle(x: number, y: number, level: number, result?: Rectangle): Rectangle;
     /**
      * Converts tile x, y coordinates and level to a cartographic rectangle in radians.
      * @param x - The integer x coordinate of the tile.
@@ -18616,7 +18621,7 @@ export class WebMercatorTilingScheme {
      * @returns The specified 'result', or a new object containing the rectangle
      *          if 'result' is undefined.
      */
-    tileXYToRectangle(x: number, y: number, level: number, result?: any): Rectangle;
+    tileXYToRectangle(x: number, y: number, level: number, result?: Rectangle): Rectangle;
     /**
      * Calculates the tile x, y coordinates of the tile containing
      * a given cartographic position.
@@ -43207,12 +43212,6 @@ export class PrimitiveCollection {
     destroy(): void;
 }
 
-/**
- * A simple Least Recently Used (LRU) cache implementation.
- */
-export class LRUCache {
-}
-
 /**
  * Creates a spatial hash key for the given longitude, latitude, and tile level.
  * The precision is adjusted based on the tile level and extent to achieve finer precision at higher levels.

```

</details>

The type definition changes look as-expected to me. The interface/class pair for the tiling scheme classes is introduced by the build system and while I don't entirely understand why, it's clearly intended by the build tool (covered by unit tests).

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13430** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)