### PR TITLE
Configure explicit file path for eslint-seatbelt

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,10 @@ import reactHooks from "eslint-plugin-react-hooks";
 import { reactRefresh } from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 import seatbelt from "eslint-seatbelt";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default [
   tseslint.configs.base,
@@ -66,6 +70,11 @@ export default [
     ...configCesium.configs.browser,
     plugins: { html, "eslint-seatbelt": seatbelt },
     processor: seatbelt.processors.seatbelt,
+    settings: {
+      seatbelt: {
+        seatbeltFile: join(__dirname, "eslint.seatbelt.tsv"),
+      },
+    },
     rules: {
       ...configCesium.configs.browser.rules,
       "eslint-seatbelt/configure": "error",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Without setting a seatbelt file path it should look for one relative to your current working directory where eslint is run. This should always be the root of the repo since that's the only place the `eslint` script is defined. However, it seems that `lint-staged` spawns processes relative to each `lint-staged.config.js`. The docs _seem_ to imply otherwise or are just unclear about this behavior.

This PR just makes the path explicit to avoid the possibility of issues. The path is now always relative to the eslint config.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

Fixes #13447

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

Test this sequence of commands on `main` and this branch. `main` should fail, this branch should succeed
```sh
echo "// touch" >> packages/engine/Source/Core/BoundingSphere.js
git add .
npx run lint-staged
```

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
