### PR TITLE
Refactor ModelReader and pickModel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 - Fix JSDoc for SkyBox.show to correctly declare it as a prototype property for TypeScript compatibility. [#13357](https://github.com/CesiumGS/cesium/pull/13357)
 - Fixed lighting affecting `EquirectangularPanorama`. [#13369](https://github.com/CesiumGS/cesium/pull/13369)
 - Fixed a `DeveloperError` thrown when loading 3D tiles containing degenerate (zero-area) triangles with edge visibility data. [#13421](https://github.com/CesiumGS/cesium/pull/13421)
+- Refactored `pickModel` to use shared util `ModelReader`, reducing duplicated scene-graph walking and vertex-reading logic. [#13433](https://github.com/CesiumGS/cesium/pull/13433)
+- Fixed incorrect argument order in `ModelReader.octDecode` for `AttributeCompression.octDecodeInRange` and `Cartesian3.pack` calls. [#13433](https://github.com/CesiumGS/cesium/pull/13433)
+- Fixed incorrect matrix multiplication for non worldspace instance transforms in `pickModel`. [#13433](https://github.com/CesiumGS/cesium/pull/13433)
 
 ## 1.140 - 2026-04-01
 

--- a/packages/engine/Source/Scene/Model/InstancingPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/InstancingPipelineStage.js
@@ -706,7 +706,7 @@ function processTransformAttributes(
   );
 
   // Only use matrices for the transforms if the rotation attribute is defined.
-  if (defined(rotationAttribute)) {
+  if (defined(rotationAttribute) || keepTypedArray) {
     processTransformMatrixAttributes(
       renderResources,
       instances,

--- a/packages/engine/Source/Scene/Model/ModelReader.js
+++ b/packages/engine/Source/Scene/Model/ModelReader.js
@@ -9,8 +9,13 @@ import AttributeCompression from "../../Core/AttributeCompression.js";
 import IndexDatatype from "../../Core/IndexDatatype.js";
 import PrimitiveType from "../../Core/PrimitiveType.js";
 import Matrix4 from "../../Core/Matrix4.js";
+import Quaternion from "../../Core/Quaternion.js";
+import Transforms from "../../Core/Transforms.js";
 
 import AttributeType from "../AttributeType.js";
+import InstanceAttributeSemantic from "../InstanceAttributeSemantic.js";
+import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
+import ModelUtility from "./ModelUtility.js";
 
 /**
  * A class for reading the data from a <code>ModelComponents.Attribute</code>.
@@ -144,7 +149,20 @@ class ModelReader {
     const byteStride = attribute.byteStride;
     const bytesPerComponent = ComponentDatatype.getSizeInBytes(componentType);
     const defaultByteStride = componentsPerElement * bytesPerComponent;
-    if (!defined(byteStride) || byteStride === defaultByteStride) {
+
+    const isDefaultStride =
+      !defined(byteStride) || byteStride === defaultByteStride;
+    const hasTypedArray = defined(attribute.typedArray);
+
+    // If in-memory — return as-is
+    // Important: typedArray is already tightly-packed on creation (See: ModelComponents.typedArray and GltfLoader.getPackedTypedArray)
+    //            byteOffset and byteStride should thus be ignored
+    if (hasTypedArray) {
+      return attribute.typedArray;
+    }
+
+    // Non-interleaved — copy from typedArray or read from GPU
+    if (isDefaultStride) {
       const typedArray = ComponentDatatype.createTypedArray(
         componentType,
         totalComponentCount,
@@ -161,6 +179,8 @@ class ModelReader {
     // have ONE "TypedArray[] getThemFrom(buffer)" call that
     // returns all of the (interleaved) attributes at once,
     // but this requires abstractions that we don't have.
+
+    // Read back from GPU if not available in memory
     const fullTypedArray = new Uint8Array(buffer.sizeInBytes);
     buffer.getBufferData(fullTypedArray);
 
@@ -320,8 +340,8 @@ class ModelReader {
     const c = new Cartesian3();
     for (let i = 0; i < elementCount; i++) {
       Cartesian3.unpack(quantizedTypedArray, i * 3, c);
-      AttributeCompression.octDecodeInRange(c, normalizationRange, c);
-      Cartesian3.pack(dequantizedTypedArray, c, i * 3);
+      AttributeCompression.octDecodeInRange(c.x, c.y, normalizationRange, c);
+      Cartesian3.pack(c, dequantizedTypedArray, i * 3);
     }
     return dequantizedTypedArray;
   }
@@ -646,6 +666,33 @@ class ModelReader {
   }
 
   /**
+   * Reads feature IDs from an implicit range feature ID set into a typed array.
+   *
+   * Generates values using <code>offset + Math.floor(i / repeat)</code> for
+   * each vertex. If <code>repeat</code> is undefined, all values are set to
+   * <code>offset</code>.
+   *
+   * @param {FeatureIdImplicitRange} featureIdSet The implicit range feature ID set.
+   * @param {object} attributeOwner An object with an <code>attributes</code> array
+   *   (a primitive or an instances object)
+   * @returns {Float32Array} The generated feature ID values.
+   */
+  static readImplicitRangeAsTypedArray(featureIdSet, attributeOwner) {
+    const count = attributeOwner.attributes[0]?.count ?? 0;
+    const offset = featureIdSet.offset;
+    const repeat = featureIdSet.repeat;
+    const typedArray = new Float32Array(count);
+    if (defined(repeat)) {
+      for (let i = 0; i < count; i++) {
+        typedArray[i] = offset + Math.floor(i / repeat);
+      }
+    } else {
+      typedArray.fill(offset);
+    }
+    return typedArray;
+  }
+
+  /**
    * Read the indices values from the given primitive indices, and
    * return them as a typed array.
    *
@@ -804,6 +851,431 @@ class ModelReader {
         `UNSIGNED_SHORT (${IndexDatatype.UNSIGNED_SHORT}, or ` +
         `UNSIGNED_INT (${IndexDatatype.UNSIGNED_INT}, but is ${indexDatatype}`,
     );
+  }
+
+  /**
+   * Per-instance data combining a transform matrix with an optional feature ID.
+   *
+   * @typedef {object} ModelReader.Instance
+   * @property {Matrix4} transform The instance transform matrix.
+   * @property {number} [featureId] The per-instance feature ID, or undefined.
+   *
+   * @private
+   */
+
+  /**
+   * A callback invoked by {@link ModelReader.forEachPrimitive} for each
+   * runtime primitive in the model.
+   *
+   * @callback ModelReader.ForEachPrimitiveCallback
+   * @param {object} runtimePrimitive The runtime primitive wrapper.
+   * @param {object} primitive The underlying model primitive (runtimePrimitive.primitive).
+   * @param {ModelReader.Instance[]} instances Per-instance data (transforms and optional feature IDs).
+   * @param {Matrix4} computedModelMatrix The computed model matrix for the node.
+   *
+   * @private
+   */
+
+  /**
+   * Iterates over every primitive in a model's scene graph, computing
+   * node transforms and instance transforms once per node and invoking
+   * a callback for each runtime primitive.
+   * <p>
+   * When a map projection is provided, the computed model matrix is
+   * projected to 2D via {@link Transforms.basisTo2D}.
+   * </p>
+   *
+   * @param {Model} model The model whose scene graph to traverse.
+   * @param {object} [options] Object with the following properties:
+   * @param {MapProjection} [options.mapProjection] The map projection for 2D mode. When defined, the computed model matrix is projected to 2D.
+   * @param {string} [options.instanceFeatureIdLabel] The label used to select which instance feature ID set to read. When defined, per-instance feature IDs are fetched. When undefined, feature IDs are not fetched.
+   * @param {ModelReader.ForEachPrimitiveCallback} callback The function invoked for each primitive.
+   *
+   * @private
+   */
+  static forEachPrimitive(model, options, callback) {
+    const mapProjection = options?.mapProjection;
+    const instanceFeatureIdLabel = options?.instanceFeatureIdLabel;
+    const sceneGraph = model.sceneGraph;
+    if (!defined(sceneGraph)) {
+      return;
+    }
+
+    const scratchNodeTransforms = {
+      nodeComputedTransform: new Matrix4(),
+      modelMatrix: new Matrix4(),
+      computedModelMatrix: new Matrix4(),
+    };
+
+    const nodes = sceneGraph._runtimeNodes;
+    const nodesLength = nodes.length;
+
+    for (let n = 0; n < nodesLength; n++) {
+      const runtimeNode = nodes[n];
+
+      const nodeTransforms = computeNodeTransforms(
+        runtimeNode,
+        sceneGraph,
+        model,
+        scratchNodeTransforms,
+      );
+
+      let computedModelMatrix = nodeTransforms.computedModelMatrix;
+
+      if (defined(mapProjection)) {
+        computedModelMatrix = Transforms.basisTo2D(
+          mapProjection,
+          computedModelMatrix,
+          computedModelMatrix,
+        );
+      }
+
+      const instanceTransforms = getInstanceTransforms(
+        runtimeNode,
+        computedModelMatrix,
+        nodeTransforms.nodeComputedTransform,
+        nodeTransforms.modelMatrix,
+      );
+
+      const instanceFeatureIds = defined(instanceFeatureIdLabel)
+        ? getInstanceFeatureIds(runtimeNode, instanceFeatureIdLabel)
+        : undefined;
+
+      const instances = [];
+      for (let i = 0; i < instanceTransforms.length; i++) {
+        instances.push({
+          transform: instanceTransforms[i],
+          featureId: defined(instanceFeatureIds)
+            ? instanceFeatureIds[i]
+            : undefined,
+        });
+      }
+
+      const primitivesLength = runtimeNode.runtimePrimitives.length;
+      for (let p = 0; p < primitivesLength; p++) {
+        const runtimePrimitive = runtimeNode.runtimePrimitives[p];
+        callback(
+          runtimePrimitive,
+          runtimePrimitive.primitive,
+          instances,
+          computedModelMatrix,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Computes the model matrix for a runtime node, accounting for instancing
+ * and world-space transforms.
+ *
+ * @param {object} runtimeNode The runtime node.
+ * @param {ModelSceneGraph} sceneGraph The model scene graph.
+ * @param {Model} model The model.
+ * @param {object} result An object with scratch matrices: { nodeComputedTransform: Matrix4, modelMatrix: Matrix4, computedModelMatrix: Matrix4 }.
+ * @returns {object} The result parameter, populated with the computed transforms.
+ *
+ * @private
+ */
+function computeNodeTransforms(runtimeNode, sceneGraph, model, result) {
+  const node = runtimeNode.node;
+
+  let nodeComputedTransform = Matrix4.clone(
+    runtimeNode.computedTransform,
+    result.nodeComputedTransform,
+  );
+  let modelMatrix = Matrix4.clone(
+    sceneGraph.computedModelMatrix,
+    result.modelMatrix,
+  );
+
+  const instances = node.instances;
+  if (defined(instances)) {
+    if (instances.transformInWorldSpace) {
+      // Replicate the multiplication order in LegacyInstancingStageVS.
+      modelMatrix = Matrix4.multiplyTransformation(
+        model.modelMatrix,
+        sceneGraph.components.transform,
+        modelMatrix,
+      );
+      nodeComputedTransform = Matrix4.multiplyTransformation(
+        sceneGraph.axisCorrectionMatrix,
+        runtimeNode.computedTransform,
+        nodeComputedTransform,
+      );
+    }
+  }
+
+  const computedModelMatrix = Matrix4.multiplyTransformation(
+    modelMatrix,
+    nodeComputedTransform,
+    result.computedModelMatrix,
+  );
+
+  result.computedModelMatrix = computedModelMatrix;
+  result.nodeComputedTransform = nodeComputedTransform;
+  result.modelMatrix = modelMatrix;
+  return result;
+}
+
+/**
+ * Builds an array of instance transforms for a node.
+ * If the node is not instanced, returns an array containing only the
+ * computedModelMatrix.
+ *
+ * @param {object} runtimeNode The runtime node.
+ * @param {Matrix4} computedModelMatrix The computed model matrix.
+ * @param {Matrix4} nodeComputedTransform The node computed transform.
+ * @param {Matrix4} modelMatrix The model matrix.
+ * @returns {Matrix4[]}
+ *
+ * @private
+ */
+function getInstanceTransforms(
+  runtimeNode,
+  computedModelMatrix,
+  nodeComputedTransform,
+  modelMatrix,
+) {
+  const transforms = [];
+  const node = runtimeNode.node;
+  const instances = node.instances;
+
+  if (defined(instances)) {
+    const transformsCount = instances.attributes[0].count;
+    const instanceComponentDatatype = instances.attributes[0].componentDatatype;
+
+    const transformElements = 12;
+    let transformsTypedArray = runtimeNode.transformsTypedArray;
+
+    if (!defined(transformsTypedArray)) {
+      const instanceTransformsBuffer = runtimeNode.instancingTransformsBuffer;
+      if (defined(instanceTransformsBuffer)) {
+        transformsTypedArray = ComponentDatatype.createTypedArray(
+          instanceComponentDatatype,
+          transformsCount * transformElements,
+        );
+        instanceTransformsBuffer.getBufferData(transformsTypedArray);
+      }
+    }
+
+    if (defined(transformsTypedArray)) {
+      buildTransformsFromTypedArray(
+        transformsTypedArray,
+        transformsCount,
+        transforms,
+      );
+    } else {
+      buildTransformsFromAttributes(instances, transformsCount, transforms);
+    }
+
+    for (let i = 0; i < transforms.length; i++) {
+      const transform = transforms[i];
+      if (instances.transformInWorldSpace) {
+        Matrix4.multiplyTransformation(
+          transform,
+          nodeComputedTransform,
+          transform,
+        );
+        Matrix4.multiplyTransformation(modelMatrix, transform, transform);
+      } else {
+        Matrix4.multiplyTransformation(
+          computedModelMatrix,
+          transform,
+          transform,
+        );
+      }
+    }
+  }
+
+  if (transforms.length === 0) {
+    transforms.push(computedModelMatrix);
+  }
+
+  return transforms;
+}
+
+/**
+ * Builds an array of per-instance feature IDs for a node.
+ * If the node is not instanced or has no matching feature ID set,
+ * returns <code>undefined</code>.
+ *
+ * @param {object} runtimeNode The runtime node.
+ * @param {string} instanceFeatureIdLabel The label used to select the feature ID set.
+ * @returns {number[]|undefined} The per-instance feature IDs, or undefined.
+ *
+ * @private
+ */
+function getInstanceFeatureIds(runtimeNode, instanceFeatureIdLabel) {
+  const node = runtimeNode.node;
+  const instances = node.instances;
+
+  if (!defined(instances)) {
+    return undefined;
+  }
+
+  const featureIdSet = ModelUtility.getFeatureIdsByLabel(
+    instances.featureIds,
+    instanceFeatureIdLabel,
+  );
+
+  if (!defined(featureIdSet)) {
+    return undefined;
+  }
+
+  let typedArray;
+
+  // Case: FeatureIdAttribute
+  if ("setIndex" in featureIdSet) {
+    const attribute = ModelUtility.getAttributeBySemantic(
+      instances,
+      VertexAttributeSemantic.FEATURE_ID,
+      featureIdSet.setIndex,
+    );
+    if (defined(attribute)) {
+      typedArray = ModelReader.readAttributeAsTypedArray(attribute);
+    }
+  }
+
+  // Case: FeatureIdImplicitRange
+  if ("offset" in featureIdSet) {
+    typedArray = ModelReader.readImplicitRangeAsTypedArray(
+      featureIdSet,
+      instances,
+    );
+  }
+
+  if (!defined(typedArray)) {
+    return undefined;
+  }
+
+  const featureIds = new Array(typedArray.length);
+  for (let i = 0; i < typedArray.length; i++) {
+    featureIds[i] = typedArray[i];
+  }
+  return featureIds;
+}
+
+/**
+ * Builds instance transforms from a packed typed array where each instance
+ * is stored as 12 floats (3 rows of 4 columns, row-major).
+ *
+ * @param {TypedArray} transformsTypedArray The packed transforms array.
+ * @param {number} count The number of instances.
+ * @param {Matrix4[]} transforms The output array to push transforms into.
+ * @private
+ */
+function buildTransformsFromTypedArray(
+  transformsTypedArray,
+  count,
+  transforms,
+) {
+  const transformElements = 12;
+  for (let i = 0; i < count; i++) {
+    const index = i * transformElements;
+
+    const transform = new Matrix4(
+      transformsTypedArray[index],
+      transformsTypedArray[index + 1],
+      transformsTypedArray[index + 2],
+      transformsTypedArray[index + 3],
+      transformsTypedArray[index + 4],
+      transformsTypedArray[index + 5],
+      transformsTypedArray[index + 6],
+      transformsTypedArray[index + 7],
+      transformsTypedArray[index + 8],
+      transformsTypedArray[index + 9],
+      transformsTypedArray[index + 10],
+      transformsTypedArray[index + 11],
+      0,
+      0,
+      0,
+      1,
+    );
+
+    transforms.push(transform);
+  }
+}
+
+/**
+ * Builds instance transforms from individual TRANSLATION, ROTATION, and SCALE
+ * attributes when no packed transformsTypedArray is available.
+ *
+ * @param {object} instances The instances object.
+ * @param {number} count The number of instances.
+ * @param {Matrix4[]} transforms The output array to push transforms into.
+ * @private
+ */
+function buildTransformsFromAttributes(instances, count, transforms) {
+  const translationAttribute = ModelUtility.getAttributeBySemantic(
+    instances,
+    InstanceAttributeSemantic.TRANSLATION,
+  );
+  const rotationAttribute = ModelUtility.getAttributeBySemantic(
+    instances,
+    InstanceAttributeSemantic.ROTATION,
+  );
+  const scaleAttribute = ModelUtility.getAttributeBySemantic(
+    instances,
+    InstanceAttributeSemantic.SCALE,
+  );
+
+  const hasTranslation = defined(translationAttribute);
+  const hasRotation = defined(rotationAttribute);
+  const hasScale = defined(scaleAttribute);
+
+  if (!hasTranslation && !hasRotation && !hasScale) {
+    return;
+  }
+
+  let translationTypedArray, rotationTypedArray, scaleTypedArray;
+  if (hasTranslation) {
+    translationTypedArray =
+      ModelReader.readAttributeAsRawCompactTypedArray(translationAttribute);
+  }
+  if (hasRotation) {
+    rotationTypedArray =
+      ModelReader.readAttributeAsRawCompactTypedArray(rotationAttribute);
+  }
+  if (hasScale) {
+    scaleTypedArray =
+      ModelReader.readAttributeAsRawCompactTypedArray(scaleAttribute);
+  }
+
+  for (let i = 0; i < count; i++) {
+    const translation = hasTranslation
+      ? new Cartesian3(
+          translationTypedArray[i * 3],
+          translationTypedArray[i * 3 + 1],
+          translationTypedArray[i * 3 + 2],
+        )
+      : Cartesian3.ZERO;
+
+    const rotation = hasRotation
+      ? new Quaternion(
+          rotationTypedArray[i * 4],
+          rotationTypedArray[i * 4 + 1],
+          rotationTypedArray[i * 4 + 2],
+          rotationTypedArray[i * 4 + 3],
+        )
+      : Quaternion.IDENTITY;
+
+    const scale = hasScale
+      ? new Cartesian3(
+          scaleTypedArray[i * 3],
+          scaleTypedArray[i * 3 + 1],
+          scaleTypedArray[i * 3 + 2],
+        )
+      : Cartesian3.ONE;
+
+    const transform = Matrix4.fromTranslationQuaternionRotationScale(
+      translation,
+      rotation,
+      scale,
+      new Matrix4(),
+    );
+
+    transforms.push(transform);
   }
 }
 

--- a/packages/engine/Source/Scene/Model/ModelReader.js
+++ b/packages/engine/Source/Scene/Model/ModelReader.js
@@ -890,8 +890,6 @@ class ModelReader {
    * @param {MapProjection} [options.mapProjection] The map projection for 2D mode. When defined, the computed model matrix is projected to 2D.
    * @param {string} [options.instanceFeatureIdLabel] The label used to select which instance feature ID set to read. When defined, per-instance feature IDs are fetched. When undefined, feature IDs are not fetched.
    * @param {ModelReader.ForEachPrimitiveCallback} callback The function invoked for each primitive.
-   *
-   * @private
    */
   static forEachPrimitive(model, options, callback) {
     const mapProjection = options?.mapProjection;
@@ -913,7 +911,7 @@ class ModelReader {
     for (let n = 0; n < nodesLength; n++) {
       const runtimeNode = nodes[n];
 
-      const nodeTransforms = computeNodeTransforms(
+      const nodeTransforms = ModelReader.computeNodeTransforms(
         runtimeNode,
         sceneGraph,
         model,
@@ -930,7 +928,7 @@ class ModelReader {
         );
       }
 
-      const instanceTransforms = getInstanceTransforms(
+      const instanceTransforms = ModelReader.computeInstanceTransforms(
         runtimeNode,
         computedModelMatrix,
         nodeTransforms.nodeComputedTransform,
@@ -938,7 +936,10 @@ class ModelReader {
       );
 
       const instanceFeatureIds = defined(instanceFeatureIdLabel)
-        ? getInstanceFeatureIds(runtimeNode, instanceFeatureIdLabel)
+        ? ModelReader.computeInstanceFeatureIds(
+            runtimeNode,
+            instanceFeatureIdLabel,
+          )
         : undefined;
 
       const instances = [];
@@ -963,319 +964,317 @@ class ModelReader {
       }
     }
   }
-}
 
-/**
- * Computes the model matrix for a runtime node, accounting for instancing
- * and world-space transforms.
- *
- * @param {object} runtimeNode The runtime node.
- * @param {ModelSceneGraph} sceneGraph The model scene graph.
- * @param {Model} model The model.
- * @param {object} result An object with scratch matrices: { nodeComputedTransform: Matrix4, modelMatrix: Matrix4, computedModelMatrix: Matrix4 }.
- * @returns {object} The result parameter, populated with the computed transforms.
- *
- * @private
- */
-function computeNodeTransforms(runtimeNode, sceneGraph, model, result) {
-  const node = runtimeNode.node;
+  /**
+   * Computes the model matrix for a runtime node, accounting for instancing
+   * and world-space transforms.
+   *
+   * @param {object} runtimeNode The runtime node.
+   * @param {ModelSceneGraph} sceneGraph The model scene graph.
+   * @param {Model} model The model.
+   * @param {object} result An object with scratch matrices: { nodeComputedTransform: Matrix4, modelMatrix: Matrix4, computedModelMatrix: Matrix4 }.
+   * @returns {object} The result parameter, populated with the computed transforms.
+   *
+   */
+  static computeNodeTransforms(runtimeNode, sceneGraph, model, result) {
+    const node = runtimeNode.node;
 
-  let nodeComputedTransform = Matrix4.clone(
-    runtimeNode.computedTransform,
-    result.nodeComputedTransform,
-  );
-  let modelMatrix = Matrix4.clone(
-    sceneGraph.computedModelMatrix,
-    result.modelMatrix,
-  );
+    let nodeComputedTransform = Matrix4.clone(
+      runtimeNode.computedTransform,
+      result.nodeComputedTransform,
+    );
+    let modelMatrix = Matrix4.clone(
+      sceneGraph.computedModelMatrix,
+      result.modelMatrix,
+    );
 
-  const instances = node.instances;
-  if (defined(instances)) {
-    if (instances.transformInWorldSpace) {
-      // Replicate the multiplication order in LegacyInstancingStageVS.
-      modelMatrix = Matrix4.multiplyTransformation(
-        model.modelMatrix,
-        sceneGraph.components.transform,
-        modelMatrix,
-      );
-      nodeComputedTransform = Matrix4.multiplyTransformation(
-        sceneGraph.axisCorrectionMatrix,
-        runtimeNode.computedTransform,
-        nodeComputedTransform,
-      );
-    }
-  }
-
-  const computedModelMatrix = Matrix4.multiplyTransformation(
-    modelMatrix,
-    nodeComputedTransform,
-    result.computedModelMatrix,
-  );
-
-  result.computedModelMatrix = computedModelMatrix;
-  result.nodeComputedTransform = nodeComputedTransform;
-  result.modelMatrix = modelMatrix;
-  return result;
-}
-
-/**
- * Builds an array of instance transforms for a node.
- * If the node is not instanced, returns an array containing only the
- * computedModelMatrix.
- *
- * @param {object} runtimeNode The runtime node.
- * @param {Matrix4} computedModelMatrix The computed model matrix.
- * @param {Matrix4} nodeComputedTransform The node computed transform.
- * @param {Matrix4} modelMatrix The model matrix.
- * @returns {Matrix4[]}
- *
- * @private
- */
-function getInstanceTransforms(
-  runtimeNode,
-  computedModelMatrix,
-  nodeComputedTransform,
-  modelMatrix,
-) {
-  const transforms = [];
-  const node = runtimeNode.node;
-  const instances = node.instances;
-
-  if (defined(instances)) {
-    const transformsCount = instances.attributes[0].count;
-    const instanceComponentDatatype = instances.attributes[0].componentDatatype;
-
-    const transformElements = 12;
-    let transformsTypedArray = runtimeNode.transformsTypedArray;
-
-    if (!defined(transformsTypedArray)) {
-      const instanceTransformsBuffer = runtimeNode.instancingTransformsBuffer;
-      if (defined(instanceTransformsBuffer)) {
-        transformsTypedArray = ComponentDatatype.createTypedArray(
-          instanceComponentDatatype,
-          transformsCount * transformElements,
-        );
-        instanceTransformsBuffer.getBufferData(transformsTypedArray);
-      }
-    }
-
-    if (defined(transformsTypedArray)) {
-      buildTransformsFromTypedArray(
-        transformsTypedArray,
-        transformsCount,
-        transforms,
-      );
-    } else {
-      buildTransformsFromAttributes(instances, transformsCount, transforms);
-    }
-
-    for (let i = 0; i < transforms.length; i++) {
-      const transform = transforms[i];
+    const instances = node.instances;
+    if (defined(instances)) {
       if (instances.transformInWorldSpace) {
-        Matrix4.multiplyTransformation(
-          transform,
-          nodeComputedTransform,
-          transform,
+        // Replicate the multiplication order in LegacyInstancingStageVS.
+        modelMatrix = Matrix4.multiplyTransformation(
+          model.modelMatrix,
+          sceneGraph.components.transform,
+          modelMatrix,
         );
-        Matrix4.multiplyTransformation(modelMatrix, transform, transform);
-      } else {
-        Matrix4.multiplyTransformation(
-          computedModelMatrix,
-          transform,
-          transform,
+        nodeComputedTransform = Matrix4.multiplyTransformation(
+          sceneGraph.axisCorrectionMatrix,
+          runtimeNode.computedTransform,
+          nodeComputedTransform,
         );
       }
     }
-  }
 
-  if (transforms.length === 0) {
-    transforms.push(computedModelMatrix);
-  }
-
-  return transforms;
-}
-
-/**
- * Builds an array of per-instance feature IDs for a node.
- * If the node is not instanced or has no matching feature ID set,
- * returns <code>undefined</code>.
- *
- * @param {object} runtimeNode The runtime node.
- * @param {string} instanceFeatureIdLabel The label used to select the feature ID set.
- * @returns {number[]|undefined} The per-instance feature IDs, or undefined.
- *
- * @private
- */
-function getInstanceFeatureIds(runtimeNode, instanceFeatureIdLabel) {
-  const node = runtimeNode.node;
-  const instances = node.instances;
-
-  if (!defined(instances)) {
-    return undefined;
-  }
-
-  const featureIdSet = ModelUtility.getFeatureIdsByLabel(
-    instances.featureIds,
-    instanceFeatureIdLabel,
-  );
-
-  if (!defined(featureIdSet)) {
-    return undefined;
-  }
-
-  let typedArray;
-
-  // Case: FeatureIdAttribute
-  if ("setIndex" in featureIdSet) {
-    const attribute = ModelUtility.getAttributeBySemantic(
-      instances,
-      VertexAttributeSemantic.FEATURE_ID,
-      featureIdSet.setIndex,
+    const computedModelMatrix = Matrix4.multiplyTransformation(
+      modelMatrix,
+      nodeComputedTransform,
+      result.computedModelMatrix,
     );
-    if (defined(attribute)) {
-      typedArray = ModelReader.readAttributeAsTypedArray(attribute);
+
+    result.computedModelMatrix = computedModelMatrix;
+    result.nodeComputedTransform = nodeComputedTransform;
+    result.modelMatrix = modelMatrix;
+    return result;
+  }
+
+  /**
+   * Builds an array of instance transforms for a node.
+   * If the node is not instanced, returns an array containing only the
+   * computedModelMatrix.
+   *
+   * @param {object} runtimeNode The runtime node.
+   * @param {Matrix4} computedModelMatrix The computed model matrix.
+   * @param {Matrix4} nodeComputedTransform The node computed transform.
+   * @param {Matrix4} modelMatrix The model matrix.
+   * @returns {Matrix4[]}
+   */
+  static computeInstanceTransforms(
+    runtimeNode,
+    computedModelMatrix,
+    nodeComputedTransform,
+    modelMatrix,
+  ) {
+    const transforms = [];
+    const node = runtimeNode.node;
+    const instances = node.instances;
+
+    if (defined(instances)) {
+      const transformsCount = instances.attributes[0].count;
+      const instanceComponentDatatype =
+        instances.attributes[0].componentDatatype;
+
+      const transformElements = 12;
+      let transformsTypedArray = runtimeNode.transformsTypedArray;
+
+      if (!defined(transformsTypedArray)) {
+        const instanceTransformsBuffer = runtimeNode.instancingTransformsBuffer;
+        if (defined(instanceTransformsBuffer)) {
+          transformsTypedArray = ComponentDatatype.createTypedArray(
+            instanceComponentDatatype,
+            transformsCount * transformElements,
+          );
+          instanceTransformsBuffer.getBufferData(transformsTypedArray);
+        }
+      }
+
+      if (defined(transformsTypedArray)) {
+        ModelReader.computeInstanceTransformsFromTypedArray(
+          transformsTypedArray,
+          transformsCount,
+          transforms,
+        );
+      } else {
+        ModelReader.computeInstanceTransformsFromAttributes(
+          instances,
+          transformsCount,
+          transforms,
+        );
+      }
+
+      for (let i = 0; i < transforms.length; i++) {
+        const transform = transforms[i];
+        if (instances.transformInWorldSpace) {
+          Matrix4.multiplyTransformation(
+            transform,
+            nodeComputedTransform,
+            transform,
+          );
+          Matrix4.multiplyTransformation(modelMatrix, transform, transform);
+        } else {
+          Matrix4.multiplyTransformation(
+            computedModelMatrix,
+            transform,
+            transform,
+          );
+        }
+      }
+    }
+
+    if (transforms.length === 0) {
+      transforms.push(computedModelMatrix);
+    }
+
+    return transforms;
+  }
+
+  /**
+   * Builds an array of per-instance feature IDs for a node.
+   * If the node is not instanced or has no matching feature ID set,
+   * returns <code>undefined</code>.
+   *
+   * @param {object} runtimeNode The runtime node.
+   * @param {string} instanceFeatureIdLabel The label used to select the feature ID set.
+   * @returns {number[]|undefined} The per-instance feature IDs, or undefined.
+   */
+  static computeInstanceFeatureIds(runtimeNode, instanceFeatureIdLabel) {
+    const node = runtimeNode.node;
+    const instances = node.instances;
+
+    if (!defined(instances)) {
+      return undefined;
+    }
+
+    const featureIdSet = ModelUtility.getFeatureIdsByLabel(
+      instances.featureIds,
+      instanceFeatureIdLabel,
+    );
+
+    if (!defined(featureIdSet)) {
+      return undefined;
+    }
+
+    let typedArray;
+
+    // Case: FeatureIdAttribute
+    if ("setIndex" in featureIdSet) {
+      const attribute = ModelUtility.getAttributeBySemantic(
+        instances,
+        VertexAttributeSemantic.FEATURE_ID,
+        featureIdSet.setIndex,
+      );
+      if (defined(attribute)) {
+        typedArray = ModelReader.readAttributeAsTypedArray(attribute);
+      }
+    }
+
+    // Case: FeatureIdImplicitRange
+    if ("offset" in featureIdSet) {
+      typedArray = ModelReader.readImplicitRangeAsTypedArray(
+        featureIdSet,
+        instances,
+      );
+    }
+
+    if (!defined(typedArray)) {
+      return undefined;
+    }
+
+    const featureIds = new Array(typedArray.length);
+    for (let i = 0; i < typedArray.length; i++) {
+      featureIds[i] = typedArray[i];
+    }
+    return featureIds;
+  }
+
+  /**
+   * Builds instance transforms from a packed typed array where each instance
+   * is stored as 12 floats (3 rows of 4 columns, row-major).
+   *
+   * @param {TypedArray} transformsTypedArray The packed transforms array.
+   * @param {number} count The number of instances.
+   * @param {Matrix4[]} transforms The output array to push transforms into.
+   */
+  static computeInstanceTransformsFromTypedArray(
+    transformsTypedArray,
+    count,
+    transforms,
+  ) {
+    const transformElements = 12;
+    for (let i = 0; i < count; i++) {
+      const index = i * transformElements;
+
+      const transform = new Matrix4(
+        transformsTypedArray[index],
+        transformsTypedArray[index + 1],
+        transformsTypedArray[index + 2],
+        transformsTypedArray[index + 3],
+        transformsTypedArray[index + 4],
+        transformsTypedArray[index + 5],
+        transformsTypedArray[index + 6],
+        transformsTypedArray[index + 7],
+        transformsTypedArray[index + 8],
+        transformsTypedArray[index + 9],
+        transformsTypedArray[index + 10],
+        transformsTypedArray[index + 11],
+        0,
+        0,
+        0,
+        1,
+      );
+
+      transforms.push(transform);
     }
   }
 
-  // Case: FeatureIdImplicitRange
-  if ("offset" in featureIdSet) {
-    typedArray = ModelReader.readImplicitRangeAsTypedArray(
-      featureIdSet,
+  /**
+   * Builds instance transforms from individual TRANSLATION, ROTATION, and SCALE
+   * attributes when no packed transformsTypedArray is available.
+   *
+   * @param {object} instances The instances object.
+   * @param {number} count The number of instances.
+   * @param {Matrix4[]} transforms The output array to push transforms into.
+   */
+  static computeInstanceTransformsFromAttributes(instances, count, transforms) {
+    const translationAttribute = ModelUtility.getAttributeBySemantic(
       instances,
+      InstanceAttributeSemantic.TRANSLATION,
     );
-  }
-
-  if (!defined(typedArray)) {
-    return undefined;
-  }
-
-  const featureIds = new Array(typedArray.length);
-  for (let i = 0; i < typedArray.length; i++) {
-    featureIds[i] = typedArray[i];
-  }
-  return featureIds;
-}
-
-/**
- * Builds instance transforms from a packed typed array where each instance
- * is stored as 12 floats (3 rows of 4 columns, row-major).
- *
- * @param {TypedArray} transformsTypedArray The packed transforms array.
- * @param {number} count The number of instances.
- * @param {Matrix4[]} transforms The output array to push transforms into.
- * @private
- */
-function buildTransformsFromTypedArray(
-  transformsTypedArray,
-  count,
-  transforms,
-) {
-  const transformElements = 12;
-  for (let i = 0; i < count; i++) {
-    const index = i * transformElements;
-
-    const transform = new Matrix4(
-      transformsTypedArray[index],
-      transformsTypedArray[index + 1],
-      transformsTypedArray[index + 2],
-      transformsTypedArray[index + 3],
-      transformsTypedArray[index + 4],
-      transformsTypedArray[index + 5],
-      transformsTypedArray[index + 6],
-      transformsTypedArray[index + 7],
-      transformsTypedArray[index + 8],
-      transformsTypedArray[index + 9],
-      transformsTypedArray[index + 10],
-      transformsTypedArray[index + 11],
-      0,
-      0,
-      0,
-      1,
+    const rotationAttribute = ModelUtility.getAttributeBySemantic(
+      instances,
+      InstanceAttributeSemantic.ROTATION,
+    );
+    const scaleAttribute = ModelUtility.getAttributeBySemantic(
+      instances,
+      InstanceAttributeSemantic.SCALE,
     );
 
-    transforms.push(transform);
-  }
-}
+    const hasTranslation = defined(translationAttribute);
+    const hasRotation = defined(rotationAttribute);
+    const hasScale = defined(scaleAttribute);
 
-/**
- * Builds instance transforms from individual TRANSLATION, ROTATION, and SCALE
- * attributes when no packed transformsTypedArray is available.
- *
- * @param {object} instances The instances object.
- * @param {number} count The number of instances.
- * @param {Matrix4[]} transforms The output array to push transforms into.
- * @private
- */
-function buildTransformsFromAttributes(instances, count, transforms) {
-  const translationAttribute = ModelUtility.getAttributeBySemantic(
-    instances,
-    InstanceAttributeSemantic.TRANSLATION,
-  );
-  const rotationAttribute = ModelUtility.getAttributeBySemantic(
-    instances,
-    InstanceAttributeSemantic.ROTATION,
-  );
-  const scaleAttribute = ModelUtility.getAttributeBySemantic(
-    instances,
-    InstanceAttributeSemantic.SCALE,
-  );
+    if (!hasTranslation && !hasRotation && !hasScale) {
+      return;
+    }
 
-  const hasTranslation = defined(translationAttribute);
-  const hasRotation = defined(rotationAttribute);
-  const hasScale = defined(scaleAttribute);
+    let translationTypedArray, rotationTypedArray, scaleTypedArray;
+    if (hasTranslation) {
+      translationTypedArray =
+        ModelReader.readAttributeAsRawCompactTypedArray(translationAttribute);
+    }
+    if (hasRotation) {
+      rotationTypedArray =
+        ModelReader.readAttributeAsRawCompactTypedArray(rotationAttribute);
+    }
+    if (hasScale) {
+      scaleTypedArray =
+        ModelReader.readAttributeAsRawCompactTypedArray(scaleAttribute);
+    }
 
-  if (!hasTranslation && !hasRotation && !hasScale) {
-    return;
-  }
+    for (let i = 0; i < count; i++) {
+      const translation = hasTranslation
+        ? new Cartesian3(
+            translationTypedArray[i * 3],
+            translationTypedArray[i * 3 + 1],
+            translationTypedArray[i * 3 + 2],
+          )
+        : Cartesian3.ZERO;
 
-  let translationTypedArray, rotationTypedArray, scaleTypedArray;
-  if (hasTranslation) {
-    translationTypedArray =
-      ModelReader.readAttributeAsRawCompactTypedArray(translationAttribute);
-  }
-  if (hasRotation) {
-    rotationTypedArray =
-      ModelReader.readAttributeAsRawCompactTypedArray(rotationAttribute);
-  }
-  if (hasScale) {
-    scaleTypedArray =
-      ModelReader.readAttributeAsRawCompactTypedArray(scaleAttribute);
-  }
+      const rotation = hasRotation
+        ? new Quaternion(
+            rotationTypedArray[i * 4],
+            rotationTypedArray[i * 4 + 1],
+            rotationTypedArray[i * 4 + 2],
+            rotationTypedArray[i * 4 + 3],
+          )
+        : Quaternion.IDENTITY;
 
-  for (let i = 0; i < count; i++) {
-    const translation = hasTranslation
-      ? new Cartesian3(
-          translationTypedArray[i * 3],
-          translationTypedArray[i * 3 + 1],
-          translationTypedArray[i * 3 + 2],
-        )
-      : Cartesian3.ZERO;
+      const scale = hasScale
+        ? new Cartesian3(
+            scaleTypedArray[i * 3],
+            scaleTypedArray[i * 3 + 1],
+            scaleTypedArray[i * 3 + 2],
+          )
+        : Cartesian3.ONE;
 
-    const rotation = hasRotation
-      ? new Quaternion(
-          rotationTypedArray[i * 4],
-          rotationTypedArray[i * 4 + 1],
-          rotationTypedArray[i * 4 + 2],
-          rotationTypedArray[i * 4 + 3],
-        )
-      : Quaternion.IDENTITY;
+      const transform = Matrix4.fromTranslationQuaternionRotationScale(
+        translation,
+        rotation,
+        scale,
+        new Matrix4(),
+      );
 
-    const scale = hasScale
-      ? new Cartesian3(
-          scaleTypedArray[i * 3],
-          scaleTypedArray[i * 3 + 1],
-          scaleTypedArray[i * 3 + 2],
-        )
-      : Cartesian3.ONE;
-
-    const transform = Matrix4.fromTranslationQuaternionRotationScale(
-      translation,
-      rotation,
-      scale,
-      new Matrix4(),
-    );
-
-    transforms.push(transform);
+      transforms.push(transform);
+    }
   }
 }
 

--- a/packages/engine/Source/Scene/Model/pickModel.js
+++ b/packages/engine/Source/Scene/Model/pickModel.js
@@ -1,30 +1,45 @@
-import AttributeCompression from "../../Core/AttributeCompression.js";
 import BoundingSphere from "../../Core/BoundingSphere.js";
 import Cartesian3 from "../../Core/Cartesian3.js";
 import Cartographic from "../../Core/Cartographic.js";
 import Check from "../../Core/Check.js";
-import ComponentDatatype from "../../Core/ComponentDatatype.js";
 import defined from "../../Core/defined.js";
 import Ellipsoid from "../../Core/Ellipsoid.js";
-import IndexDatatype from "../../Core/IndexDatatype.js";
 import IntersectionTests from "../../Core/IntersectionTests.js";
-import Ray from "../../Core/Ray.js";
 import Matrix4 from "../../Core/Matrix4.js";
-import Transforms from "../../Core/Transforms.js";
+import Ray from "../../Core/Ray.js";
 import VerticalExaggeration from "../../Core/VerticalExaggeration.js";
 import AttributeType from "../AttributeType.js";
 import SceneMode from "../SceneMode.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
+import ModelReader from "./ModelReader.js";
 import ModelUtility from "./ModelUtility.js";
 
 const scratchV0 = new Cartesian3();
 const scratchV1 = new Cartesian3();
 const scratchV2 = new Cartesian3();
-const scratchNodeComputedTransform = new Matrix4();
-const scratchModelMatrix = new Matrix4();
-const scratchcomputedModelMatrix = new Matrix4();
+const scratchV0_t = new Cartesian3();
+const scratchV1_t = new Cartesian3();
+const scratchV2_t = new Cartesian3();
 const scratchPickCartographic = new Cartographic();
 const scratchBoundingSphere = new BoundingSphere();
+
+/**
+ * Reads a 3D position from a flat vertex array at the given element index.
+ *
+ * @param {TypedArray} vertices The flat array of vertex components.
+ * @param {number} index The vertex index (element index, not byte offset).
+ * @param {number} elementStride The number of components per vertex element.
+ * @param {Cartesian3} result The object into which to store the position.
+ * @returns {Cartesian3} The modified result parameter.
+ * @private
+ */
+function readPosition(vertices, index, elementStride, result) {
+  const i = index * elementStride;
+  result.x = vertices[i];
+  result.y = vertices[i + 1];
+  result.z = vertices[i + 2];
+  return result;
+}
 
 /**
  * Find an intersection between a ray and the model surface that was rendered. The ray must be given in world coordinates.
@@ -60,125 +75,22 @@ export default function pickModel(
   }
 
   let minT = Number.MAX_VALUE;
-  const sceneGraph = model.sceneGraph;
 
-  const nodes = sceneGraph._runtimeNodes;
-  for (let i = 0; i < nodes.length; i++) {
-    const runtimeNode = nodes[i];
-    const node = runtimeNode.node;
+  ellipsoid = ellipsoid ?? Ellipsoid.default;
+  verticalExaggeration = verticalExaggeration ?? 1.0;
+  relativeHeight = relativeHeight ?? 0.0;
 
-    let nodeComputedTransform = Matrix4.clone(
-      runtimeNode.computedTransform,
-      scratchNodeComputedTransform,
-    );
-    let modelMatrix = Matrix4.clone(
-      sceneGraph.computedModelMatrix,
-      scratchModelMatrix,
-    );
+  const mapProjection =
+    frameState.mode !== SceneMode.SCENE3D
+      ? frameState.mapProjection
+      : undefined;
 
-    const instances = node.instances;
-    if (defined(instances)) {
-      if (instances.transformInWorldSpace) {
-        // Replicate the multiplication order in LegacyInstancingStageVS.
-        modelMatrix = Matrix4.multiplyTransformation(
-          model.modelMatrix,
-          sceneGraph.components.transform,
-          modelMatrix,
-        );
-
-        nodeComputedTransform = Matrix4.multiplyTransformation(
-          sceneGraph.axisCorrectionMatrix,
-          runtimeNode.computedTransform,
-          nodeComputedTransform,
-        );
-      }
-    }
-
-    let computedModelMatrix = Matrix4.multiplyTransformation(
-      modelMatrix,
-      nodeComputedTransform,
-      scratchcomputedModelMatrix,
-    );
-
-    if (frameState.mode !== SceneMode.SCENE3D) {
-      computedModelMatrix = Transforms.basisTo2D(
-        frameState.mapProjection,
-        computedModelMatrix,
-        computedModelMatrix,
-      );
-    }
-
-    const transforms = [];
-    if (defined(instances)) {
-      const transformsCount = instances.attributes[0].count;
-      const instanceComponentDatatype =
-        instances.attributes[0].componentDatatype;
-
-      const transformElements = 12;
-      let transformsTypedArray = runtimeNode.transformsTypedArray;
-      if (!defined(transformsTypedArray)) {
-        const instanceTransformsBuffer = runtimeNode.instancingTransformsBuffer;
-        if (defined(instanceTransformsBuffer) && frameState.context.webgl2) {
-          transformsTypedArray = ComponentDatatype.createTypedArray(
-            instanceComponentDatatype,
-            transformsCount * transformElements,
-          );
-          instanceTransformsBuffer.getBufferData(transformsTypedArray);
-        }
-      }
-
-      if (defined(transformsTypedArray)) {
-        for (let i = 0; i < transformsCount; i++) {
-          const index = i * transformElements;
-
-          const transform = new Matrix4(
-            transformsTypedArray[index],
-            transformsTypedArray[index + 1],
-            transformsTypedArray[index + 2],
-            transformsTypedArray[index + 3],
-            transformsTypedArray[index + 4],
-            transformsTypedArray[index + 5],
-            transformsTypedArray[index + 6],
-            transformsTypedArray[index + 7],
-            transformsTypedArray[index + 8],
-            transformsTypedArray[index + 9],
-            transformsTypedArray[index + 10],
-            transformsTypedArray[index + 11],
-            0,
-            0,
-            0,
-            1,
-          );
-
-          if (instances.transformInWorldSpace) {
-            Matrix4.multiplyTransformation(
-              transform,
-              nodeComputedTransform,
-              transform,
-            );
-            Matrix4.multiplyTransformation(modelMatrix, transform, transform);
-          } else {
-            Matrix4.multiplyTransformation(
-              transform,
-              computedModelMatrix,
-              transform,
-            );
-          }
-          transforms.push(transform);
-        }
-      }
-    }
-
-    if (transforms.length === 0) {
-      transforms.push(computedModelMatrix);
-    }
-
-    const primitivesLength = runtimeNode.runtimePrimitives.length;
-    for (let j = 0; j < primitivesLength; j++) {
-      const runtimePrimitive = runtimeNode.runtimePrimitives[j];
-      const primitive = runtimePrimitive.primitive;
-
-      if (defined(runtimePrimitive.boundingSphere) && !defined(instances)) {
+  ModelReader.forEachPrimitive(
+    model,
+    { mapProjection: mapProjection },
+    function (runtimePrimitive, primitive, instances, computedModelMatrix) {
+      // Bounding sphere early-out for non-instanced primitives
+      if (defined(runtimePrimitive.boundingSphere) && instances.length === 1) {
         const boundingSphere = BoundingSphere.transform(
           runtimePrimitive.boundingSphere,
           computedModelMatrix,
@@ -189,99 +101,36 @@ export default function pickModel(
           boundingSphere,
         );
         if (!defined(boundsIntersection)) {
-          continue;
+          return;
         }
       }
 
+      if (!defined(primitive.indices)) {
+        // Point clouds
+        return;
+      }
+
+      let vertices;
+      let numPosComponents;
       const positionAttribute = ModelUtility.getAttributeBySemantic(
         primitive,
         VertexAttributeSemantic.POSITION,
       );
-      const byteOffset = positionAttribute.byteOffset;
-      const byteStride = positionAttribute.byteStride;
-      const vertexCount = positionAttribute.count;
-
-      if (!defined(primitive.indices)) {
-        // Point clouds
-        continue;
+      if (defined(positionAttribute)) {
+        numPosComponents = AttributeType.getNumberOfComponents(
+          positionAttribute.type,
+        );
+        vertices = ModelReader.readAttributeAsTypedArray(positionAttribute);
       }
 
-      let indices = primitive.indices.typedArray;
-      if (!defined(indices)) {
-        const indicesBuffer = primitive.indices.buffer;
-        const indicesCount = primitive.indices.count;
-        const indexDatatype = primitive.indices.indexDatatype;
-        if (defined(indicesBuffer) && frameState.context.webgl2) {
-          if (indexDatatype === IndexDatatype.UNSIGNED_BYTE) {
-            indices = new Uint8Array(indicesCount);
-          } else if (indexDatatype === IndexDatatype.UNSIGNED_SHORT) {
-            indices = new Uint16Array(indicesCount);
-          } else if (indexDatatype === IndexDatatype.UNSIGNED_INT) {
-            indices = new Uint32Array(indicesCount);
-          }
-
-          indicesBuffer.getBufferData(indices);
-        }
-      }
-
-      let vertices = positionAttribute.typedArray;
-      let componentDatatype = positionAttribute.componentDatatype;
-      let attributeType = positionAttribute.type;
-
-      const quantization = positionAttribute.quantization;
-      if (defined(quantization)) {
-        componentDatatype = positionAttribute.quantization.componentDatatype;
-        attributeType = positionAttribute.quantization.type;
-      }
-
-      const numComponents = AttributeType.getNumberOfComponents(attributeType);
-      const bytes = ComponentDatatype.getSizeInBytes(componentDatatype);
-      const isInterleaved =
-        !defined(vertices) &&
-        defined(byteStride) &&
-        byteStride !== numComponents * bytes;
-
-      let elementStride = numComponents;
-      let offset = 0;
-      if (isInterleaved) {
-        elementStride = byteStride / bytes;
-        offset = byteOffset / bytes;
-      }
-      const elementCount = vertexCount * elementStride;
-
-      if (!defined(vertices)) {
-        const verticesBuffer = positionAttribute.buffer;
-
-        if (defined(verticesBuffer) && frameState.context.webgl2) {
-          vertices = ComponentDatatype.createTypedArray(
-            componentDatatype,
-            elementCount,
-          );
-          verticesBuffer.getBufferData(
-            vertices,
-            isInterleaved ? 0 : byteOffset,
-            0,
-            elementCount,
-          );
-        }
-
-        if (quantization && positionAttribute.normalized) {
-          vertices = AttributeCompression.dequantize(
-            vertices,
-            componentDatatype,
-            attributeType,
-            vertexCount,
-          );
-        }
+      let indices;
+      if (defined(primitive.indices)) {
+        indices = ModelReader.readIndicesAsTypedArray(primitive.indices);
       }
 
       if (!defined(indices) || !defined(vertices)) {
         return;
       }
-
-      ellipsoid = ellipsoid ?? Ellipsoid.default;
-      verticalExaggeration = verticalExaggeration ?? 1.0;
-      relativeHeight = relativeHeight ?? 0.0;
 
       const indicesLength = indices.length;
       for (let i = 0; i < indicesLength; i += 3) {
@@ -289,43 +138,50 @@ export default function pickModel(
         const i1 = indices[i + 1];
         const i2 = indices[i + 2];
 
-        for (const instanceTransform of transforms) {
-          const v0 = getVertexPosition(
-            vertices,
-            i0,
-            offset,
-            elementStride,
-            quantization,
-            instanceTransform,
-            verticalExaggeration,
-            relativeHeight,
-            ellipsoid,
+        readPosition(vertices, i0, numPosComponents, scratchV0);
+        readPosition(vertices, i1, numPosComponents, scratchV1);
+        readPosition(vertices, i2, numPosComponents, scratchV2);
+
+        for (const instance of instances) {
+          const v0 = Matrix4.multiplyByPoint(
+            instance.transform,
             scratchV0,
+            scratchV0_t,
           );
-          const v1 = getVertexPosition(
-            vertices,
-            i1,
-            offset,
-            elementStride,
-            quantization,
-            instanceTransform,
-            verticalExaggeration,
-            relativeHeight,
-            ellipsoid,
+          const v1 = Matrix4.multiplyByPoint(
+            instance.transform,
             scratchV1,
+            scratchV1_t,
           );
-          const v2 = getVertexPosition(
-            vertices,
-            i2,
-            offset,
-            elementStride,
-            quantization,
-            instanceTransform,
-            verticalExaggeration,
-            relativeHeight,
-            ellipsoid,
+          const v2 = Matrix4.multiplyByPoint(
+            instance.transform,
             scratchV2,
+            scratchV2_t,
           );
+
+          if (verticalExaggeration !== 1.0) {
+            VerticalExaggeration.getPosition(
+              v0,
+              ellipsoid,
+              verticalExaggeration,
+              relativeHeight,
+              v0,
+            );
+            VerticalExaggeration.getPosition(
+              v1,
+              ellipsoid,
+              verticalExaggeration,
+              relativeHeight,
+              v1,
+            );
+            VerticalExaggeration.getPosition(
+              v2,
+              ellipsoid,
+              verticalExaggeration,
+              relativeHeight,
+              v2,
+            );
+          }
 
           const t = IntersectionTests.rayTriangleParametric(
             ray,
@@ -342,8 +198,8 @@ export default function pickModel(
           }
         }
       }
-    }
-  }
+    },
+  );
 
   if (minT === Number.MAX_VALUE) {
     return undefined;
@@ -358,67 +214,6 @@ export default function pickModel(
 
     const cartographic = projection.unproject(result, scratchPickCartographic);
     ellipsoid.cartographicToCartesian(cartographic, result);
-  }
-
-  return result;
-}
-
-function getVertexPosition(
-  vertices,
-  index,
-  offset,
-  numElements,
-  quantization,
-  instanceTransform,
-  verticalExaggeration,
-  relativeHeight,
-  ellipsoid,
-  result,
-) {
-  const i = offset + index * numElements;
-  result.x = vertices[i];
-  result.y = vertices[i + 1];
-  result.z = vertices[i + 2];
-
-  if (defined(quantization)) {
-    if (quantization.octEncoded) {
-      result = AttributeCompression.octDecodeInRange(
-        result,
-        quantization.normalizationRange,
-        result,
-      );
-
-      if (quantization.octEncodedZXY) {
-        const x = result.x;
-        result.x = result.z;
-        result.z = result.y;
-        result.y = x;
-      }
-    } else {
-      result = Cartesian3.multiplyComponents(
-        result,
-        quantization.quantizedVolumeStepSize,
-        result,
-      );
-
-      result = Cartesian3.add(
-        result,
-        quantization.quantizedVolumeOffset,
-        result,
-      );
-    }
-  }
-
-  result = Matrix4.multiplyByPoint(instanceTransform, result, result);
-
-  if (verticalExaggeration !== 1.0) {
-    VerticalExaggeration.getPosition(
-      result,
-      ellipsoid,
-      verticalExaggeration,
-      relativeHeight,
-      result,
-    );
   }
 
   return result;

--- a/packages/engine/Specs/Scene/Model/ModelReaderSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelReaderSpec.js
@@ -1,12 +1,20 @@
 import {
   Model,
+  ModelComponents,
   ModelUtility,
   ResourceCache,
   Math as CesiumMath,
+  AttributeCompression,
+  AttributeType,
   Cartesian2,
   Cartesian3,
+  ComponentDatatype,
+  Ellipsoid,
+  GeographicProjection,
+  IndexDatatype,
   Matrix4,
   ModelReader,
+  Quaternion,
   TranslationRotationScale,
 } from "../../../index.js";
 
@@ -436,6 +444,2159 @@ describe(
           `Expected ${actualName} to contain the same geometry as ${expectedName}`,
         )
         .toBeTrue();
+    });
+
+    describe("readAttributeAsTypedArray", function () {
+      /**
+       * Creates a mock buffer that serves the given data from getBufferData.
+       * @param {TypedArray} data The backing data
+       * @returns {object} A mock buffer object
+       */
+      function createMockBuffer(data) {
+        const bytes = new Uint8Array(
+          data.buffer,
+          data.byteOffset,
+          data.byteLength,
+        );
+        return {
+          sizeInBytes: bytes.byteLength,
+          getBufferData: function (outputArray, srcByteOffset) {
+            srcByteOffset = srcByteOffset ?? 0;
+            if (outputArray instanceof Uint8Array) {
+              outputArray.set(bytes);
+            } else {
+              const srcView = new DataView(
+                bytes.buffer,
+                bytes.byteOffset,
+                bytes.byteLength,
+              );
+              const bytesPerElement = outputArray.BYTES_PER_ELEMENT;
+              for (let i = 0; i < outputArray.length; i++) {
+                const byteIdx = srcByteOffset + i * bytesPerElement;
+                if (outputArray instanceof Float32Array) {
+                  outputArray[i] = srcView.getFloat32(byteIdx, true);
+                } else if (outputArray instanceof Uint16Array) {
+                  outputArray[i] = srcView.getUint16(byteIdx, true);
+                } else if (outputArray instanceof Uint8Array) {
+                  outputArray[i] = srcView.getUint8(byteIdx);
+                } else if (outputArray instanceof Int8Array) {
+                  outputArray[i] = srcView.getInt8(byteIdx);
+                } else if (outputArray instanceof Int16Array) {
+                  outputArray[i] = srcView.getInt16(byteIdx, true);
+                } else if (outputArray instanceof Uint32Array) {
+                  outputArray[i] = srcView.getUint32(byteIdx, true);
+                } else if (outputArray instanceof Float64Array) {
+                  outputArray[i] = srcView.getFloat64(byteIdx, true);
+                }
+              }
+            }
+          },
+        };
+      }
+
+      /**
+       * Creates a mock attribute with sensible defaults.
+       */
+      function createAttribute(options) {
+        return Object.assign(
+          {
+            type: AttributeType.VEC3,
+            count: 0,
+            componentDatatype: ComponentDatatype.FLOAT,
+            normalized: false,
+            quantization: undefined,
+            byteOffset: 0,
+            byteStride: undefined,
+            buffer: undefined,
+          },
+          options,
+        );
+      }
+
+      it("returns compact float data for a simple VEC3 FLOAT attribute", function () {
+        const data = new Float32Array([1, 2, 3, 4, 5, 6]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(1);
+        expect(result[1]).toBe(2);
+        expect(result[2]).toBe(3);
+        expect(result[3]).toBe(4);
+        expect(result[4]).toBe(5);
+        expect(result[5]).toBe(6);
+      });
+
+      it("returns compact float data for a VEC2 FLOAT attribute", function () {
+        const data = new Float32Array([10, 20, 30, 40]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC2,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result.length).toBe(4);
+        expect(result[0]).toBe(10);
+        expect(result[1]).toBe(20);
+        expect(result[2]).toBe(30);
+        expect(result[3]).toBe(40);
+      });
+
+      it("returns compact data for a SCALAR FLOAT attribute", function () {
+        const data = new Float32Array([7, 8, 9]);
+        const attribute = createAttribute({
+          type: AttributeType.SCALAR,
+          count: 3,
+          componentDatatype: ComponentDatatype.FLOAT,
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(7);
+        expect(result[1]).toBe(8);
+        expect(result[2]).toBe(9);
+      });
+
+      it("deinterleaves data when byteStride exceeds default", function () {
+        // VEC3 FLOAT: 3 components * 4 bytes = 12 bytes default stride
+        // Set byteStride to 24 to simulate interleaving with 12 bytes of padding
+        // Layout: [x0, y0, z0, pad, pad, pad, x1, y1, z1, pad, pad, pad]
+        const interleaved = new Float32Array([
+          1, 2, 3, 99, 99, 99, 4, 5, 6, 99, 99, 99,
+        ]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteStride: 24,
+          byteOffset: 0,
+          buffer: createMockBuffer(interleaved),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(1);
+        expect(result[1]).toBe(2);
+        expect(result[2]).toBe(3);
+        expect(result[3]).toBe(4);
+        expect(result[4]).toBe(5);
+        expect(result[5]).toBe(6);
+      });
+
+      it("respects byteOffset when deinterleaving", function () {
+        // VEC3 FLOAT with byteStride=24, byteOffset=12
+        // Layout per element: [pad, pad, pad, x, y, z]
+        const interleaved = new Float32Array([
+          99, 99, 99, 10, 20, 30, 99, 99, 99, 40, 50, 60,
+        ]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteStride: 24,
+          byteOffset: 12,
+          buffer: createMockBuffer(interleaved),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(10);
+        expect(result[1]).toBe(20);
+        expect(result[2]).toBe(30);
+        expect(result[3]).toBe(40);
+        expect(result[4]).toBe(50);
+        expect(result[5]).toBe(60);
+      });
+
+      it("applies normalization to UNSIGNED_BYTE data", function () {
+        // UNSIGNED_BYTE VEC3, normalized
+        // Values 0 and 255 should map to 0.0 and 1.0
+        const data = new Uint8Array([0, 128, 255, 255, 0, 128]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+          normalized: true,
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(6);
+        expect(result[0]).toBeCloseTo(0.0, 5);
+        expect(result[2]).toBeCloseTo(1.0, 5);
+        expect(result[3]).toBeCloseTo(1.0, 5);
+        expect(result[4]).toBeCloseTo(0.0, 5);
+      });
+
+      it("applies normalization to UNSIGNED_SHORT data", function () {
+        const data = new Uint16Array([0, 65535, 32768]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+          normalized: true,
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBeCloseTo(0.0, 5);
+        expect(result[1]).toBeCloseTo(1.0, 5);
+        expect(result[2]).toBeCloseTo(32768 / 65535, 3);
+      });
+
+      it("dequantizes VEC3 data with stepSize and offset", function () {
+        // Quantized VEC3: value * stepSize + offset
+        const data = new Uint16Array([100, 200, 300]);
+        const stepSize = new Cartesian3(0.01, 0.02, 0.03);
+        const offset = new Cartesian3(1, 2, 3);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            type: AttributeType.VEC3,
+            octEncoded: false,
+            quantizedVolumeStepSize: stepSize,
+            quantizedVolumeOffset: offset,
+          },
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        // 100 * 0.01 + 1 = 2.0
+        expect(result[0]).toBeCloseTo(2.0, 3);
+        // 200 * 0.02 + 2 = 6.0
+        expect(result[1]).toBeCloseTo(6.0, 3);
+        // 300 * 0.03 + 3 = 12.0
+        expect(result[2]).toBeCloseTo(12.0, 3);
+      });
+
+      it("dequantizes VEC2 data with stepSize and offset", function () {
+        const data = new Uint16Array([10, 20, 30, 40]);
+        const stepSize = new Cartesian2(0.1, 0.2);
+        const offset = new Cartesian2(5, 10);
+        const attribute = createAttribute({
+          type: AttributeType.VEC2,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            type: AttributeType.VEC2,
+            octEncoded: false,
+            quantizedVolumeStepSize: stepSize,
+            quantizedVolumeOffset: offset,
+          },
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(4);
+        // 10 * 0.1 + 5 = 6.0
+        expect(result[0]).toBeCloseTo(6.0, 3);
+        // 20 * 0.2 + 10 = 14.0
+        expect(result[1]).toBeCloseTo(14.0, 3);
+      });
+
+      it("dequantizes SCALAR data with stepSize and offset", function () {
+        const data = new Uint16Array([100, 200]);
+        const attribute = createAttribute({
+          type: AttributeType.SCALAR,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            type: AttributeType.SCALAR,
+            octEncoded: false,
+            quantizedVolumeStepSize: 0.5,
+            quantizedVolumeOffset: 10,
+          },
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(2);
+        // 100 * 0.5 + 10 = 60.0
+        expect(result[0]).toBeCloseTo(60.0, 3);
+        // 200 * 0.5 + 10 = 110.0
+        expect(result[1]).toBeCloseTo(110.0, 3);
+      });
+
+      it("oct-decodes quantized normals", function () {
+        // Create oct-encoded normals: encode (0, 0, 1) to see if it decodes back
+        const normal = new Cartesian3(0, 0, 1);
+        const range = 255;
+        const encodedC2 = AttributeCompression.octEncodeInRange(
+          normal,
+          range,
+          new Cartesian2(),
+        );
+        const encodedData = new Uint8Array([encodedC2.x, encodedC2.y, 0]);
+
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+            type: AttributeType.VEC3,
+            octEncoded: true,
+            octEncodedZXY: false,
+            normalizationRange: range,
+          },
+          buffer: createMockBuffer(encodedData),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        // The decoded normal should be approximately (0, 0, 1)
+        const decodedNormal = new Cartesian3(result[0], result[1], result[2]);
+        expect(
+          Cartesian3.equalsEpsilon(decodedNormal, normal, CesiumMath.EPSILON2),
+        ).toBe(true);
+      });
+
+      it("returns data without normalization or dequantization when neither is set", function () {
+        const data = new Float32Array([1.5, 2.5, 3.5]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          normalized: false,
+          quantization: undefined,
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result[0]).toBe(1.5);
+        expect(result[1]).toBe(2.5);
+        expect(result[2]).toBe(3.5);
+      });
+
+      it("reads UNSIGNED_SHORT data without normalization", function () {
+        const data = new Uint16Array([100, 200, 300, 400, 500, 600]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Uint16Array);
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(100);
+        expect(result[5]).toBe(600);
+      });
+
+      it("uses quantized componentDatatype for raw read when quantization is present", function () {
+        // Attribute says FLOAT but quantization says UNSIGNED_SHORT
+        // The raw read should use UNSIGNED_SHORT
+        const data = new Uint16Array([10, 20, 30]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            type: AttributeType.VEC3,
+            octEncoded: false,
+            quantizedVolumeStepSize: new Cartesian3(1, 1, 1),
+            quantizedVolumeOffset: new Cartesian3(0, 0, 0),
+          },
+          buffer: createMockBuffer(data),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        // After dequantization: value * 1 + 0 = value, as Float32Array
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBeCloseTo(10, 3);
+        expect(result[1]).toBeCloseTo(20, 3);
+        expect(result[2]).toBeCloseTo(30, 3);
+      });
+
+      it("applies normalization to UNSIGNED_BYTE typedArray data", function () {
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+          normalized: true,
+          typedArray: new Uint8Array([0, 128, 255, 255, 0, 128]),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(6);
+        expect(result[0]).toBeCloseTo(0.0, 5);
+        expect(result[2]).toBeCloseTo(1.0, 5);
+        expect(result[3]).toBeCloseTo(1.0, 5);
+        expect(result[4]).toBeCloseTo(0.0, 5);
+      });
+
+      it("applies normalization to UNSIGNED_SHORT typedArray data", function () {
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+          normalized: true,
+          typedArray: new Uint16Array([0, 65535, 32768]),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBeCloseTo(0.0, 5);
+        expect(result[1]).toBeCloseTo(1.0, 5);
+        expect(result[2]).toBeCloseTo(32768 / 65535, 3);
+      });
+
+      it("dequantizes VEC3 typedArray data with stepSize and offset", function () {
+        const stepSize = new Cartesian3(0.01, 0.02, 0.03);
+        const offset = new Cartesian3(1, 2, 3);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            type: AttributeType.VEC3,
+            octEncoded: false,
+            quantizedVolumeStepSize: stepSize,
+            quantizedVolumeOffset: offset,
+          },
+          typedArray: new Uint16Array([100, 200, 300]),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBeCloseTo(2.0, 3);
+        expect(result[1]).toBeCloseTo(6.0, 3);
+        expect(result[2]).toBeCloseTo(12.0, 3);
+      });
+
+      it("dequantizes SCALAR typedArray data with stepSize and offset", function () {
+        const attribute = createAttribute({
+          type: AttributeType.SCALAR,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            type: AttributeType.SCALAR,
+            octEncoded: false,
+            quantizedVolumeStepSize: 0.5,
+            quantizedVolumeOffset: 10,
+          },
+          typedArray: new Uint16Array([100, 200]),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(2);
+        expect(result[0]).toBeCloseTo(60.0, 3);
+        expect(result[1]).toBeCloseTo(110.0, 3);
+      });
+
+      it("oct-decodes quantized normals from typedArray", function () {
+        const normal = new Cartesian3(0, 0, 1);
+        const range = 255;
+        const encodedC2 = AttributeCompression.octEncodeInRange(
+          normal,
+          range,
+          new Cartesian2(),
+        );
+
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+            type: AttributeType.VEC3,
+            octEncoded: true,
+            octEncodedZXY: false,
+            normalizationRange: range,
+          },
+          typedArray: new Uint8Array([encodedC2.x, encodedC2.y, 0]),
+        });
+
+        const result = ModelReader.readAttributeAsTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        const decodedNormal = new Cartesian3(result[0], result[1], result[2]);
+        expect(
+          Cartesian3.equalsEpsilon(decodedNormal, normal, CesiumMath.EPSILON2),
+        ).toBe(true);
+      });
+    });
+
+    describe("readAttributeAsRawCompactTypedArray", function () {
+      function createAttribute(options) {
+        return Object.assign(
+          {
+            type: AttributeType.VEC3,
+            count: 0,
+            componentDatatype: ComponentDatatype.FLOAT,
+            normalized: false,
+            quantization: undefined,
+            byteOffset: 0,
+            byteStride: undefined,
+            buffer: undefined,
+            typedArray: undefined,
+          },
+          options,
+        );
+      }
+
+      // A buffer whose getBufferData must never be called.
+      // Provided alongside typedArray to verify typedArray is preferred.
+      function createUnreachableBuffer() {
+        return {
+          sizeInBytes: 0,
+          getBufferData: function () {
+            fail(
+              "getBufferData should not be called when typedArray is defined",
+            );
+          },
+        };
+      }
+
+      /**
+       * Creates a mock buffer that serves the given data from getBufferData.
+       * @param {TypedArray} data The backing data
+       * @returns {object} A mock buffer object
+       */
+      function createMockBuffer(data) {
+        const bytes = new Uint8Array(
+          data.buffer,
+          data.byteOffset,
+          data.byteLength,
+        );
+        return {
+          sizeInBytes: bytes.byteLength,
+          getBufferData: function (outputArray, srcByteOffset) {
+            srcByteOffset = srcByteOffset ?? 0;
+            if (outputArray instanceof Uint8Array) {
+              outputArray.set(bytes);
+            } else {
+              const srcView = new DataView(
+                bytes.buffer,
+                bytes.byteOffset,
+                bytes.byteLength,
+              );
+              const bytesPerElement = outputArray.BYTES_PER_ELEMENT;
+              for (let i = 0; i < outputArray.length; i++) {
+                const byteIdx = srcByteOffset + i * bytesPerElement;
+                if (outputArray instanceof Float32Array) {
+                  outputArray[i] = srcView.getFloat32(byteIdx, true);
+                } else if (outputArray instanceof Uint16Array) {
+                  outputArray[i] = srcView.getUint16(byteIdx, true);
+                } else if (outputArray instanceof Int8Array) {
+                  outputArray[i] = srcView.getInt8(byteIdx);
+                } else if (outputArray instanceof Int16Array) {
+                  outputArray[i] = srcView.getInt16(byteIdx, true);
+                } else if (outputArray instanceof Uint32Array) {
+                  outputArray[i] = srcView.getUint32(byteIdx, true);
+                } else if (outputArray instanceof Float64Array) {
+                  outputArray[i] = srcView.getFloat64(byteIdx, true);
+                }
+              }
+            }
+          },
+        };
+      }
+
+      // --- Tests for typedArray (prefered over buffer if defined) ---
+
+      it("returns attribute.typedArray directly when byteOffset is 0 and stride is default", function () {
+        const typedArray = new Float32Array([1, 2, 3, 4, 5, 6]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 0,
+          typedArray: typedArray,
+          buffer: createUnreachableBuffer(),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        // Should be the exact same reference
+        expect(result).toBe(typedArray);
+      });
+
+      it("returns attribute.typedArray directly when byteOffset is undefined and stride is default", function () {
+        const typedArray = new Float32Array([10, 20, 30]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: undefined,
+          typedArray: typedArray,
+          buffer: createUnreachableBuffer(),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBe(typedArray);
+      });
+
+      it("returns attribute.typedArray directly when byteOffset is non-zero and stride is default", function () {
+        const typedArray = new Float32Array([1, 2, 3, 4, 5, 6]); // typedArray should always be tightly-packed
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 12, // should be ignored as typedArray is already unpacked
+          typedArray: typedArray,
+          buffer: createUnreachableBuffer(),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        // Should be the same reference
+        expect(result).toBe(typedArray);
+      });
+
+      it("returns attribute.typedArray directly when byteOffset is zero and stride is non-zero", function () {
+        const typedArray = new Float32Array([1, 2, 3, 4, 5, 6]); // typedArray should always be tightly-packed
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteStride: 24, // should be ignored as typedArray is already unpacked
+          byteOffset: 0,
+          typedArray: typedArray,
+          buffer: createUnreachableBuffer(),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        // Should be the same reference
+        expect(result).toBe(typedArray);
+      });
+
+      it("returns attribute.typedArray directly when byteOffset is non-zero and stride is non-zero", function () {
+        const typedArray = new Float32Array([1, 2, 3, 4, 5, 6]); // typedArray should always be tightly-packed
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteStride: 24, // should be ignored as typedArray is already unpacked
+          byteOffset: 12, // should be ignored as typedArray is already unpacked
+          typedArray: typedArray,
+          buffer: createUnreachableBuffer(),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        // Should be the same reference
+        expect(result).toBe(typedArray);
+      });
+
+      it("uses quantized componentDatatype when reading from typedArray", function () {
+        // Attribute says FLOAT but quantization says UNSIGNED_SHORT
+        const typedArray = new Uint16Array([10, 20, 30]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 0,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+          },
+          typedArray: typedArray,
+          buffer: createUnreachableBuffer(),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        // Should return the typedArray directly (zero offset, default stride)
+        expect(result).toBe(typedArray);
+      });
+
+      it("handles SCALAR FLOAT typedArray returned directly", function () {
+        const typedArray = new Float32Array([7, 8, 9]);
+        const attribute = createAttribute({
+          type: AttributeType.SCALAR,
+          count: 3,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 0,
+          typedArray: typedArray,
+          buffer: createUnreachableBuffer(),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBe(typedArray);
+      });
+
+      // --- Tests for getBufferData (typedArray is undefined) ---
+
+      it("reads VEC3 FLOAT from buffer when typedArray is undefined", function () {
+        const data = new Float32Array([1, 2, 3, 4, 5, 6]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 0,
+          buffer: createMockBuffer(data),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(1);
+        expect(result[1]).toBe(2);
+        expect(result[2]).toBe(3);
+        expect(result[3]).toBe(4);
+        expect(result[4]).toBe(5);
+        expect(result[5]).toBe(6);
+      });
+
+      it("reads from buffer with non-zero byteOffset and default stride", function () {
+        // Buffer contains 3 extra floats at the start, then the real data
+        const data = new Float32Array([99, 99, 99, 1, 2, 3, 4, 5, 6]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 12, // skip 3 floats * 4 bytes
+          buffer: createMockBuffer(data),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(1);
+        expect(result[1]).toBe(2);
+        expect(result[2]).toBe(3);
+        expect(result[3]).toBe(4);
+        expect(result[4]).toBe(5);
+        expect(result[5]).toBe(6);
+      });
+
+      it("deinterleaves from buffer when byteStride exceeds default", function () {
+        // VEC3 FLOAT: default stride = 12 bytes. Set byteStride = 24.
+        const interleaved = new Float32Array([
+          1, 2, 3, 99, 99, 99, 4, 5, 6, 99, 99, 99,
+        ]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteStride: 24,
+          byteOffset: 0,
+          buffer: createMockBuffer(interleaved),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(1);
+        expect(result[1]).toBe(2);
+        expect(result[2]).toBe(3);
+        expect(result[3]).toBe(4);
+        expect(result[4]).toBe(5);
+        expect(result[5]).toBe(6);
+      });
+
+      it("deinterleaves from buffer with byteOffset", function () {
+        // VEC3 FLOAT with byteStride=24, byteOffset=12
+        const interleaved = new Float32Array([
+          99, 99, 99, 10, 20, 30, 99, 99, 99, 40, 50, 60,
+        ]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 2,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteStride: 24,
+          byteOffset: 12,
+          buffer: createMockBuffer(interleaved),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(6);
+        expect(result[0]).toBe(10);
+        expect(result[1]).toBe(20);
+        expect(result[2]).toBe(30);
+        expect(result[3]).toBe(40);
+        expect(result[4]).toBe(50);
+        expect(result[5]).toBe(60);
+      });
+
+      it("reads quantized componentDatatype from buffer", function () {
+        const data = new Uint16Array([10, 20, 30]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC3,
+          count: 1,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 0,
+          quantization: {
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+          },
+          buffer: createMockBuffer(data),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Uint16Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(10);
+        expect(result[1]).toBe(20);
+        expect(result[2]).toBe(30);
+      });
+
+      it("reads VEC2 UNSIGNED_SHORT from buffer with non-zero byteOffset", function () {
+        const data = new Uint16Array([99, 99, 10, 20, 30, 40]);
+        const attribute = createAttribute({
+          type: AttributeType.VEC2,
+          count: 2,
+          componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+          byteOffset: 4, // skip 2 shorts * 2 bytes
+          buffer: createMockBuffer(data),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Uint16Array);
+        expect(result.length).toBe(4);
+        expect(result[0]).toBe(10);
+        expect(result[1]).toBe(20);
+        expect(result[2]).toBe(30);
+        expect(result[3]).toBe(40);
+      });
+
+      it("reads SCALAR FLOAT from buffer", function () {
+        const data = new Float32Array([7, 8, 9]);
+        const attribute = createAttribute({
+          type: AttributeType.SCALAR,
+          count: 3,
+          componentDatatype: ComponentDatatype.FLOAT,
+          byteOffset: 0,
+          buffer: createMockBuffer(data),
+        });
+
+        const result =
+          ModelReader.readAttributeAsRawCompactTypedArray(attribute);
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(7);
+        expect(result[1]).toBe(8);
+        expect(result[2]).toBe(9);
+      });
+    });
+
+    describe("readIndicesAsTypedArray", function () {
+      function createMockIndicesBuffer(data) {
+        return {
+          getBufferData: function (outputArray) {
+            for (let i = 0; i < data.length; i++) {
+              outputArray[i] = data[i];
+            }
+          },
+        };
+      }
+
+      it("returns existing typedArray when available", function () {
+        const typedArray = new Uint16Array([0, 1, 2, 3, 4, 5]);
+        const primitiveIndices = {
+          typedArray: typedArray,
+          count: 6,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        };
+
+        const result = ModelReader.readIndicesAsTypedArray(primitiveIndices);
+
+        expect(result).toBe(typedArray);
+      });
+
+      it("reads UNSIGNED_BYTE indices from buffer", function () {
+        const data = new Uint8Array([0, 1, 2]);
+        const primitiveIndices = {
+          typedArray: undefined,
+          buffer: createMockIndicesBuffer(data),
+          count: 3,
+          indexDatatype: IndexDatatype.UNSIGNED_BYTE,
+        };
+
+        const result = ModelReader.readIndicesAsTypedArray(primitiveIndices);
+
+        expect(result).toBeInstanceOf(Uint8Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(0);
+        expect(result[1]).toBe(1);
+        expect(result[2]).toBe(2);
+      });
+
+      it("reads UNSIGNED_SHORT indices from buffer", function () {
+        const data = new Uint16Array([10, 20, 30]);
+        const primitiveIndices = {
+          typedArray: undefined,
+          buffer: createMockIndicesBuffer(data),
+          count: 3,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        };
+
+        const result = ModelReader.readIndicesAsTypedArray(primitiveIndices);
+
+        expect(result).toBeInstanceOf(Uint16Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(10);
+        expect(result[1]).toBe(20);
+        expect(result[2]).toBe(30);
+      });
+
+      it("reads UNSIGNED_INT indices from buffer", function () {
+        const data = new Uint32Array([100, 200, 300]);
+        const primitiveIndices = {
+          typedArray: undefined,
+          buffer: createMockIndicesBuffer(data),
+          count: 3,
+          indexDatatype: IndexDatatype.UNSIGNED_INT,
+        };
+
+        const result = ModelReader.readIndicesAsTypedArray(primitiveIndices);
+
+        expect(result).toBeInstanceOf(Uint32Array);
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(100);
+        expect(result[1]).toBe(200);
+        expect(result[2]).toBe(300);
+      });
+
+      it("reads correct count of indices from buffer", function () {
+        const data = new Uint16Array([0, 1, 2, 3, 4, 5]);
+        const primitiveIndices = {
+          typedArray: undefined,
+          buffer: createMockIndicesBuffer(data),
+          count: 6,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        };
+
+        const result = ModelReader.readIndicesAsTypedArray(primitiveIndices);
+
+        expect(result.length).toBe(6);
+        expect(result[5]).toBe(5);
+      });
+
+      it("prefers typedArray over buffer when both are present", function () {
+        const typedArray = new Uint16Array([10, 11, 12]);
+        const bufferData = new Uint16Array([99, 99, 99]);
+        const primitiveIndices = {
+          typedArray: typedArray,
+          buffer: createMockIndicesBuffer(bufferData),
+          count: 3,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        };
+
+        const result = ModelReader.readIndicesAsTypedArray(primitiveIndices);
+
+        expect(result).toBe(typedArray);
+        expect(result[0]).toBe(10);
+      });
+    });
+
+    describe("readImplicitRangeAsTypedArray", function () {
+      function createMockAttributeOwner(count) {
+        return {
+          attributes: [{ count: count }],
+        };
+      }
+
+      it("generates values using offset and repeat", function () {
+        const featureIdSet = { offset: 0, repeat: 1 };
+        const attributeOwner = createMockAttributeOwner(5);
+
+        const result = ModelReader.readImplicitRangeAsTypedArray(
+          featureIdSet,
+          attributeOwner,
+        );
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(5);
+        expect(result[0]).toBe(0);
+        expect(result[1]).toBe(1);
+        expect(result[2]).toBe(2);
+        expect(result[3]).toBe(3);
+        expect(result[4]).toBe(4);
+      });
+
+      it("applies offset to generated values", function () {
+        const featureIdSet = { offset: 10, repeat: 1 };
+        const attributeOwner = createMockAttributeOwner(3);
+
+        const result = ModelReader.readImplicitRangeAsTypedArray(
+          featureIdSet,
+          attributeOwner,
+        );
+
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(10);
+        expect(result[1]).toBe(11);
+        expect(result[2]).toBe(12);
+      });
+
+      it("repeats feature IDs when repeat is greater than 1", function () {
+        const featureIdSet = { offset: 0, repeat: 3 };
+        const attributeOwner = createMockAttributeOwner(9);
+
+        const result = ModelReader.readImplicitRangeAsTypedArray(
+          featureIdSet,
+          attributeOwner,
+        );
+
+        expect(result.length).toBe(9);
+        // First 3 vertices get feature ID 0
+        expect(result[0]).toBe(0);
+        expect(result[1]).toBe(0);
+        expect(result[2]).toBe(0);
+        // Next 3 vertices get feature ID 1
+        expect(result[3]).toBe(1);
+        expect(result[4]).toBe(1);
+        expect(result[5]).toBe(1);
+        // Next 3 vertices get feature ID 2
+        expect(result[6]).toBe(2);
+        expect(result[7]).toBe(2);
+        expect(result[8]).toBe(2);
+      });
+
+      it("combines offset and repeat", function () {
+        const featureIdSet = { offset: 5, repeat: 2 };
+        const attributeOwner = createMockAttributeOwner(6);
+
+        const result = ModelReader.readImplicitRangeAsTypedArray(
+          featureIdSet,
+          attributeOwner,
+        );
+
+        expect(result.length).toBe(6);
+        // offset + floor(i / repeat)
+        expect(result[0]).toBe(5); // 5 + floor(0/2)
+        expect(result[1]).toBe(5); // 5 + floor(1/2)
+        expect(result[2]).toBe(6); // 5 + floor(2/2)
+        expect(result[3]).toBe(6); // 5 + floor(3/2)
+        expect(result[4]).toBe(7); // 5 + floor(4/2)
+        expect(result[5]).toBe(7); // 5 + floor(5/2)
+      });
+
+      it("fills all values with offset when repeat is undefined", function () {
+        const featureIdSet = { offset: 42, repeat: undefined };
+        const attributeOwner = createMockAttributeOwner(4);
+
+        const result = ModelReader.readImplicitRangeAsTypedArray(
+          featureIdSet,
+          attributeOwner,
+        );
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(4);
+        expect(result[0]).toBe(42);
+        expect(result[1]).toBe(42);
+        expect(result[2]).toBe(42);
+        expect(result[3]).toBe(42);
+      });
+
+      it("returns empty array when count is zero", function () {
+        const featureIdSet = { offset: 0, repeat: 1 };
+        const attributeOwner = createMockAttributeOwner(0);
+
+        const result = ModelReader.readImplicitRangeAsTypedArray(
+          featureIdSet,
+          attributeOwner,
+        );
+
+        expect(result).toBeInstanceOf(Float32Array);
+        expect(result.length).toBe(0);
+      });
+
+      it("handles offset of zero with undefined repeat", function () {
+        const featureIdSet = { offset: 0, repeat: undefined };
+        const attributeOwner = createMockAttributeOwner(3);
+
+        const result = ModelReader.readImplicitRangeAsTypedArray(
+          featureIdSet,
+          attributeOwner,
+        );
+
+        expect(result.length).toBe(3);
+        expect(result[0]).toBe(0);
+        expect(result[1]).toBe(0);
+        expect(result[2]).toBe(0);
+      });
+    });
+
+    describe("forEachPrimitive", function () {
+      function createMockRuntimeNode(options) {
+        options = options ?? {};
+        return {
+          computedTransform: options.computedTransform ?? Matrix4.IDENTITY,
+          node: {
+            instances: options.instances,
+          },
+          transformsTypedArray: options.transformsTypedArray,
+          instancingTransformsBuffer: options.instancingTransformsBuffer,
+        };
+      }
+
+      function createMockSceneGraph(options) {
+        options = options ?? {};
+        return {
+          computedModelMatrix: options.computedModelMatrix ?? Matrix4.IDENTITY,
+          components: {
+            transform: options.componentsTransform ?? Matrix4.IDENTITY,
+          },
+          axisCorrectionMatrix:
+            options.axisCorrectionMatrix ?? Matrix4.IDENTITY,
+        };
+      }
+
+      function createMockModel(options) {
+        options = options ?? {};
+        return {
+          modelMatrix: options.modelMatrix ?? Matrix4.IDENTITY,
+        };
+      }
+
+      function createMockModelForTraversal(options) {
+        options = options ?? {};
+        const runtimePrimitives = (options.primitives ?? []).map(function (p) {
+          return {
+            primitive: p,
+            boundingSphere: p._boundingSphere,
+          };
+        });
+        const runtimeNode = createMockRuntimeNode(options.nodeOptions);
+        runtimeNode.runtimePrimitives = runtimePrimitives;
+
+        const sceneGraph = createMockSceneGraph(options.sceneGraphOptions);
+        sceneGraph._runtimeNodes = options.runtimeNodes ?? [runtimeNode];
+
+        const model = createMockModel(options.modelOptions);
+        model._ready = options.ready !== undefined ? options.ready : true;
+        model.sceneGraph = sceneGraph;
+
+        return model;
+      }
+
+      it("does nothing when sceneGraph is undefined", function () {
+        const model = {
+          sceneGraph: undefined,
+        };
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).not.toHaveBeenCalled();
+      });
+
+      it("does nothing when there are no runtime nodes", function () {
+        const model = createMockModelForTraversal({
+          primitives: [],
+        });
+        model.sceneGraph._runtimeNodes = [];
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).not.toHaveBeenCalled();
+      });
+
+      it("invokes callback once per primitive", function () {
+        const primitiveA = { id: "a" };
+        const primitiveB = { id: "b" };
+        const model = createMockModelForTraversal({
+          primitives: [primitiveA, primitiveB],
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(2);
+      });
+
+      it("passes runtimePrimitive, primitive, instances, and computedModelMatrix to callback", function () {
+        const primitive = { id: "test" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        const args = callback.calls.argsFor(0);
+        // runtimePrimitive
+        expect(args[0].primitive).toBe(primitive);
+        // primitive
+        expect(args[1]).toBe(primitive);
+        // instances (array of InstanceEntry)
+        expect(Array.isArray(args[2])).toBe(true);
+        expect(args[2].length).toBe(1);
+        expect(args[2][0].transform).toEqual(Matrix4.IDENTITY);
+        expect(args[2][0].featureId).toBeUndefined();
+        // computedModelMatrix
+        expect(args[3]).toBeDefined();
+        expect(args[3]).toEqual(Matrix4.IDENTITY);
+      });
+
+      it("computes correct transforms from non-identity node and model matrices", function () {
+        const nodeTransform = Matrix4.fromTranslation(new Cartesian3(1, 2, 3));
+        const modelMatrix = Matrix4.fromTranslation(new Cartesian3(10, 20, 30));
+        const primitive = { id: "p" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            computedTransform: nodeTransform,
+          },
+          sceneGraphOptions: {
+            computedModelMatrix: modelMatrix,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        const expected = Matrix4.multiplyTransformation(
+          modelMatrix,
+          nodeTransform,
+          new Matrix4(),
+        );
+        const computedModelMatrix = callback.calls.argsFor(0)[3];
+        expect(computedModelMatrix).toEqual(expected);
+      });
+
+      it("iterates over primitives across multiple nodes", function () {
+        const primA = { id: "a" };
+        const primB = { id: "b" };
+
+        const nodeA = createMockRuntimeNode();
+        nodeA.runtimePrimitives = [{ primitive: primA }];
+
+        const nodeB = createMockRuntimeNode();
+        nodeB.runtimePrimitives = [{ primitive: primB }];
+
+        const sceneGraph = createMockSceneGraph();
+        sceneGraph._runtimeNodes = [nodeA, nodeB];
+
+        const model = createMockModel();
+        model.sceneGraph = sceneGraph;
+
+        const primitives = [];
+        ModelReader.forEachPrimitive(
+          model,
+          undefined,
+          function (rp, primitive) {
+            primitives.push(primitive);
+          },
+        );
+
+        expect(primitives.length).toBe(2);
+        expect(primitives[0]).toBe(primA);
+        expect(primitives[1]).toBe(primB);
+      });
+
+      it("provides instance transforms from MAT4 typedArray when node has instancing", function () {
+        // Two instance transforms packed as 12 floats each (3 rows of 4).
+        // Matrix4 constructor takes row-major args, so each 12-float block is:
+        //   row0: [col0.x, col1.x, col2.x, col3.x]
+        //   row1: [col0.y, col1.y, col2.y, col3.y]
+        //   row2: [col0.z, col1.z, col2.z, col3.z]
+        const twoInstances = new Float32Array([
+          // prettier-ignore
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0, // Instance 0: identity
+          // prettier-ignore
+          1,
+          0,
+          0,
+          5,
+          0,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0, // Instance 1: translation (5, 0, 0)
+        ]);
+        const modelMatrix = Matrix4.fromTranslation(new Cartesian3(10, 20, 30));
+        const primitive = { id: "instanced" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              attributes: [
+                { count: 2, componentDatatype: ComponentDatatype.FLOAT },
+              ],
+            },
+            transformsTypedArray: twoInstances,
+          },
+          sceneGraphOptions: {
+            computedModelMatrix: modelMatrix,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+
+        // Each instance transform is pre-multiplied by computedModelMatrix
+        // (computedModelMatrix = modelMatrix * nodeTransform, nodeTransform is identity here).
+        // Instance 0: modelMatrix * identity = modelMatrix
+        expect(instances[0].transform).toEqual(modelMatrix);
+        // Instance 1: modelMatrix * translation(5,0,0) = translation(15, 20, 30)
+        const expectedInstance1 = Matrix4.multiplyTransformation(
+          modelMatrix,
+          Matrix4.fromTranslation(new Cartesian3(5, 0, 0)),
+          new Matrix4(),
+        );
+        expect(instances[1].transform).toEqual(expectedInstance1);
+      });
+
+      it("provides instance transforms from MAT4 buffer when node has instancing", function () {
+        const readbackData = new Float32Array([
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+        ]);
+        const mockBuffer = {
+          getBufferData: function (outputArray) {
+            for (let i = 0; i < readbackData.length; i++) {
+              outputArray[i] = readbackData[i];
+            }
+          },
+        };
+
+        const nodeOptions = {
+          instances: {
+            transformInWorldSpace: false,
+            attributes: [
+              { count: 1, componentDatatype: ComponentDatatype.FLOAT },
+            ],
+          },
+          transformsTypedArray: undefined,
+        };
+
+        const primitive = { id: "gpuReadback" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: nodeOptions,
+        });
+        // Attach the mock buffer after createMockModelForTraversal builds the node
+        model.sceneGraph._runtimeNodes[0].instancingTransformsBuffer =
+          mockBuffer;
+
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        // Should have read back successfully, producing 1 instance transform
+        expect(instances.length).toBe(1);
+        // The transform should not just be the fallback computedModelMatrix
+        expect(instances[0].transform).toBeDefined();
+      });
+
+      it("provides instance transforms from VEC3 attributes typedArray", function () {
+        // Same setup as "provides instance transforms when node has instancing"
+        // but using Vec3 translation attributes instead of transformsTypedArray.
+        // Instance 0: translation (0, 0, 0) — identity
+        // Instance 1: translation (5, 0, 0)
+        const translationTypedArray = new Float32Array([
+          0,
+          0,
+          0, // instance 0 translation
+          5,
+          0,
+          0, // instance 1 translation
+        ]);
+        const modelMatrix = Matrix4.fromTranslation(new Cartesian3(10, 20, 30));
+        const primitive = { id: "vec3Instanced" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              attributes: [
+                {
+                  semantic: "TRANSLATION",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC3,
+                  typedArray: translationTypedArray,
+                },
+              ],
+            },
+          },
+          sceneGraphOptions: {
+            computedModelMatrix: modelMatrix,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+
+        // Instance 0: modelMatrix * identity = modelMatrix
+        expect(instances[0].transform).toEqual(modelMatrix);
+        // Instance 1: modelMatrix * translation(5,0,0) = translation(15, 20, 30)
+        const expectedInstance1 = Matrix4.multiplyTransformation(
+          modelMatrix,
+          Matrix4.fromTranslation(new Cartesian3(5, 0, 0)),
+          new Matrix4(),
+        );
+        expect(instances[1].transform).toEqual(expectedInstance1);
+      });
+
+      it("provides instance transforms from VEC3 attributes typedArray with translation, rotation, and scale", function () {
+        // Two instances with TRANSLATION, ROTATION, and SCALE Vec3/Vec4 attributes.
+        // Instance 0: origin, identity rotation, unit scale → identity
+        // Instance 1: translation (5,0,0), 90° around Z, scale (2,2,2)
+        const sqrt1_2 = Math.sqrt(0.5);
+        const translationTypedArray = new Float32Array([
+          0,
+          0,
+          0, // instance 0
+          5,
+          0,
+          0, // instance 1
+        ]);
+        const rotationTypedArray = new Float32Array([
+          0,
+          0,
+          0,
+          1, // instance 0: identity quaternion (x,y,z,w)
+          0,
+          0,
+          sqrt1_2,
+          sqrt1_2, // instance 1: 90° around Z
+        ]);
+        const scaleTypedArray = new Float32Array([
+          1,
+          1,
+          1, // instance 0
+          2,
+          2,
+          2, // instance 1
+        ]);
+        const modelMatrix = Matrix4.fromTranslation(new Cartesian3(10, 20, 30));
+        const primitive = { id: "vec3TRS" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              attributes: [
+                {
+                  semantic: "TRANSLATION",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC3,
+                  typedArray: translationTypedArray,
+                },
+                {
+                  semantic: "ROTATION",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC4,
+                  typedArray: rotationTypedArray,
+                },
+                {
+                  semantic: "SCALE",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC3,
+                  typedArray: scaleTypedArray,
+                },
+              ],
+            },
+          },
+          sceneGraphOptions: {
+            computedModelMatrix: modelMatrix,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+
+        // Instance 0: modelMatrix * identity TRS = modelMatrix
+        expect(instances[0].transform).toEqual(modelMatrix);
+
+        // Instance 1: modelMatrix * TRS(translate(5,0,0), rot90Z, scale(2,2,2))
+        const expectedRaw = Matrix4.fromTranslationQuaternionRotationScale(
+          new Cartesian3(5, 0, 0),
+          new Quaternion(0, 0, sqrt1_2, sqrt1_2),
+          new Cartesian3(2, 2, 2),
+          new Matrix4(),
+        );
+        const expectedInstance1 = Matrix4.multiplyTransformation(
+          modelMatrix,
+          expectedRaw,
+          new Matrix4(),
+        );
+        expect(instances[1].transform).toEqualEpsilon(
+          expectedInstance1,
+          CesiumMath.EPSILON3,
+        );
+      });
+
+      it("provides instance transforms from interleaved Vec3 attribute buffer with translation, rotation, and scale", function () {
+        // Same logical instances as the Vec3 TRS test, but all attributes
+        // are packed into a single interleaved Float32Array buffer with
+        // byteOffset and byteStride, simulating a GPU-backed interleaved
+        // vertex buffer.
+        //
+        // Per-instance layout (10 floats = 40 bytes):
+        //   offset  0: TRANSLATION (VEC3, 3 floats, 12 bytes)
+        //   offset 12: ROTATION    (VEC4, 4 floats, 16 bytes)
+        //   offset 28: SCALE       (VEC3, 3 floats, 12 bytes)
+        // Stride = 40 bytes
+        //
+        // Instance 0: identity
+        // Instance 1: translation(5,0,0), 90° around Z, scale(2,2,2)
+        const sqrt1_2 = Math.sqrt(0.5);
+
+        // prettier-ignore
+        const interleavedData = new Float32Array([
+          // Instance 0: T(0,0,0), R(0,0,0,1), S(1,1,1)
+          0, 0, 0,   0, 0, 0, 1,   1, 1, 1,
+          // Instance 1: T(5,0,0), R(0,0,√½,√½), S(2,2,2)
+          5, 0, 0,   0, 0, sqrt1_2, sqrt1_2,   2, 2, 2,
+        ]);
+
+        const stride = 40; // 10 floats * 4 bytes
+        const mockBuffer = {
+          sizeInBytes: interleavedData.byteLength,
+          getBufferData: function (outputArray, srcByteOffset) {
+            srcByteOffset = srcByteOffset ?? 0;
+            const src = new Uint8Array(
+              interleavedData.buffer,
+              interleavedData.byteOffset,
+              interleavedData.byteLength,
+            );
+            if (outputArray instanceof Uint8Array) {
+              outputArray.set(src);
+            } else {
+              const view = new DataView(
+                src.buffer,
+                src.byteOffset,
+                src.byteLength,
+              );
+              for (let i = 0; i < outputArray.length; i++) {
+                outputArray[i] = view.getFloat32(srcByteOffset + i * 4, true);
+              }
+            }
+          },
+        };
+
+        const modelMatrix = Matrix4.fromTranslation(new Cartesian3(10, 20, 30));
+        const primitive = { id: "interleavedTRS" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              attributes: [
+                {
+                  semantic: "TRANSLATION",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC3,
+                  byteOffset: 0,
+                  byteStride: stride,
+                  buffer: mockBuffer,
+                },
+                {
+                  semantic: "ROTATION",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC4,
+                  byteOffset: 12,
+                  byteStride: stride,
+                  buffer: mockBuffer,
+                },
+                {
+                  semantic: "SCALE",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC3,
+                  byteOffset: 28,
+                  byteStride: stride,
+                  buffer: mockBuffer,
+                },
+              ],
+            },
+          },
+          sceneGraphOptions: {
+            computedModelMatrix: modelMatrix,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+
+        // Instance 0: modelMatrix * identity = modelMatrix
+        expect(instances[0].transform).toEqual(modelMatrix);
+
+        // Instance 1: modelMatrix * TRS(translate(5,0,0), rot90Z, scale(2,2,2))
+        const expectedRaw = Matrix4.fromTranslationQuaternionRotationScale(
+          new Cartesian3(5, 0, 0),
+          new Quaternion(0, 0, sqrt1_2, sqrt1_2),
+          new Cartesian3(2, 2, 2),
+          new Matrix4(),
+        );
+        const expectedInstance1 = Matrix4.multiplyTransformation(
+          modelMatrix,
+          expectedRaw,
+          new Matrix4(),
+        );
+        expect(instances[1].transform).toEqualEpsilon(
+          expectedInstance1,
+          CesiumMath.EPSILON3,
+        );
+      });
+
+      it("computes world-space instance transforms when transformInWorldSpace is true", function () {
+        // When transformInWorldSpace is true, computeNodeTransforms overrides:
+        //   modelMatrix = model.modelMatrix * sceneGraph.components.transform
+        //   nodeComputedTransform = sceneGraph.axisCorrectionMatrix * runtimeNode.computedTransform
+        //   computedModelMatrix = modelMatrix * nodeComputedTransform
+        // Then getInstanceTransforms applies:
+        //   finalTransform = modelMatrix * (instanceTransform * nodeComputedTransform)
+        const twoInstances = new Float32Array([
+          // Instance 0: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+          // Instance 1: translation (5, 0, 0)
+          1, 0, 0, 5, 0, 1, 0, 0, 0, 0, 1, 0,
+        ]);
+
+        const modelModelMatrix = Matrix4.fromTranslation(
+          new Cartesian3(100, 0, 0),
+        );
+        const componentsTransform = Matrix4.fromTranslation(
+          new Cartesian3(0, 200, 0),
+        );
+        const axisCorrectionMatrix = Matrix4.IDENTITY;
+        const nodeComputedTransform = Matrix4.fromTranslation(
+          new Cartesian3(0, 0, 50),
+        );
+
+        const primitive = { id: "worldSpace" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            computedTransform: nodeComputedTransform,
+            instances: {
+              transformInWorldSpace: true,
+              attributes: [
+                { count: 2, componentDatatype: ComponentDatatype.FLOAT },
+              ],
+            },
+            transformsTypedArray: twoInstances,
+          },
+          sceneGraphOptions: {
+            // This gets overridden by the world-space path, but must be provided
+            computedModelMatrix: Matrix4.IDENTITY,
+            componentsTransform: componentsTransform,
+            axisCorrectionMatrix: axisCorrectionMatrix,
+          },
+          modelOptions: {
+            modelMatrix: modelModelMatrix,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+
+        // modelMatrix = model.modelMatrix * components.transform = translate(100, 200, 0)
+        const expectedModelMatrix = Matrix4.multiplyTransformation(
+          modelModelMatrix,
+          componentsTransform,
+          new Matrix4(),
+        );
+        // nodeComputedTransform = axisCorrectionMatrix * runtimeNode.computedTransform = translate(0, 0, 50)
+        const expectedNodeTransform = Matrix4.multiplyTransformation(
+          axisCorrectionMatrix,
+          nodeComputedTransform,
+          new Matrix4(),
+        );
+
+        // Instance 0 (identity):
+        //   transform = identity * nodeComputedTransform = translate(0, 0, 50)
+        //   final = modelMatrix * transform = translate(100, 200, 50)
+        const expectedInst0 = Matrix4.multiplyTransformation(
+          expectedModelMatrix,
+          Matrix4.multiplyTransformation(
+            Matrix4.IDENTITY,
+            expectedNodeTransform,
+            new Matrix4(),
+          ),
+          new Matrix4(),
+        );
+        expect(instances[0].transform).toEqual(expectedInst0);
+
+        // Instance 1 (translate(5,0,0)):
+        //   transform = translate(5,0,0) * nodeComputedTransform = translate(5, 0, 50)
+        //   final = modelMatrix * transform = translate(105, 200, 50)
+        const instanceTransform1 = Matrix4.fromTranslation(
+          new Cartesian3(5, 0, 0),
+        );
+        const expectedInst1 = Matrix4.multiplyTransformation(
+          expectedModelMatrix,
+          Matrix4.multiplyTransformation(
+            instanceTransform1,
+            expectedNodeTransform,
+            new Matrix4(),
+          ),
+          new Matrix4(),
+        );
+        expect(instances[1].transform).toEqual(expectedInst1);
+      });
+
+      it("applies 2D projection when mapProjection is provided", function () {
+        const primitive = { id: "2d" };
+        const modelMatrix = Matrix4.fromTranslation(
+          new Cartesian3(1000000, 0, 0),
+        );
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          sceneGraphOptions: {
+            computedModelMatrix: modelMatrix,
+          },
+        });
+
+        const ellipsoid = Ellipsoid.WGS84;
+        const projection = new GeographicProjection(ellipsoid);
+
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(
+          model,
+          { mapProjection: projection },
+          callback,
+        );
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const computedModelMatrix = callback.calls.argsFor(0)[3];
+        // The 2D-projected matrix should differ from the original
+        expect(computedModelMatrix).not.toEqual(modelMatrix);
+      });
+
+      it("does not project to 2D when mapProjection is undefined", function () {
+        const primitive = { id: "noFrameState" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const computedModelMatrix = callback.calls.argsFor(0)[3];
+        expect(computedModelMatrix).toEqual(Matrix4.IDENTITY);
+      });
+
+      it("skips nodes with no runtimePrimitives", function () {
+        const nodeA = createMockRuntimeNode();
+        nodeA.runtimePrimitives = [];
+
+        const prim = { id: "only" };
+        const nodeB = createMockRuntimeNode();
+        nodeB.runtimePrimitives = [{ primitive: prim }];
+
+        const sceneGraph = createMockSceneGraph();
+        sceneGraph._runtimeNodes = [nodeA, nodeB];
+
+        const model = createMockModel();
+        model.sceneGraph = sceneGraph;
+
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback.calls.argsFor(0)[1]).toBe(prim);
+      });
+
+      it("provides instance featureIds when node has _FEATURE_ID attribute", function () {
+        const featureIdTypedArray = new Float32Array([10, 20]);
+        const twoInstances = new Float32Array([
+          // Instance 0: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+          // Instance 1: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+        ]);
+        const featureIdSet = new ModelComponents.FeatureIdAttribute();
+        featureIdSet.positionalLabel = "instanceFeatureId_0";
+        const primitive = { id: "featureIdInstanced" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              featureIds: [featureIdSet],
+              attributes: [
+                {
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                },
+                {
+                  semantic: "_FEATURE_ID",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.SCALAR,
+                  typedArray: featureIdTypedArray,
+                },
+              ],
+            },
+            transformsTypedArray: twoInstances,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(
+          model,
+          { instanceFeatureIdLabel: "instanceFeatureId_0" },
+          callback,
+        );
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+        expect(instances[0].featureId).toBe(10);
+        expect(instances[1].featureId).toBe(20);
+      });
+
+      it("does not populate featureId when instanceFeatureIdLabel option is not set", function () {
+        const featureIdTypedArray = new Float32Array([10, 20]);
+        const twoInstances = new Float32Array([
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+          0,
+        ]);
+        const featureIdSet = new ModelComponents.FeatureIdAttribute();
+        featureIdSet.positionalLabel = "instanceFeatureId_0";
+        const primitive = { id: "featureIdNotRequested" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              featureIds: [featureIdSet],
+              attributes: [
+                {
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                },
+                {
+                  semantic: "_FEATURE_ID",
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.SCALAR,
+                  typedArray: featureIdTypedArray,
+                },
+              ],
+            },
+            transformsTypedArray: twoInstances,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(model, undefined, callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+        expect(instances[0].featureId).toBeUndefined();
+        expect(instances[1].featureId).toBeUndefined();
+      });
+
+      it("sets featureId to undefined when node has no _FEATURE_ID attribute", function () {
+        const twoInstances = new Float32Array([
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+          0,
+        ]);
+        const primitive = { id: "noFeatureId" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              featureIds: [],
+              attributes: [
+                {
+                  count: 2,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                },
+              ],
+            },
+            transformsTypedArray: twoInstances,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(
+          model,
+          { instanceFeatureIdLabel: "instanceFeatureId_0" },
+          callback,
+        );
+
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(2);
+        expect(instances[0].featureId).toBeUndefined();
+        expect(instances[1].featureId).toBeUndefined();
+      });
+
+      it("sets featureId to undefined for non-instanced nodes", function () {
+        const primitive = { id: "nonInstanced" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(
+          model,
+          { instanceFeatureIdLabel: "instanceFeatureId_0" },
+          callback,
+        );
+
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(1);
+        expect(instances[0].featureId).toBeUndefined();
+      });
+
+      it("provides instance featureIds from FeatureIdAttribute with VEC3 translation attributes", function () {
+        const featureIdTypedArray = new Float32Array([42, 99, 7]);
+        const translationTypedArray = new Float32Array([
+          0, 0, 0, 1, 0, 0, 0, 1, 0,
+        ]);
+        const featureIdSet = new ModelComponents.FeatureIdAttribute();
+        featureIdSet.positionalLabel = "instanceFeatureId_0";
+        const primitive = { id: "vec3WithFeatureIds" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              featureIds: [featureIdSet],
+              attributes: [
+                {
+                  semantic: "TRANSLATION",
+                  count: 3,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.VEC3,
+                  typedArray: translationTypedArray,
+                },
+                {
+                  semantic: "_FEATURE_ID",
+                  count: 3,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                  type: AttributeType.SCALAR,
+                  typedArray: featureIdTypedArray,
+                },
+              ],
+            },
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(
+          model,
+          { instanceFeatureIdLabel: "instanceFeatureId_0" },
+          callback,
+        );
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(3);
+        expect(instances[0].featureId).toBe(42);
+        expect(instances[1].featureId).toBe(99);
+        expect(instances[2].featureId).toBe(7);
+        // Also verify transforms are still present
+        expect(instances[0].transform).toBeDefined();
+        expect(instances[1].transform).toBeDefined();
+        expect(instances[2].transform).toBeDefined();
+      });
+
+      it("provides instance featureIds from FeatureIdImplicitRange with repeat", function () {
+        const twoInstances = new Float32Array([
+          // Instance 0: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+          // Instance 1: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+          // Instance 2: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+          // Instance 3: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+        ]);
+        const featureIdSet = new ModelComponents.FeatureIdImplicitRange();
+        featureIdSet.offset = 5;
+        featureIdSet.repeat = 2;
+        featureIdSet.positionalLabel = "instanceFeatureId_0";
+        const primitive = { id: "implicitRangeInstanced" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              featureIds: [featureIdSet],
+              attributes: [
+                {
+                  count: 4,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                },
+              ],
+            },
+            transformsTypedArray: twoInstances,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(
+          model,
+          { instanceFeatureIdLabel: "instanceFeatureId_0" },
+          callback,
+        );
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(4);
+        // offset + floor(i / repeat) = 5 + floor(i / 2)
+        expect(instances[0].featureId).toBe(5);
+        expect(instances[1].featureId).toBe(5);
+        expect(instances[2].featureId).toBe(6);
+        expect(instances[3].featureId).toBe(6);
+      });
+
+      it("provides instance featureIds from FeatureIdImplicitRange without repeat", function () {
+        const twoInstances = new Float32Array([
+          // Instance 0: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+          // Instance 1: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+          // Instance 2: identity
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0,
+        ]);
+        const featureIdSet = new ModelComponents.FeatureIdImplicitRange();
+        featureIdSet.offset = 7;
+        featureIdSet.repeat = undefined;
+        featureIdSet.positionalLabel = "instanceFeatureId_0";
+        const primitive = { id: "implicitRangeNoRepeat" };
+        const model = createMockModelForTraversal({
+          primitives: [primitive],
+          nodeOptions: {
+            instances: {
+              transformInWorldSpace: false,
+              featureIds: [featureIdSet],
+              attributes: [
+                {
+                  count: 3,
+                  componentDatatype: ComponentDatatype.FLOAT,
+                },
+              ],
+            },
+            transformsTypedArray: twoInstances,
+          },
+        });
+        const callback = jasmine.createSpy("callback");
+
+        ModelReader.forEachPrimitive(
+          model,
+          { instanceFeatureIdLabel: "instanceFeatureId_0" },
+          callback,
+        );
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        const instances = callback.calls.argsFor(0)[2];
+        expect(instances.length).toBe(3);
+        // All instances get the same featureId (offset) when repeat is undefined
+        expect(instances[0].featureId).toBe(7);
+        expect(instances[1].featureId).toBe(7);
+        expect(instances[2].featureId).toBe(7);
+      });
     });
   },
   "WebGL",

--- a/packages/engine/Specs/Scene/Model/pickModelSpec.js
+++ b/packages/engine/Specs/Scene/Model/pickModelSpec.js
@@ -3,7 +3,6 @@ import {
   Cartesian2,
   Cartesian3,
   Ellipsoid,
-  HeadingPitchRange,
   Math as CesiumMath,
   Model,
   Ray,
@@ -122,17 +121,17 @@ describe("Scene/Model/pickModel", function () {
         url: boxTexturedGltfUrl,
         enablePick: true,
       },
-      scene,
+      sceneWithWebgl1,
     );
-    const ray = scene.camera.getPickRay(
+    const ray = sceneWithWebgl1.camera.getPickRay(
       new Cartesian2(
-        scene.drawingBufferWidth / 2.0,
-        scene.drawingBufferHeight / 2.0,
+        sceneWithWebgl1.drawingBufferWidth / 2.0,
+        sceneWithWebgl1.drawingBufferHeight / 2.0,
       ),
     );
 
     const expected = new Cartesian3(0.5, 0, 0.5);
-    expect(pickModel(model, ray, scene.frameState)).toEqualEpsilon(
+    expect(pickModel(model, ray, sceneWithWebgl1.frameState)).toEqualEpsilon(
       expected,
       CesiumMath.EPSILON12,
     );
@@ -251,31 +250,57 @@ describe("Scene/Model/pickModel", function () {
   });
 
   it("returns position of intersection with instanced model", async function () {
-    // None of the 4 instanced cubes are in the center of the model's bounding
-    // sphere, so set up a camera view that focuses in on one of them.
-    const offset = new HeadingPitchRange(
-      CesiumMath.PI_OVER_TWO,
-      -CesiumMath.PI_OVER_FOUR,
-      1,
-    );
-
+    // Model is one unit cube with vertices in [-0.5, 0.5].
+    // Instancing places 4 instances at glTF translations [+-2, +-2, 0].
+    // The axis correction (glTF Y-up/Z-forward to Cesium Z-up/X-forward)
+    // maps (x,y,z) -> (z,x,y), so instance centers in Cesium coordinates
+    // are at (0, +-2, +-2).
     const model = await loadAndZoomToModelAsync(
       {
         url: boxInstanced,
         enablePick: !scene.frameState.context.webgl2,
-        offset,
       },
       scene,
     );
-    const ray = scene.camera.getPickRay(
+
+    // First test pick center [0, 0] — no instance there, expect no hit
+    scene.camera.setView({
+      destination: Cartesian3.fromElements(model.boundingSphere.radius, 0, 0),
+      orientation: {
+        direction: Cartesian3.fromElements(-1, 0, 0),
+        up: Cartesian3.fromElements(0, 0, 1),
+      },
+    });
+    const ray0 = scene.camera.getPickRay(
       new Cartesian2(
         scene.drawingBufferWidth / 2.0,
         scene.drawingBufferHeight / 2.0,
       ),
     );
 
-    const expected = new Cartesian3(0, -0.5, 0.5);
-    expect(pickModel(model, ray, scene.frameState)).toEqualEpsilon(
+    expect(pickModel(model, ray0, scene.frameState)).toBeUndefined();
+
+    // Then test pick at instance location.
+    // Instance at glTF (-2, -2, 0) maps to Cesium center (0, -2, -2),
+    // with the cube extending +-0.5 in each axis: x in [-0.5, 0.5],
+    // y in [-2.5, -1.5], z in [-2.5, -1.5].
+    // Looking from (radius, -2, -2) along -X hits the +X face at x=0.5.
+    scene.camera.setView({
+      destination: Cartesian3.fromElements(model.boundingSphere.radius, -2, -2),
+      orientation: {
+        direction: Cartesian3.fromElements(-1, 0, 0),
+        up: Cartesian3.fromElements(0, 0, 1),
+      },
+    });
+    const ray1 = scene.camera.getPickRay(
+      new Cartesian2(
+        scene.drawingBufferWidth / 2.0,
+        scene.drawingBufferHeight / 2.0,
+      ),
+    );
+
+    const expected = new Cartesian3(0.5, -2, -2);
+    expect(pickModel(model, ray1, scene.frameState)).toEqualEpsilon(
       expected,
       CesiumMath.EPSILON12,
     );


### PR DESCRIPTION
## Summary

Extracts scene-graph traversal, instance transform computation, and GPU buffer readback logic from `pickModel.js` into reusable static methods on `ModelReader`, then rewrites `pickModel` to use those shared helpers. Adds comprehensive unit tests for `ModelReader`.

## Motivation

`pickModel.js` contained ~300 lines of inline logic for:
- Walking the model scene graph and computing per-node transforms
- Reading instance transforms from GPU buffers or individual Translation, Rotation, Scale attributes
- Reading vertex positions (with interleaving, quantization, and dequantization)
- Reading index buffers from the GPU

This logic is useful beyond picking (e.g. spatial queries, custom analysis) but was not reusable. This PR centralizes it in `ModelReader` so other consumers can leverage the same code paths.

## Changes

### `ModelReader.js`
- **`forEachPrimitive(model, options, callback)`** — new static method that traverses every primitive in a model's scene graph. Computes node transforms (including world-space instancing and 2D map projection), builds per-instance transform matrices + optional per-instance feature IDs, and invokes a callback for each runtime primitive.
- **`readImplicitRangeAsTypedArray(featureIdSet, attributeOwner)`** — new static method that generates feature IDs from an implicit-range feature ID set (`offset + floor(i / repeat)`).
- **`readAttributeAsTypedArray`** — when an attribute already has an in-memory `typedArray`, return it directly instead of re-reading from the GPU buffer (the typed array is already tightly packed).
- Extracted private helpers: `computeNodeTransforms`, `getInstanceTransforms`, `getInstanceFeatureIds`, `buildTransformsFromTypedArray`, `buildTransformsFromAttributes`.

### `pickModel.js`
- Replaced ~300 lines of inline traversal / buffer-reading code with a single call to `ModelReader.forEachPrimitive` + `ModelReader.readAttributeAsTypedArray` / `ModelReader.readIndicesAsTypedArray`.
- Removed the `getVertexPosition` helper (quantization/dequantization is now handled inside `ModelReader.readAttributeAsTypedArray`).

### `InstancingPipelineStage.js`
- Respect when `keepTypedArray` is true, always go through the matrix code path (not just when a rotation attribute is present). This ensures `runtimeNode.transformsTypedArray` is populated for CPU-side readback even for translation+scale-only instances. Without this fix pickModelSpec will not be able to execute correctly using webgl1.

## Bug fixes

### `ModelReader.js`
- **`octDecode` bug fix** — Fixed incorrect argument order in `AttributeCompression.octDecodeInRange` call (was passing a `Cartesian3`, now correctly passes `c.x, c.y`) and fixed swapped arguments in the subsequent `Cartesian3.pack` call. (found in [pickModel](https://github.com/CesiumGS/cesium/blob/0da68a8f1055f534f43d7d74a7050e193246fbc7/packages/engine/Source/Scene/Model/pickModel.js#L386))
- **`getInstanceTransforms` bug fix** — Fixed incorrect matrix multiplication order for meshes with EXT_mesh_gpu_instancing. (found in [pickModel](https://github.com/CesiumGS/cesium/blob/0da68a8f1055f534f43d7d74a7050e193246fbc7/packages/engine/Source/Scene/Model/pickModel.js#L162))

## Tests
- **`ModelReaderSpec.js`** — new spec file with ~2100 lines of tests covering attribute reading (float, quantized, interleaved, GPU-backed), index reading, implicit range feature IDs, `forEachPrimitive` traversal (single node, instanced, multi-node, 2D projection, feature IDs), and edge cases.
- **`pickModelSpec.js`** — updated instanced picking test to be more explicit about expected geometry and camera setup; fixed one test to correctly use `sceneWithWebgl1`.

## Testing

All existing `pickModelSpec` tests pass with the refactored implementation. New `ModelReaderSpec` tests exercise the extracted helpers in isolation.

# Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

GitHub Copilot

If yes, I used the following Model(s):

Claude 4.6 Opus