### PR TITLE
Types: Texture, Texture3D, Sampler, Context to ES6 classes

### DIFF
--- a/packages/engine/Source/Core/PixelFormat.js
+++ b/packages/engine/Source/Core/PixelFormat.js
@@ -600,4 +600,6 @@ PixelFormat.toInternalFormat = function (pixelFormat, pixelDatatype, context) {
   return pixelFormat;
 };
 
-export default Object.freeze(PixelFormat);
+Object.freeze(PixelFormat);
+
+export default PixelFormat;

--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -34,243 +34,217 @@ import VertexArray from "./VertexArray.js";
 
 /**
  * @private
- * @constructor
- *
- * @param {HTMLCanvasElement} canvas The canvas element to which the context will be associated
- * @param {ContextOptions} [options] Options to control WebGL settings for the context
  */
-function Context(canvas, options) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("canvas", canvas);
-  //>>includeEnd('debug');
+class Context {
+  /**
+   * @param {HTMLCanvasElement} canvas The canvas element to which the context will be associated
+   * @param {ContextOptions} [options] Options to control WebGL settings for the context
+   */
+  constructor(canvas, options) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("canvas", canvas);
+    //>>includeEnd('debug');
 
-  const {
-    getWebGLStub,
-    requestWebgl1,
-    webgl: webglOptions = {},
-    allowTextureFilterAnisotropic = true,
-  } = options ?? {};
+    const {
+      getWebGLStub,
+      requestWebgl1,
+      webgl: webglOptions = {},
+      allowTextureFilterAnisotropic = true,
+    } = options ?? {};
 
-  // Override select WebGL defaults
-  webglOptions.alpha = webglOptions.alpha ?? false; // WebGL default is true
-  webglOptions.stencil = webglOptions.stencil ?? true; // WebGL default is false
-  webglOptions.powerPreference =
-    webglOptions.powerPreference ?? "high-performance"; // WebGL default is "default"
+    // Override select WebGL defaults
+    webglOptions.alpha = webglOptions.alpha ?? false; // WebGL default is true
+    webglOptions.stencil = webglOptions.stencil ?? true; // WebGL default is false
+    webglOptions.powerPreference =
+      webglOptions.powerPreference ?? "high-performance"; // WebGL default is "default"
 
-  const glContext = defined(getWebGLStub)
-    ? getWebGLStub(canvas, webglOptions)
-    : getWebGLContext(canvas, webglOptions, requestWebgl1);
+    const glContext = defined(getWebGLStub)
+      ? getWebGLStub(canvas, webglOptions)
+      : getWebGLContext(canvas, webglOptions, requestWebgl1);
 
-  // Get context type. instanceof will throw if WebGL2 is not supported
-  const webgl2Supported = typeof WebGL2RenderingContext !== "undefined";
-  const webgl2 = webgl2Supported && glContext instanceof WebGL2RenderingContext;
+    // Get context type. instanceof will throw if WebGL2 is not supported
+    const webgl2Supported = typeof WebGL2RenderingContext !== "undefined";
+    const webgl2 =
+      webgl2Supported && glContext instanceof WebGL2RenderingContext;
 
-  this._canvas = canvas;
-  this._originalGLContext = glContext;
-  this._gl = glContext;
-  this._webgl2 = webgl2;
-  this._id = createGuid();
+    this._canvas = canvas;
+    this._originalGLContext = glContext;
+    this._gl = glContext;
+    this._webgl2 = webgl2;
+    this._id = createGuid();
 
-  // Validation and logging disabled by default for speed.
-  this.validateFramebuffer = false;
-  this.validateShaderProgram = false;
-  this.logShaderCompilation = false;
+    // Validation and logging disabled by default for speed.
+    this.validateFramebuffer = false;
+    this.validateShaderProgram = false;
+    this.logShaderCompilation = false;
 
-  this._throwOnWebGLError = false;
+    this._throwOnWebGLError = false;
 
-  this._shaderCache = new ShaderCache(this);
-  this._textureCache = new TextureCache();
+    this._shaderCache = new ShaderCache(this);
+    this._textureCache = new TextureCache();
 
-  const gl = glContext;
+    const gl = glContext;
 
-  this._stencilBits = gl.getParameter(gl.STENCIL_BITS);
+    this._stencilBits = gl.getParameter(gl.STENCIL_BITS);
 
-  ContextLimits._maximumCombinedTextureImageUnits = gl.getParameter(
-    gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS,
-  );
-  ContextLimits._maximumCubeMapSize = gl.getParameter(
-    gl.MAX_CUBE_MAP_TEXTURE_SIZE,
-  );
-  ContextLimits._maximumFragmentUniformVectors = gl.getParameter(
-    gl.MAX_FRAGMENT_UNIFORM_VECTORS,
-  );
-  ContextLimits._maximumTextureImageUnits = gl.getParameter(
-    gl.MAX_TEXTURE_IMAGE_UNITS,
-  );
-  ContextLimits._maximumRenderbufferSize = gl.getParameter(
-    gl.MAX_RENDERBUFFER_SIZE,
-  );
-  ContextLimits._maximumTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-  ContextLimits._maximum3DTextureSize = gl.getParameter(gl.MAX_3D_TEXTURE_SIZE);
-  ContextLimits._maximumVaryingVectors = gl.getParameter(
-    gl.MAX_VARYING_VECTORS,
-  );
-  ContextLimits._maximumVertexAttributes = gl.getParameter(
-    gl.MAX_VERTEX_ATTRIBS,
-  );
-  ContextLimits._maximumVertexTextureImageUnits = gl.getParameter(
-    gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS,
-  );
-  ContextLimits._maximumVertexUniformVectors = gl.getParameter(
-    gl.MAX_VERTEX_UNIFORM_VECTORS,
-  );
+    ContextLimits._maximumCombinedTextureImageUnits = gl.getParameter(
+      gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS,
+    );
+    ContextLimits._maximumCubeMapSize = gl.getParameter(
+      gl.MAX_CUBE_MAP_TEXTURE_SIZE,
+    );
+    ContextLimits._maximumFragmentUniformVectors = gl.getParameter(
+      gl.MAX_FRAGMENT_UNIFORM_VECTORS,
+    );
+    ContextLimits._maximumTextureImageUnits = gl.getParameter(
+      gl.MAX_TEXTURE_IMAGE_UNITS,
+    );
+    ContextLimits._maximumRenderbufferSize = gl.getParameter(
+      gl.MAX_RENDERBUFFER_SIZE,
+    );
+    ContextLimits._maximumTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    ContextLimits._maximum3DTextureSize = gl.getParameter(
+      gl.MAX_3D_TEXTURE_SIZE,
+    );
+    ContextLimits._maximumVaryingVectors = gl.getParameter(
+      gl.MAX_VARYING_VECTORS,
+    );
+    ContextLimits._maximumVertexAttributes = gl.getParameter(
+      gl.MAX_VERTEX_ATTRIBS,
+    );
+    ContextLimits._maximumVertexTextureImageUnits = gl.getParameter(
+      gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS,
+    );
+    ContextLimits._maximumVertexUniformVectors = gl.getParameter(
+      gl.MAX_VERTEX_UNIFORM_VECTORS,
+    );
 
-  ContextLimits._maximumSamples = this._webgl2
-    ? gl.getParameter(gl.MAX_SAMPLES)
-    : 0;
+    ContextLimits._maximumSamples = this._webgl2
+      ? gl.getParameter(gl.MAX_SAMPLES)
+      : 0;
 
-  const aliasedLineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE); // must include 1
-  ContextLimits._minimumAliasedLineWidth = aliasedLineWidthRange[0];
-  ContextLimits._maximumAliasedLineWidth = aliasedLineWidthRange[1];
+    const aliasedLineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE); // must include 1
+    ContextLimits._minimumAliasedLineWidth = aliasedLineWidthRange[0];
+    ContextLimits._maximumAliasedLineWidth = aliasedLineWidthRange[1];
 
-  const aliasedPointSizeRange = gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE); // must include 1
-  ContextLimits._minimumAliasedPointSize = aliasedPointSizeRange[0];
-  ContextLimits._maximumAliasedPointSize = aliasedPointSizeRange[1];
+    const aliasedPointSizeRange = gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE); // must include 1
+    ContextLimits._minimumAliasedPointSize = aliasedPointSizeRange[0];
+    ContextLimits._maximumAliasedPointSize = aliasedPointSizeRange[1];
 
-  const maximumViewportDimensions = gl.getParameter(gl.MAX_VIEWPORT_DIMS);
-  ContextLimits._maximumViewportWidth = maximumViewportDimensions[0];
-  ContextLimits._maximumViewportHeight = maximumViewportDimensions[1];
+    const maximumViewportDimensions = gl.getParameter(gl.MAX_VIEWPORT_DIMS);
+    ContextLimits._maximumViewportWidth = maximumViewportDimensions[0];
+    ContextLimits._maximumViewportHeight = maximumViewportDimensions[1];
 
-  const highpFloat = gl.getShaderPrecisionFormat(
-    gl.FRAGMENT_SHADER,
-    gl.HIGH_FLOAT,
-  );
-  ContextLimits._highpFloatSupported = highpFloat.precision !== 0;
-  const highpInt = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_INT);
-  ContextLimits._highpIntSupported = highpInt.rangeMax !== 0;
+    const highpFloat = gl.getShaderPrecisionFormat(
+      gl.FRAGMENT_SHADER,
+      gl.HIGH_FLOAT,
+    );
+    ContextLimits._highpFloatSupported = highpFloat.precision !== 0;
+    const highpInt = gl.getShaderPrecisionFormat(
+      gl.FRAGMENT_SHADER,
+      gl.HIGH_INT,
+    );
+    ContextLimits._highpIntSupported = highpInt.rangeMax !== 0;
 
-  this._antialias = gl.getContextAttributes().antialias;
+    this._antialias = gl.getContextAttributes().antialias;
 
-  // Query and initialize extensions
-  this._standardDerivatives = !!getExtension(gl, ["OES_standard_derivatives"]);
-  this._blendMinmax = !!getExtension(gl, ["EXT_blend_minmax"]);
-  this._elementIndexUint = !!getExtension(gl, ["OES_element_index_uint"]);
-  this._depthTexture = !!getExtension(gl, [
-    "WEBGL_depth_texture",
-    "WEBKIT_WEBGL_depth_texture",
-  ]);
-  this._fragDepth = !!getExtension(gl, ["EXT_frag_depth"]);
-  this._debugShaders = getExtension(gl, ["WEBGL_debug_shaders"]);
+    // Query and initialize extensions
+    this._standardDerivatives = !!getExtension(gl, [
+      "OES_standard_derivatives",
+    ]);
+    this._blendMinmax = !!getExtension(gl, ["EXT_blend_minmax"]);
+    this._elementIndexUint = !!getExtension(gl, ["OES_element_index_uint"]);
+    this._depthTexture = !!getExtension(gl, [
+      "WEBGL_depth_texture",
+      "WEBKIT_WEBGL_depth_texture",
+    ]);
+    this._fragDepth = !!getExtension(gl, ["EXT_frag_depth"]);
+    this._debugShaders = getExtension(gl, ["WEBGL_debug_shaders"]);
 
-  this._textureFloat = !!getExtension(gl, ["OES_texture_float"]);
-  this._textureHalfFloat = !!getExtension(gl, ["OES_texture_half_float"]);
+    this._textureFloat = !!getExtension(gl, ["OES_texture_float"]);
+    this._textureHalfFloat = !!getExtension(gl, ["OES_texture_half_float"]);
 
-  this._textureFloatLinear = !!getExtension(gl, ["OES_texture_float_linear"]);
-  this._textureHalfFloatLinear = !!getExtension(gl, [
-    "OES_texture_half_float_linear",
-  ]);
+    this._textureFloatLinear = !!getExtension(gl, ["OES_texture_float_linear"]);
+    this._textureHalfFloatLinear = !!getExtension(gl, [
+      "OES_texture_half_float_linear",
+    ]);
 
-  this._supportsTextureLod = !!getExtension(gl, ["EXT_shader_texture_lod"]);
+    this._supportsTextureLod = !!getExtension(gl, ["EXT_shader_texture_lod"]);
 
-  this._colorBufferFloat = !!getExtension(gl, [
-    "EXT_color_buffer_float",
-    "WEBGL_color_buffer_float",
-  ]);
-  this._floatBlend = !!getExtension(gl, ["EXT_float_blend"]);
-  this._colorBufferHalfFloat = !!getExtension(gl, [
-    "EXT_color_buffer_half_float",
-  ]);
+    this._colorBufferFloat = !!getExtension(gl, [
+      "EXT_color_buffer_float",
+      "WEBGL_color_buffer_float",
+    ]);
+    this._floatBlend = !!getExtension(gl, ["EXT_float_blend"]);
+    this._colorBufferHalfFloat = !!getExtension(gl, [
+      "EXT_color_buffer_half_float",
+    ]);
 
-  this._s3tc = !!getExtension(gl, [
-    "WEBGL_compressed_texture_s3tc",
-    "MOZ_WEBGL_compressed_texture_s3tc",
-    "WEBKIT_WEBGL_compressed_texture_s3tc",
-  ]);
-  this._pvrtc = !!getExtension(gl, [
-    "WEBGL_compressed_texture_pvrtc",
-    "WEBKIT_WEBGL_compressed_texture_pvrtc",
-  ]);
-  this._astc = !!getExtension(gl, ["WEBGL_compressed_texture_astc"]);
-  this._etc = !!getExtension(gl, ["WEBG_compressed_texture_etc"]);
-  this._etc1 = !!getExtension(gl, ["WEBGL_compressed_texture_etc1"]);
-  this._bc7 = !!getExtension(gl, ["EXT_texture_compression_bptc"]);
+    this._s3tc = !!getExtension(gl, [
+      "WEBGL_compressed_texture_s3tc",
+      "MOZ_WEBGL_compressed_texture_s3tc",
+      "WEBKIT_WEBGL_compressed_texture_s3tc",
+    ]);
+    this._pvrtc = !!getExtension(gl, [
+      "WEBGL_compressed_texture_pvrtc",
+      "WEBKIT_WEBGL_compressed_texture_pvrtc",
+    ]);
+    this._astc = !!getExtension(gl, ["WEBGL_compressed_texture_astc"]);
+    this._etc = !!getExtension(gl, ["WEBG_compressed_texture_etc"]);
+    this._etc1 = !!getExtension(gl, ["WEBGL_compressed_texture_etc1"]);
+    this._bc7 = !!getExtension(gl, ["EXT_texture_compression_bptc"]);
 
-  // It is necessary to pass supported formats to loadKTX2
-  // because imagery layers don't have access to the context.
-  loadKTX2.setKTX2SupportedFormats(
-    this._s3tc,
-    this._pvrtc,
-    this._astc,
-    this._etc,
-    this._etc1,
-    this._bc7,
-  );
+    // It is necessary to pass supported formats to loadKTX2
+    // because imagery layers don't have access to the context.
+    loadKTX2.setKTX2SupportedFormats(
+      this._s3tc,
+      this._pvrtc,
+      this._astc,
+      this._etc,
+      this._etc1,
+      this._bc7,
+    );
 
-  const textureFilterAnisotropic = allowTextureFilterAnisotropic
-    ? getExtension(gl, [
-        "EXT_texture_filter_anisotropic",
-        "WEBKIT_EXT_texture_filter_anisotropic",
-      ])
-    : undefined;
-  this._textureFilterAnisotropic = textureFilterAnisotropic;
-  ContextLimits._maximumTextureFilterAnisotropy = defined(
-    textureFilterAnisotropic,
-  )
-    ? gl.getParameter(textureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT)
-    : 1.0;
+    const textureFilterAnisotropic = allowTextureFilterAnisotropic
+      ? getExtension(gl, [
+          "EXT_texture_filter_anisotropic",
+          "WEBKIT_EXT_texture_filter_anisotropic",
+        ])
+      : undefined;
+    this._textureFilterAnisotropic = textureFilterAnisotropic;
+    ContextLimits._maximumTextureFilterAnisotropy = defined(
+      textureFilterAnisotropic,
+    )
+      ? gl.getParameter(textureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT)
+      : 1.0;
 
-  let glCreateVertexArray;
-  let glBindVertexArray;
-  let glDeleteVertexArray;
+    let glCreateVertexArray;
+    let glBindVertexArray;
+    let glDeleteVertexArray;
 
-  let glDrawElementsInstanced;
-  let glDrawArraysInstanced;
-  let glVertexAttribDivisor;
+    let glDrawElementsInstanced;
+    let glDrawArraysInstanced;
+    let glVertexAttribDivisor;
 
-  let glDrawBuffers;
+    let glDrawBuffers;
 
-  let vertexArrayObject;
-  let instancedArrays;
-  let drawBuffers;
+    let vertexArrayObject;
+    let instancedArrays;
+    let drawBuffers;
 
-  if (webgl2) {
-    const that = this;
+    if (webgl2) {
+      const that = this;
 
-    glCreateVertexArray = function () {
-      return that._gl.createVertexArray();
-    };
-    glBindVertexArray = function (vao) {
-      that._gl.bindVertexArray(vao);
-    };
-    glDeleteVertexArray = function (vao) {
-      that._gl.deleteVertexArray(vao);
-    };
-
-    glDrawElementsInstanced = function (
-      mode,
-      count,
-      type,
-      offset,
-      instanceCount,
-    ) {
-      gl.drawElementsInstanced(mode, count, type, offset, instanceCount);
-    };
-    glDrawArraysInstanced = function (mode, first, count, instanceCount) {
-      gl.drawArraysInstanced(mode, first, count, instanceCount);
-    };
-    glVertexAttribDivisor = function (index, divisor) {
-      gl.vertexAttribDivisor(index, divisor);
-    };
-
-    glDrawBuffers = function (buffers) {
-      gl.drawBuffers(buffers);
-    };
-  } else {
-    vertexArrayObject = getExtension(gl, ["OES_vertex_array_object"]);
-    if (defined(vertexArrayObject)) {
       glCreateVertexArray = function () {
-        return vertexArrayObject.createVertexArrayOES();
+        return that._gl.createVertexArray();
       };
-      glBindVertexArray = function (vertexArray) {
-        vertexArrayObject.bindVertexArrayOES(vertexArray);
+      glBindVertexArray = function (vao) {
+        that._gl.bindVertexArray(vao);
       };
-      glDeleteVertexArray = function (vertexArray) {
-        vertexArrayObject.deleteVertexArrayOES(vertexArray);
+      glDeleteVertexArray = function (vao) {
+        that._gl.deleteVertexArray(vao);
       };
-    }
 
-    instancedArrays = getExtension(gl, ["ANGLE_instanced_arrays"]);
-    if (defined(instancedArrays)) {
       glDrawElementsInstanced = function (
         mode,
         count,
@@ -278,114 +252,977 @@ function Context(canvas, options) {
         offset,
         instanceCount,
       ) {
-        instancedArrays.drawElementsInstancedANGLE(
+        gl.drawElementsInstanced(mode, count, type, offset, instanceCount);
+      };
+      glDrawArraysInstanced = function (mode, first, count, instanceCount) {
+        gl.drawArraysInstanced(mode, first, count, instanceCount);
+      };
+      glVertexAttribDivisor = function (index, divisor) {
+        gl.vertexAttribDivisor(index, divisor);
+      };
+
+      glDrawBuffers = function (buffers) {
+        gl.drawBuffers(buffers);
+      };
+    } else {
+      vertexArrayObject = getExtension(gl, ["OES_vertex_array_object"]);
+      if (defined(vertexArrayObject)) {
+        glCreateVertexArray = function () {
+          return vertexArrayObject.createVertexArrayOES();
+        };
+        glBindVertexArray = function (vertexArray) {
+          vertexArrayObject.bindVertexArrayOES(vertexArray);
+        };
+        glDeleteVertexArray = function (vertexArray) {
+          vertexArrayObject.deleteVertexArrayOES(vertexArray);
+        };
+      }
+
+      instancedArrays = getExtension(gl, ["ANGLE_instanced_arrays"]);
+      if (defined(instancedArrays)) {
+        glDrawElementsInstanced = function (
           mode,
           count,
           type,
           offset,
           instanceCount,
-        );
-      };
-      glDrawArraysInstanced = function (mode, first, count, instanceCount) {
-        instancedArrays.drawArraysInstancedANGLE(
-          mode,
-          first,
-          count,
-          instanceCount,
-        );
-      };
-      glVertexAttribDivisor = function (index, divisor) {
-        instancedArrays.vertexAttribDivisorANGLE(index, divisor);
-      };
+        ) {
+          instancedArrays.drawElementsInstancedANGLE(
+            mode,
+            count,
+            type,
+            offset,
+            instanceCount,
+          );
+        };
+        glDrawArraysInstanced = function (mode, first, count, instanceCount) {
+          instancedArrays.drawArraysInstancedANGLE(
+            mode,
+            first,
+            count,
+            instanceCount,
+          );
+        };
+        glVertexAttribDivisor = function (index, divisor) {
+          instancedArrays.vertexAttribDivisorANGLE(index, divisor);
+        };
+      }
+
+      drawBuffers = getExtension(gl, ["WEBGL_draw_buffers"]);
+      if (defined(drawBuffers)) {
+        glDrawBuffers = function (buffers) {
+          drawBuffers.drawBuffersWEBGL(buffers);
+        };
+      }
     }
 
-    drawBuffers = getExtension(gl, ["WEBGL_draw_buffers"]);
-    if (defined(drawBuffers)) {
-      glDrawBuffers = function (buffers) {
-        drawBuffers.drawBuffersWEBGL(buffers);
-      };
+    this.glCreateVertexArray = glCreateVertexArray;
+    this.glBindVertexArray = glBindVertexArray;
+    this.glDeleteVertexArray = glDeleteVertexArray;
+
+    this.glDrawElementsInstanced = glDrawElementsInstanced;
+    this.glDrawArraysInstanced = glDrawArraysInstanced;
+    this.glVertexAttribDivisor = glVertexAttribDivisor;
+
+    this.glDrawBuffers = glDrawBuffers;
+
+    this._vertexArrayObject = !!vertexArrayObject;
+    this._instancedArrays = !!instancedArrays;
+    this._drawBuffers = !!drawBuffers;
+
+    ContextLimits._maximumDrawBuffers = this.drawBuffers
+      ? gl.getParameter(WebGLConstants.MAX_DRAW_BUFFERS)
+      : 1;
+    ContextLimits._maximumColorAttachments = this.drawBuffers
+      ? gl.getParameter(WebGLConstants.MAX_COLOR_ATTACHMENTS)
+      : 1;
+
+    this._clearColor = new Color(0.0, 0.0, 0.0, 0.0);
+    this._clearDepth = 1.0;
+    this._clearStencil = 0;
+
+    const us = new UniformState();
+    const ps = new PassState(this);
+    const rs = RenderState.fromCache();
+
+    this._defaultPassState = ps;
+    this._defaultRenderState = rs;
+    // default texture has a value of (1, 1, 1)
+    // default emissive texture has a value of (0, 0, 0)
+    // default normal texture is +z which is encoded as (0.5, 0.5, 1)
+    this._defaultTexture = undefined;
+    this._defaultEmissiveTexture = undefined;
+    this._defaultNormalTexture = undefined;
+    this._defaultCubeMap = undefined;
+
+    this._us = us;
+    this._currentRenderState = rs;
+    this._currentPassState = ps;
+    this._currentFramebuffer = undefined;
+    this._maxFrameTextureUnitIndex = 0;
+
+    // Vertex attribute divisor state cache. Workaround for ANGLE (also look at VertexArray.setVertexAttribDivisor)
+    this._vertexAttribDivisors = [];
+    this._previousDrawInstanced = false;
+    for (let i = 0; i < ContextLimits._maximumVertexAttributes; i++) {
+      this._vertexAttribDivisors.push(0);
     }
+
+    this._pickObjects = new Map();
+    this._nextPickColor = new Uint32Array(1);
+
+    /**
+     * The options used to construct this context
+     *
+     * @type {ContextOptions}
+     */
+    this.options = {
+      getWebGLStub: getWebGLStub,
+      requestWebgl1: requestWebgl1,
+      webgl: webglOptions,
+      allowTextureFilterAnisotropic: allowTextureFilterAnisotropic,
+    };
+
+    /**
+     * A cache of objects tied to this context.  Just before the Context is destroyed,
+     * <code>destroy</code> will be invoked on each object in this object literal that has
+     * such a method.  This is useful for caching any objects that might otherwise
+     * be stored globally, except they're tied to a particular context, and to manage
+     * their lifetime.
+     *
+     * @type {object}
+     */
+    this.cache = {};
+
+    RenderState.apply(gl, rs, ps);
   }
 
-  this.glCreateVertexArray = glCreateVertexArray;
-  this.glBindVertexArray = glBindVertexArray;
-  this.glDeleteVertexArray = glDeleteVertexArray;
-
-  this.glDrawElementsInstanced = glDrawElementsInstanced;
-  this.glDrawArraysInstanced = glDrawArraysInstanced;
-  this.glVertexAttribDivisor = glVertexAttribDivisor;
-
-  this.glDrawBuffers = glDrawBuffers;
-
-  this._vertexArrayObject = !!vertexArrayObject;
-  this._instancedArrays = !!instancedArrays;
-  this._drawBuffers = !!drawBuffers;
-
-  ContextLimits._maximumDrawBuffers = this.drawBuffers
-    ? gl.getParameter(WebGLConstants.MAX_DRAW_BUFFERS)
-    : 1;
-  ContextLimits._maximumColorAttachments = this.drawBuffers
-    ? gl.getParameter(WebGLConstants.MAX_COLOR_ATTACHMENTS)
-    : 1;
-
-  this._clearColor = new Color(0.0, 0.0, 0.0, 0.0);
-  this._clearDepth = 1.0;
-  this._clearStencil = 0;
-
-  const us = new UniformState();
-  const ps = new PassState(this);
-  const rs = RenderState.fromCache();
-
-  this._defaultPassState = ps;
-  this._defaultRenderState = rs;
-  // default texture has a value of (1, 1, 1)
-  // default emissive texture has a value of (0, 0, 0)
-  // default normal texture is +z which is encoded as (0.5, 0.5, 1)
-  this._defaultTexture = undefined;
-  this._defaultEmissiveTexture = undefined;
-  this._defaultNormalTexture = undefined;
-  this._defaultCubeMap = undefined;
-
-  this._us = us;
-  this._currentRenderState = rs;
-  this._currentPassState = ps;
-  this._currentFramebuffer = undefined;
-  this._maxFrameTextureUnitIndex = 0;
-
-  // Vertex attribute divisor state cache. Workaround for ANGLE (also look at VertexArray.setVertexAttribDivisor)
-  this._vertexAttribDivisors = [];
-  this._previousDrawInstanced = false;
-  for (let i = 0; i < ContextLimits._maximumVertexAttributes; i++) {
-    this._vertexAttribDivisors.push(0);
+  get id() {
+    return this._id;
   }
 
-  this._pickObjects = new Map();
-  this._nextPickColor = new Uint32Array(1);
+  get webgl2() {
+    return this._webgl2;
+  }
+
+  get canvas() {
+    return this._canvas;
+  }
+
+  get shaderCache() {
+    return this._shaderCache;
+  }
+
+  get textureCache() {
+    return this._textureCache;
+  }
+
+  get uniformState() {
+    return this._us;
+  }
 
   /**
-   * The options used to construct this context
-   *
-   * @type {ContextOptions}
+   * The number of stencil bits per pixel in the default bound framebuffer.  The minimum is eight bits.
+   * @type {number}
+   * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGet.xml|glGet} with <code>STENCIL_BITS</code>.
    */
-  this.options = {
-    getWebGLStub: getWebGLStub,
-    requestWebgl1: requestWebgl1,
-    webgl: webglOptions,
-    allowTextureFilterAnisotropic: allowTextureFilterAnisotropic,
-  };
+  get stencilBits() {
+    return this._stencilBits;
+  }
 
   /**
-   * A cache of objects tied to this context.  Just before the Context is destroyed,
-   * <code>destroy</code> will be invoked on each object in this object literal that has
-   * such a method.  This is useful for caching any objects that might otherwise
-   * be stored globally, except they're tied to a particular context, and to manage
-   * their lifetime.
-   *
+   * <code>true</code> if the WebGL context supports stencil buffers.
+   * Stencil buffers are not supported by all systems.
+   * @type {boolean}
+   */
+  get stencilBuffer() {
+    return this._stencilBits >= 8;
+  }
+
+  /**
+   * <code>true</code> if the WebGL context supports antialiasing.  By default
+   * antialiasing is requested, but it is not supported by all systems.
+   * @type {boolean}
+   */
+  get antialias() {
+    return this._antialias;
+  }
+
+  /**
+   * <code>true</code> if the WebGL context supports multisample antialiasing. Requires
+   * WebGL2.
+   * @type {boolean}
+   */
+  get msaa() {
+    return this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if the OES_standard_derivatives extension is supported.  This
+   * extension provides access to <code>dFdx</code>, <code>dFdy</code>, and <code>fwidth</code>
+   * functions from GLSL.  A shader using these functions still needs to explicitly enable the
+   * extension with <code>#extension GL_OES_standard_derivatives : enable</code>.
+   * @type {boolean}
+   * @see {@link http://www.khronos.org/registry/gles/extensions/OES/OES_standard_derivatives.txt|OES_standard_derivatives}
+   */
+  get standardDerivatives() {
+    return this._standardDerivatives || this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if the EXT_float_blend extension is supported. This
+   * extension enables blending with 32-bit float values.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/}
+   */
+  get floatBlend() {
+    return this._floatBlend;
+  }
+
+  /**
+   * <code>true</code> if the EXT_blend_minmax extension is supported.  This
+   * extension extends blending capabilities by adding two new blend equations:
+   * the minimum or maximum color components of the source and destination colors.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/}
+   */
+  get blendMinmax() {
+    return this._blendMinmax || this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if the OES_element_index_uint extension is supported.  This
+   * extension allows the use of unsigned int indices, which can improve performance by
+   * eliminating batch breaking caused by unsigned short indices.
+   * @type {boolean}
+   * @see {@link http://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/|OES_element_index_uint}
+   */
+  get elementIndexUint() {
+    return this._elementIndexUint || this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if WEBGL_depth_texture is supported.  This extension provides
+   * access to depth textures that, for example, can be attached to framebuffers for shadow mapping.
+   * @type {boolean}
+   * @see {@link http://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/|WEBGL_depth_texture}
+   */
+  get depthTexture() {
+    return this._depthTexture || this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if OES_texture_float is supported. This extension provides
+   * access to floating point textures that, for example, can be attached to framebuffers for high dynamic range.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_float/}
+   */
+  get floatingPointTexture() {
+    return this._webgl2 || this._textureFloat;
+  }
+
+  /**
+   * <code>true</code> if OES_texture_half_float is supported. This extension provides
+   * access to floating point textures that, for example, can be attached to framebuffers for high dynamic range.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/}
+   */
+  get halfFloatingPointTexture() {
+    return this._webgl2 || this._textureHalfFloat;
+  }
+
+  /**
+   * <code>true</code> if OES_texture_float_linear is supported. This extension provides
+   * access to linear sampling methods for minification and magnification filters of floating-point textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/}
+   */
+  get textureFloatLinear() {
+    return this._textureFloatLinear;
+  }
+
+  /**
+   * <code>true</code> if OES_texture_half_float_linear is supported. This extension provides
+   * access to linear sampling methods for minification and magnification filters of half floating-point textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/}
+   */
+  get textureHalfFloatLinear() {
+    return (
+      (this._webgl2 && this._textureFloatLinear) ||
+      (!this._webgl2 && this._textureHalfFloatLinear)
+    );
+  }
+
+  /**
+   * <code>true</code> if EXT_shader_texture_lod is supported. This extension provides
+   * access to explicit LOD selection in texture sampling functions.
+   * @type {boolean}
+   * @see {@link https://registry.khronos.org/webgl/extensions/EXT_shader_texture_lod/}
+   */
+  get supportsTextureLod() {
+    return this._webgl2 || this._supportsTextureLod;
+  }
+
+  /**
+   * <code>true</code> if EXT_texture_filter_anisotropic is supported. This extension provides
+   * access to anisotropic filtering for textured surfaces at an oblique angle from the viewer.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/}
+   */
+  get textureFilterAnisotropic() {
+    return !!this._textureFilterAnisotropic;
+  }
+
+  /**
+   * <code>true</code> if WEBGL_compressed_texture_s3tc is supported.  This extension provides
+   * access to DXT compressed textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/}
+   */
+  get s3tc() {
+    return this._s3tc;
+  }
+
+  /**
+   * <code>true</code> if WEBGL_compressed_texture_pvrtc is supported.  This extension provides
+   * access to PVR compressed textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/}
+   */
+  get pvrtc() {
+    return this._pvrtc;
+  }
+
+  /**
+   * <code>true</code> if WEBGL_compressed_texture_astc is supported.  This extension provides
+   * access to ASTC compressed textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/}
+   */
+  get astc() {
+    return this._astc;
+  }
+
+  /**
+   * <code>true</code> if WEBGL_compressed_texture_etc is supported.  This extension provides
+   * access to ETC compressed textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/}
+   */
+  get etc() {
+    return this._etc;
+  }
+
+  /**
+   * <code>true</code> if WEBGL_compressed_texture_etc1 is supported.  This extension provides
+   * access to ETC1 compressed textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/}
+   */
+  get etc1() {
+    return this._etc1;
+  }
+
+  /**
+   * <code>true</code> if EXT_texture_compression_bptc is supported.  This extension provides
+   * access to BC7 compressed textures.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/}
+   */
+  get bc7() {
+    return this._bc7;
+  }
+
+  /**
+   * <code>true</code> if S3TC, PVRTC, ASTC, ETC, ETC1, or BC7 compression is supported.
+   * @type {boolean}
+   */
+  get supportsBasis() {
+    return (
+      this._s3tc ||
+      this._pvrtc ||
+      this._astc ||
+      this._etc ||
+      this._etc1 ||
+      this._bc7
+    );
+  }
+
+  /**
+   * <code>true</code> if the OES_vertex_array_object extension is supported.  This
+   * extension can improve performance by reducing the overhead of switching vertex arrays.
+   * When enabled, this extension is automatically used by {@link VertexArray}.
+   * @type {boolean}
+   * @see {@link http://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/|OES_vertex_array_object}
+   */
+  get vertexArrayObject() {
+    return this._vertexArrayObject || this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if the EXT_frag_depth extension is supported.  This
+   * extension provides access to the <code>gl_FragDepthEXT</code> built-in output variable
+   * from GLSL fragment shaders.  A shader using these functions still needs to explicitly enable the
+   * extension with <code>#extension GL_EXT_frag_depth : enable</code>.
+   * @type {boolean}
+   * @see {@link http://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/|EXT_frag_depth}
+   */
+  get fragmentDepth() {
+    return this._fragDepth || this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if the ANGLE_instanced_arrays extension is supported.  This
+   * extension provides access to instanced rendering.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays}
+   */
+  get instancedArrays() {
+    return this._instancedArrays || this._webgl2;
+  }
+
+  /**
+   * <code>true</code> if the EXT_color_buffer_float extension is supported.  This
+   * extension makes the gl.RGBA32F format color renderable.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/}
+   */
+  get colorBufferFloat() {
+    return this._colorBufferFloat;
+  }
+
+  /**
+   * <code>true</code> if the EXT_color_buffer_half_float extension is supported.  This
+   * extension makes the format gl.RGBA16F format color renderable.
+   * @type {boolean}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/}
+   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/}
+   */
+  get colorBufferHalfFloat() {
+    return (
+      (this._webgl2 && this._colorBufferFloat) ||
+      (!this._webgl2 && this._colorBufferHalfFloat)
+    );
+  }
+
+  /**
+   * <code>true</code> if the WEBGL_draw_buffers extension is supported. This
+   * extensions provides support for multiple render targets. The framebuffer object can have mutiple
+   * color attachments and the GLSL fragment shader can write to the built-in output array <code>gl_FragData</code>.
+   * A shader using this feature needs to explicitly enable the extension with
+   * <code>#extension GL_EXT_draw_buffers : enable</code>.
+   * @type {boolean}
+   * @see {@link http://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/|WEBGL_draw_buffers}
+   */
+  get drawBuffers() {
+    return this._drawBuffers || this._webgl2;
+  }
+
+  get debugShaders() {
+    return this._debugShaders;
+  }
+
+  get throwOnWebGLError() {
+    return this._throwOnWebGLError;
+  }
+
+  set throwOnWebGLError(value) {
+    this._throwOnWebGLError = value;
+    this._gl = wrapGL(
+      this._originalGLContext,
+      value ? throwOnError : undefined,
+    );
+  }
+
+  /**
+   * A 1x1 RGBA texture initialized to [255, 255, 255, 255].  This can
+   * be used as a placeholder texture while other textures are downloaded.
+   * @type {Texture}
+   */
+  get defaultTexture() {
+    if (this._defaultTexture === undefined) {
+      this._defaultTexture = new Texture({
+        context: this,
+        source: {
+          width: 1,
+          height: 1,
+          arrayBufferView: new Uint8Array([255, 255, 255, 255]),
+        },
+        flipY: false,
+      });
+    }
+
+    return this._defaultTexture;
+  }
+
+  /**
+   * A 1x1 RGB texture initialized to [0, 0, 0] representing a material that is
+   * not emissive. This can be used as a placeholder texture for emissive
+   * textures while other textures are downloaded.
+   * @type {Texture}
+   */
+  get defaultEmissiveTexture() {
+    if (this._defaultEmissiveTexture === undefined) {
+      this._defaultEmissiveTexture = new Texture({
+        context: this,
+        pixelFormat: PixelFormat.RGB,
+        source: {
+          width: 1,
+          height: 1,
+          arrayBufferView: new Uint8Array([0, 0, 0]),
+        },
+        flipY: false,
+      });
+    }
+
+    return this._defaultEmissiveTexture;
+  }
+
+  /**
+   * A 1x1 RGBA texture initialized to [128, 128, 255] to encode a tangent
+   * space normal pointing in the +z direction, i.e. (0, 0, 1). This can
+   * be used as a placeholder normal texture while other textures are
+   * downloaded.
+   * @type {Texture}
+   */
+  get defaultNormalTexture() {
+    if (this._defaultNormalTexture === undefined) {
+      this._defaultNormalTexture = new Texture({
+        context: this,
+        pixelFormat: PixelFormat.RGB,
+        source: {
+          width: 1,
+          height: 1,
+          arrayBufferView: new Uint8Array([128, 128, 255]),
+        },
+        flipY: false,
+      });
+    }
+
+    return this._defaultNormalTexture;
+  }
+
+  /**
+   * A cube map, where each face is a 1x1 RGBA texture initialized to
+   * [255, 255, 255, 255].  This can be used as a placeholder cube map while
+   * other cube maps are downloaded.
+   * @type {CubeMap}
+   */
+  get defaultCubeMap() {
+    if (this._defaultCubeMap === undefined) {
+      const face = {
+        width: 1,
+        height: 1,
+        arrayBufferView: new Uint8Array([255, 255, 255, 255]),
+      };
+
+      this._defaultCubeMap = new CubeMap({
+        context: this,
+        source: {
+          positiveX: face,
+          negativeX: face,
+          positiveY: face,
+          negativeY: face,
+          positiveZ: face,
+          negativeZ: face,
+        },
+        flipY: false,
+      });
+    }
+
+    return this._defaultCubeMap;
+  }
+
+  /**
+   * The drawingBufferHeight of the underlying GL context.
+   * @type {number}
+   * @see {@link https://www.khronos.org/registry/webgl/specs/1.0/#DOM-WebGLRenderingContext-drawingBufferHeight|drawingBufferHeight}
+   */
+  get drawingBufferHeight() {
+    return this._gl.drawingBufferHeight;
+  }
+
+  /**
+   * The drawingBufferWidth of the underlying GL context.
+   * @type {number}
+   * @see {@link https://www.khronos.org/registry/webgl/specs/1.0/#DOM-WebGLRenderingContext-drawingBufferWidth|drawingBufferWidth}
+   */
+  get drawingBufferWidth() {
+    return this._gl.drawingBufferWidth;
+  }
+
+  /**
+   * Gets an object representing the currently bound framebuffer.  While this instance is not an actual
+   * {@link Framebuffer}, it is used to represent the default framebuffer in calls to
+   * {@link Texture.fromFramebuffer}.
    * @type {object}
    */
-  this.cache = {};
+  get defaultFramebuffer() {
+    return defaultFramebufferMarker;
+  }
 
-  RenderState.apply(gl, rs, ps);
+  clear(clearCommand, passState) {
+    clearCommand = clearCommand ?? defaultClearCommand;
+    passState = passState ?? this._defaultPassState;
+
+    const gl = this._gl;
+    let bitmask = 0;
+
+    const c = clearCommand.color;
+    const d = clearCommand.depth;
+    const s = clearCommand.stencil;
+
+    if (defined(c)) {
+      if (!Color.equals(this._clearColor, c)) {
+        Color.clone(c, this._clearColor);
+        gl.clearColor(c.red, c.green, c.blue, c.alpha);
+      }
+      bitmask |= gl.COLOR_BUFFER_BIT;
+    }
+
+    if (defined(d)) {
+      if (d !== this._clearDepth) {
+        this._clearDepth = d;
+        gl.clearDepth(d);
+      }
+      bitmask |= gl.DEPTH_BUFFER_BIT;
+    }
+
+    if (defined(s)) {
+      if (s !== this._clearStencil) {
+        this._clearStencil = s;
+        gl.clearStencil(s);
+      }
+      bitmask |= gl.STENCIL_BUFFER_BIT;
+    }
+
+    const rs = clearCommand.renderState ?? this._defaultRenderState;
+    applyRenderState(this, rs, passState, true);
+
+    // The command's framebuffer takes presidence over the pass' framebuffer, e.g., for off-screen rendering.
+    const framebuffer = clearCommand.framebuffer ?? passState.framebuffer;
+    bindFramebuffer(this, framebuffer);
+
+    gl.clear(bitmask);
+  }
+
+  draw(drawCommand, passState, shaderProgram, uniformMap) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("drawCommand", drawCommand);
+    Check.defined("drawCommand.shaderProgram", drawCommand._shaderProgram);
+    //>>includeEnd('debug');
+
+    passState = passState ?? this._defaultPassState;
+    // The command's framebuffer takes precedence over the pass' framebuffer, e.g., for off-screen rendering.
+    const framebuffer = drawCommand._framebuffer ?? passState.framebuffer;
+    const renderState = drawCommand._renderState ?? this._defaultRenderState;
+    shaderProgram = shaderProgram ?? drawCommand._shaderProgram;
+    uniformMap = uniformMap ?? drawCommand._uniformMap;
+
+    beginDraw(this, framebuffer, passState, shaderProgram, renderState);
+    continueDraw(this, drawCommand, shaderProgram, uniformMap);
+  }
+
+  beginFrame() {
+    // A no-op. Overridden when drawing to a SharedContext.
+  }
+
+  endFrame() {
+    const gl = this._gl;
+    gl.useProgram(null);
+
+    this._currentFramebuffer = undefined;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    const buffers = scratchBackBufferArray;
+    if (this.drawBuffers) {
+      this.glDrawBuffers(buffers);
+    }
+
+    const length = this._maxFrameTextureUnitIndex;
+    this._maxFrameTextureUnitIndex = 0;
+
+    for (let i = 0; i < length; ++i) {
+      gl.activeTexture(gl.TEXTURE0 + i);
+      gl.bindTexture(gl.TEXTURE_2D, null);
+      gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
+    }
+  }
+
+  /**
+   * @typedef {object} ReadState
+   *
+   * Options defining a rectangle to read pixels from.
+   *
+   * @private
+   * @property {number} [x=0] The x offset of the rectangle to read from.
+   * @property {number} [y=0] The y offset of the rectangle to read from.
+   * @property {number} [width=this.drawingBufferWidth] The width of the rectangle to read from.
+   * @property {number} [height=this.drawingBufferHeight] The height of the rectangle to read from.
+   * @property {FrameBuffer|undefined} [framebuffer] The framebuffer to read from. If undefined, the read will be from the default framebuffer.
+   */
+
+  /**
+   * Read pixels from a framebuffer into a Pixel Buffer Object (PBO).
+   *
+   * @private
+   * @param {ReadState} readState Options defining a rectangle to read pixels from.
+   * @returns {Buffer} A PixelBuffer containing the pixels read from the specified rectangle.
+   *
+   * @exception {DeveloperError} A WebGL 2 context is required to read pixels using a PBO.
+   */
+  readPixelsToPBO(readState) {
+    const gl = this._gl;
+
+    readState = readState ?? Frozen.EMPTY_OBJECT;
+    const x = Math.max(readState.x ?? 0, 0);
+    const y = Math.max(readState.y ?? 0, 0);
+    const width = readState.width ?? this.drawingBufferWidth;
+    const height = readState.height ?? this.drawingBufferHeight;
+    const framebuffer = readState.framebuffer;
+
+    if (!this._webgl2) {
+      throw new DeveloperError(
+        "A WebGL 2 context is required to read pixels using a PBO.",
+      );
+    }
+
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.number.greaterThan("readState.width", width, 0);
+    Check.typeOf.number.greaterThan("readState.height", height, 0);
+    //>>includeEnd('debug');
+
+    let pixelDatatype = PixelDatatype.UNSIGNED_BYTE;
+    let pixelFormat = PixelFormat.RGBA;
+    if (defined(framebuffer) && framebuffer.numberOfColorAttachments > 0) {
+      pixelDatatype = framebuffer.getColorTexture(0).pixelDatatype;
+      pixelFormat = framebuffer.getColorTexture(0).pixelFormat;
+    }
+
+    const pixels = Buffer.createPixelBuffer({
+      context: this,
+      sizeInBytes: PixelFormat.textureSizeInBytes(
+        pixelFormat,
+        pixelDatatype,
+        width,
+        height,
+      ),
+      usage: BufferUsage.DYNAMIC_READ,
+    });
+
+    bindFramebuffer(this, framebuffer);
+
+    pixels._bind();
+    gl.readPixels(
+      x,
+      y,
+      width,
+      height,
+      pixelFormat,
+      PixelDatatype.toWebGLConstant(pixelDatatype, this),
+      0,
+    );
+    pixels._unBind();
+
+    return pixels;
+  }
+
+  /**
+   * Read pixels from a framebuffer into a typed array.
+   *
+   * @private
+   * @param {ReadState} readState Options defining a rectangle to read pixels from.
+   * @returns {Uint8Array|Uint16Array|Float32Array|Uint32Array} The pixels in the specified rectangle.
+   */
+  readPixels(readState) {
+    const gl = this._gl;
+
+    readState = readState ?? Frozen.EMPTY_OBJECT;
+    const x = Math.max(readState.x ?? 0, 0);
+    const y = Math.max(readState.y ?? 0, 0);
+    const width = readState.width ?? this.drawingBufferWidth;
+    const height = readState.height ?? this.drawingBufferHeight;
+    const framebuffer = readState.framebuffer;
+
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.number.greaterThan("readState.width", width, 0);
+    Check.typeOf.number.greaterThan("readState.height", height, 0);
+    //>>includeEnd('debug');
+
+    let pixelDatatype = PixelDatatype.UNSIGNED_BYTE;
+    let pixelFormat = PixelFormat.RGBA;
+    if (defined(framebuffer) && framebuffer.numberOfColorAttachments > 0) {
+      pixelDatatype = framebuffer.getColorTexture(0).pixelDatatype;
+      pixelFormat = framebuffer.getColorTexture(0).pixelFormat;
+    }
+
+    const pixels = PixelFormat.createTypedArray(
+      pixelFormat,
+      pixelDatatype,
+      width,
+      height,
+    );
+
+    bindFramebuffer(this, framebuffer);
+
+    gl.readPixels(
+      x,
+      y,
+      width,
+      height,
+      PixelFormat.RGBA,
+      PixelDatatype.toWebGLConstant(pixelDatatype, this),
+      pixels,
+    );
+
+    return pixels;
+  }
+
+  getViewportQuadVertexArray() {
+    // Per-context cache for viewport quads
+    let vertexArray = this.cache.viewportQuad_vertexArray;
+
+    if (!defined(vertexArray)) {
+      const geometry = new Geometry({
+        attributes: {
+          position: new GeometryAttribute({
+            componentDatatype: ComponentDatatype.FLOAT,
+            componentsPerAttribute: 2,
+            values: [-1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0, 1.0],
+          }),
+
+          textureCoordinates: new GeometryAttribute({
+            componentDatatype: ComponentDatatype.FLOAT,
+            componentsPerAttribute: 2,
+            values: [0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0],
+          }),
+        },
+        // Workaround Internet Explorer 11.0.8 lack of TRIANGLE_FAN
+        indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+        primitiveType: PrimitiveType.TRIANGLES,
+      });
+
+      vertexArray = VertexArray.fromGeometry({
+        context: this,
+        geometry: geometry,
+        attributeLocations: viewportQuadAttributeLocations,
+        bufferUsage: BufferUsage.STATIC_DRAW,
+        interleave: true,
+      });
+
+      this.cache.viewportQuad_vertexArray = vertexArray;
+    }
+
+    return vertexArray;
+  }
+
+  createViewportQuadCommand(fragmentShaderSource, overrides) {
+    overrides = overrides ?? Frozen.EMPTY_OBJECT;
+
+    return new DrawCommand({
+      vertexArray: this.getViewportQuadVertexArray(),
+      primitiveType: PrimitiveType.TRIANGLES,
+      renderState: overrides.renderState,
+      shaderProgram: ShaderProgram.fromCache({
+        context: this,
+        vertexShaderSource: ViewportQuadVS,
+        fragmentShaderSource: fragmentShaderSource,
+        attributeLocations: viewportQuadAttributeLocations,
+      }),
+      uniformMap: overrides.uniformMap,
+      owner: overrides.owner,
+      framebuffer: overrides.framebuffer,
+      pass: overrides.pass,
+    });
+  }
+
+  /**
+   * Gets the object associated with a pick color.
+   *
+   * @param {number} pickColor The unsigned 32-bit RGBA pick color
+   * @returns {object} The object associated with the pick color, or undefined if no object is associated with that color.
+   *
+   * @example
+   * const object = context.getObjectByPickColor(pickColor);
+   *
+   * @see Context#createPickId
+   */
+  getObjectByPickColor(pickColor) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("pickColor", pickColor);
+    //>>includeEnd('debug');
+
+    return this._pickObjects.get(pickColor);
+  }
+
+  /**
+   * Creates a unique ID associated with the input object for use with color-buffer picking.
+   * The ID has an RGBA color value unique to this context.  You must call destroy()
+   * on the pick ID when destroying the input object.
+   *
+   * @param {object} object The object to associate with the pick ID.
+   * @returns {PickId} A PickId object with a <code>color</code> property.
+   *
+   * @exception {RuntimeError} Out of unique Pick IDs.
+   *
+   *
+   * @example
+   * this._pickId = context.createPickId({
+   *   primitive : this,
+   *   id : this.id
+   * });
+   *
+   * @see Context#getObjectByPickColor
+   */
+  createPickId(object) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("object", object);
+    //>>includeEnd('debug');
+
+    // the increment and assignment have to be separate statements to
+    // actually detect overflow in the Uint32 value
+    ++this._nextPickColor[0];
+    const key = this._nextPickColor[0];
+    if (key === 0) {
+      // In case of overflow
+      throw new RuntimeError("Out of unique Pick IDs.");
+    }
+
+    this._pickObjects.set(key, object);
+    return new PickId(this._pickObjects, key, Color.fromRgba(key));
+  }
+
+  isDestroyed() {
+    return false;
+  }
+
+  destroy() {
+    // Destroy all objects in the cache that have a destroy method.
+    const cache = this.cache;
+    for (const property in cache) {
+      if (cache.hasOwnProperty(property)) {
+        const propertyValue = cache[property];
+        if (defined(propertyValue.destroy)) {
+          propertyValue.destroy();
+        }
+      }
+    }
+
+    this._shaderCache = this._shaderCache.destroy();
+    this._textureCache = this._textureCache.destroy();
+    this._defaultTexture =
+      this._defaultTexture && this._defaultTexture.destroy();
+    this._defaultEmissiveTexture =
+      this._defaultEmissiveTexture && this._defaultEmissiveTexture.destroy();
+    this._defaultNormalTexture =
+      this._defaultNormalTexture && this._defaultNormalTexture.destroy();
+    this._defaultCubeMap =
+      this._defaultCubeMap && this._defaultCubeMap.destroy();
+
+    return destroyObject(this);
+  }
 }
 
 /**
@@ -575,587 +1412,6 @@ function getExtension(gl, names) {
 
 const defaultFramebufferMarker = {};
 
-Object.defineProperties(Context.prototype, {
-  id: {
-    get: function () {
-      return this._id;
-    },
-  },
-  webgl2: {
-    get: function () {
-      return this._webgl2;
-    },
-  },
-  canvas: {
-    get: function () {
-      return this._canvas;
-    },
-  },
-  shaderCache: {
-    get: function () {
-      return this._shaderCache;
-    },
-  },
-  textureCache: {
-    get: function () {
-      return this._textureCache;
-    },
-  },
-  uniformState: {
-    get: function () {
-      return this._us;
-    },
-  },
-
-  /**
-   * The number of stencil bits per pixel in the default bound framebuffer.  The minimum is eight bits.
-   * @memberof Context.prototype
-   * @type {number}
-   * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGet.xml|glGet} with <code>STENCIL_BITS</code>.
-   */
-  stencilBits: {
-    get: function () {
-      return this._stencilBits;
-    },
-  },
-
-  /**
-   * <code>true</code> if the WebGL context supports stencil buffers.
-   * Stencil buffers are not supported by all systems.
-   * @memberof Context.prototype
-   * @type {boolean}
-   */
-  stencilBuffer: {
-    get: function () {
-      return this._stencilBits >= 8;
-    },
-  },
-
-  /**
-   * <code>true</code> if the WebGL context supports antialiasing.  By default
-   * antialiasing is requested, but it is not supported by all systems.
-   * @memberof Context.prototype
-   * @type {boolean}
-   */
-  antialias: {
-    get: function () {
-      return this._antialias;
-    },
-  },
-
-  /**
-   * <code>true</code> if the WebGL context supports multisample antialiasing. Requires
-   * WebGL2.
-   * @memberof Context.prototype
-   * @type {boolean}
-   */
-  msaa: {
-    get: function () {
-      return this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if the OES_standard_derivatives extension is supported.  This
-   * extension provides access to <code>dFdx</code>, <code>dFdy</code>, and <code>fwidth</code>
-   * functions from GLSL.  A shader using these functions still needs to explicitly enable the
-   * extension with <code>#extension GL_OES_standard_derivatives : enable</code>.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link http://www.khronos.org/registry/gles/extensions/OES/OES_standard_derivatives.txt|OES_standard_derivatives}
-   */
-  standardDerivatives: {
-    get: function () {
-      return this._standardDerivatives || this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if the EXT_float_blend extension is supported. This
-   * extension enables blending with 32-bit float values.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/}
-   */
-  floatBlend: {
-    get: function () {
-      return this._floatBlend;
-    },
-  },
-
-  /**
-   * <code>true</code> if the EXT_blend_minmax extension is supported.  This
-   * extension extends blending capabilities by adding two new blend equations:
-   * the minimum or maximum color components of the source and destination colors.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/}
-   */
-  blendMinmax: {
-    get: function () {
-      return this._blendMinmax || this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if the OES_element_index_uint extension is supported.  This
-   * extension allows the use of unsigned int indices, which can improve performance by
-   * eliminating batch breaking caused by unsigned short indices.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link http://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/|OES_element_index_uint}
-   */
-  elementIndexUint: {
-    get: function () {
-      return this._elementIndexUint || this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if WEBGL_depth_texture is supported.  This extension provides
-   * access to depth textures that, for example, can be attached to framebuffers for shadow mapping.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link http://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/|WEBGL_depth_texture}
-   */
-  depthTexture: {
-    get: function () {
-      return this._depthTexture || this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if OES_texture_float is supported. This extension provides
-   * access to floating point textures that, for example, can be attached to framebuffers for high dynamic range.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_float/}
-   */
-  floatingPointTexture: {
-    get: function () {
-      return this._webgl2 || this._textureFloat;
-    },
-  },
-
-  /**
-   * <code>true</code> if OES_texture_half_float is supported. This extension provides
-   * access to floating point textures that, for example, can be attached to framebuffers for high dynamic range.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/}
-   */
-  halfFloatingPointTexture: {
-    get: function () {
-      return this._webgl2 || this._textureHalfFloat;
-    },
-  },
-
-  /**
-   * <code>true</code> if OES_texture_float_linear is supported. This extension provides
-   * access to linear sampling methods for minification and magnification filters of floating-point textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/}
-   */
-  textureFloatLinear: {
-    get: function () {
-      return this._textureFloatLinear;
-    },
-  },
-
-  /**
-   * <code>true</code> if OES_texture_half_float_linear is supported. This extension provides
-   * access to linear sampling methods for minification and magnification filters of half floating-point textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/}
-   */
-  textureHalfFloatLinear: {
-    get: function () {
-      return (
-        (this._webgl2 && this._textureFloatLinear) ||
-        (!this._webgl2 && this._textureHalfFloatLinear)
-      );
-    },
-  },
-
-  /**
-   * <code>true</code> if EXT_shader_texture_lod is supported. This extension provides
-   * access to explicit LOD selection in texture sampling functions.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://registry.khronos.org/webgl/extensions/EXT_shader_texture_lod/}
-   */
-  supportsTextureLod: {
-    get: function () {
-      return this._webgl2 || this._supportsTextureLod;
-    },
-  },
-
-  /**
-   * <code>true</code> if EXT_texture_filter_anisotropic is supported. This extension provides
-   * access to anisotropic filtering for textured surfaces at an oblique angle from the viewer.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/}
-   */
-  textureFilterAnisotropic: {
-    get: function () {
-      return !!this._textureFilterAnisotropic;
-    },
-  },
-
-  /**
-   * <code>true</code> if WEBGL_compressed_texture_s3tc is supported.  This extension provides
-   * access to DXT compressed textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/}
-   */
-  s3tc: {
-    get: function () {
-      return this._s3tc;
-    },
-  },
-
-  /**
-   * <code>true</code> if WEBGL_compressed_texture_pvrtc is supported.  This extension provides
-   * access to PVR compressed textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/}
-   */
-  pvrtc: {
-    get: function () {
-      return this._pvrtc;
-    },
-  },
-
-  /**
-   * <code>true</code> if WEBGL_compressed_texture_astc is supported.  This extension provides
-   * access to ASTC compressed textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/}
-   */
-  astc: {
-    get: function () {
-      return this._astc;
-    },
-  },
-
-  /**
-   * <code>true</code> if WEBGL_compressed_texture_etc is supported.  This extension provides
-   * access to ETC compressed textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/}
-   */
-  etc: {
-    get: function () {
-      return this._etc;
-    },
-  },
-
-  /**
-   * <code>true</code> if WEBGL_compressed_texture_etc1 is supported.  This extension provides
-   * access to ETC1 compressed textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/}
-   */
-  etc1: {
-    get: function () {
-      return this._etc1;
-    },
-  },
-
-  /**
-   * <code>true</code> if EXT_texture_compression_bptc is supported.  This extension provides
-   * access to BC7 compressed textures.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/}
-   */
-  bc7: {
-    get: function () {
-      return this._bc7;
-    },
-  },
-
-  /**
-   * <code>true</code> if S3TC, PVRTC, ASTC, ETC, ETC1, or BC7 compression is supported.
-   * @memberof Context.prototype
-   * @type {boolean}
-   */
-  supportsBasis: {
-    get: function () {
-      return (
-        this._s3tc ||
-        this._pvrtc ||
-        this._astc ||
-        this._etc ||
-        this._etc1 ||
-        this._bc7
-      );
-    },
-  },
-
-  /**
-   * <code>true</code> if the OES_vertex_array_object extension is supported.  This
-   * extension can improve performance by reducing the overhead of switching vertex arrays.
-   * When enabled, this extension is automatically used by {@link VertexArray}.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link http://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/|OES_vertex_array_object}
-   */
-  vertexArrayObject: {
-    get: function () {
-      return this._vertexArrayObject || this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if the EXT_frag_depth extension is supported.  This
-   * extension provides access to the <code>gl_FragDepthEXT</code> built-in output variable
-   * from GLSL fragment shaders.  A shader using these functions still needs to explicitly enable the
-   * extension with <code>#extension GL_EXT_frag_depth : enable</code>.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link http://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/|EXT_frag_depth}
-   */
-  fragmentDepth: {
-    get: function () {
-      return this._fragDepth || this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if the ANGLE_instanced_arrays extension is supported.  This
-   * extension provides access to instanced rendering.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays}
-   */
-  instancedArrays: {
-    get: function () {
-      return this._instancedArrays || this._webgl2;
-    },
-  },
-
-  /**
-   * <code>true</code> if the EXT_color_buffer_float extension is supported.  This
-   * extension makes the gl.RGBA32F format color renderable.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/}
-   */
-  colorBufferFloat: {
-    get: function () {
-      return this._colorBufferFloat;
-    },
-  },
-
-  /**
-   * <code>true</code> if the EXT_color_buffer_half_float extension is supported.  This
-   * extension makes the format gl.RGBA16F format color renderable.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/}
-   * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/}
-   */
-  colorBufferHalfFloat: {
-    get: function () {
-      return (
-        (this._webgl2 && this._colorBufferFloat) ||
-        (!this._webgl2 && this._colorBufferHalfFloat)
-      );
-    },
-  },
-
-  /**
-   * <code>true</code> if the WEBGL_draw_buffers extension is supported. This
-   * extensions provides support for multiple render targets. The framebuffer object can have mutiple
-   * color attachments and the GLSL fragment shader can write to the built-in output array <code>gl_FragData</code>.
-   * A shader using this feature needs to explicitly enable the extension with
-   * <code>#extension GL_EXT_draw_buffers : enable</code>.
-   * @memberof Context.prototype
-   * @type {boolean}
-   * @see {@link http://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/|WEBGL_draw_buffers}
-   */
-  drawBuffers: {
-    get: function () {
-      return this._drawBuffers || this._webgl2;
-    },
-  },
-
-  debugShaders: {
-    get: function () {
-      return this._debugShaders;
-    },
-  },
-
-  throwOnWebGLError: {
-    get: function () {
-      return this._throwOnWebGLError;
-    },
-    set: function (value) {
-      this._throwOnWebGLError = value;
-      this._gl = wrapGL(
-        this._originalGLContext,
-        value ? throwOnError : undefined,
-      );
-    },
-  },
-
-  /**
-   * A 1x1 RGBA texture initialized to [255, 255, 255, 255].  This can
-   * be used as a placeholder texture while other textures are downloaded.
-   * @memberof Context.prototype
-   * @type {Texture}
-   */
-  defaultTexture: {
-    get: function () {
-      if (this._defaultTexture === undefined) {
-        this._defaultTexture = new Texture({
-          context: this,
-          source: {
-            width: 1,
-            height: 1,
-            arrayBufferView: new Uint8Array([255, 255, 255, 255]),
-          },
-          flipY: false,
-        });
-      }
-
-      return this._defaultTexture;
-    },
-  },
-  /**
-   * A 1x1 RGB texture initialized to [0, 0, 0] representing a material that is
-   * not emissive. This can be used as a placeholder texture for emissive
-   * textures while other textures are downloaded.
-   * @memberof Context.prototype
-   * @type {Texture}
-   */
-  defaultEmissiveTexture: {
-    get: function () {
-      if (this._defaultEmissiveTexture === undefined) {
-        this._defaultEmissiveTexture = new Texture({
-          context: this,
-          pixelFormat: PixelFormat.RGB,
-          source: {
-            width: 1,
-            height: 1,
-            arrayBufferView: new Uint8Array([0, 0, 0]),
-          },
-          flipY: false,
-        });
-      }
-
-      return this._defaultEmissiveTexture;
-    },
-  },
-  /**
-   * A 1x1 RGBA texture initialized to [128, 128, 255] to encode a tangent
-   * space normal pointing in the +z direction, i.e. (0, 0, 1). This can
-   * be used as a placeholder normal texture while other textures are
-   * downloaded.
-   * @memberof Context.prototype
-   * @type {Texture}
-   */
-  defaultNormalTexture: {
-    get: function () {
-      if (this._defaultNormalTexture === undefined) {
-        this._defaultNormalTexture = new Texture({
-          context: this,
-          pixelFormat: PixelFormat.RGB,
-          source: {
-            width: 1,
-            height: 1,
-            arrayBufferView: new Uint8Array([128, 128, 255]),
-          },
-          flipY: false,
-        });
-      }
-
-      return this._defaultNormalTexture;
-    },
-  },
-
-  /**
-   * A cube map, where each face is a 1x1 RGBA texture initialized to
-   * [255, 255, 255, 255].  This can be used as a placeholder cube map while
-   * other cube maps are downloaded.
-   * @memberof Context.prototype
-   * @type {CubeMap}
-   */
-  defaultCubeMap: {
-    get: function () {
-      if (this._defaultCubeMap === undefined) {
-        const face = {
-          width: 1,
-          height: 1,
-          arrayBufferView: new Uint8Array([255, 255, 255, 255]),
-        };
-
-        this._defaultCubeMap = new CubeMap({
-          context: this,
-          source: {
-            positiveX: face,
-            negativeX: face,
-            positiveY: face,
-            negativeY: face,
-            positiveZ: face,
-            negativeZ: face,
-          },
-          flipY: false,
-        });
-      }
-
-      return this._defaultCubeMap;
-    },
-  },
-
-  /**
-   * The drawingBufferHeight of the underlying GL context.
-   * @memberof Context.prototype
-   * @type {number}
-   * @see {@link https://www.khronos.org/registry/webgl/specs/1.0/#DOM-WebGLRenderingContext-drawingBufferHeight|drawingBufferHeight}
-   */
-  drawingBufferHeight: {
-    get: function () {
-      return this._gl.drawingBufferHeight;
-    },
-  },
-
-  /**
-   * The drawingBufferWidth of the underlying GL context.
-   * @memberof Context.prototype
-   * @type {number}
-   * @see {@link https://www.khronos.org/registry/webgl/specs/1.0/#DOM-WebGLRenderingContext-drawingBufferWidth|drawingBufferWidth}
-   */
-  drawingBufferWidth: {
-    get: function () {
-      return this._gl.drawingBufferWidth;
-    },
-  },
-
-  /**
-   * Gets an object representing the currently bound framebuffer.  While this instance is not an actual
-   * {@link Framebuffer}, it is used to represent the default framebuffer in calls to
-   * {@link Texture.fromFramebuffer}.
-   * @memberof Context.prototype
-   * @type {object}
-   */
-  defaultFramebuffer: {
-    get: function () {
-      return defaultFramebufferMarker;
-    },
-  },
-});
-
 /**
  * Validates a framebuffer.
  * Available in debug builds only.
@@ -1239,51 +1495,6 @@ function bindFramebuffer(context, framebuffer) {
 }
 
 const defaultClearCommand = new ClearCommand();
-
-Context.prototype.clear = function (clearCommand, passState) {
-  clearCommand = clearCommand ?? defaultClearCommand;
-  passState = passState ?? this._defaultPassState;
-
-  const gl = this._gl;
-  let bitmask = 0;
-
-  const c = clearCommand.color;
-  const d = clearCommand.depth;
-  const s = clearCommand.stencil;
-
-  if (defined(c)) {
-    if (!Color.equals(this._clearColor, c)) {
-      Color.clone(c, this._clearColor);
-      gl.clearColor(c.red, c.green, c.blue, c.alpha);
-    }
-    bitmask |= gl.COLOR_BUFFER_BIT;
-  }
-
-  if (defined(d)) {
-    if (d !== this._clearDepth) {
-      this._clearDepth = d;
-      gl.clearDepth(d);
-    }
-    bitmask |= gl.DEPTH_BUFFER_BIT;
-  }
-
-  if (defined(s)) {
-    if (s !== this._clearStencil) {
-      this._clearStencil = s;
-      gl.clearStencil(s);
-    }
-    bitmask |= gl.STENCIL_BUFFER_BIT;
-  }
-
-  const rs = clearCommand.renderState ?? this._defaultRenderState;
-  applyRenderState(this, rs, passState, true);
-
-  // The command's framebuffer takes presidence over the pass' framebuffer, e.g., for off-screen rendering.
-  const framebuffer = clearCommand.framebuffer ?? passState.framebuffer;
-  bindFramebuffer(this, framebuffer);
-
-  gl.clear(bitmask);
-};
 
 function beginDraw(
   context,
@@ -1396,331 +1607,9 @@ function continueDraw(context, drawCommand, shaderProgram, uniformMap) {
   va._unBind();
 }
 
-Context.prototype.draw = function (
-  drawCommand,
-  passState,
-  shaderProgram,
-  uniformMap,
-) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("drawCommand", drawCommand);
-  Check.defined("drawCommand.shaderProgram", drawCommand._shaderProgram);
-  //>>includeEnd('debug');
-
-  passState = passState ?? this._defaultPassState;
-  // The command's framebuffer takes precedence over the pass' framebuffer, e.g., for off-screen rendering.
-  const framebuffer = drawCommand._framebuffer ?? passState.framebuffer;
-  const renderState = drawCommand._renderState ?? this._defaultRenderState;
-  shaderProgram = shaderProgram ?? drawCommand._shaderProgram;
-  uniformMap = uniformMap ?? drawCommand._uniformMap;
-
-  beginDraw(this, framebuffer, passState, shaderProgram, renderState);
-  continueDraw(this, drawCommand, shaderProgram, uniformMap);
-};
-
-Context.prototype.beginFrame = function () {
-  // A no-op. Overridden when drawing to a SharedContext.
-};
-
-Context.prototype.endFrame = function () {
-  const gl = this._gl;
-  gl.useProgram(null);
-
-  this._currentFramebuffer = undefined;
-  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-
-  const buffers = scratchBackBufferArray;
-  if (this.drawBuffers) {
-    this.glDrawBuffers(buffers);
-  }
-
-  const length = this._maxFrameTextureUnitIndex;
-  this._maxFrameTextureUnitIndex = 0;
-
-  for (let i = 0; i < length; ++i) {
-    gl.activeTexture(gl.TEXTURE0 + i);
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
-  }
-};
-
-/**
- * @typedef {object} ReadState
- *
- * Options defining a rectangle to read pixels from.
- *
- * @private
- * @property {number} [x=0] The x offset of the rectangle to read from.
- * @property {number} [y=0] The y offset of the rectangle to read from.
- * @property {number} [width=this.drawingBufferWidth] The width of the rectangle to read from.
- * @property {number} [height=this.drawingBufferHeight] The height of the rectangle to read from.
- * @property {FrameBuffer|undefined} [framebuffer] The framebuffer to read from. If undefined, the read will be from the default framebuffer.
- */
-
-/**
- * Read pixels from a framebuffer into a Pixel Buffer Object (PBO).
- *
- * @private
- * @param {ReadState} readState Options defining a rectangle to read pixels from.
- * @returns {Buffer} A PixelBuffer containing the pixels read from the specified rectangle.
- *
- * @exception {DeveloperError} A WebGL 2 context is required to read pixels using a PBO.
- */
-Context.prototype.readPixelsToPBO = function (readState) {
-  const gl = this._gl;
-
-  readState = readState ?? Frozen.EMPTY_OBJECT;
-  const x = Math.max(readState.x ?? 0, 0);
-  const y = Math.max(readState.y ?? 0, 0);
-  const width = readState.width ?? this.drawingBufferWidth;
-  const height = readState.height ?? this.drawingBufferHeight;
-  const framebuffer = readState.framebuffer;
-
-  if (!this._webgl2) {
-    throw new DeveloperError(
-      "A WebGL 2 context is required to read pixels using a PBO.",
-    );
-  }
-
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.number.greaterThan("readState.width", width, 0);
-  Check.typeOf.number.greaterThan("readState.height", height, 0);
-  //>>includeEnd('debug');
-
-  let pixelDatatype = PixelDatatype.UNSIGNED_BYTE;
-  let pixelFormat = PixelFormat.RGBA;
-  if (defined(framebuffer) && framebuffer.numberOfColorAttachments > 0) {
-    pixelDatatype = framebuffer.getColorTexture(0).pixelDatatype;
-    pixelFormat = framebuffer.getColorTexture(0).pixelFormat;
-  }
-
-  const pixels = Buffer.createPixelBuffer({
-    context: this,
-    sizeInBytes: PixelFormat.textureSizeInBytes(
-      pixelFormat,
-      pixelDatatype,
-      width,
-      height,
-    ),
-    usage: BufferUsage.DYNAMIC_READ,
-  });
-
-  bindFramebuffer(this, framebuffer);
-
-  pixels._bind();
-  gl.readPixels(
-    x,
-    y,
-    width,
-    height,
-    pixelFormat,
-    PixelDatatype.toWebGLConstant(pixelDatatype, this),
-    0,
-  );
-  pixels._unBind();
-
-  return pixels;
-};
-
-/**
- * Read pixels from a framebuffer into a typed array.
- *
- * @private
- * @param {ReadState} readState Options defining a rectangle to read pixels from.
- * @returns {Uint8Array|Uint16Array|Float32Array|Uint32Array} The pixels in the specified rectangle.
- */
-Context.prototype.readPixels = function (readState) {
-  const gl = this._gl;
-
-  readState = readState ?? Frozen.EMPTY_OBJECT;
-  const x = Math.max(readState.x ?? 0, 0);
-  const y = Math.max(readState.y ?? 0, 0);
-  const width = readState.width ?? this.drawingBufferWidth;
-  const height = readState.height ?? this.drawingBufferHeight;
-  const framebuffer = readState.framebuffer;
-
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.number.greaterThan("readState.width", width, 0);
-  Check.typeOf.number.greaterThan("readState.height", height, 0);
-  //>>includeEnd('debug');
-
-  let pixelDatatype = PixelDatatype.UNSIGNED_BYTE;
-  let pixelFormat = PixelFormat.RGBA;
-  if (defined(framebuffer) && framebuffer.numberOfColorAttachments > 0) {
-    pixelDatatype = framebuffer.getColorTexture(0).pixelDatatype;
-    pixelFormat = framebuffer.getColorTexture(0).pixelFormat;
-  }
-
-  const pixels = PixelFormat.createTypedArray(
-    pixelFormat,
-    pixelDatatype,
-    width,
-    height,
-  );
-
-  bindFramebuffer(this, framebuffer);
-
-  gl.readPixels(
-    x,
-    y,
-    width,
-    height,
-    PixelFormat.RGBA,
-    PixelDatatype.toWebGLConstant(pixelDatatype, this),
-    pixels,
-  );
-
-  return pixels;
-};
-
 const viewportQuadAttributeLocations = {
   position: 0,
   textureCoordinates: 1,
-};
-
-Context.prototype.getViewportQuadVertexArray = function () {
-  // Per-context cache for viewport quads
-  let vertexArray = this.cache.viewportQuad_vertexArray;
-
-  if (!defined(vertexArray)) {
-    const geometry = new Geometry({
-      attributes: {
-        position: new GeometryAttribute({
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 2,
-          values: [-1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0, 1.0],
-        }),
-
-        textureCoordinates: new GeometryAttribute({
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 2,
-          values: [0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0],
-        }),
-      },
-      // Workaround Internet Explorer 11.0.8 lack of TRIANGLE_FAN
-      indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
-      primitiveType: PrimitiveType.TRIANGLES,
-    });
-
-    vertexArray = VertexArray.fromGeometry({
-      context: this,
-      geometry: geometry,
-      attributeLocations: viewportQuadAttributeLocations,
-      bufferUsage: BufferUsage.STATIC_DRAW,
-      interleave: true,
-    });
-
-    this.cache.viewportQuad_vertexArray = vertexArray;
-  }
-
-  return vertexArray;
-};
-
-Context.prototype.createViewportQuadCommand = function (
-  fragmentShaderSource,
-  overrides,
-) {
-  overrides = overrides ?? Frozen.EMPTY_OBJECT;
-
-  return new DrawCommand({
-    vertexArray: this.getViewportQuadVertexArray(),
-    primitiveType: PrimitiveType.TRIANGLES,
-    renderState: overrides.renderState,
-    shaderProgram: ShaderProgram.fromCache({
-      context: this,
-      vertexShaderSource: ViewportQuadVS,
-      fragmentShaderSource: fragmentShaderSource,
-      attributeLocations: viewportQuadAttributeLocations,
-    }),
-    uniformMap: overrides.uniformMap,
-    owner: overrides.owner,
-    framebuffer: overrides.framebuffer,
-    pass: overrides.pass,
-  });
-};
-
-/**
- * Gets the object associated with a pick color.
- *
- * @param {number} pickColor The unsigned 32-bit RGBA pick color
- * @returns {object} The object associated with the pick color, or undefined if no object is associated with that color.
- *
- * @example
- * const object = context.getObjectByPickColor(pickColor);
- *
- * @see Context#createPickId
- */
-Context.prototype.getObjectByPickColor = function (pickColor) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("pickColor", pickColor);
-  //>>includeEnd('debug');
-
-  return this._pickObjects.get(pickColor);
-};
-
-/**
- * Creates a unique ID associated with the input object for use with color-buffer picking.
- * The ID has an RGBA color value unique to this context.  You must call destroy()
- * on the pick ID when destroying the input object.
- *
- * @param {object} object The object to associate with the pick ID.
- * @returns {PickId} A PickId object with a <code>color</code> property.
- *
- * @exception {RuntimeError} Out of unique Pick IDs.
- *
- *
- * @example
- * this._pickId = context.createPickId({
- *   primitive : this,
- *   id : this.id
- * });
- *
- * @see Context#getObjectByPickColor
- */
-Context.prototype.createPickId = function (object) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("object", object);
-  //>>includeEnd('debug');
-
-  // the increment and assignment have to be separate statements to
-  // actually detect overflow in the Uint32 value
-  ++this._nextPickColor[0];
-  const key = this._nextPickColor[0];
-  if (key === 0) {
-    // In case of overflow
-    throw new RuntimeError("Out of unique Pick IDs.");
-  }
-
-  this._pickObjects.set(key, object);
-  return new PickId(this._pickObjects, key, Color.fromRgba(key));
-};
-
-Context.prototype.isDestroyed = function () {
-  return false;
-};
-
-Context.prototype.destroy = function () {
-  // Destroy all objects in the cache that have a destroy method.
-  const cache = this.cache;
-  for (const property in cache) {
-    if (cache.hasOwnProperty(property)) {
-      const propertyValue = cache[property];
-      if (defined(propertyValue.destroy)) {
-        propertyValue.destroy();
-      }
-    }
-  }
-
-  this._shaderCache = this._shaderCache.destroy();
-  this._textureCache = this._textureCache.destroy();
-  this._defaultTexture = this._defaultTexture && this._defaultTexture.destroy();
-  this._defaultEmissiveTexture =
-    this._defaultEmissiveTexture && this._defaultEmissiveTexture.destroy();
-  this._defaultNormalTexture =
-    this._defaultNormalTexture && this._defaultNormalTexture.destroy();
-  this._defaultCubeMap = this._defaultCubeMap && this._defaultCubeMap.destroy();
-
-  return destroyObject(this);
 };
 
 export default Context;

--- a/packages/engine/Source/Renderer/ContextLimits.js
+++ b/packages/engine/Source/Renderer/ContextLimits.js
@@ -1,332 +1,264 @@
+// @ts-check
+
 /**
  * These are set in the constructor for {@link Context}
  *
  * @private
  */
-const ContextLimits = {
-  _maximumCombinedTextureImageUnits: 0,
-  _maximumCubeMapSize: 0,
-  _maximumFragmentUniformVectors: 0,
-  _maximumTextureImageUnits: 0,
-  _maximumRenderbufferSize: 0,
-  _maximumTextureSize: 0,
-  _maximum3DTextureSize: 0,
-  _maximumVaryingVectors: 0,
-  _maximumVertexAttributes: 0,
-  _maximumVertexTextureImageUnits: 0,
-  _maximumVertexUniformVectors: 0,
-  _minimumAliasedLineWidth: 0,
-  _maximumAliasedLineWidth: 0,
-  _minimumAliasedPointSize: 0,
-  _maximumAliasedPointSize: 0,
-  _maximumViewportWidth: 0,
-  _maximumViewportHeight: 0,
-  _maximumTextureFilterAnisotropy: 0,
-  _maximumDrawBuffers: 0,
-  _maximumColorAttachments: 0,
-  _maximumSamples: 0,
-  _highpFloatSupported: false,
-  _highpIntSupported: false,
-};
+class ContextLimits {
+  static _maximumCombinedTextureImageUnits = 0;
+  static _maximumCubeMapSize = 0;
+  static _maximumFragmentUniformVectors = 0;
+  static _maximumTextureImageUnits = 0;
+  static _maximumRenderbufferSize = 0;
+  static _maximumTextureSize = 0;
+  static _maximum3DTextureSize = 0;
+  static _maximumVaryingVectors = 0;
+  static _maximumVertexAttributes = 0;
+  static _maximumVertexTextureImageUnits = 0;
+  static _maximumVertexUniformVectors = 0;
+  static _minimumAliasedLineWidth = 0;
+  static _maximumAliasedLineWidth = 0;
+  static _minimumAliasedPointSize = 0;
+  static _maximumAliasedPointSize = 0;
+  static _maximumViewportWidth = 0;
+  static _maximumViewportHeight = 0;
+  static _maximumTextureFilterAnisotropy = 0;
+  static _maximumDrawBuffers = 0;
+  static _maximumColorAttachments = 0;
+  static _maximumSamples = 0;
+  static _highpFloatSupported = false;
+  static _highpIntSupported = false;
 
-Object.defineProperties(ContextLimits, {
   /**
    * The maximum number of texture units that can be used from the vertex and fragment
    * shader with this WebGL implementation.
    * If both shaders access the same texture unit, this counts as two texture units.
    * The minimum in WebGL2 contexts is 32, or 8 in WebGL1 contexts.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_COMBINED_TEXTURE_IMAGE_UNITS</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumCombinedTextureImageUnits: {
-    get: function () {
-      return ContextLimits._maximumCombinedTextureImageUnits;
-    },
-  },
+  static get maximumCombinedTextureImageUnits() {
+    return ContextLimits._maximumCombinedTextureImageUnits;
+  }
 
   /**
    * The approximate maximum cube map width and height supported by this WebGL implementation.
    * The minimum in WebGL2 contexts is 2048, but most desktop and laptop implementations will support much larger sizes like 8192.
    * The minimum in WebGL1 contexts is 16.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_CUBE_MAP_TEXTURE_SIZE</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumCubeMapSize: {
-    get: function () {
-      return ContextLimits._maximumCubeMapSize;
-    },
-  },
+  static get maximumCubeMapSize() {
+    return ContextLimits._maximumCubeMapSize;
+  }
 
   /**
    * The maximum number of <code>vec4</code>, <code>ivec4</code>, and <code>bvec4</code>
    * uniforms that can be used by a fragment shader with this WebGL implementation.
    * The minimum in WebGL2 contexts is 224, or 16 in WebGL1 contexts.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_FRAGMENT_UNIFORM_VECTORS</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumFragmentUniformVectors: {
-    get: function () {
-      return ContextLimits._maximumFragmentUniformVectors;
-    },
-  },
+  static get maximumFragmentUniformVectors() {
+    return ContextLimits._maximumFragmentUniformVectors;
+  }
 
   /**
    * The maximum number of texture units that can be used from the fragment shader with this WebGL implementation.
    * The minimum in WebGL2 contexts is 16, or 8 in WebGL1 contexts.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_TEXTURE_IMAGE_UNITS</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumTextureImageUnits: {
-    get: function () {
-      return ContextLimits._maximumTextureImageUnits;
-    },
-  },
+  static get maximumTextureImageUnits() {
+    return ContextLimits._maximumTextureImageUnits;
+  }
 
   /**
    * The maximum renderbuffer width and height supported by this WebGL implementation.
    * The minimum in WebGL2 contexts is 2048, but most desktop and laptop implementations will support much larger sizes like 8192.
    * The minimum in WebGL1 contexts is 1.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_RENDERBUFFER_SIZE</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumRenderbufferSize: {
-    get: function () {
-      return ContextLimits._maximumRenderbufferSize;
-    },
-  },
+  static get maximumRenderbufferSize() {
+    return ContextLimits._maximumRenderbufferSize;
+  }
 
   /**
    * The approximate maximum texture width and height supported by this WebGL implementation.
    * The minimum in WebGL2 contexts is 2048, but most desktop and laptop implementations will support much larger sizes like 8192.
    * The minimum in WebGL1 contexts is 64.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_TEXTURE_SIZE</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumTextureSize: {
-    get: function () {
-      return ContextLimits._maximumTextureSize;
-    },
-  },
+  static get maximumTextureSize() {
+    return ContextLimits._maximumTextureSize;
+  }
 
   /**
    * The approximate maximum texture width, height, and depth supported by this WebGL2 implementation.
    * The minimum is 256, but most desktop and laptop implementations will support much larger sizes like 2048.
    * 3D textures are not supported in WebGL1 contexts.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_3D_TEXTURE_SIZE</code>.
    */
-  maximum3DTextureSize: {
-    get: function () {
-      return ContextLimits._maximum3DTextureSize;
-    },
-  },
+  static get maximum3DTextureSize() {
+    return ContextLimits._maximum3DTextureSize;
+  }
 
   /**
    * The maximum number of <code>vec4</code> varying variables supported by this WebGL implementation.
    * The minimum is 15 in WebGL2 contexts, or 8 in WebGL1 contexts. Matrices and arrays count as multiple <code>vec4</code>s.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_VARYING_VECTORS</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumVaryingVectors: {
-    get: function () {
-      return ContextLimits._maximumVaryingVectors;
-    },
-  },
+  static get maximumVaryingVectors() {
+    return ContextLimits._maximumVaryingVectors;
+  }
 
   /**
    * The maximum number of <code>vec4</code> vertex attributes supported by this WebGL implementation.
    * The minimum is 16 in WebGL2 contexts, or 8 in WebGL1 contexts.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_VERTEX_ATTRIBS</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumVertexAttributes: {
-    get: function () {
-      return ContextLimits._maximumVertexAttributes;
-    },
-  },
+  static get maximumVertexAttributes() {
+    return ContextLimits._maximumVertexAttributes;
+  }
 
   /**
    * The maximum number of texture units that can be used from the vertex shader with this WebGL implementation.
    * The minimum is 16 in WebGL2 contexts, or 0 in WebGL1 contexts.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_VERTEX_TEXTURE_IMAGE_UNITS</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumVertexTextureImageUnits: {
-    get: function () {
-      return ContextLimits._maximumVertexTextureImageUnits;
-    },
-  },
+  static get maximumVertexTextureImageUnits() {
+    return ContextLimits._maximumVertexTextureImageUnits;
+  }
 
   /**
    * The maximum number of <code>vec4</code>, <code>ivec4</code>, and <code>bvec4</code>
    * uniforms that can be used by a vertex shader with this WebGL implementation.
    * The minimum is 256 in WebGL2 contexts, or 128 in WebGL1 contexts.
-   * @memberof ContextLimits
    * @type {number}
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_VERTEX_UNIFORM_VECTORS</code>.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGet.xml|glGet in OpenGL ES 2.0} for WebGL1 contexts.
    */
-  maximumVertexUniformVectors: {
-    get: function () {
-      return ContextLimits._maximumVertexUniformVectors;
-    },
-  },
+  static get maximumVertexUniformVectors() {
+    return ContextLimits._maximumVertexUniformVectors;
+  }
 
   /**
    * The minimum aliased line width, in pixels, supported by this WebGL implementation. It will be at most one.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>ALIASED_LINE_WIDTH_RANGE</code>.
-   * @memberof ContextLimits
    * @type {number}
    */
-  minimumAliasedLineWidth: {
-    get: function () {
-      return ContextLimits._minimumAliasedLineWidth;
-    },
-  },
+  static get minimumAliasedLineWidth() {
+    return ContextLimits._minimumAliasedLineWidth;
+  }
 
   /**
    * The maximum aliased line width, in pixels, supported by this WebGL implementation. It will be at least one.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>ALIASED_LINE_WIDTH_RANGE</code>.
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumAliasedLineWidth: {
-    get: function () {
-      return ContextLimits._maximumAliasedLineWidth;
-    },
-  },
+  static get maximumAliasedLineWidth() {
+    return ContextLimits._maximumAliasedLineWidth;
+  }
 
   /**
    * The minimum aliased point size, in pixels, supported by this WebGL implementation. It will be at most one.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>ALIASED_POINT_SIZE_RANGE</code>.
-   * @memberof ContextLimits
    * @type {number}
    */
-  minimumAliasedPointSize: {
-    get: function () {
-      return ContextLimits._minimumAliasedPointSize;
-    },
-  },
+  static get minimumAliasedPointSize() {
+    return ContextLimits._minimumAliasedPointSize;
+  }
 
   /**
    * The maximum aliased point size, in pixels, supported by this WebGL implementation. It will be at least one.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>ALIASED_POINT_SIZE_RANGE</code>.
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumAliasedPointSize: {
-    get: function () {
-      return ContextLimits._maximumAliasedPointSize;
-    },
-  },
+  static get maximumAliasedPointSize() {
+    return ContextLimits._maximumAliasedPointSize;
+  }
 
   /**
    * The maximum supported width of the viewport. It will be at least as large as the visible width of the associated canvas.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_VIEWPORT_DIMS</code>.
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumViewportWidth: {
-    get: function () {
-      return ContextLimits._maximumViewportWidth;
-    },
-  },
+  static get maximumViewportWidth() {
+    return ContextLimits._maximumViewportWidth;
+  }
 
   /**
    * The maximum supported height of the viewport. It will be at least as large as the visible height of the associated canvas.
    * @see {@link https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml|glGet in OpenGL ES 3.0} with <code>MAX_VIEWPORT_DIMS</code>.
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumViewportHeight: {
-    get: function () {
-      return ContextLimits._maximumViewportHeight;
-    },
-  },
+  static get maximumViewportHeight() {
+    return ContextLimits._maximumViewportHeight;
+  }
 
   /**
    * The maximum degree of anisotropy for texture filtering
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumTextureFilterAnisotropy: {
-    get: function () {
-      return ContextLimits._maximumTextureFilterAnisotropy;
-    },
-  },
+  static get maximumTextureFilterAnisotropy() {
+    return ContextLimits._maximumTextureFilterAnisotropy;
+  }
 
   /**
    * The maximum number of simultaneous outputs that may be written in a fragment shader.
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumDrawBuffers: {
-    get: function () {
-      return ContextLimits._maximumDrawBuffers;
-    },
-  },
+  static get maximumDrawBuffers() {
+    return ContextLimits._maximumDrawBuffers;
+  }
 
   /**
    * The maximum number of color attachments supported.
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumColorAttachments: {
-    get: function () {
-      return ContextLimits._maximumColorAttachments;
-    },
-  },
+  static get maximumColorAttachments() {
+    return ContextLimits._maximumColorAttachments;
+  }
 
   /**
    * The maximum number of samples supported for multisampling.
-   * @memberof ContextLimits
    * @type {number}
    */
-  maximumSamples: {
-    get: function () {
-      return ContextLimits._maximumSamples;
-    },
-  },
+  static get maximumSamples() {
+    return ContextLimits._maximumSamples;
+  }
 
   /**
    * High precision float supported (<code>highp</code>) in fragment shaders.
-   * @memberof ContextLimits
    * @type {boolean}
    */
-  highpFloatSupported: {
-    get: function () {
-      return ContextLimits._highpFloatSupported;
-    },
-  },
+  static get highpFloatSupported() {
+    return ContextLimits._highpFloatSupported;
+  }
 
   /**
    * High precision int supported (<code>highp</code>) in fragment shaders.
-   * @memberof ContextLimits
    * @type {boolean}
    */
-  highpIntSupported: {
-    get: function () {
-      return ContextLimits._highpIntSupported;
-    },
-  },
-});
+  static get highpIntSupported() {
+    return ContextLimits._highpIntSupported;
+  }
+}
+
 export default ContextLimits;

--- a/packages/engine/Source/Renderer/Sampler.js
+++ b/packages/engine/Source/Renderer/Sampler.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import Check from "../Core/Check.js";
 import Frozen from "../Core/Frozen.js";
 import defined from "../Core/defined.js";
@@ -7,102 +9,115 @@ import TextureMinificationFilter from "./TextureMinificationFilter.js";
 import TextureWrap from "./TextureWrap.js";
 
 /**
+ * @typedef {object} SamplerConstructorOptions
+ * @property {TextureWrap} [wrapR]
+ * @property {TextureWrap} [wrapS]
+ * @property {TextureWrap} [wrapT]
+ * @property {TextureMinificationFilter} [minificationFilter]
+ * @property {TextureMagnificationFilter} [magnificationFilter]
+ * @property {number} [maximumAnisotropy]
+ *
+ * @ignore
+ */
+
+/**
  * @private
  */
-function Sampler(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class Sampler {
+  /** @param {SamplerConstructorOptions} options */
+  constructor(options) {
+    options = options ?? Frozen.EMPTY_OBJECT;
 
-  const {
-    wrapR = TextureWrap.CLAMP_TO_EDGE,
-    wrapS = TextureWrap.CLAMP_TO_EDGE,
-    wrapT = TextureWrap.CLAMP_TO_EDGE,
-    minificationFilter = TextureMinificationFilter.LINEAR,
-    magnificationFilter = TextureMagnificationFilter.LINEAR,
-    maximumAnisotropy = 1.0,
-  } = options;
+    const {
+      wrapR = TextureWrap.CLAMP_TO_EDGE,
+      wrapS = TextureWrap.CLAMP_TO_EDGE,
+      wrapT = TextureWrap.CLAMP_TO_EDGE,
+      minificationFilter = TextureMinificationFilter.LINEAR,
+      magnificationFilter = TextureMagnificationFilter.LINEAR,
+      maximumAnisotropy = 1.0,
+    } = options;
 
-  //>>includeStart('debug', pragmas.debug);
-  if (!TextureWrap.validate(wrapR)) {
-    throw new DeveloperError("Invalid sampler.wrapR.");
+    //>>includeStart('debug', pragmas.debug);
+    if (!TextureWrap.validate(wrapR)) {
+      throw new DeveloperError("Invalid sampler.wrapR.");
+    }
+
+    if (!TextureWrap.validate(wrapS)) {
+      throw new DeveloperError("Invalid sampler.wrapS.");
+    }
+
+    if (!TextureWrap.validate(wrapT)) {
+      throw new DeveloperError("Invalid sampler.wrapT.");
+    }
+
+    // @ts-expect-error https://github.com/CesiumGS/cesium/issues/13420
+    if (!TextureMinificationFilter.validate(minificationFilter)) {
+      throw new DeveloperError("Invalid sampler.minificationFilter.");
+    }
+
+    // @ts-expect-error https://github.com/CesiumGS/cesium/issues/13420
+    if (!TextureMagnificationFilter.validate(magnificationFilter)) {
+      throw new DeveloperError("Invalid sampler.magnificationFilter.");
+    }
+
+    Check.typeOf.number.greaterThanOrEquals(
+      "maximumAnisotropy",
+      maximumAnisotropy,
+      1.0,
+    );
+    //>>includeEnd('debug');
+
+    this._wrapR = wrapR;
+    this._wrapS = wrapS;
+    this._wrapT = wrapT;
+    this._minificationFilter = minificationFilter;
+    this._magnificationFilter = magnificationFilter;
+    this._maximumAnisotropy = maximumAnisotropy;
   }
 
-  if (!TextureWrap.validate(wrapS)) {
-    throw new DeveloperError("Invalid sampler.wrapS.");
+  get wrapR() {
+    return this._wrapR;
   }
 
-  if (!TextureWrap.validate(wrapT)) {
-    throw new DeveloperError("Invalid sampler.wrapT.");
+  get wrapS() {
+    return this._wrapS;
   }
 
-  if (!TextureMinificationFilter.validate(minificationFilter)) {
-    throw new DeveloperError("Invalid sampler.minificationFilter.");
+  get wrapT() {
+    return this._wrapT;
   }
 
-  if (!TextureMagnificationFilter.validate(magnificationFilter)) {
-    throw new DeveloperError("Invalid sampler.magnificationFilter.");
+  get minificationFilter() {
+    return this._minificationFilter;
   }
 
-  Check.typeOf.number.greaterThanOrEquals(
-    "maximumAnisotropy",
-    maximumAnisotropy,
-    1.0,
-  );
-  //>>includeEnd('debug');
+  get magnificationFilter() {
+    return this._magnificationFilter;
+  }
 
-  this._wrapR = wrapR;
-  this._wrapS = wrapS;
-  this._wrapT = wrapT;
-  this._minificationFilter = minificationFilter;
-  this._magnificationFilter = magnificationFilter;
-  this._maximumAnisotropy = maximumAnisotropy;
+  get maximumAnisotropy() {
+    return this._maximumAnisotropy;
+  }
+
+  /**
+   * @param {Sampler} left
+   * @param {Sampler} right
+   * @returns {boolean}
+   */
+  static equals(left, right) {
+    return (
+      left === right ||
+      (defined(left) &&
+        defined(right) &&
+        left._wrapR === right._wrapR &&
+        left._wrapS === right._wrapS &&
+        left._wrapT === right._wrapT &&
+        left._minificationFilter === right._minificationFilter &&
+        left._magnificationFilter === right._magnificationFilter &&
+        left._maximumAnisotropy === right._maximumAnisotropy)
+    );
+  }
 }
-
-Object.defineProperties(Sampler.prototype, {
-  wrapR: {
-    get: function () {
-      return this._wrapR;
-    },
-  },
-  wrapS: {
-    get: function () {
-      return this._wrapS;
-    },
-  },
-  wrapT: {
-    get: function () {
-      return this._wrapT;
-    },
-  },
-  minificationFilter: {
-    get: function () {
-      return this._minificationFilter;
-    },
-  },
-  magnificationFilter: {
-    get: function () {
-      return this._magnificationFilter;
-    },
-  },
-  maximumAnisotropy: {
-    get: function () {
-      return this._maximumAnisotropy;
-    },
-  },
-});
-
-Sampler.equals = function (left, right) {
-  return (
-    left === right ||
-    (defined(left) &&
-      defined(right) &&
-      left._wrapR === right._wrapR &&
-      left._wrapS === right._wrapS &&
-      left._wrapT === right._wrapT &&
-      left._minificationFilter === right._minificationFilter &&
-      left._magnificationFilter === right._magnificationFilter &&
-      left._maximumAnisotropy === right._maximumAnisotropy)
-  );
-};
 
 Sampler.NEAREST = Object.freeze(
   new Sampler({

--- a/packages/engine/Source/Renderer/Texture.js
+++ b/packages/engine/Source/Renderer/Texture.js
@@ -14,11 +14,19 @@ import Sampler from "./Sampler.js";
 import TextureMagnificationFilter from "./TextureMagnificationFilter.js";
 import TextureMinificationFilter from "./TextureMinificationFilter.js";
 
+/** @import Context from "./Context.js"; */
+
 /**
- * @typedef {object} Texture.ConstructorOptions
+ * @typedef {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|OffscreenCanvas|ImageBitmap} TextureSource
+ *
+ * @private
+ */
+
+/**
+ * @typedef {object} TextureConstructorOptions
  *
  * @property {Context} context
- * @property {object} [source] The source for texel values to be loaded into the texture. A {@link ImageData}, {@link HTMLImageElement}, {@link HTMLCanvasElement},
+ * @property {TextureSource} [source] The source for texel values to be loaded into the texture. A {@link ImageData}, {@link HTMLImageElement}, {@link HTMLCanvasElement},
  *                        {@link HTMLVideoElement}, {@link OffscreenCanvas}, or {@link ImageBitmap},
  *                        or an object with width, height, and arrayBufferView properties.
  * @property {PixelFormat} [pixelFormat=PixelFormat.RGBA] The format of each pixel, i.e., the number of components it has and what they represent.
@@ -38,212 +46,514 @@ import TextureMinificationFilter from "./TextureMinificationFilter.js";
  * A wrapper for a {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture|WebGLTexture}
  * to abstract away the verbose GL calls associated with setting up a texture.
  *
- * @alias Texture
- * @constructor
- *
- * @param {Texture.ConstructorOptions} options
  * @private
  */
-function Texture(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class Texture {
+  /** @param {TextureConstructorOptions} [options] */
+  constructor(options) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("options.context", options.context);
+    //>>includeEnd('debug');
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("options.context", options.context);
-  //>>includeEnd('debug');
+    const {
+      context,
+      source,
+      pixelFormat = PixelFormat.RGBA,
+      pixelDatatype = PixelDatatype.UNSIGNED_BYTE,
+      flipY = true,
+      skipColorSpaceConversion = false,
+      sampler = new Sampler(),
+    } = options;
 
-  const {
-    context,
-    source,
-    pixelFormat = PixelFormat.RGBA,
-    pixelDatatype = PixelDatatype.UNSIGNED_BYTE,
-    flipY = true,
-    skipColorSpaceConversion = false,
-    sampler = new Sampler(),
-  } = options;
-
-  let { width, height } = options;
-  if (defined(source)) {
-    // Make sure we are using the element's intrinsic width and height where available
-    if (!defined(width)) {
-      width = source.videoWidth ?? source.naturalWidth ?? source.width;
-    }
-    if (!defined(height)) {
-      height = source.videoHeight ?? source.naturalHeight ?? source.height;
-    }
-  }
-
-  // Use premultiplied alpha for opaque textures should perform better on Chrome:
-  // http://media.tojicode.com/webglCamp4/#20
-  const preMultiplyAlpha =
-    options.preMultiplyAlpha ||
-    pixelFormat === PixelFormat.RGB ||
-    pixelFormat === PixelFormat.LUMINANCE;
-
-  const internalFormat = PixelFormat.toInternalFormat(
-    pixelFormat,
-    pixelDatatype,
-    context,
-  );
-
-  const isCompressed = PixelFormat.isCompressedFormat(internalFormat);
-
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(width) || !defined(height)) {
-    throw new DeveloperError(
-      "options requires a source field to create an initialized texture or width and height fields to create a blank texture.",
-    );
-  }
-
-  Check.typeOf.number.greaterThan("width", width, 0);
-
-  if (width > ContextLimits.maximumTextureSize) {
-    throw new DeveloperError(
-      `Width must be less than or equal to the maximum texture size (${ContextLimits.maximumTextureSize}).  Check maximumTextureSize.`,
-    );
-  }
-
-  Check.typeOf.number.greaterThan("height", height, 0);
-
-  if (height > ContextLimits.maximumTextureSize) {
-    throw new DeveloperError(
-      `Height must be less than or equal to the maximum texture size (${ContextLimits.maximumTextureSize}).  Check maximumTextureSize.`,
-    );
-  }
-
-  if (!PixelFormat.validate(pixelFormat)) {
-    throw new DeveloperError("Invalid options.pixelFormat.");
-  }
-
-  if (!isCompressed && !PixelDatatype.validate(pixelDatatype)) {
-    throw new DeveloperError("Invalid options.pixelDatatype.");
-  }
-
-  if (
-    pixelFormat === PixelFormat.DEPTH_COMPONENT &&
-    pixelDatatype !== PixelDatatype.UNSIGNED_SHORT &&
-    pixelDatatype !== PixelDatatype.UNSIGNED_INT
-  ) {
-    throw new DeveloperError(
-      "When options.pixelFormat is DEPTH_COMPONENT, options.pixelDatatype must be UNSIGNED_SHORT or UNSIGNED_INT.",
-    );
-  }
-
-  if (
-    pixelFormat === PixelFormat.DEPTH_STENCIL &&
-    pixelDatatype !== PixelDatatype.UNSIGNED_INT_24_8
-  ) {
-    throw new DeveloperError(
-      "When options.pixelFormat is DEPTH_STENCIL, options.pixelDatatype must be UNSIGNED_INT_24_8.",
-    );
-  }
-
-  if (pixelDatatype === PixelDatatype.FLOAT && !context.floatingPointTexture) {
-    throw new DeveloperError(
-      "When options.pixelDatatype is FLOAT, this WebGL implementation must support the OES_texture_float extension.  Check context.floatingPointTexture.",
-    );
-  }
-
-  if (
-    pixelDatatype === PixelDatatype.HALF_FLOAT &&
-    !context.halfFloatingPointTexture
-  ) {
-    throw new DeveloperError(
-      "When options.pixelDatatype is HALF_FLOAT, this WebGL implementation must support the OES_texture_half_float extension. Check context.halfFloatingPointTexture.",
-    );
-  }
-
-  if (PixelFormat.isDepthFormat(pixelFormat)) {
+    let { width, height } = options;
     if (defined(source)) {
+      // Make sure we are using the element's intrinsic width and height where available
+      if (!defined(width)) {
+        // @ts-expect-error Safe to check for these properties on truthy inputs.
+        width = source.videoWidth ?? source.naturalWidth ?? source.width;
+      }
+      if (!defined(height)) {
+        // @ts-expect-error Safe to check for these properties on truthy inputs.
+        height = source.videoHeight ?? source.naturalHeight ?? source.height;
+      }
+    }
+
+    // Use premultiplied alpha for opaque textures should perform better on Chrome:
+    // http://media.tojicode.com/webglCamp4/#20
+    const preMultiplyAlpha =
+      options.preMultiplyAlpha ||
+      pixelFormat === PixelFormat.RGB ||
+      pixelFormat === PixelFormat.LUMINANCE;
+
+    // @ts-expect-error https://github.com/CesiumGS/cesium/issues/13420
+    const internalFormat = PixelFormat.toInternalFormat(
+      pixelFormat,
+      pixelDatatype,
+      context,
+    );
+
+    // @ts-expect-error https://github.com/CesiumGS/cesium/issues/13420
+    const isCompressed = PixelFormat.isCompressedFormat(internalFormat);
+
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(width) || !defined(height)) {
       throw new DeveloperError(
-        "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, source cannot be provided.",
+        "options requires a source field to create an initialized texture or width and height fields to create a blank texture.",
       );
     }
 
-    if (!context.depthTexture) {
-      throw new DeveloperError(
-        "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, this WebGL implementation must support WEBGL_depth_texture.  Check context.depthTexture.",
-      );
-    }
-  }
+    Check.typeOf.number.greaterThan("width", width, 0);
 
-  if (isCompressed) {
-    if (!defined(source) || !defined(source.arrayBufferView)) {
+    if (width > ContextLimits.maximumTextureSize) {
       throw new DeveloperError(
-        "When options.pixelFormat is compressed, options.source.arrayBufferView must be defined.",
+        `Width must be less than or equal to the maximum texture size (${ContextLimits.maximumTextureSize}).  Check maximumTextureSize.`,
       );
     }
 
-    if (PixelFormat.isDXTFormat(internalFormat) && !context.s3tc) {
+    Check.typeOf.number.greaterThan("height", height, 0);
+
+    if (height > ContextLimits.maximumTextureSize) {
       throw new DeveloperError(
-        "When options.pixelFormat is S3TC compressed, this WebGL implementation must support the WEBGL_compressed_texture_s3tc extension. Check context.s3tc.",
+        `Height must be less than or equal to the maximum texture size (${ContextLimits.maximumTextureSize}).  Check maximumTextureSize.`,
       );
-    } else if (PixelFormat.isPVRTCFormat(internalFormat) && !context.pvrtc) {
+    }
+
+    // @ts-expect-error https://github.com/CesiumGS/cesium/issues/13420
+    if (!PixelFormat.validate(pixelFormat)) {
+      throw new DeveloperError("Invalid options.pixelFormat.");
+    }
+
+    // @ts-expect-error https://github.com/CesiumGS/cesium/issues/13420
+    if (!isCompressed && !PixelDatatype.validate(pixelDatatype)) {
+      throw new DeveloperError("Invalid options.pixelDatatype.");
+    }
+
+    if (
+      pixelFormat === PixelFormat.DEPTH_COMPONENT &&
+      pixelDatatype !== PixelDatatype.UNSIGNED_SHORT &&
+      pixelDatatype !== PixelDatatype.UNSIGNED_INT
+    ) {
       throw new DeveloperError(
-        "When options.pixelFormat is PVRTC compressed, this WebGL implementation must support the WEBGL_compressed_texture_pvrtc extension. Check context.pvrtc.",
-      );
-    } else if (PixelFormat.isASTCFormat(internalFormat) && !context.astc) {
-      throw new DeveloperError(
-        "When options.pixelFormat is ASTC compressed, this WebGL implementation must support the WEBGL_compressed_texture_astc extension. Check context.astc.",
-      );
-    } else if (PixelFormat.isETC2Format(internalFormat) && !context.etc) {
-      throw new DeveloperError(
-        "When options.pixelFormat is ETC2 compressed, this WebGL implementation must support the WEBGL_compressed_texture_etc extension. Check context.etc.",
-      );
-    } else if (PixelFormat.isETC1Format(internalFormat) && !context.etc1) {
-      throw new DeveloperError(
-        "When options.pixelFormat is ETC1 compressed, this WebGL implementation must support the WEBGL_compressed_texture_etc1 extension. Check context.etc1.",
-      );
-    } else if (PixelFormat.isBC7Format(internalFormat) && !context.bc7) {
-      throw new DeveloperError(
-        "When options.pixelFormat is BC7 compressed, this WebGL implementation must support the EXT_texture_compression_bptc extension. Check context.bc7.",
+        "When options.pixelFormat is DEPTH_COMPONENT, options.pixelDatatype must be UNSIGNED_SHORT or UNSIGNED_INT.",
       );
     }
 
     if (
-      PixelFormat.compressedTextureSizeInBytes(
-        internalFormat,
-        width,
-        height,
-      ) !== source.arrayBufferView.byteLength
+      pixelFormat === PixelFormat.DEPTH_STENCIL &&
+      pixelDatatype !== PixelDatatype.UNSIGNED_INT_24_8
     ) {
       throw new DeveloperError(
-        "The byte length of the array buffer is invalid for the compressed texture with the given width and height.",
+        "When options.pixelFormat is DEPTH_STENCIL, options.pixelDatatype must be UNSIGNED_INT_24_8.",
       );
     }
+
+    if (
+      pixelDatatype === PixelDatatype.FLOAT &&
+      !context.floatingPointTexture
+    ) {
+      throw new DeveloperError(
+        "When options.pixelDatatype is FLOAT, this WebGL implementation must support the OES_texture_float extension.  Check context.floatingPointTexture.",
+      );
+    }
+
+    if (
+      pixelDatatype === PixelDatatype.HALF_FLOAT &&
+      !context.halfFloatingPointTexture
+    ) {
+      throw new DeveloperError(
+        "When options.pixelDatatype is HALF_FLOAT, this WebGL implementation must support the OES_texture_half_float extension. Check context.halfFloatingPointTexture.",
+      );
+    }
+
+    if (PixelFormat.isDepthFormat(pixelFormat)) {
+      if (defined(source)) {
+        throw new DeveloperError(
+          "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, source cannot be provided.",
+        );
+      }
+
+      if (!context.depthTexture) {
+        throw new DeveloperError(
+          "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, this WebGL implementation must support WEBGL_depth_texture.  Check context.depthTexture.",
+        );
+      }
+    }
+
+    if (isCompressed) {
+      if (!defined(source) || !defined(source.arrayBufferView)) {
+        throw new DeveloperError(
+          "When options.pixelFormat is compressed, options.source.arrayBufferView must be defined.",
+        );
+      }
+
+      if (PixelFormat.isDXTFormat(internalFormat) && !context.s3tc) {
+        throw new DeveloperError(
+          "When options.pixelFormat is S3TC compressed, this WebGL implementation must support the WEBGL_compressed_texture_s3tc extension. Check context.s3tc.",
+        );
+      } else if (PixelFormat.isPVRTCFormat(internalFormat) && !context.pvrtc) {
+        throw new DeveloperError(
+          "When options.pixelFormat is PVRTC compressed, this WebGL implementation must support the WEBGL_compressed_texture_pvrtc extension. Check context.pvrtc.",
+        );
+      } else if (PixelFormat.isASTCFormat(internalFormat) && !context.astc) {
+        throw new DeveloperError(
+          "When options.pixelFormat is ASTC compressed, this WebGL implementation must support the WEBGL_compressed_texture_astc extension. Check context.astc.",
+        );
+      } else if (PixelFormat.isETC2Format(internalFormat) && !context.etc) {
+        throw new DeveloperError(
+          "When options.pixelFormat is ETC2 compressed, this WebGL implementation must support the WEBGL_compressed_texture_etc extension. Check context.etc.",
+        );
+      } else if (PixelFormat.isETC1Format(internalFormat) && !context.etc1) {
+        throw new DeveloperError(
+          "When options.pixelFormat is ETC1 compressed, this WebGL implementation must support the WEBGL_compressed_texture_etc1 extension. Check context.etc1.",
+        );
+      } else if (PixelFormat.isBC7Format(internalFormat) && !context.bc7) {
+        throw new DeveloperError(
+          "When options.pixelFormat is BC7 compressed, this WebGL implementation must support the EXT_texture_compression_bptc extension. Check context.bc7.",
+        );
+      }
+
+      if (
+        PixelFormat.compressedTextureSizeInBytes(
+          internalFormat,
+          width,
+          height,
+        ) !== source.arrayBufferView.byteLength
+      ) {
+        throw new DeveloperError(
+          "The byte length of the array buffer is invalid for the compressed texture with the given width and height.",
+        );
+      }
+    }
+    //>>includeEnd('debug');
+
+    const gl = context._gl;
+
+    const sizeInBytes = isCompressed
+      ? PixelFormat.compressedTextureSizeInBytes(pixelFormat, width, height)
+      : PixelFormat.textureSizeInBytes(
+          pixelFormat,
+          pixelDatatype,
+          width,
+          height,
+        );
+
+    this._id = options.id ?? createGuid();
+    this._context = context;
+    this._textureFilterAnisotropic = context._textureFilterAnisotropic;
+    this._textureTarget = gl.TEXTURE_2D;
+    this._texture = gl.createTexture();
+    this._internalFormat = internalFormat;
+    this._pixelFormat = pixelFormat;
+    this._pixelDatatype = pixelDatatype;
+    this._width = width;
+    this._height = height;
+    this._dimensions = new Cartesian2(width, height);
+    this._hasMipmap = false;
+    this._sizeInBytes = sizeInBytes;
+    this._preMultiplyAlpha = preMultiplyAlpha;
+    this._flipY = flipY;
+    this._initialized = false;
+    this._sampler = undefined;
+
+    this._sampler = sampler;
+    setupSampler(this, sampler);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(this._textureTarget, this._texture);
+
+    if (defined(source)) {
+      if (skipColorSpaceConversion) {
+        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+      } else {
+        gl.pixelStorei(
+          gl.UNPACK_COLORSPACE_CONVERSION_WEBGL,
+          gl.BROWSER_DEFAULT_WEBGL,
+        );
+      }
+      if (defined(source.arrayBufferView)) {
+        const isCompressed = PixelFormat.isCompressedFormat(internalFormat);
+        if (isCompressed) {
+          loadCompressedBufferSource(this, source);
+        } else {
+          loadBufferSource(this, source);
+        }
+      } else if (defined(source.framebuffer)) {
+        loadFramebufferSource(this, source);
+      } else {
+        loadImageSource(this, source);
+      }
+      this._initialized = true;
+    } else {
+      loadNull(this);
+    }
+
+    gl.bindTexture(this._textureTarget, null);
   }
-  //>>includeEnd('debug');
 
-  const gl = context._gl;
+  /**
+   * This function is identical to using the Texture constructor except that it can be
+   * replaced with a mock/spy in tests.
+   * @private
+   */
+  static create(options) {
+    return new Texture(options);
+  }
 
-  const sizeInBytes = isCompressed
-    ? PixelFormat.compressedTextureSizeInBytes(pixelFormat, width, height)
-    : PixelFormat.textureSizeInBytes(pixelFormat, pixelDatatype, width, height);
+  /**
+   * Creates a texture, and copies a subimage of the framebuffer to it.  When called without arguments,
+   * the texture is the same width and height as the framebuffer and contains its contents.
+   *
+   * @param {object} options Object with the following properties:
+   * @param {Context} options.context The context in which the Texture gets created.
+   * @param {PixelFormat} [options.pixelFormat=PixelFormat.RGB] The texture's internal pixel format.
+   * @param {number} [options.framebufferXOffset=0] An offset in the x direction in the framebuffer where copying begins from.
+   * @param {number} [options.framebufferYOffset=0] An offset in the y direction in the framebuffer where copying begins from.
+   * @param {number} [options.width=canvas.clientWidth] The width of the texture in texels.
+   * @param {number} [options.height=canvas.clientHeight] The height of the texture in texels.
+   * @param {Framebuffer} [options.framebuffer=defaultFramebuffer] The framebuffer from which to create the texture.  If this
+   *        parameter is not specified, the default framebuffer is used.
+   * @returns {Texture} A texture with contents from the framebuffer.
+   *
+   * @exception {DeveloperError} Invalid pixelFormat.
+   * @exception {DeveloperError} pixelFormat cannot be DEPTH_COMPONENT, DEPTH_STENCIL or a compressed format.
+   * @exception {DeveloperError} framebufferXOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} framebufferYOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} framebufferXOffset + width must be less than or equal to canvas.clientWidth.
+   * @exception {DeveloperError} framebufferYOffset + height must be less than or equal to canvas.clientHeight.
+   *
+   *
+   * @example
+   * // Create a texture with the contents of the framebuffer.
+   * const t = Texture.fromFramebuffer({
+   *     context : context
+   * });
+   *
+   * @see Sampler
+   *
+   * @private
+   */
+  static fromFramebuffer(options) {
+    options = options ?? Frozen.EMPTY_OBJECT;
 
-  this._id = options.id ?? createGuid();
-  this._context = context;
-  this._textureFilterAnisotropic = context._textureFilterAnisotropic;
-  this._textureTarget = gl.TEXTURE_2D;
-  this._texture = gl.createTexture();
-  this._internalFormat = internalFormat;
-  this._pixelFormat = pixelFormat;
-  this._pixelDatatype = pixelDatatype;
-  this._width = width;
-  this._height = height;
-  this._dimensions = new Cartesian2(width, height);
-  this._hasMipmap = false;
-  this._sizeInBytes = sizeInBytes;
-  this._preMultiplyAlpha = preMultiplyAlpha;
-  this._flipY = flipY;
-  this._initialized = false;
-  this._sampler = undefined;
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("options.context", options.context);
+    //>>includeEnd('debug');
 
-  this._sampler = sampler;
-  setupSampler(this, sampler);
+    const context = options.context;
+    const {
+      pixelFormat = PixelFormat.RGB,
+      framebufferXOffset = 0,
+      framebufferYOffset = 0,
+      width = context.drawingBufferWidth,
+      height = context.drawingBufferHeight,
+      framebuffer,
+    } = options;
 
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(this._textureTarget, this._texture);
+    //>>includeStart('debug', pragmas.debug);
+    if (!PixelFormat.validate(pixelFormat)) {
+      throw new DeveloperError("Invalid pixelFormat.");
+    }
+    if (
+      PixelFormat.isDepthFormat(pixelFormat) ||
+      PixelFormat.isCompressedFormat(pixelFormat)
+    ) {
+      throw new DeveloperError(
+        "pixelFormat cannot be DEPTH_COMPONENT, DEPTH_STENCIL or a compressed format.",
+      );
+    }
+    Check.defined("options.context", context);
+    Check.typeOf.number.greaterThanOrEquals(
+      "framebufferXOffset",
+      framebufferXOffset,
+      0,
+    );
+    Check.typeOf.number.greaterThanOrEquals(
+      "framebufferYOffset",
+      framebufferYOffset,
+      0,
+    );
+    if (framebufferXOffset + width > context.drawingBufferWidth) {
+      throw new DeveloperError(
+        "framebufferXOffset + width must be less than or equal to drawingBufferWidth",
+      );
+    }
+    if (framebufferYOffset + height > context.drawingBufferHeight) {
+      throw new DeveloperError(
+        "framebufferYOffset + height must be less than or equal to drawingBufferHeight.",
+      );
+    }
+    //>>includeEnd('debug');
 
-  if (defined(source)) {
+    const texture = new Texture({
+      context: context,
+      width: width,
+      height: height,
+      pixelFormat: pixelFormat,
+      source: {
+        framebuffer: defined(framebuffer)
+          ? framebuffer
+          : context.defaultFramebuffer,
+        xOffset: framebufferXOffset,
+        yOffset: framebufferYOffset,
+        width: width,
+        height: height,
+      },
+    });
+
+    return texture;
+  }
+
+  /**
+   * A unique id for the texture
+   * @type {string}
+   * @readonly
+   * @ignore
+   */
+  get id() {
+    return this._id;
+  }
+
+  /**
+   * The sampler to use when sampling this texture.
+   * Create a sampler by calling {@link Sampler}.  If this
+   * parameter is not specified, a default sampler is used.  The default sampler clamps texture
+   * coordinates in both directions, uses linear filtering for both magnification and minification,
+   * and uses a maximum anisotropy of 1.0.
+   * @type {Sampler}
+   * @ignore
+   */
+  get sampler() {
+    return this._sampler;
+  }
+
+  set sampler(sampler) {
+    setupSampler(this, sampler);
+    this._sampler = sampler;
+  }
+
+  get pixelFormat() {
+    return this._pixelFormat;
+  }
+
+  get pixelDatatype() {
+    return this._pixelDatatype;
+  }
+
+  get dimensions() {
+    return this._dimensions;
+  }
+
+  get preMultiplyAlpha() {
+    return this._preMultiplyAlpha;
+  }
+
+  get flipY() {
+    return this._flipY;
+  }
+
+  get width() {
+    return this._width;
+  }
+
+  get height() {
+    return this._height;
+  }
+
+  get sizeInBytes() {
+    if (this._hasMipmap) {
+      return Math.floor((this._sizeInBytes * 4) / 3);
+    }
+    return this._sizeInBytes;
+  }
+
+  get _target() {
+    return this._textureTarget;
+  }
+
+  /**
+   * Copy new image data into this texture, from a source {@link ImageData}, {@link HTMLImageElement}, {@link HTMLCanvasElement}, or {@link HTMLVideoElement}.
+   * or an object with width, height, and arrayBufferView properties.
+   * @param {object} options Object with the following properties:
+   * @param {TextureSource} options.source The source {@link ImageData}, {@link HTMLImageElement}, {@link HTMLCanvasElement}, {@link HTMLVideoElement},
+   *                        {@link OffscreenCanvas}, or {@link ImageBitmap},
+   *                        or an object with width, height, and arrayBufferView properties.
+   * @param {number} [options.xOffset=0] The offset in the x direction within the texture to copy into.
+   * @param {number} [options.yOffset=0] The offset in the y direction within the texture to copy into.
+   * @param {boolean} [options.skipColorSpaceConversion=false] If true, any custom gamma or color profiles in the texture will be ignored.
+   *
+   * @exception {DeveloperError} Cannot call copyFrom when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
+   * @exception {DeveloperError} Cannot call copyFrom with a compressed texture pixel format.
+   * @exception {DeveloperError} xOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} yOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} xOffset + source.width must be less than or equal to width.
+   * @exception {DeveloperError} yOffset + source.height must be less than or equal to height.
+   * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
+   * @private
+   * @example
+   * texture.copyFrom({
+   *  source: {
+   *   width : 1,
+   *   height : 1,
+   *   arrayBufferView : new Uint8Array([255, 0, 0, 255])
+   *  }
+   * });
+   */
+  copyFrom(options) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("options", options);
+    //>>includeEnd('debug');
+
+    const {
+      xOffset = 0,
+      yOffset = 0,
+      source,
+      skipColorSpaceConversion = false,
+    } = options;
+
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("options.source", source);
+    if (PixelFormat.isDepthFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call copyFrom when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
+      );
+    }
+    if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call copyFrom with a compressed texture pixel format.",
+      );
+    }
+    Check.typeOf.number.greaterThanOrEquals("xOffset", xOffset, 0);
+    Check.typeOf.number.greaterThanOrEquals("yOffset", yOffset, 0);
+    Check.typeOf.number.lessThanOrEquals(
+      "xOffset + options.source.width",
+      xOffset + source.width,
+      this._width,
+    );
+    Check.typeOf.number.lessThanOrEquals(
+      "yOffset + options.source.height",
+      yOffset + source.height,
+      this._height,
+    );
+    //>>includeEnd('debug');
+
+    const context = this._context;
+    const gl = context._gl;
+    const target = this._textureTarget;
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(target, this._texture);
+
+    let { width, height } = source;
+
+    // Make sure we are using the element's intrinsic width and height where available
+    if (defined(source.videoWidth) && defined(source.videoHeight)) {
+      width = source.videoWidth;
+      height = source.videoHeight;
+    } else if (defined(source.naturalWidth) && defined(source.naturalHeight)) {
+      width = source.naturalWidth;
+      height = source.naturalHeight;
+    }
+
     if (skipColorSpaceConversion) {
       gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
     } else {
@@ -252,24 +562,209 @@ function Texture(options) {
         gl.BROWSER_DEFAULT_WEBGL,
       );
     }
-    if (defined(source.arrayBufferView)) {
-      const isCompressed = PixelFormat.isCompressedFormat(internalFormat);
-      if (isCompressed) {
-        loadCompressedBufferSource(this, source);
+
+    let uploaded = false;
+    if (!this._initialized) {
+      if (
+        xOffset === 0 &&
+        yOffset === 0 &&
+        width === this._width &&
+        height === this._height
+      ) {
+        // initialize the entire texture
+        if (defined(source.arrayBufferView)) {
+          loadBufferSource(this, source);
+        } else {
+          loadImageSource(this, source);
+        }
+        uploaded = true;
       } else {
-        loadBufferSource(this, source);
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        loadNull(this);
       }
-    } else if (defined(source.framebuffer)) {
-      loadFramebufferSource(this, source);
-    } else {
-      loadImageSource(this, source);
+      this._initialized = true;
     }
-    this._initialized = true;
-  } else {
-    loadNull(this);
+
+    if (!uploaded) {
+      if (defined(source.arrayBufferView)) {
+        loadPartialBufferSource(
+          this,
+          source.arrayBufferView,
+          xOffset,
+          yOffset,
+          width,
+          height,
+        );
+      } else {
+        loadPartialImageSource(this, source, xOffset, yOffset);
+      }
+    }
+
+    gl.bindTexture(target, null);
   }
 
-  gl.bindTexture(this._textureTarget, null);
+  /**
+   * @param {number} [xOffset=0] The offset in the x direction within the texture to copy into.
+   * @param {number} [yOffset=0] The offset in the y direction within the texture to copy into.
+   * @param {number} [framebufferXOffset=0] optional
+   * @param {number} [framebufferYOffset=0] optional
+   * @param {number} [width=width] optional
+   * @param {number} [height=height] optional
+   * @private
+   * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
+   * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.
+   * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.
+   * @exception {DeveloperError} Cannot call copyFrom with a compressed texture pixel format.
+   * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
+   * @exception {DeveloperError} xOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} yOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} framebufferXOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} framebufferYOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} xOffset + width must be less than or equal to width.
+   * @exception {DeveloperError} yOffset + height must be less than or equal to height.
+   */
+  copyFromFramebuffer(
+    xOffset,
+    yOffset,
+    framebufferXOffset,
+    framebufferYOffset,
+    width,
+    height,
+  ) {
+    xOffset = xOffset ?? 0;
+    yOffset = yOffset ?? 0;
+    framebufferXOffset = framebufferXOffset ?? 0;
+    framebufferYOffset = framebufferYOffset ?? 0;
+    width = width ?? this._width;
+    height = height ?? this._height;
+
+    //>>includeStart('debug', pragmas.debug);
+    if (PixelFormat.isDepthFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call copyFromFramebuffer when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
+      );
+    }
+    if (this._pixelDatatype === PixelDatatype.FLOAT) {
+      throw new DeveloperError(
+        "Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.",
+      );
+    }
+    if (this._pixelDatatype === PixelDatatype.HALF_FLOAT) {
+      throw new DeveloperError(
+        "Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.",
+      );
+    }
+    if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call copyFrom with a compressed texture pixel format.",
+      );
+    }
+
+    Check.typeOf.number.greaterThanOrEquals("xOffset", xOffset, 0);
+    Check.typeOf.number.greaterThanOrEquals("yOffset", yOffset, 0);
+    Check.typeOf.number.greaterThanOrEquals(
+      "framebufferXOffset",
+      framebufferXOffset,
+      0,
+    );
+    Check.typeOf.number.greaterThanOrEquals(
+      "framebufferYOffset",
+      framebufferYOffset,
+      0,
+    );
+    Check.typeOf.number.lessThanOrEquals(
+      "xOffset + width",
+      xOffset + width,
+      this._width,
+    );
+    Check.typeOf.number.lessThanOrEquals(
+      "yOffset + height",
+      yOffset + height,
+      this._height,
+    );
+    //>>includeEnd('debug');
+
+    const gl = this._context._gl;
+    const target = this._textureTarget;
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(target, this._texture);
+    gl.copyTexSubImage2D(
+      target,
+      0,
+      xOffset,
+      yOffset,
+      framebufferXOffset,
+      framebufferYOffset,
+      width,
+      height,
+    );
+    gl.bindTexture(target, null);
+    this._initialized = true;
+  }
+
+  /**
+   * @param {MipmapHint} [hint=MipmapHint.DONT_CARE] optional.
+   * @private
+   * @exception {DeveloperError} Cannot call generateMipmap when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
+   * @exception {DeveloperError} Cannot call generateMipmap when the texture pixel format is a compressed format.
+   * @exception {DeveloperError} hint is invalid.
+   * @exception {DeveloperError} This texture's width must be a power of two to call generateMipmap() in a WebGL1 context.
+   * @exception {DeveloperError} This texture's height must be a power of two to call generateMipmap() in a WebGL1 context.
+   * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
+   */
+  generateMipmap(hint) {
+    hint = hint ?? MipmapHint.DONT_CARE;
+
+    //>>includeStart('debug', pragmas.debug);
+    if (PixelFormat.isDepthFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call generateMipmap when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
+      );
+    }
+    if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call generateMipmap with a compressed pixel format.",
+      );
+    }
+    if (!this._context.webgl2) {
+      if (this._width > 1 && !CesiumMath.isPowerOfTwo(this._width)) {
+        throw new DeveloperError(
+          "width must be a power of two to call generateMipmap() in a WebGL1 context.",
+        );
+      }
+      if (this._height > 1 && !CesiumMath.isPowerOfTwo(this._height)) {
+        throw new DeveloperError(
+          "height must be a power of two to call generateMipmap() in a WebGL1 context.",
+        );
+      }
+    }
+    if (!MipmapHint.validate(hint)) {
+      throw new DeveloperError("hint is invalid.");
+    }
+    //>>includeEnd('debug');
+
+    this._hasMipmap = true;
+
+    const gl = this._context._gl;
+    const target = this._textureTarget;
+
+    gl.hint(gl.GENERATE_MIPMAP_HINT, hint);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(target, this._texture);
+    gl.generateMipmap(target);
+    gl.bindTexture(target, null);
+  }
+
+  isDestroyed() {
+    return false;
+  }
+
+  destroy() {
+    this._context._gl.deleteTexture(this._texture);
+    return destroyObject(this);
+  }
 }
 
 /**
@@ -574,201 +1069,6 @@ function loadNull(texture) {
 }
 
 /**
- * This function is identical to using the Texture constructor except that it can be
- * replaced with a mock/spy in tests.
- * @private
- */
-Texture.create = function (options) {
-  return new Texture(options);
-};
-
-/**
- * Creates a texture, and copies a subimage of the framebuffer to it.  When called without arguments,
- * the texture is the same width and height as the framebuffer and contains its contents.
- *
- * @param {object} options Object with the following properties:
- * @param {Context} options.context The context in which the Texture gets created.
- * @param {PixelFormat} [options.pixelFormat=PixelFormat.RGB] The texture's internal pixel format.
- * @param {number} [options.framebufferXOffset=0] An offset in the x direction in the framebuffer where copying begins from.
- * @param {number} [options.framebufferYOffset=0] An offset in the y direction in the framebuffer where copying begins from.
- * @param {number} [options.width=canvas.clientWidth] The width of the texture in texels.
- * @param {number} [options.height=canvas.clientHeight] The height of the texture in texels.
- * @param {Framebuffer} [options.framebuffer=defaultFramebuffer] The framebuffer from which to create the texture.  If this
- *        parameter is not specified, the default framebuffer is used.
- * @returns {Texture} A texture with contents from the framebuffer.
- *
- * @exception {DeveloperError} Invalid pixelFormat.
- * @exception {DeveloperError} pixelFormat cannot be DEPTH_COMPONENT, DEPTH_STENCIL or a compressed format.
- * @exception {DeveloperError} framebufferXOffset must be greater than or equal to zero.
- * @exception {DeveloperError} framebufferYOffset must be greater than or equal to zero.
- * @exception {DeveloperError} framebufferXOffset + width must be less than or equal to canvas.clientWidth.
- * @exception {DeveloperError} framebufferYOffset + height must be less than or equal to canvas.clientHeight.
- *
- *
- * @example
- * // Create a texture with the contents of the framebuffer.
- * const t = Texture.fromFramebuffer({
- *     context : context
- * });
- *
- * @see Sampler
- *
- * @private
- */
-Texture.fromFramebuffer = function (options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("options.context", options.context);
-  //>>includeEnd('debug');
-
-  const context = options.context;
-  const {
-    pixelFormat = PixelFormat.RGB,
-    framebufferXOffset = 0,
-    framebufferYOffset = 0,
-    width = context.drawingBufferWidth,
-    height = context.drawingBufferHeight,
-    framebuffer,
-  } = options;
-
-  //>>includeStart('debug', pragmas.debug);
-  if (!PixelFormat.validate(pixelFormat)) {
-    throw new DeveloperError("Invalid pixelFormat.");
-  }
-  if (
-    PixelFormat.isDepthFormat(pixelFormat) ||
-    PixelFormat.isCompressedFormat(pixelFormat)
-  ) {
-    throw new DeveloperError(
-      "pixelFormat cannot be DEPTH_COMPONENT, DEPTH_STENCIL or a compressed format.",
-    );
-  }
-  Check.defined("options.context", context);
-  Check.typeOf.number.greaterThanOrEquals(
-    "framebufferXOffset",
-    framebufferXOffset,
-    0,
-  );
-  Check.typeOf.number.greaterThanOrEquals(
-    "framebufferYOffset",
-    framebufferYOffset,
-    0,
-  );
-  if (framebufferXOffset + width > context.drawingBufferWidth) {
-    throw new DeveloperError(
-      "framebufferXOffset + width must be less than or equal to drawingBufferWidth",
-    );
-  }
-  if (framebufferYOffset + height > context.drawingBufferHeight) {
-    throw new DeveloperError(
-      "framebufferYOffset + height must be less than or equal to drawingBufferHeight.",
-    );
-  }
-  //>>includeEnd('debug');
-
-  const texture = new Texture({
-    context: context,
-    width: width,
-    height: height,
-    pixelFormat: pixelFormat,
-    source: {
-      framebuffer: defined(framebuffer)
-        ? framebuffer
-        : context.defaultFramebuffer,
-      xOffset: framebufferXOffset,
-      yOffset: framebufferYOffset,
-      width: width,
-      height: height,
-    },
-  });
-
-  return texture;
-};
-
-Object.defineProperties(Texture.prototype, {
-  /**
-   * A unique id for the texture
-   * @memberof Texture.prototype
-   * @type {string}
-   * @readonly
-   * @private
-   */
-  id: {
-    get: function () {
-      return this._id;
-    },
-  },
-  /**
-   * The sampler to use when sampling this texture.
-   * Create a sampler by calling {@link Sampler}.  If this
-   * parameter is not specified, a default sampler is used.  The default sampler clamps texture
-   * coordinates in both directions, uses linear filtering for both magnification and minification,
-   * and uses a maximum anisotropy of 1.0.
-   * @memberof Texture.prototype
-   * @type {Sampler}
-   * @private
-   */
-  sampler: {
-    get: function () {
-      return this._sampler;
-    },
-    set: function (sampler) {
-      setupSampler(this, sampler);
-      this._sampler = sampler;
-    },
-  },
-  pixelFormat: {
-    get: function () {
-      return this._pixelFormat;
-    },
-  },
-  pixelDatatype: {
-    get: function () {
-      return this._pixelDatatype;
-    },
-  },
-  dimensions: {
-    get: function () {
-      return this._dimensions;
-    },
-  },
-  preMultiplyAlpha: {
-    get: function () {
-      return this._preMultiplyAlpha;
-    },
-  },
-  flipY: {
-    get: function () {
-      return this._flipY;
-    },
-  },
-  width: {
-    get: function () {
-      return this._width;
-    },
-  },
-  height: {
-    get: function () {
-      return this._height;
-    },
-  },
-  sizeInBytes: {
-    get: function () {
-      if (this._hasMipmap) {
-        return Math.floor((this._sizeInBytes * 4) / 3);
-      }
-      return this._sizeInBytes;
-    },
-  },
-  _target: {
-    get: function () {
-      return this._textureTarget;
-    },
-  },
-});
-
-/**
  * Set up a sampler for use with a texture
  * @param {Texture} texture The texture to be sampled by this sampler
  * @param {Sampler} sampler Information about how to sample the texture
@@ -828,299 +1128,4 @@ function setupSampler(texture, sampler) {
   gl.bindTexture(target, null);
 }
 
-/**
- * Copy new image data into this texture, from a source {@link ImageData}, {@link HTMLImageElement}, {@link HTMLCanvasElement}, or {@link HTMLVideoElement}.
- * or an object with width, height, and arrayBufferView properties.
- * @param {object} options Object with the following properties:
- * @param {object} options.source The source {@link ImageData}, {@link HTMLImageElement}, {@link HTMLCanvasElement}, {@link HTMLVideoElement},
- *                        {@link OffscreenCanvas}, or {@link ImageBitmap},
- *                        or an object with width, height, and arrayBufferView properties.
- * @param {number} [options.xOffset=0] The offset in the x direction within the texture to copy into.
- * @param {number} [options.yOffset=0] The offset in the y direction within the texture to copy into.
- * @param {boolean} [options.skipColorSpaceConversion=false] If true, any custom gamma or color profiles in the texture will be ignored.
- *
- * @exception {DeveloperError} Cannot call copyFrom when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
- * @exception {DeveloperError} Cannot call copyFrom with a compressed texture pixel format.
- * @exception {DeveloperError} xOffset must be greater than or equal to zero.
- * @exception {DeveloperError} yOffset must be greater than or equal to zero.
- * @exception {DeveloperError} xOffset + source.width must be less than or equal to width.
- * @exception {DeveloperError} yOffset + source.height must be less than or equal to height.
- * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
- * @private
- * @example
- * texture.copyFrom({
- *  source: {
- *   width : 1,
- *   height : 1,
- *   arrayBufferView : new Uint8Array([255, 0, 0, 255])
- *  }
- * });
- */
-Texture.prototype.copyFrom = function (options) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("options", options);
-  //>>includeEnd('debug');
-
-  const {
-    xOffset = 0,
-    yOffset = 0,
-    source,
-    skipColorSpaceConversion = false,
-  } = options;
-
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("options.source", source);
-  if (PixelFormat.isDepthFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call copyFrom when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
-    );
-  }
-  if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call copyFrom with a compressed texture pixel format.",
-    );
-  }
-  Check.typeOf.number.greaterThanOrEquals("xOffset", xOffset, 0);
-  Check.typeOf.number.greaterThanOrEquals("yOffset", yOffset, 0);
-  Check.typeOf.number.lessThanOrEquals(
-    "xOffset + options.source.width",
-    xOffset + source.width,
-    this._width,
-  );
-  Check.typeOf.number.lessThanOrEquals(
-    "yOffset + options.source.height",
-    yOffset + source.height,
-    this._height,
-  );
-  //>>includeEnd('debug');
-
-  const context = this._context;
-  const gl = context._gl;
-  const target = this._textureTarget;
-
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(target, this._texture);
-
-  let { width, height } = source;
-
-  // Make sure we are using the element's intrinsic width and height where available
-  if (defined(source.videoWidth) && defined(source.videoHeight)) {
-    width = source.videoWidth;
-    height = source.videoHeight;
-  } else if (defined(source.naturalWidth) && defined(source.naturalHeight)) {
-    width = source.naturalWidth;
-    height = source.naturalHeight;
-  }
-
-  if (skipColorSpaceConversion) {
-    gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
-  } else {
-    gl.pixelStorei(
-      gl.UNPACK_COLORSPACE_CONVERSION_WEBGL,
-      gl.BROWSER_DEFAULT_WEBGL,
-    );
-  }
-
-  let uploaded = false;
-  if (!this._initialized) {
-    if (
-      xOffset === 0 &&
-      yOffset === 0 &&
-      width === this._width &&
-      height === this._height
-    ) {
-      // initialize the entire texture
-      if (defined(source.arrayBufferView)) {
-        loadBufferSource(this, source);
-      } else {
-        loadImageSource(this, source);
-      }
-      uploaded = true;
-    } else {
-      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-      loadNull(this);
-    }
-    this._initialized = true;
-  }
-
-  if (!uploaded) {
-    if (defined(source.arrayBufferView)) {
-      loadPartialBufferSource(
-        this,
-        source.arrayBufferView,
-        xOffset,
-        yOffset,
-        width,
-        height,
-      );
-    } else {
-      loadPartialImageSource(this, source, xOffset, yOffset);
-    }
-  }
-
-  gl.bindTexture(target, null);
-};
-
-/**
- * @param {number} [xOffset=0] The offset in the x direction within the texture to copy into.
- * @param {number} [yOffset=0] The offset in the y direction within the texture to copy into.
- * @param {number} [framebufferXOffset=0] optional
- * @param {number} [framebufferYOffset=0] optional
- * @param {number} [width=width] optional
- * @param {number} [height=height] optional
- * @private
- * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
- * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.
- * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.
- * @exception {DeveloperError} Cannot call copyFrom with a compressed texture pixel format.
- * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
- * @exception {DeveloperError} xOffset must be greater than or equal to zero.
- * @exception {DeveloperError} yOffset must be greater than or equal to zero.
- * @exception {DeveloperError} framebufferXOffset must be greater than or equal to zero.
- * @exception {DeveloperError} framebufferYOffset must be greater than or equal to zero.
- * @exception {DeveloperError} xOffset + width must be less than or equal to width.
- * @exception {DeveloperError} yOffset + height must be less than or equal to height.
- */
-Texture.prototype.copyFromFramebuffer = function (
-  xOffset,
-  yOffset,
-  framebufferXOffset,
-  framebufferYOffset,
-  width,
-  height,
-) {
-  xOffset = xOffset ?? 0;
-  yOffset = yOffset ?? 0;
-  framebufferXOffset = framebufferXOffset ?? 0;
-  framebufferYOffset = framebufferYOffset ?? 0;
-  width = width ?? this._width;
-  height = height ?? this._height;
-
-  //>>includeStart('debug', pragmas.debug);
-  if (PixelFormat.isDepthFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call copyFromFramebuffer when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
-    );
-  }
-  if (this._pixelDatatype === PixelDatatype.FLOAT) {
-    throw new DeveloperError(
-      "Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.",
-    );
-  }
-  if (this._pixelDatatype === PixelDatatype.HALF_FLOAT) {
-    throw new DeveloperError(
-      "Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.",
-    );
-  }
-  if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call copyFrom with a compressed texture pixel format.",
-    );
-  }
-
-  Check.typeOf.number.greaterThanOrEquals("xOffset", xOffset, 0);
-  Check.typeOf.number.greaterThanOrEquals("yOffset", yOffset, 0);
-  Check.typeOf.number.greaterThanOrEquals(
-    "framebufferXOffset",
-    framebufferXOffset,
-    0,
-  );
-  Check.typeOf.number.greaterThanOrEquals(
-    "framebufferYOffset",
-    framebufferYOffset,
-    0,
-  );
-  Check.typeOf.number.lessThanOrEquals(
-    "xOffset + width",
-    xOffset + width,
-    this._width,
-  );
-  Check.typeOf.number.lessThanOrEquals(
-    "yOffset + height",
-    yOffset + height,
-    this._height,
-  );
-  //>>includeEnd('debug');
-
-  const gl = this._context._gl;
-  const target = this._textureTarget;
-
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(target, this._texture);
-  gl.copyTexSubImage2D(
-    target,
-    0,
-    xOffset,
-    yOffset,
-    framebufferXOffset,
-    framebufferYOffset,
-    width,
-    height,
-  );
-  gl.bindTexture(target, null);
-  this._initialized = true;
-};
-
-/**
- * @param {MipmapHint} [hint=MipmapHint.DONT_CARE] optional.
- * @private
- * @exception {DeveloperError} Cannot call generateMipmap when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
- * @exception {DeveloperError} Cannot call generateMipmap when the texture pixel format is a compressed format.
- * @exception {DeveloperError} hint is invalid.
- * @exception {DeveloperError} This texture's width must be a power of two to call generateMipmap() in a WebGL1 context.
- * @exception {DeveloperError} This texture's height must be a power of two to call generateMipmap() in a WebGL1 context.
- * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
- */
-Texture.prototype.generateMipmap = function (hint) {
-  hint = hint ?? MipmapHint.DONT_CARE;
-
-  //>>includeStart('debug', pragmas.debug);
-  if (PixelFormat.isDepthFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call generateMipmap when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
-    );
-  }
-  if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call generateMipmap with a compressed pixel format.",
-    );
-  }
-  if (!this._context.webgl2) {
-    if (this._width > 1 && !CesiumMath.isPowerOfTwo(this._width)) {
-      throw new DeveloperError(
-        "width must be a power of two to call generateMipmap() in a WebGL1 context.",
-      );
-    }
-    if (this._height > 1 && !CesiumMath.isPowerOfTwo(this._height)) {
-      throw new DeveloperError(
-        "height must be a power of two to call generateMipmap() in a WebGL1 context.",
-      );
-    }
-  }
-  if (!MipmapHint.validate(hint)) {
-    throw new DeveloperError("hint is invalid.");
-  }
-  //>>includeEnd('debug');
-
-  this._hasMipmap = true;
-
-  const gl = this._context._gl;
-  const target = this._textureTarget;
-
-  gl.hint(gl.GENERATE_MIPMAP_HINT, hint);
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(target, this._texture);
-  gl.generateMipmap(target);
-  gl.bindTexture(target, null);
-};
-
-Texture.prototype.isDestroyed = function () {
-  return false;
-};
-
-Texture.prototype.destroy = function () {
-  this._context._gl.deleteTexture(this._texture);
-  return destroyObject(this);
-};
 export default Texture;

--- a/packages/engine/Source/Renderer/Texture3D.js
+++ b/packages/engine/Source/Renderer/Texture3D.js
@@ -13,20 +13,25 @@ import Sampler from "./Sampler.js";
 import TextureMagnificationFilter from "./TextureMagnificationFilter.js";
 import TextureMinificationFilter from "./TextureMinificationFilter.js";
 
+/** @import Context from "./Context.js"; */
+/** @import { TypedArray } from "../Core/globalTypes.js"; */
+
 /**
- * @typedef {object} Texture3D.Source
+ * @typedef {object} Texture3DSource
  * @property {number} width The width (in pixels) of the 3D texture source data.
  * @property {number} height The height (in pixels) of the 3D texture source data.
  * @property {number} depth The depth (in pixels) of the 3D texture source data.
  * @property {TypedArray|DataView} arrayBufferView The source data for a 3D texture. The type of each element needs to match the pixelDatatype.
  * @property {TypedArray|DataView} [mipLevels] An array of mip level data. Each element in the array should be a TypedArray or DataView that matches the pixelDatatype.
+ *
+ * @private
  */
 
 /**
- * @typedef {object} Texture3D.ConstructorOptions
+ * @typedef {object} Texture3DConstructorOptions
  *
  * @property {Context} context
- * @property {Texture3D.Source} [source] The source for texel values to be loaded into the 3D texture.
+ * @property {Texture3DSource} [source] The source for texel values to be loaded into the 3D texture.
  * @property {PixelFormat} [pixelFormat=PixelFormat.RGBA] The format of each pixel, i.e., the number of components it has and what they represent.
  * @property {PixelDatatype} [pixelDatatype=PixelDatatype.UNSIGNED_BYTE] The data type of each pixel.
  * @property {boolean} [flipY=true] If true, the source values will be read as if the y-axis is inverted (y=0 at the top).
@@ -45,218 +50,457 @@ import TextureMinificationFilter from "./TextureMinificationFilter.js";
  * A wrapper for a {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture|WebGLTexture}
  * to abstract away the verbose GL calls associated with setting up a texture3D.
  *
- * @alias Texture3D
- * @constructor
- *
- * @param {Texture3D.ConstructorOptions} options
  * @private
  */
-function Texture3D(options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
+class Texture3D {
+  /**
+   * @param {Texture3DConstructorOptions} options
+   */
+  constructor(options) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("options.context", options.context);
+    //>>includeEnd('debug');
 
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("options.context", options.context);
-  //>>includeEnd('debug');
+    const {
+      context,
+      source,
+      pixelFormat = PixelFormat.RGBA,
+      pixelDatatype = PixelDatatype.UNSIGNED_BYTE,
+      flipY = true,
+      skipColorSpaceConversion = false,
+      sampler = new Sampler(),
+    } = options;
 
-  const {
-    context,
-    source,
-    pixelFormat = PixelFormat.RGBA,
-    pixelDatatype = PixelDatatype.UNSIGNED_BYTE,
-    flipY = true,
-    skipColorSpaceConversion = false,
-    sampler = new Sampler(),
-  } = options;
-
-  // 3D textures are not supported in a WebGL1 context. But we allow a stub context for testing.
-  if (!context.webgl2 && !defined(context.options.getWebGLStub)) {
-    throw new DeveloperError(
-      "WebGL1 does not support texture3D. Please use a WebGL2 context.",
-    );
-  }
-
-  let { width, height, depth } = options;
-  if (defined(source)) {
-    // Make sure we are using the element's intrinsic width and height where available
-    if (!defined(width)) {
-      width = source.width;
+    // 3D textures are not supported in a WebGL1 context. But we allow a stub context for testing.
+    if (!context.webgl2 && !defined(context.options.getWebGLStub)) {
+      throw new DeveloperError(
+        "WebGL1 does not support texture3D. Please use a WebGL2 context.",
+      );
     }
-    if (!defined(height)) {
-      height = source.height;
-    }
-    // depth is not used for 2D textures, but is required for 3D textures
-    if (!defined(depth)) {
-      depth = source.depth;
-    }
-  }
 
-  // Use premultiplied alpha for opaque textures should perform better on Chrome:
-  // http://media.tojicode.com/webglCamp4/#20
-  const preMultiplyAlpha =
-    options.preMultiplyAlpha ||
-    pixelFormat === PixelFormat.RGB ||
-    pixelFormat === PixelFormat.LUMINANCE;
-
-  const internalFormat = PixelFormat.toInternalFormat(
-    pixelFormat,
-    pixelDatatype,
-    context,
-  );
-
-  const isCompressed = PixelFormat.isCompressedFormat(internalFormat);
-
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(width) || !defined(height) || !defined(depth)) {
-    throw new DeveloperError(
-      "options requires a source field to create an initialized texture3D or width, height and depth fields to create a blank texture3D.",
-    );
-  }
-
-  Check.typeOf.number.greaterThan("width", width, 0);
-
-  if (width > ContextLimits.maximum3DTextureSize) {
-    throw new DeveloperError(
-      `Width must be less than or equal to the maximum texture3D size (${ContextLimits.maximum3DTextureSize}).  Check maximum3DTextureSize.`,
-    );
-  }
-
-  Check.typeOf.number.greaterThan("height", height, 0);
-
-  if (height > ContextLimits.maximum3DTextureSize) {
-    throw new DeveloperError(
-      `Height must be less than or equal to the maximum texture3D size (${ContextLimits.maximum3DTextureSize}).  Check maximum3DTextureSize.`,
-    );
-  }
-
-  Check.typeOf.number.greaterThan("depth", depth, 0);
-
-  if (depth > ContextLimits.maximum3DTextureSize) {
-    throw new DeveloperError(
-      `Depth must be less than or equal to the maximum texture3D size (${ContextLimits.maximum3DTextureSize}).  Check maximum3DTextureSize.`,
-    );
-  }
-
-  if (!PixelFormat.validate(pixelFormat)) {
-    throw new DeveloperError("Invalid options.pixelFormat.");
-  }
-
-  if (!isCompressed && !PixelDatatype.validate(pixelDatatype)) {
-    throw new DeveloperError("Invalid options.pixelDatatype.");
-  }
-
-  if (
-    pixelFormat === PixelFormat.DEPTH_COMPONENT &&
-    pixelDatatype !== PixelDatatype.UNSIGNED_SHORT &&
-    pixelDatatype !== PixelDatatype.UNSIGNED_INT
-  ) {
-    throw new DeveloperError(
-      "When options.pixelFormat is DEPTH_COMPONENT, options.pixelDatatype must be UNSIGNED_SHORT or UNSIGNED_INT.",
-    );
-  }
-
-  if (
-    pixelFormat === PixelFormat.DEPTH_STENCIL &&
-    pixelDatatype !== PixelDatatype.UNSIGNED_INT_24_8
-  ) {
-    throw new DeveloperError(
-      "When options.pixelFormat is DEPTH_STENCIL, options.pixelDatatype must be UNSIGNED_INT_24_8.",
-    );
-  }
-
-  if (pixelDatatype === PixelDatatype.FLOAT && !context.floatingPointTexture) {
-    throw new DeveloperError(
-      "When options.pixelDatatype is FLOAT, this WebGL implementation must support the OES_texture_float extension.  Check context.floatingPointTexture.",
-    );
-  }
-
-  if (
-    pixelDatatype === PixelDatatype.HALF_FLOAT &&
-    !context.halfFloatingPointTexture
-  ) {
-    throw new DeveloperError(
-      "When options.pixelDatatype is HALF_FLOAT, this WebGL implementation must support the OES_texture_half_float extension. Check context.halfFloatingPointTexture.",
-    );
-  }
-
-  if (PixelFormat.isDepthFormat(pixelFormat)) {
+    let { width, height, depth } = options;
     if (defined(source)) {
-      throw new DeveloperError(
-        "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, source cannot be provided.",
-      );
+      // Make sure we are using the element's intrinsic width and height where available
+      if (!defined(width)) {
+        width = source.width;
+      }
+      if (!defined(height)) {
+        height = source.height;
+      }
+      // depth is not used for 2D textures, but is required for 3D textures
+      if (!defined(depth)) {
+        depth = source.depth;
+      }
     }
 
-    if (!context.depthTexture) {
-      throw new DeveloperError(
-        "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, this WebGL implementation must support WEBGL_depth_texture.  Check context.depthTexture.",
-      );
-    }
-  }
+    // Use premultiplied alpha for opaque textures should perform better on Chrome:
+    // http://media.tojicode.com/webglCamp4/#20
+    const preMultiplyAlpha =
+      options.preMultiplyAlpha ||
+      pixelFormat === PixelFormat.RGB ||
+      pixelFormat === PixelFormat.LUMINANCE;
 
-  if (isCompressed) {
-    throw new DeveloperError(
-      "Texture3D does not currently support compressed formats.",
+    const internalFormat = PixelFormat.toInternalFormat(
+      pixelFormat,
+      pixelDatatype,
+      context,
     );
-  }
-  //>>includeEnd('debug');
 
-  const gl = context._gl;
+    const isCompressed = PixelFormat.isCompressedFormat(internalFormat);
 
-  const sizeInBytes = PixelFormat.texture3DSizeInBytes(
-    pixelFormat,
-    pixelDatatype,
-    width,
-    height,
-    depth,
-  );
-
-  this._id = options.id ?? createGuid();
-  this._context = context;
-  this._textureFilterAnisotropic = context._textureFilterAnisotropic;
-  this._textureTarget = gl.TEXTURE_3D;
-  this._texture = gl.createTexture();
-  this._internalFormat = internalFormat;
-  this._pixelFormat = pixelFormat;
-  this._pixelDatatype = pixelDatatype;
-  this._width = width;
-  this._height = height;
-  this._depth = depth;
-  this._dimensions = new Cartesian3(width, height, depth);
-  this._hasMipmap = false;
-  this._sizeInBytes = sizeInBytes;
-  this._preMultiplyAlpha = preMultiplyAlpha;
-  this._flipY = flipY;
-  this._initialized = false;
-  this._sampler = undefined;
-
-  this._sampler = sampler;
-  setupSampler(this, sampler);
-
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(this._textureTarget, this._texture);
-
-  if (defined(source)) {
-    if (skipColorSpaceConversion) {
-      gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
-    } else {
-      gl.pixelStorei(
-        gl.UNPACK_COLORSPACE_CONVERSION_WEBGL,
-        gl.BROWSER_DEFAULT_WEBGL,
-      );
-    }
-    if (!defined(source.arrayBufferView)) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(width) || !defined(height) || !defined(depth)) {
       throw new DeveloperError(
-        "For Texture3D, options.source.arrayBufferView must be defined",
+        "options requires a source field to create an initialized texture3D or width, height and depth fields to create a blank texture3D.",
       );
     }
 
-    loadBufferSource(this, source);
+    Check.typeOf.number.greaterThan("width", width, 0);
 
-    this._initialized = true;
-  } else {
-    loadNull(this);
+    if (width > ContextLimits.maximum3DTextureSize) {
+      throw new DeveloperError(
+        `Width must be less than or equal to the maximum texture3D size (${ContextLimits.maximum3DTextureSize}).  Check maximum3DTextureSize.`,
+      );
+    }
+
+    Check.typeOf.number.greaterThan("height", height, 0);
+
+    if (height > ContextLimits.maximum3DTextureSize) {
+      throw new DeveloperError(
+        `Height must be less than or equal to the maximum texture3D size (${ContextLimits.maximum3DTextureSize}).  Check maximum3DTextureSize.`,
+      );
+    }
+
+    Check.typeOf.number.greaterThan("depth", depth, 0);
+
+    if (depth > ContextLimits.maximum3DTextureSize) {
+      throw new DeveloperError(
+        `Depth must be less than or equal to the maximum texture3D size (${ContextLimits.maximum3DTextureSize}).  Check maximum3DTextureSize.`,
+      );
+    }
+
+    if (!PixelFormat.validate(pixelFormat)) {
+      throw new DeveloperError("Invalid options.pixelFormat.");
+    }
+
+    if (!isCompressed && !PixelDatatype.validate(pixelDatatype)) {
+      throw new DeveloperError("Invalid options.pixelDatatype.");
+    }
+
+    if (
+      pixelFormat === PixelFormat.DEPTH_COMPONENT &&
+      pixelDatatype !== PixelDatatype.UNSIGNED_SHORT &&
+      pixelDatatype !== PixelDatatype.UNSIGNED_INT
+    ) {
+      throw new DeveloperError(
+        "When options.pixelFormat is DEPTH_COMPONENT, options.pixelDatatype must be UNSIGNED_SHORT or UNSIGNED_INT.",
+      );
+    }
+
+    if (
+      pixelFormat === PixelFormat.DEPTH_STENCIL &&
+      pixelDatatype !== PixelDatatype.UNSIGNED_INT_24_8
+    ) {
+      throw new DeveloperError(
+        "When options.pixelFormat is DEPTH_STENCIL, options.pixelDatatype must be UNSIGNED_INT_24_8.",
+      );
+    }
+
+    if (
+      pixelDatatype === PixelDatatype.FLOAT &&
+      !context.floatingPointTexture
+    ) {
+      throw new DeveloperError(
+        "When options.pixelDatatype is FLOAT, this WebGL implementation must support the OES_texture_float extension.  Check context.floatingPointTexture.",
+      );
+    }
+
+    if (
+      pixelDatatype === PixelDatatype.HALF_FLOAT &&
+      !context.halfFloatingPointTexture
+    ) {
+      throw new DeveloperError(
+        "When options.pixelDatatype is HALF_FLOAT, this WebGL implementation must support the OES_texture_half_float extension. Check context.halfFloatingPointTexture.",
+      );
+    }
+
+    if (PixelFormat.isDepthFormat(pixelFormat)) {
+      if (defined(source)) {
+        throw new DeveloperError(
+          "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, source cannot be provided.",
+        );
+      }
+
+      if (!context.depthTexture) {
+        throw new DeveloperError(
+          "When options.pixelFormat is DEPTH_COMPONENT or DEPTH_STENCIL, this WebGL implementation must support WEBGL_depth_texture.  Check context.depthTexture.",
+        );
+      }
+    }
+
+    if (isCompressed) {
+      throw new DeveloperError(
+        "Texture3D does not currently support compressed formats.",
+      );
+    }
+    //>>includeEnd('debug');
+
+    const gl = context._gl;
+
+    const sizeInBytes = PixelFormat.texture3DSizeInBytes(
+      pixelFormat,
+      pixelDatatype,
+      width,
+      height,
+      depth,
+    );
+
+    this._id = options.id ?? createGuid();
+    this._context = context;
+    this._textureFilterAnisotropic = context._textureFilterAnisotropic;
+    this._textureTarget = gl.TEXTURE_3D;
+    this._texture = gl.createTexture();
+    this._internalFormat = internalFormat;
+    this._pixelFormat = pixelFormat;
+    this._pixelDatatype = pixelDatatype;
+    this._width = width;
+    this._height = height;
+    this._depth = depth;
+    this._dimensions = new Cartesian3(width, height, depth);
+    this._hasMipmap = false;
+    this._sizeInBytes = sizeInBytes;
+    this._preMultiplyAlpha = preMultiplyAlpha;
+    this._flipY = flipY;
+    this._initialized = false;
+    this._sampler = undefined;
+
+    this._sampler = sampler;
+    setupSampler(this, sampler);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(this._textureTarget, this._texture);
+
+    if (defined(source)) {
+      if (skipColorSpaceConversion) {
+        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+      } else {
+        gl.pixelStorei(
+          gl.UNPACK_COLORSPACE_CONVERSION_WEBGL,
+          gl.BROWSER_DEFAULT_WEBGL,
+        );
+      }
+      if (!defined(source.arrayBufferView)) {
+        throw new DeveloperError(
+          "For Texture3D, options.source.arrayBufferView must be defined",
+        );
+      }
+
+      loadBufferSource(this, source);
+
+      this._initialized = true;
+    } else {
+      loadNull(this);
+    }
+
+    gl.bindTexture(this._textureTarget, null);
   }
 
-  gl.bindTexture(this._textureTarget, null);
+  /**
+   * Copy new image data into this texture, from a source object with width, height, depth, and arrayBufferView properties.
+   * @param {object} options Object with the following properties:
+   * @param {object} options.source The source object with width, height, depth, and arrayBufferView properties.
+   * @param {number} [options.xOffset=0] The offset in the x direction within the texture to copy into.
+   * @param {number} [options.yOffset=0] The offset in the y direction within the texture to copy into.
+   * @param {number} [options.zOffset=0] The offset in the z direction within the texture to copy into.
+   * @param {boolean} [options.skipColorSpaceConversion=false] If true, any custom gamma or color profiles in the texture will be ignored.
+   *
+   * @exception {DeveloperError} Unsupported copyFrom with a compressed texture pixel format.
+   * @exception {DeveloperError} xOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} yOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} zOffset must be greater than or equal to zero.
+   * @exception {DeveloperError} xOffset + source.width must be less than or equal to width.
+   * @exception {DeveloperError} yOffset + source.height must be less than or equal to height.
+   * @exception {DeveloperError} zOffset + source.depth must be less than or equal to depth.
+   * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
+   * @private
+   * @example
+   * texture.copyFrom({
+   *  source: {
+   *   width : 1,
+   *   height : 1,
+   *   depth : 1,
+   *   arrayBufferView : new Uint8Array([255, 0, 0, 255])
+   *  }
+   * });
+   */
+  copyFrom(options) {
+    options = options ?? Frozen.EMPTY_OBJECT;
+
+    const { source, xOffset = 0, yOffset = 0, zOffset = 0 } = options;
+
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("options.source", source);
+    Check.defined("options.source.arrayBufferView", source.arrayBufferView);
+    if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Unsupported copyFrom with a compressed texture pixel format.",
+      );
+    }
+    Check.typeOf.number.greaterThanOrEquals("xOffset", xOffset, 0);
+    Check.typeOf.number.greaterThanOrEquals("yOffset", yOffset, 0);
+    Check.typeOf.number.greaterThanOrEquals("zOffset", zOffset, 0);
+    Check.typeOf.number.lessThanOrEquals(
+      "xOffset + options.source.width",
+      xOffset + source.width,
+      this._width,
+    );
+    Check.typeOf.number.lessThanOrEquals(
+      "yOffset + options.source.height",
+      yOffset + source.height,
+      this._height,
+    );
+    Check.typeOf.number.lessThanOrEquals(
+      "zOffset + options.source.depth",
+      zOffset + source.depth,
+      this._depth,
+    );
+    //>>includeEnd('debug');
+
+    const context = this._context;
+    const gl = context._gl;
+    const target = this._textureTarget;
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(target, this._texture);
+
+    const { width, height, depth } = source;
+    let uploaded = false;
+    if (!this._initialized) {
+      if (
+        xOffset === 0 &&
+        yOffset === 0 &&
+        zOffset === 0 &&
+        width === this._width &&
+        height === this._height &&
+        depth === this._depth
+      ) {
+        loadBufferSource(this, source);
+        uploaded = true;
+      } else {
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        loadNull(this);
+      }
+      this._initialized = true;
+    }
+
+    if (!uploaded) {
+      loadPartialBufferSource(
+        this,
+        source.arrayBufferView,
+        xOffset,
+        yOffset,
+        zOffset,
+        width,
+        height,
+        depth,
+      );
+    }
+
+    gl.bindTexture(target, null);
+  }
+
+  /**
+   * This function is identical to using the Texture3D constructor except that it can be
+   * replaced with a mock/spy in tests.
+   * @param {Texture3DConstructorOptions} options
+   * @ignore
+   */
+  static create(options) {
+    return new Texture3D(options);
+  }
+
+  /**
+   * A unique id for the texture3D
+   * @type {string}
+   * @readonly
+   * @ignore
+   */
+  get id() {
+    return this._id;
+  }
+
+  /**
+   * The sampler to use when sampling this texture3D.
+   * Create a sampler by calling {@link Sampler}.  If this
+   * parameter is not specified, a default sampler is used.  The default sampler clamps texture3D
+   * coordinates in both directions, uses linear filtering for both magnification and minification,
+   * and uses a maximum anisotropy of 1.0.
+   * @type {Sampler}
+   * @ignore
+   */
+  get sampler() {
+    return this._sampler;
+  }
+
+  set sampler(sampler) {
+    setupSampler(this, sampler);
+    this._sampler = sampler;
+  }
+
+  get pixelFormat() {
+    return this._pixelFormat;
+  }
+
+  get pixelDatatype() {
+    return this._pixelDatatype;
+  }
+
+  get dimensions() {
+    return this._dimensions;
+  }
+
+  get preMultiplyAlpha() {
+    return this._preMultiplyAlpha;
+  }
+
+  get flipY() {
+    return this._flipY;
+  }
+
+  get width() {
+    return this._width;
+  }
+
+  get height() {
+    return this._height;
+  }
+
+  get depth() {
+    return this._depth;
+  }
+
+  get sizeInBytes() {
+    if (this._hasMipmap) {
+      return Math.floor((this._sizeInBytes * 8) / 7);
+    }
+    return this._sizeInBytes;
+  }
+
+  get _target() {
+    return this._textureTarget;
+  }
+
+  /**
+   * @param {MipmapHint} [hint=MipmapHint.DONT_CARE] optional.
+   * @private
+   * @exception {DeveloperError} Cannot call generateMipmap when the texture3D pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
+   * @exception {DeveloperError} Cannot call generateMipmap when the texture3D pixel format is a compressed format.
+   * @exception {DeveloperError} hint is invalid.
+   * @exception {DeveloperError} This texture3D's width must be a power of two to call generateMipmap() in a WebGL1 context.
+   * @exception {DeveloperError} This texture3D's height must be a power of two to call generateMipmap() in a WebGL1 context.
+   * @exception {DeveloperError} This texture3D was destroyed, i.e., destroy() was called.
+   */
+  generateMipmap(hint) {
+    hint = hint ?? MipmapHint.DONT_CARE;
+
+    //>>includeStart('debug', pragmas.debug);
+    if (PixelFormat.isDepthFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call generateMipmap when the texture3D pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
+      );
+    }
+    if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
+      throw new DeveloperError(
+        "Cannot call generateMipmap with a compressed pixel format.",
+      );
+    }
+
+    if (!MipmapHint.validate(hint)) {
+      throw new DeveloperError("hint is invalid.");
+    }
+    //>>includeEnd('debug');
+
+    this._hasMipmap = true;
+
+    const gl = this._context._gl;
+    const target = this._textureTarget;
+
+    gl.hint(gl.GENERATE_MIPMAP_HINT, hint);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(target, this._texture);
+    gl.generateMipmap(target);
+    gl.bindTexture(target, null);
+  }
+
+  isDestroyed() {
+    return false;
+  }
+
+  destroy() {
+    this._context._gl.deleteTexture(this._texture);
+    return destroyObject(this);
+  }
 }
 
 /**
@@ -333,111 +577,6 @@ function loadBufferSource(texture3D, source) {
     }
   }
 }
-
-/**
- * Copy new image data into this texture, from a source object with width, height, depth, and arrayBufferView properties.
- * @param {object} options Object with the following properties:
- * @param {object} options.source The source object with width, height, depth, and arrayBufferView properties.
- * @param {number} [options.xOffset=0] The offset in the x direction within the texture to copy into.
- * @param {number} [options.yOffset=0] The offset in the y direction within the texture to copy into.
- * @param {number} [options.zOffset=0] The offset in the z direction within the texture to copy into.
- * @param {boolean} [options.skipColorSpaceConversion=false] If true, any custom gamma or color profiles in the texture will be ignored.
- *
- * @exception {DeveloperError} Unsupported copyFrom with a compressed texture pixel format.
- * @exception {DeveloperError} xOffset must be greater than or equal to zero.
- * @exception {DeveloperError} yOffset must be greater than or equal to zero.
- * @exception {DeveloperError} zOffset must be greater than or equal to zero.
- * @exception {DeveloperError} xOffset + source.width must be less than or equal to width.
- * @exception {DeveloperError} yOffset + source.height must be less than or equal to height.
- * @exception {DeveloperError} zOffset + source.depth must be less than or equal to depth.
- * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
- * @private
- * @example
- * texture.copyFrom({
- *  source: {
- *   width : 1,
- *   height : 1,
- *   depth : 1,
- *   arrayBufferView : new Uint8Array([255, 0, 0, 255])
- *  }
- * });
- */
-Texture3D.prototype.copyFrom = function (options) {
-  options = options ?? Frozen.EMPTY_OBJECT;
-
-  const { source, xOffset = 0, yOffset = 0, zOffset = 0 } = options;
-
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("options.source", source);
-  Check.defined("options.source.arrayBufferView", source.arrayBufferView);
-  if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Unsupported copyFrom with a compressed texture pixel format.",
-    );
-  }
-  Check.typeOf.number.greaterThanOrEquals("xOffset", xOffset, 0);
-  Check.typeOf.number.greaterThanOrEquals("yOffset", yOffset, 0);
-  Check.typeOf.number.greaterThanOrEquals("zOffset", zOffset, 0);
-  Check.typeOf.number.lessThanOrEquals(
-    "xOffset + options.source.width",
-    xOffset + source.width,
-    this._width,
-  );
-  Check.typeOf.number.lessThanOrEquals(
-    "yOffset + options.source.height",
-    yOffset + source.height,
-    this._height,
-  );
-  Check.typeOf.number.lessThanOrEquals(
-    "zOffset + options.source.depth",
-    zOffset + source.depth,
-    this._depth,
-  );
-  //>>includeEnd('debug');
-
-  const context = this._context;
-  const gl = context._gl;
-  const target = this._textureTarget;
-
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(target, this._texture);
-
-  const { width, height, depth } = source;
-  let uploaded = false;
-  if (!this._initialized) {
-    if (
-      xOffset === 0 &&
-      yOffset === 0 &&
-      zOffset === 0 &&
-      width === this._width &&
-      height === this._height &&
-      depth === this._depth
-    ) {
-      loadBufferSource(this, source);
-      uploaded = true;
-    } else {
-      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-      loadNull(this);
-    }
-    this._initialized = true;
-  }
-
-  if (!uploaded) {
-    loadPartialBufferSource(
-      this,
-      source.arrayBufferView,
-      xOffset,
-      yOffset,
-      zOffset,
-      width,
-      height,
-      depth,
-    );
-  }
-
-  gl.bindTexture(target, null);
-};
 
 /**
  * Load texel data from a buffer into part of a 3D texture
@@ -530,102 +669,6 @@ function loadNull(texture3D) {
 }
 
 /**
- * This function is identical to using the Texture3D constructor except that it can be
- * replaced with a mock/spy in tests.
- * @private
- */
-Texture3D.create = function (options) {
-  return new Texture3D(options);
-};
-
-Object.defineProperties(Texture3D.prototype, {
-  /**
-   * A unique id for the texture3D
-   * @memberof Texture3D.prototype
-   * @type {string}
-   * @readonly
-   * @private
-   */
-  id: {
-    get: function () {
-      return this._id;
-    },
-  },
-  /**
-   * The sampler to use when sampling this texture3D.
-   * Create a sampler by calling {@link Sampler}.  If this
-   * parameter is not specified, a default sampler is used.  The default sampler clamps texture3D
-   * coordinates in both directions, uses linear filtering for both magnification and minification,
-   * and uses a maximum anisotropy of 1.0.
-   * @memberof Texture3D.prototype
-   * @type {Sampler}
-   * @private
-   */
-  sampler: {
-    get: function () {
-      return this._sampler;
-    },
-    set: function (sampler) {
-      setupSampler(this, sampler);
-      this._sampler = sampler;
-    },
-  },
-  pixelFormat: {
-    get: function () {
-      return this._pixelFormat;
-    },
-  },
-  pixelDatatype: {
-    get: function () {
-      return this._pixelDatatype;
-    },
-  },
-  dimensions: {
-    get: function () {
-      return this._dimensions;
-    },
-  },
-  preMultiplyAlpha: {
-    get: function () {
-      return this._preMultiplyAlpha;
-    },
-  },
-  flipY: {
-    get: function () {
-      return this._flipY;
-    },
-  },
-  width: {
-    get: function () {
-      return this._width;
-    },
-  },
-  height: {
-    get: function () {
-      return this._height;
-    },
-  },
-  depth: {
-    get: function () {
-      return this._depth;
-    },
-  },
-  sizeInBytes: {
-    get: function () {
-      if (this._hasMipmap) {
-        return Math.floor((this._sizeInBytes * 8) / 7);
-      }
-      return this._sizeInBytes;
-    },
-  },
-  _target: {
-    get: function () {
-      return this._textureTarget;
-    },
-  },
-});
-
-/**
  * Set up a sampler for use with a texture3D
  * @param {Texture3D} texture3D The texture3D to be sampled by this sampler
  * @param {Sampler} sampler Information about how to sample the texture3D
@@ -684,54 +727,4 @@ function setupSampler(texture3D, sampler) {
   gl.bindTexture(target, null);
 }
 
-/**
- * @param {MipmapHint} [hint=MipmapHint.DONT_CARE] optional.
- * @private
- * @exception {DeveloperError} Cannot call generateMipmap when the texture3D pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
- * @exception {DeveloperError} Cannot call generateMipmap when the texture3D pixel format is a compressed format.
- * @exception {DeveloperError} hint is invalid.
- * @exception {DeveloperError} This texture3D's width must be a power of two to call generateMipmap() in a WebGL1 context.
- * @exception {DeveloperError} This texture3D's height must be a power of two to call generateMipmap() in a WebGL1 context.
- * @exception {DeveloperError} This texture3D was destroyed, i.e., destroy() was called.
- */
-Texture3D.prototype.generateMipmap = function (hint) {
-  hint = hint ?? MipmapHint.DONT_CARE;
-
-  //>>includeStart('debug', pragmas.debug);
-  if (PixelFormat.isDepthFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call generateMipmap when the texture3D pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.",
-    );
-  }
-  if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
-    throw new DeveloperError(
-      "Cannot call generateMipmap with a compressed pixel format.",
-    );
-  }
-
-  if (!MipmapHint.validate(hint)) {
-    throw new DeveloperError("hint is invalid.");
-  }
-  //>>includeEnd('debug');
-
-  this._hasMipmap = true;
-
-  const gl = this._context._gl;
-  const target = this._textureTarget;
-
-  gl.hint(gl.GENERATE_MIPMAP_HINT, hint);
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(target, this._texture);
-  gl.generateMipmap(target);
-  gl.bindTexture(target, null);
-};
-
-Texture3D.prototype.isDestroyed = function () {
-  return false;
-};
-
-Texture3D.prototype.destroy = function () {
-  this._context._gl.deleteTexture(this._texture);
-  return destroyObject(this);
-};
 export default Texture3D;

--- a/packages/engine/Source/Renderer/TextureMagnificationFilter.js
+++ b/packages/engine/Source/Renderer/TextureMagnificationFilter.js
@@ -38,4 +38,6 @@ TextureMagnificationFilter.validate = function (textureMagnificationFilter) {
   );
 };
 
-export default Object.freeze(TextureMagnificationFilter);
+Object.freeze(TextureMagnificationFilter);
+
+export default TextureMagnificationFilter;

--- a/packages/engine/Source/Renderer/TextureMinificationFilter.js
+++ b/packages/engine/Source/Renderer/TextureMinificationFilter.js
@@ -91,4 +91,6 @@ TextureMinificationFilter.validate = function (textureMinificationFilter) {
   );
 };
 
-export default Object.freeze(TextureMinificationFilter);
+Object.freeze(TextureMinificationFilter);
+
+export default TextureMinificationFilter;

--- a/packages/engine/Source/Renderer/TextureWrap.js
+++ b/packages/engine/Source/Renderer/TextureWrap.js
@@ -1,6 +1,7 @@
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
+ * @enum {number}
  * @private
  */
 const TextureWrap = {
@@ -16,4 +17,7 @@ const TextureWrap = {
     );
   },
 };
-export default Object.freeze(TextureWrap);
+
+Object.freeze(TextureWrap);
+
+export default TextureWrap;


### PR DESCRIPTION
# Description

Migrates Texture, Texture3D, and Sampler to ES6 classes. Type-checking only partially added, I fixed a few issues but there were too many dependencies to include without cluttering the PR further.

> [!WARNING]
> Currently blocked by:
> - #12266

## Issue number and link

- #4434

## Testing plan

TODO

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13452** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)