### PR TITLE
BufferPointCollection: Fix for dynamic geometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.142 - 2026-06-01
+
+### cesium
+
+#### Fixes :wrench:
+
+- Fixed a bug causing `BufferPointCollection` to not update after changes to point positions. [#13465](https://github.com/CesiumGS/cesium/pull/13465)
+
 ## 1.141 - 2026-05-01
 
 ### cesium

--- a/packages/engine/Source/Scene/BufferPoint.js
+++ b/packages/engine/Source/Scene/BufferPoint.js
@@ -123,6 +123,7 @@ class BufferPoint extends BufferPrimitive {
     collection._positionView[vertexOffset * 3 + 1] = position.y;
     collection._positionView[vertexOffset * 3 + 2] = position.z;
 
+    this._dirty = true;
     collection._makeDirtyBoundingVolume();
   }
 

--- a/packages/engine/Source/Scene/BufferPointCollection.js
+++ b/packages/engine/Source/Scene/BufferPointCollection.js
@@ -7,6 +7,7 @@ import Frozen from "../Core/Frozen.js";
 import renderPoints from "./renderBufferPointCollection.js";
 import BufferPointMaterial from "./BufferPointMaterial.js";
 
+/** @import ComponentDatatype from "../Core/ComponentDatatype.js"; */
 /** @import Matrix4 from "../Core/Matrix4.js"; */
 /** @import FrameState from "./FrameState.js"; */
 
@@ -55,10 +56,12 @@ import BufferPointMaterial from "./BufferPointMaterial.js";
 class BufferPointCollection extends BufferPrimitiveCollection {
   /**
    * @param {object} options
+   * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] Transforms geometry from model to world coordinates.
    * @param {number} [options.primitiveCountMax=BufferPrimitiveCollection.DEFAULT_CAPACITY]
    * @param {boolean} [options.show=true]
+   * @param {ComponentDatatype} [options.positionDatatype=ComponentDatatype.DOUBLE]
+   * @param {boolean} [options.allowPicking=false] When <code>true</code>, primitives are pickable with {@link Scene#pick}. When <code>false</code>, memory and initialization cost are lower.
    * @param {boolean} [options.debugShowBoundingVolume=false]
-   * @param {boolean} [options.allowPicking=false]
    */
   constructor(options = Frozen.EMPTY_OBJECT) {
     super({ ...options, vertexCountMax: options.primitiveCountMax });

--- a/packages/engine/Source/Scene/BufferPolygon.js
+++ b/packages/engine/Source/Scene/BufferPolygon.js
@@ -180,6 +180,7 @@ class BufferPolygon extends BufferPrimitive {
       positionView[(vertexOffset + i) * 3 + 2] = positions[i * 3 + 2];
     }
 
+    this._dirty = true;
     collection._makeDirtyBoundingVolume();
   }
 
@@ -308,6 +309,7 @@ class BufferPolygon extends BufferPrimitive {
       holeIndexView[holeOffset + i] = holes[i];
     }
 
+    this._dirty = true;
     collection._makeDirtyBoundingVolume();
   }
 
@@ -489,6 +491,7 @@ class BufferPolygon extends BufferPrimitive {
       dstIndices[(triangleOffset + i) * 3 + 2] = indices[i * 3 + 2];
     }
 
+    this._dirty = true;
     collection._makeDirtyBoundingVolume();
   }
 

--- a/packages/engine/Source/Scene/BufferPolygon.js
+++ b/packages/engine/Source/Scene/BufferPolygon.js
@@ -310,7 +310,6 @@ class BufferPolygon extends BufferPrimitive {
     }
 
     this._dirty = true;
-    collection._makeDirtyBoundingVolume();
   }
 
   /**
@@ -492,7 +491,6 @@ class BufferPolygon extends BufferPrimitive {
     }
 
     this._dirty = true;
-    collection._makeDirtyBoundingVolume();
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/engine/Source/Scene/BufferPolyline.js
+++ b/packages/engine/Source/Scene/BufferPolyline.js
@@ -160,6 +160,7 @@ class BufferPolyline extends BufferPrimitive {
       positionView[(vertexOffset + i) * 3 + 2] = positions[i * 3 + 2];
     }
 
+    this._dirty = true;
     collection._makeDirtyBoundingVolume();
   }
 

--- a/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
@@ -68,13 +68,23 @@ describe(
 
     it("renders points with updated positions", function () {
       const point = new BufferPoint();
-      collection.add({ position: new Cartesian3(0, 0, 0) }, point);
+      const material = new BufferPointMaterial({ size: 8 });
+      const position = new Cartesian3(0, -1000, 0);
+
+      Color.fromBytes(255, 0, 0, 255, material.color);
+      collection.add({ position, material }, point);
+
+      // Use extra primitive to keep bounding volume in view, and require
+      // that geometry (not just bounding volume) is updated.
+      Color.fromBytes(0, 0, 255, 255, material.color);
+      collection.add({ position, material }, point);
 
       scene.primitives.add(collection);
-      expect(scene).toRender([0, 0, 0, 255]);
+      expect(scene).toRender([255, 0, 0, 255]);
 
-      point.setPosition(new Cartesian3(0, -1000, 0));
-      expect(scene).toRender([255, 255, 255, 255]);
+      collection.get(0, point);
+      point.setPosition(new Cartesian3(1e6, 1e6, 1e6));
+      expect(scene).toRender([0, 0, 255, 255]);
     });
 
     it("renders points with sort order", function () {

--- a/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
@@ -25,6 +25,13 @@ describe(
       -1000, +2000, -1000,
     ]);
 
+    // prettier-ignore
+    const positionsOutOfView = new Int32Array([
+      -1000, +1000, -1000,
+      -1000, +1000, +2000,
+      -1000, +3000, -1000,
+    ]);
+
     const triangles = new Uint16Array([0, 1, 2]);
 
     beforeAll(function () {
@@ -78,21 +85,23 @@ describe(
     });
 
     it("renders polygons with updated positions", function () {
-      // prettier-ignore
-      const badPositions = new Int32Array([
-        -1000, +1000, -1000,
-        -1000, +1000, +2000,
-        -1000, +3000, -1000,
-      ]);
-
       const polygon = new BufferPolygon();
-      collection.add({ positions: badPositions, triangles }, polygon);
+      const material = new BufferPolygonMaterial();
+
+      Color.fromBytes(255, 0, 0, 255, material.color);
+      collection.add({ positions, triangles, material }, polygon);
+
+      // Use extra primitive to keep bounding volume in view, and require
+      // that geometry (not just bounding volume) is updated.
+      Color.fromBytes(0, 0, 255, 255, material.color);
+      collection.add({ positions, triangles, material }, polygon);
 
       scene.primitives.add(collection);
-      expect(scene).toRender([0, 0, 0, 255]);
+      expect(scene).toRender([255, 0, 0, 255]);
 
-      polygon.setPositions(positions);
-      expect(scene).toRender([255, 255, 255, 255]);
+      collection.get(0, polygon);
+      polygon.setPositions(positionsOutOfView);
+      expect(scene).toRender([0, 0, 255, 255]);
     });
 
     it("renders polygons with sort order", function () {

--- a/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
@@ -68,14 +68,25 @@ describe(
 
     it("renders polylines with updated positions", function () {
       const line = new BufferPolyline();
-      const positions = new Int32Array([0, +5000, 0, 0, +1000000, 0]);
-      collection.add({ positions }, line);
+      const material = new BufferPolylineMaterial();
+
+      const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
+      const positionsOutOfView = new Int32Array([0, +5000, 0, 0, +1000000, 0]);
+
+      Color.fromBytes(255, 0, 0, 255, material.color);
+      collection.add({ positions, material }, line);
+
+      // Use extra primitive to keep bounding volume in view, and require
+      // that geometry (not just bounding volume) is updated.
+      Color.fromBytes(0, 0, 255, 255, material.color);
+      collection.add({ positions, material }, line);
 
       scene.primitives.add(collection);
-      expect(scene).toRender([0, 0, 0, 255]);
+      expect(scene).toRender([255, 0, 0, 255]);
 
-      line.setPositions(new Int32Array([0, -1000000, 0, 0, +1000000, 0]));
-      expect(scene).toRender([255, 255, 255, 255]);
+      collection.get(0, line);
+      line.setPositions(positionsOutOfView);
+      expect(scene).toRender([0, 0, 255, 255]);
     });
 
     it("renders polylines with sort order", function () {


### PR DESCRIPTION
# Description

Fixes a bug in BufferPointCollection, where calling `point.setPosition(position)` did not update the dirty flag. The bug did not affect BufferPolylineCollection or BufferPolygonCollection because they make other assignments that set the dirty flag. I've added explicit calls to `this._dirty = true` in all three collections, to make this obvious and explicit.

The unit tests didn't catch this, because the implementation _did_ update the bounding volume, causing the primitives not to render when out of view. I've updated the unit tests to verify that geometry is updated, not just the bounding volume.

## Issue number and link

n/a

## Testing plan

See attached unit test, and sandcastle script below.

```javascript
import {
  BufferPoint,
  BufferPointCollection,
  BufferPointMaterial,
  Cartesian3,
  Color,
  ComponentDatatype,
  Viewer,
} from "cesium";

const viewer = new Viewer("cesiumContainer", { shouldAnimate: true });
viewer.scene.debugShowFramesPerSecond = true;

const PRIMITIVE_COUNT = 100_000;
const OFFSET_HEIGHT = 500_000;

const collection = new BufferPointCollection({
  primitiveCountMax: PRIMITIVE_COUNT,
  positionDatatype: ComponentDatatype.FLOAT,
});

const point = new BufferPoint();
const material = new BufferPointMaterial({ size: 2 });

// Scratch.
const position = new Cartesian3();

// Fill polyline collection.
for (let i = 0, il = collection.primitiveCountMax; i < il; i++) {
  initializePointPosition(position);
  Color.lerp(Color.RED, Color.BLUE, Math.random(), material.color);
  collection.add({ position, material }, point);
}

viewer.scene.primitives.add(collection);
window.collection = collection;

// Update point positions.
viewer.clock.onTick.addEventListener(() => {
  console.time("tick");
  for (let i = 0, il = collection.primitiveCount; i < il; i++) {
    collection.get(i, point);
    point.getPosition(position);
    updatePointPosition(position);
    point.setPosition(position);
  }
  console.timeEnd("tick");
});

function initializePointPosition(result) {
  return Cartesian3.fromDegrees(
    Math.random() * 360 - 180,
    Math.random() * 180 - 90,
    Math.random() * OFFSET_HEIGHT,
    undefined,
    result,
  );
}

function updatePointPosition(result) {
  result.x += (Math.random() * 2 - 1) * 2500;
  result.y += (Math.random() * 2 - 1) * 2500;
  result.z += (Math.random() * 2 - 1) * 2500;
  return result;
}
```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13465** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)