### PR TITLE
[codex] Allow Sandcastle code pane to collapse

### DIFF
--- a/Specs/e2e/sandcastle-layout.spec.js
+++ b/Specs/e2e/sandcastle-layout.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from "./test.js";
+
+async function getWidth(locator) {
+  const box = await locator.boundingBox();
+  return box?.width ?? 0;
+}
+
+test.describe("Sandcastle layout", () => {
+  test("toggles and restores the code pane from the application bar", async ({
+    page,
+  }) => {
+    await page.goto("/Apps/Sandcastle2/index.html?id=hello-world");
+
+    const editorButton = page.getByRole("button", { name: "Editor" });
+    const leftPanel = page.locator(".left-panel");
+
+    await expect(leftPanel).toBeVisible();
+    const initialWidth = await getWidth(leftPanel);
+    expect(initialWidth).toBeGreaterThan(350);
+
+    await editorButton.click();
+    await expect(leftPanel).toBeHidden();
+
+    await editorButton.click();
+    await expect(leftPanel).toBeVisible();
+    await expect.poll(async () => getWidth(leftPanel)).toBeGreaterThan(350);
+    const reopenedWidth = await getWidth(leftPanel);
+    expect(Math.abs(reopenedWidth - initialWidth)).toBeLessThanOrEqual(2);
+  });
+
+  test("reopens the code pane to half width after it is dragged closed", async ({
+    page,
+  }) => {
+    await page.goto("/Apps/Sandcastle2/index.html?id=hello-world");
+
+    const editorButton = page.getByRole("button", { name: "Editor" });
+    const content = page.locator(".content");
+    const leftPanel = page.locator(".left-panel");
+
+    await expect(leftPanel).toBeVisible();
+    const contentBox = await content.boundingBox();
+    const leftBox = await leftPanel.boundingBox();
+    expect(contentBox).not.toBeNull();
+    expect(leftBox).not.toBeNull();
+
+    const dragY = leftBox.y + leftBox.height / 2;
+    await page.mouse.move(leftBox.x + leftBox.width, dragY);
+    await page.mouse.down();
+    await page.mouse.move(contentBox.x, dragY, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(leftPanel).toBeHidden();
+
+    await editorButton.click();
+    await expect(leftPanel).toBeVisible();
+    await expect.poll(async () => getWidth(leftPanel)).toBeGreaterThan(350);
+    const reopenedWidth = await getWidth(leftPanel);
+    expect(Math.abs(reopenedWidth - contentBox.width / 2)).toBeLessThanOrEqual(
+      2,
+    );
+  });
+});

--- a/packages/sandcastle/src/App.tsx
+++ b/packages/sandcastle/src/App.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   useTransition,
 } from "react";
-import { Allotment } from "allotment";
+import { Allotment, type AllotmentHandle } from "allotment";
 import "allotment/dist/style.css";
 import "./App.css";
 
@@ -63,6 +63,9 @@ const cesiumVersion = __CESIUM_VERSION__;
 const versionString = __COMMIT_SHA__
   ? `Commit: ${__COMMIT_SHA__.replaceAll(/['"]/g, "").substring(0, 7)} - ${cesiumVersion}`
   : cesiumVersion;
+const defaultContentSizes = [40, 60];
+const dragCollapsedEditorSize = 0.5;
+const leftPanelCollapseThreshold = 8;
 
 function AppBarButton({
   children,
@@ -80,7 +83,12 @@ function AppBarButton({
   if (active) {
     return (
       <Tooltip content={label} type="label" placement="right">
-        <Button tone="accent" onClick={onClick} onAuxClick={onAuxClick}>
+        <Button
+          tone="accent"
+          onClick={onClick}
+          onAuxClick={onAuxClick}
+          aria-label={label}
+        >
           {children}
         </Button>
       </Tooltip>
@@ -88,7 +96,12 @@ function AppBarButton({
   }
   return (
     <Tooltip content={label} type="label" placement="right">
-      <Button variant="ghost" onClick={onClick} onAuxClick={onAuxClick}>
+      <Button
+        variant="ghost"
+        onClick={onClick}
+        onAuxClick={onAuxClick}
+        aria-label={label}
+      >
         {children}
       </Button>
     </Tooltip>
@@ -97,6 +110,11 @@ function AppBarButton({
 
 function App() {
   const { settings, updateSettings } = useContext(SettingsContext);
+  const contentRef = useRef<AllotmentHandle>(null);
+  const leftPanelRef = useRef<HTMLDivElement>(null);
+  const contentSizes = useRef<number[]>([0, 0]);
+  const previousLeftPanelWidth = useRef<number | undefined>(undefined);
+  const leftPanelWasDraggedClosed = useRef(false);
   const rightSideRef = useRef<ViewerConsoleStackRef>(null);
   const consoleCollapsedHeight = 33;
   const [consoleExpanded, setConsoleExpanded] = useState(false);
@@ -107,6 +125,7 @@ function App() {
   const [leftPanel, setLeftPanel] = useState<LeftPanel>(
     startOnEditor ? "editor" : "gallery",
   );
+  const [leftPanelVisible, setLeftPanelVisible] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const [sandcastleTitle, setSandcastleTitle] = useState("New Sandcastle");
@@ -294,6 +313,108 @@ function App() {
     window.open(docsUrl, "_blank")?.focus();
   }
 
+  const getContentWidth = useCallback(() => {
+    const [left, right] = contentSizes.current;
+    const totalWidth = left + right;
+    if (totalWidth > 0) {
+      return totalWidth;
+    }
+
+    const contentWidth =
+      leftPanelRef.current?.parentElement?.getBoundingClientRect().width;
+    return contentWidth && contentWidth > 0 ? contentWidth : window.innerWidth;
+  }, []);
+
+  const resizeLeftPanel = useCallback(
+    (leftPanelWidth: number) => {
+      requestAnimationFrame(() => {
+        const totalWidth = getContentWidth();
+        const nextLeftPanelWidth = Math.max(
+          0,
+          Math.min(leftPanelWidth, totalWidth),
+        );
+        contentSizes.current = [
+          nextLeftPanelWidth,
+          totalWidth - nextLeftPanelWidth,
+        ];
+        contentRef.current?.resize(contentSizes.current);
+      });
+    },
+    [getContentWidth],
+  );
+
+  const openLeftPanel = useCallback(
+    (panel: LeftPanel) => {
+      const totalWidth = getContentWidth();
+      const defaultLeftPanelWidth = totalWidth * (defaultContentSizes[0] / 100);
+      const targetWidth = leftPanelWasDraggedClosed.current
+        ? totalWidth * dragCollapsedEditorSize
+        : (previousLeftPanelWidth.current ?? defaultLeftPanelWidth);
+
+      setLeftPanel(panel);
+      setLeftPanelVisible(true);
+      leftPanelWasDraggedClosed.current = false;
+      resizeLeftPanel(targetWidth);
+    },
+    [getContentWidth, resizeLeftPanel],
+  );
+
+  const closeLeftPanel = useCallback(
+    (draggedClosed = false) => {
+      const currentWidth =
+        contentSizes.current[0] ||
+        leftPanelRef.current?.getBoundingClientRect().width ||
+        0;
+
+      if (!draggedClosed && currentWidth > leftPanelCollapseThreshold) {
+        previousLeftPanelWidth.current = currentWidth;
+      }
+
+      leftPanelWasDraggedClosed.current = draggedClosed;
+      setLeftPanelVisible(false);
+      resizeLeftPanel(0);
+    },
+    [resizeLeftPanel],
+  );
+
+  const toggleEditorPanel = useCallback(() => {
+    if (leftPanelVisible && leftPanel === "editor") {
+      closeLeftPanel();
+      return;
+    }
+
+    openLeftPanel("editor");
+  }, [closeLeftPanel, leftPanel, leftPanelVisible, openLeftPanel]);
+
+  const onContentChange = useCallback(
+    (sizes: number[]) => {
+      contentSizes.current = sizes;
+      const [leftPanelWidth] = sizes;
+
+      if (leftPanelVisible && leftPanelWidth > leftPanelCollapseThreshold) {
+        previousLeftPanelWidth.current = leftPanelWidth;
+        leftPanelWasDraggedClosed.current = false;
+      }
+    },
+    [leftPanelVisible],
+  );
+
+  const onContentDragEnd = useCallback(
+    (sizes: number[]) => {
+      contentSizes.current = sizes;
+      const [leftPanelWidth] = sizes;
+
+      if (leftPanelWidth <= leftPanelCollapseThreshold) {
+        closeLeftPanel(true);
+        return;
+      }
+
+      previousLeftPanelWidth.current = leftPanelWidth;
+      leftPanelWasDraggedClosed.current = false;
+    },
+    [closeLeftPanel],
+  );
+
   const onRunCode = useCallback(
     async ({ id, title, getJsCode, getHtmlCode }: GalleryItem) => {
       if (!confirmLeave()) {
@@ -327,8 +448,8 @@ function App() {
   );
 
   const onOpenCode = useCallback(() => {
-    setLeftPanel("editor");
-  }, []);
+    openLeftPanel("editor");
+  }, [openLeftPanel]);
 
   return (
     <Root
@@ -380,15 +501,15 @@ function App() {
       </header>
       <div className="application-bar">
         <AppBarButton
-          onClick={() => setLeftPanel("gallery")}
-          active={leftPanel === "gallery"}
+          onClick={() => openLeftPanel("gallery")}
+          active={leftPanelVisible && leftPanel === "gallery"}
           label="Gallery"
         >
           <Icon href={`${image}#icon-large`} size="large" />
         </AppBarButton>
         <AppBarButton
-          onClick={() => setLeftPanel("editor")}
-          active={leftPanel === "editor"}
+          onClick={toggleEditorPanel}
+          active={leftPanelVisible && leftPanel === "editor"}
           label="Editor"
         >
           <Icon href={`${script}#icon-large`} size="large" />
@@ -397,7 +518,7 @@ function App() {
         <AppBarButton
           onClick={() => {
             resetSandcastle();
-            setLeftPanel("editor");
+            openLeftPanel("editor");
           }}
           label="New Sandcastle"
         >
@@ -435,8 +556,19 @@ function App() {
         </AppBarButton>
         <SettingsModal open={settingsOpen} setOpen={setSettingsOpen} />
       </div>
-      <Allotment defaultSizes={[40, 60]} className="content">
-        <Allotment.Pane minSize={400} className="left-panel">
+      <Allotment
+        ref={contentRef}
+        defaultSizes={defaultContentSizes}
+        className="content"
+        onChange={onContentChange}
+        onDragEnd={onContentDragEnd}
+      >
+        <Allotment.Pane
+          ref={leftPanelRef}
+          minSize={0}
+          visible={leftPanelVisible}
+          className="left-panel"
+        >
           {leftPanel === "editor" && (
             <SandcastleEditor
               darkTheme={settings.theme === "dark"}


### PR DESCRIPTION
## Summary
- Allow the Sandcastle Editor button to close and reopen the code pane.
- Preserve the current code pane width for button toggles, but reopen to 50% after a drag-collapse.
- Let the left pane drag all the way closed and cover the behavior with Playwright e2e tests.

## Root Cause
The app bar only switched the active left-panel tab and the left Allotment pane had a 400px minimum size. There was no controlled visibility state or width restore path for closing the code pane, so the Editor button could not toggle the pane and the divider could not collapse it.

## Testing
- `npm exec --package=typescript -- tsc --project packages/sandcastle/tsconfig.json`
- `npm run build-sandcastle`
- `npx eslint packages/sandcastle/src/App.tsx Specs/e2e/sandcastle-layout.spec.js --quiet`
- `npx playwright test -c Specs/e2e/playwright.config.js --project=chromium Specs/e2e/sandcastle-layout.spec.js`