### PR TITLE
Don't load search on the Sandcastle standalone page

### DIFF
--- a/packages/sandcastle/src/Gallery/GalleryItemStore.ts
+++ b/packages/sandcastle/src/Gallery/GalleryItemStore.ts
@@ -42,7 +42,7 @@ export type HighlightedGalleryItem = ReturnType<typeof applyHighlightToItem>;
 export type GalleryFilter = Record<string, string | string[]> | null;
 export type GalleryFilters = PagefindFilterCounts | null;
 
-export function useGalleryItemStore() {
+export function useGalleryItemStore({ withoutSearch = false } = {}) {
   const { settings } = useContext(SettingsContext);
   const embeddingSearchEnabled = settings.embeddingSearch;
 
@@ -88,7 +88,7 @@ export function useGalleryItemStore() {
 
   useEffect(() => {
     const pagefind = getPagefind();
-    if (!pagefind) {
+    if (!pagefind || withoutSearch) {
       return;
     }
 
@@ -147,7 +147,13 @@ export function useGalleryItemStore() {
     return () => {
       abortController.abort();
     };
-  }, [searchTerm, searchFilter, embeddingModelLoaded, embeddingSearchEnabled]);
+  }, [
+    withoutSearch,
+    searchTerm,
+    searchFilter,
+    embeddingModelLoaded,
+    embeddingSearchEnabled,
+  ]);
 
   const memoizedSearchResults = useMemo(() => {
     if (!searchResults) {
@@ -200,6 +206,9 @@ export function useGalleryItemStore() {
   // Pagefind search configuration is loaded with the rest of the gallery options.
   // Once we've loaded those options, load and intiate pagefind.
   useEffect(() => {
+    if (withoutSearch) {
+      return;
+    }
     const fetchPagefindAction = async () => {
       let pagefind = getPagefind();
       if (!pagefind) {
@@ -233,7 +242,7 @@ export function useGalleryItemStore() {
     if (searchOptions) {
       startTransition(fetchPagefindAction);
     }
-  }, [searchOptions, defaultSearchFilter]);
+  }, [withoutSearch, searchOptions, defaultSearchFilter]);
 
   // Kick off initial gallery fetch
   useEffect(() => {
@@ -287,13 +296,14 @@ export function useGalleryItemStore() {
 
   useEffect(() => {
     if (
+      !withoutSearch &&
       embeddingSearchEnabled &&
       !embeddingModelLoaded &&
       entriesRef.current.length > 0
     ) {
       initializeEmbeddingSearch(entriesRef.current);
     }
-  }, [embeddingSearchEnabled, embeddingModelLoaded, legacyIds]);
+  }, [withoutSearch, embeddingSearchEnabled, embeddingModelLoaded, legacyIds]);
 
   const useLoadFromUrl = useCallback(() => {
     const isGalleryLoaded = items.length > 0;

--- a/packages/sandcastle/src/Standalone/AppStandalone.tsx
+++ b/packages/sandcastle/src/Standalone/AppStandalone.tsx
@@ -23,7 +23,7 @@ import {
 } from "../util/useCodeState";
 
 function AppStandalone() {
-  const galleryItemStore = useGalleryItemStore();
+  const galleryItemStore = useGalleryItemStore({ withoutSearch: true });
   const loadFromUrl = galleryItemStore.useLoadFromUrl();
   const [initialized, setInitialized] = useState(false);
   const [isLoadPending, startLoadPending] = useTransition();


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

The standalone page doesn't need search functionality. However the way we load the gallery items for `?id=[slug]` urls to work currently loads the search libraries. This PR disables that on the standalone page which should help reduce network load. This was required for #13457 to help spec load times but is a generally good improvement overall.

I meant this change to go into https://github.com/CesiumGS/cesium/pull/13381 but apparently it was only in my local `git` at the time :facepalm:  

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

no issue

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- run `npm run build-sandcastle` and/or test in CI
- open DevTools > Application and _delete_ the `transformers-cache` under Cache storage on the left (not sure where that is on firefox)
- open DevTools > network tab and refresh
- Search for `pagefind`, `huggingface` and `onnx`, these should all have some results on the main sandcastle page
- Repeat the deletion and open the standalone page
- Do the same searches in the network tab. _none_ of them should have results.
- Test that search actually still works on the main Sandcastle gallery, both pagefind results (with code samples) and semantic results (without samples)

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
