### PR TITLE
Types: Fix type checks against remaining enums

### DIFF
--- a/Tools/ast-grep/rules/no-export-object-freeze.yml
+++ b/Tools/ast-grep/rules/no-export-object-freeze.yml
@@ -3,6 +3,7 @@ message: >
   Exporting the result of Object.freeze(...) will lose type information
   associated with the enum. Instead, freeze the enum on one line and export
   the original (now frozen) enum on the next.
+  See: https://github.com/CesiumGS/cesium/issues/13420
 severity: error
 language: JavaScript
 files:
@@ -11,13 +12,9 @@ rule:
   pattern:
     selector: export_statement
     context: export default Object.freeze($A)
-  # Require the export statement to _immediately_ follow the enum declaration,
-  # which exempts enums with attached utility functions from this rule. In the
-  # future, when utility functions are moved or type checking conflicts
-  # resolved, this 'follows' block can include all preceeding declarations.
-  # See: https://github.com/CesiumGS/cesium/issues/13420
   follows:
     kind: lexical_declaration
+    stopBy: end
     has:
       pattern: $A
       stopBy: end

--- a/Tools/ast-grep/tests/__snapshots__/no-export-object-freeze-snapshot.yml
+++ b/Tools/ast-grep/tests/__snapshots__/no-export-object-freeze-snapshot.yml
@@ -1,6 +1,25 @@
 id: no-export-object-freeze
 snapshots:
   ? |
+    /** @enum {number} */ const MyInteger = { ONE: 1, TWO: 2 }; MyInteger.validate = () => {}; export default Object.freeze(MyInteger);
+  : labels:
+    - source: export default Object.freeze(MyInteger);
+      style: primary
+      start: 91
+      end: 131
+    - source: MyInteger
+      style: secondary
+      start: 28
+      end: 37
+    - source: /** @enum {number} */
+      style: secondary
+      start: 0
+      end: 21
+    - source: 'const MyInteger = { ONE: 1, TWO: 2 };'
+      style: secondary
+      start: 22
+      end: 59
+  ? |
     /** @enum {number} */ const MyInteger = { ONE: 1, TWO: 2 }; export default Object.freeze(MyInteger);
   : labels:
     - source: export default Object.freeze(MyInteger);

--- a/Tools/ast-grep/tests/no-export-object-freeze.test.yml
+++ b/Tools/ast-grep/tests/no-export-object-freeze.test.yml
@@ -5,13 +5,13 @@ valid:
     const MyInteger = { ONE: 1, TWO: 2 };
     Object.freeze(MyInteger);
     export default MyInteger;
-  - >
-    /** @enum {number} */
-    const MyInteger = { ONE: 1, TWO: 2 };
-    MyInteger.validate = () => {};
-    export Object.freeze(MyInteger);
 invalid:
   - >
     /** @enum {number} */
     const MyInteger = { ONE: 1, TWO: 2 };
+    export default Object.freeze(MyInteger);
+  - >
+    /** @enum {number} */
+    const MyInteger = { ONE: 1, TWO: 2 };
+    MyInteger.validate = () => {};
     export default Object.freeze(MyInteger);

--- a/packages/engine/Source/Core/ComponentDatatype.js
+++ b/packages/engine/Source/Core/ComponentDatatype.js
@@ -335,4 +335,7 @@ ComponentDatatype.fromName = function (name) {
     //>>includeEnd('debug');
   }
 };
-export default Object.freeze(ComponentDatatype);
+
+Object.freeze(ComponentDatatype);
+
+export default ComponentDatatype;

--- a/packages/engine/Source/Core/IndexDatatype.js
+++ b/packages/engine/Source/Core/IndexDatatype.js
@@ -196,4 +196,6 @@ IndexDatatype.fromTypedArray = function (array) {
   //>>includeEnd('debug');
 };
 
-export default Object.freeze(IndexDatatype);
+Object.freeze(IndexDatatype);
+
+export default IndexDatatype;

--- a/packages/engine/Source/Core/PixelFormat.js
+++ b/packages/engine/Source/Core/PixelFormat.js
@@ -600,4 +600,6 @@ PixelFormat.toInternalFormat = function (pixelFormat, pixelDatatype, context) {
   return pixelFormat;
 };
 
-export default Object.freeze(PixelFormat);
+Object.freeze(PixelFormat);
+
+export default PixelFormat;

--- a/packages/engine/Source/Core/WindingOrder.js
+++ b/packages/engine/Source/Core/WindingOrder.js
@@ -33,4 +33,6 @@ WindingOrder.validate = function (windingOrder) {
   );
 };
 
-export default Object.freeze(WindingOrder);
+Object.freeze(WindingOrder);
+
+export default WindingOrder;

--- a/packages/engine/Source/Renderer/MipmapHint.js
+++ b/packages/engine/Source/Renderer/MipmapHint.js
@@ -1,6 +1,7 @@
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
+ * @enum {number}
  * @private
  */
 const MipmapHint = {
@@ -16,4 +17,7 @@ const MipmapHint = {
     );
   },
 };
-export default Object.freeze(MipmapHint);
+
+Object.freeze(MipmapHint);
+
+export default MipmapHint;

--- a/packages/engine/Source/Renderer/PixelDatatype.js
+++ b/packages/engine/Source/Renderer/PixelDatatype.js
@@ -118,4 +118,6 @@ PixelDatatype.getTypedArrayConstructor = function (pixelDatatype) {
   return Uint32Array;
 };
 
-export default Object.freeze(PixelDatatype);
+Object.freeze(PixelDatatype);
+
+export default PixelDatatype;

--- a/packages/engine/Source/Renderer/RenderbufferFormat.js
+++ b/packages/engine/Source/Renderer/RenderbufferFormat.js
@@ -1,6 +1,7 @@
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
+ * @enum {number}
  * @private
  */
 const RenderbufferFormat = {
@@ -39,4 +40,7 @@ const RenderbufferFormat = {
     return RenderbufferFormat.RGBA8;
   },
 };
-export default Object.freeze(RenderbufferFormat);
+
+Object.freeze(RenderbufferFormat);
+
+export default RenderbufferFormat;

--- a/packages/engine/Source/Renderer/ShaderDestination.js
+++ b/packages/engine/Source/Renderer/ShaderDestination.js
@@ -5,6 +5,7 @@ import DeveloperError from "../Core/DeveloperError.js";
  * A bit flag describing whether a variable should be added to the
  * vertex shader, the fragment shader, or both (or none).
  *
+ * @enum {number}
  * @private
  */
 const ShaderDestination = {
@@ -89,4 +90,6 @@ ShaderDestination.intersection = function (...destinations) {
   return result;
 };
 
-export default Object.freeze(ShaderDestination);
+Object.freeze(ShaderDestination);
+
+export default ShaderDestination;

--- a/packages/engine/Source/Renderer/TextureMagnificationFilter.js
+++ b/packages/engine/Source/Renderer/TextureMagnificationFilter.js
@@ -38,4 +38,6 @@ TextureMagnificationFilter.validate = function (textureMagnificationFilter) {
   );
 };
 
-export default Object.freeze(TextureMagnificationFilter);
+Object.freeze(TextureMagnificationFilter);
+
+export default TextureMagnificationFilter;

--- a/packages/engine/Source/Renderer/TextureMinificationFilter.js
+++ b/packages/engine/Source/Renderer/TextureMinificationFilter.js
@@ -91,4 +91,6 @@ TextureMinificationFilter.validate = function (textureMinificationFilter) {
   );
 };
 
-export default Object.freeze(TextureMinificationFilter);
+Object.freeze(TextureMinificationFilter);
+
+export default TextureMinificationFilter;

--- a/packages/engine/Source/Renderer/TextureWrap.js
+++ b/packages/engine/Source/Renderer/TextureWrap.js
@@ -1,6 +1,7 @@
 import WebGLConstants from "../Core/WebGLConstants.js";
 
 /**
+ * @enum {number}
  * @private
  */
 const TextureWrap = {
@@ -16,4 +17,7 @@ const TextureWrap = {
     );
   },
 };
-export default Object.freeze(TextureWrap);
+
+Object.freeze(TextureWrap);
+
+export default TextureWrap;

--- a/packages/engine/Source/Scene/AttributeType.js
+++ b/packages/engine/Source/Scene/AttributeType.js
@@ -197,4 +197,6 @@ AttributeType.getGlslType = function (attributeType) {
   }
 };
 
-export default Object.freeze(AttributeType);
+Object.freeze(AttributeType);
+
+export default AttributeType;

--- a/packages/engine/Source/Scene/Axis.js
+++ b/packages/engine/Source/Scene/Axis.js
@@ -113,4 +113,6 @@ Axis.fromName = function (name) {
   return Axis[name];
 };
 
-export default Object.freeze(Axis);
+Object.freeze(Axis);
+
+export default Axis;

--- a/packages/engine/Source/Scene/BufferPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/BufferPrimitiveCollection.js
@@ -212,7 +212,6 @@ class BufferPrimitiveCollection {
 
     this._allocatePrimitiveBuffer();
     this._allocatePositionBuffer(
-      // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
       options.positionDatatype ?? ComponentDatatype.DOUBLE,
     );
     this._allocateMaterialBuffer();
@@ -635,7 +634,6 @@ class BufferPrimitiveCollection {
 
   /** @param {object} frameState */
   update(frameState) {
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
     if (/** @type {FrameState} */ (frameState).mode !== SceneMode.SCENE3D) {
       oneTimeWarning(
         "bufferprim-scenemode",

--- a/packages/engine/Source/Scene/Cesium3DTileContentType.js
+++ b/packages/engine/Source/Scene/Cesium3DTileContentType.js
@@ -176,4 +176,6 @@ Cesium3DTileContentType.isBinaryFormat = function (contentType) {
   }
 };
 
-export default Object.freeze(Cesium3DTileContentType);
+Object.freeze(Cesium3DTileContentType);
+
+export default Cesium3DTileContentType;

--- a/packages/engine/Source/Scene/Cesium3DTilePass.js
+++ b/packages/engine/Source/Scene/Cesium3DTilePass.js
@@ -1,6 +1,7 @@
 /**
  * The pass in which a 3D Tileset is updated.
  *
+ * @enum {number}
  * @private
  */
 const Cesium3DTilePass = {
@@ -76,4 +77,7 @@ passOptions[Cesium3DTilePass.MOST_DETAILED_PICK] = Object.freeze({
 Cesium3DTilePass.getPassOptions = function (pass) {
   return passOptions[pass];
 };
-export default Object.freeze(Cesium3DTilePass);
+
+Object.freeze(Cesium3DTilePass);
+
+export default Cesium3DTilePass;

--- a/packages/engine/Source/Scene/ClassificationType.js
+++ b/packages/engine/Source/Scene/ClassificationType.js
@@ -32,4 +32,6 @@ const ClassificationType = {
  */
 ClassificationType.NUMBER_OF_CLASSIFICATION_TYPES = 3;
 
-export default Object.freeze(ClassificationType);
+Object.freeze(ClassificationType);
+
+export default ClassificationType;

--- a/packages/engine/Source/Scene/CloudType.js
+++ b/packages/engine/Source/Scene/CloudType.js
@@ -30,4 +30,6 @@ CloudType.validate = function (cloudType) {
   return cloudType === CloudType.CUMULUS;
 };
 
-export default Object.freeze(CloudType);
+Object.freeze(CloudType);
+
+export default CloudType;

--- a/packages/engine/Source/Scene/ColorBlendMode.js
+++ b/packages/engine/Source/Scene/ColorBlendMode.js
@@ -30,4 +30,7 @@ ColorBlendMode.getColorBlend = function (colorBlendMode, colorBlendAmount) {
     return CesiumMath.clamp(colorBlendAmount, CesiumMath.EPSILON4, 1.0);
   }
 };
-export default Object.freeze(ColorBlendMode);
+
+Object.freeze(ColorBlendMode);
+
+export default ColorBlendMode;

--- a/packages/engine/Source/Scene/DynamicAtmosphereLightingType.js
+++ b/packages/engine/Source/Scene/DynamicAtmosphereLightingType.js
@@ -53,4 +53,6 @@ DynamicAtmosphereLightingType.fromGlobeFlags = function (globe) {
   return DynamicAtmosphereLightingType.SCENE_LIGHT;
 };
 
-export default Object.freeze(DynamicAtmosphereLightingType);
+Object.freeze(DynamicAtmosphereLightingType);
+
+export default DynamicAtmosphereLightingType;

--- a/packages/engine/Source/Scene/ImplicitSubdivisionScheme.js
+++ b/packages/engine/Source/Scene/ImplicitSubdivisionScheme.js
@@ -45,4 +45,6 @@ ImplicitSubdivisionScheme.getBranchingFactor = function (subdivisionScheme) {
   }
 };
 
-export default Object.freeze(ImplicitSubdivisionScheme);
+Object.freeze(ImplicitSubdivisionScheme);
+
+export default ImplicitSubdivisionScheme;

--- a/packages/engine/Source/Scene/InstanceAttributeSemantic.js
+++ b/packages/engine/Source/Scene/InstanceAttributeSemantic.js
@@ -76,4 +76,6 @@ InstanceAttributeSemantic.fromGltfSemantic = function (gltfSemantic) {
   return undefined;
 };
 
-export default Object.freeze(InstanceAttributeSemantic);
+Object.freeze(InstanceAttributeSemantic);
+
+export default InstanceAttributeSemantic;

--- a/packages/engine/Source/Scene/MetadataComponentType.js
+++ b/packages/engine/Source/Scene/MetadataComponentType.js
@@ -593,4 +593,6 @@ MetadataComponentType.getDataViewAccessors = function (view, componentType) {
   return accessors[componentType];
 };
 
-export default Object.freeze(MetadataComponentType);
+Object.freeze(MetadataComponentType);
+
+export default MetadataComponentType;

--- a/packages/engine/Source/Scene/MetadataType.js
+++ b/packages/engine/Source/Scene/MetadataType.js
@@ -217,4 +217,6 @@ MetadataType.getMathType = function (type) {
   }
 };
 
-export default Object.freeze(MetadataType);
+Object.freeze(MetadataType);
+
+export default MetadataType;

--- a/packages/engine/Source/Scene/Model/CustomShaderMode.js
+++ b/packages/engine/Source/Scene/Model/CustomShaderMode.js
@@ -37,4 +37,6 @@ CustomShaderMode.getDefineName = function (customShaderMode) {
   return `CUSTOM_SHADER_${customShaderMode}`;
 };
 
-export default Object.freeze(CustomShaderMode);
+Object.freeze(CustomShaderMode);
+
+export default CustomShaderMode;

--- a/packages/engine/Source/Scene/Model/ModelType.js
+++ b/packages/engine/Source/Scene/Model/ModelType.js
@@ -91,4 +91,6 @@ ModelType.is3DTiles = function (modelType) {
   }
 };
 
-export default Object.freeze(ModelType);
+Object.freeze(ModelType);
+
+export default ModelType;

--- a/packages/engine/Source/Scene/Model/StyleCommandsNeeded.js
+++ b/packages/engine/Source/Scene/Model/StyleCommandsNeeded.js
@@ -26,4 +26,6 @@ StyleCommandsNeeded.getStyleCommandsNeeded = function (
   return StyleCommandsNeeded.OPAQUE_AND_TRANSLUCENT;
 };
 
-export default Object.freeze(StyleCommandsNeeded);
+Object.freeze(StyleCommandsNeeded);
+
+export default StyleCommandsNeeded;

--- a/packages/engine/Source/Scene/SceneMode.js
+++ b/packages/engine/Source/Scene/SceneMode.js
@@ -53,4 +53,7 @@ SceneMode.getMorphTime = function (value) {
   }
   return 0.0;
 };
-export default Object.freeze(SceneMode);
+
+Object.freeze(SceneMode);
+
+export default SceneMode;

--- a/packages/engine/Source/Scene/ShadowMode.js
+++ b/packages/engine/Source/Scene/ShadowMode.js
@@ -75,4 +75,6 @@ ShadowMode.fromCastReceive = function (castShadows, receiveShadows) {
   return ShadowMode.DISABLED;
 };
 
-export default Object.freeze(ShadowMode);
+Object.freeze(ShadowMode);
+
+export default ShadowMode;

--- a/packages/engine/Source/Scene/VertexAttributeSemantic.js
+++ b/packages/engine/Source/Scene/VertexAttributeSemantic.js
@@ -316,4 +316,6 @@ VertexAttributeSemantic.getVariableName = function (semantic, setIndex) {
   return variableName;
 };
 
-export default Object.freeze(VertexAttributeSemantic);
+Object.freeze(VertexAttributeSemantic);
+
+export default VertexAttributeSemantic;

--- a/packages/engine/Source/Scene/VoxelShapeType.js
+++ b/packages/engine/Source/Scene/VoxelShapeType.js
@@ -102,4 +102,6 @@ VoxelShapeType.getShapeConstructor = function (shapeType) {
   }
 };
 
-export default Object.freeze(VoxelShapeType);
+Object.freeze(VoxelShapeType);
+
+export default VoxelShapeType;


### PR DESCRIPTION
# Description

Continuation of #13429, with a partial fix for the remaining enums missing type checking support. These enums have utility functions attached to the enum object, and so we can't (yet) enable `// @ts-check` on their source files. We can, however, fix the `export default Object.freeze(MyEnum)` issue preventing files _depending on_ these enums from running type checks against their values.

NOTE: After this PR, type-checked files depending on these enums will need to use `// @ts-expect-error` when calling the utility functions attached to these enums, but not for passing and comparing against the enum values themselves. Steps toward the longer-term support, see #13420.t

## Issue number and link

- #13420
- #4434

## Testing plan

- npm run tsc
- npm run sg-scan
- npm run build-ts

Output of ./scripts/diff-types.sh:

\<empty>

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13453** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)