### PR TITLE
Vector Tiles: Fix missing cases for tile content with multiple property tables

### DIFF
--- a/packages/engine/Source/Scene/Model/createVectorTileBuffersFromModelComponents.js
+++ b/packages/engine/Source/Scene/Model/createVectorTileBuffersFromModelComponents.js
@@ -26,9 +26,10 @@ import Cesium3DTileVectorFeature from "../Cesium3DTileVectorFeature.js";
 
 /**
  * @typedef {object} VectorTileResult
- * @property {Array<BufferPrimitiveCollection<BufferPrimitive>>} collections
- * @property {Array<Matrix4>} collectionLocalMatrices
- * @property {Map<number, Cesium3DTileVectorFeature>} features
+ * @property {Array<BufferPrimitiveCollection<BufferPrimitive>>} collections List of all vector primitive collections.
+ * @property {Array<Matrix4>} collectionLocalMatrices List of transform matrices for each collection; order matches 'collections'.
+ * @property {Map<BufferPrimitiveCollection<BufferPrimitive>, number>} collectionFeatureTableIds Maps vector primitive collection -> propertyTableId.
+ * @property {Map<number, Map<number, Cesium3DTileVectorFeature>>} featuresByTableId Maps propertyTableId -> featureId -> feature.
  * @ignore
  */
 
@@ -53,7 +54,8 @@ function createVectorTileBuffersFromModelComponents(content, components) {
   const result = {
     collections: [],
     collectionLocalMatrices: [],
-    features: new Map(),
+    collectionFeatureTableIds: new Map(),
+    featuresByTableId: new Map(),
   };
 
   for (let i = 0; i < rootNodes.length; i++) {
@@ -354,15 +356,22 @@ function appendNodeToBuffers(content, node, parentTransform, result) {
       });
     }
 
+    const featureIdComponent = primitive.featureIds?.[0];
+    const propertyTableId = featureIdComponent?.propertyTableId;
+    if (!result.featuresByTableId.has(propertyTableId)) {
+      result.featuresByTableId.set(propertyTableId, new Map());
+    }
+
     result.collections.push(collection);
     result.collectionLocalMatrices.push(Matrix4.clone(nodeTransform));
+    result.collectionFeatureTableIds.set(collection, propertyTableId);
 
     appendPrimitiveToBuffers(
       content,
       primitive,
       collection,
       result.collections.length - 1,
-      result.features,
+      result.featuresByTableId.get(propertyTableId),
     );
   }
 

--- a/packages/engine/Source/Scene/ModelComponents.js
+++ b/packages/engine/Source/Scene/ModelComponents.js
@@ -499,7 +499,7 @@ export class FeatureIdTexture {
      * The ID of the property table that feature IDs index into. If undefined,
      * feature IDs are used for classification, but no metadata is associated.
      *
-     * @type {string}
+     * @type {number}
      * @ignore
      */
     this.propertyTableId = undefined;

--- a/packages/engine/Source/Scene/VectorGltf3DTileContent.js
+++ b/packages/engine/Source/Scene/VectorGltf3DTileContent.js
@@ -19,6 +19,7 @@ import createVectorTileBuffersFromModelComponents from "./Model/createVectorTile
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
+import Check from "../Core/Check.js";
 
 /** @import BufferPrimitive from "./BufferPrimitive.js"; */
 /** @import BufferPrimitiveCollection from "./BufferPrimitiveCollection.js"; */
@@ -73,14 +74,30 @@ class VectorGltf3DTileContent {
     /** @type {Model} */
     this._model = undefined;
 
-    /** @type {Array<BufferPrimitiveCollection<BufferPrimitive>>} */
+    /**
+     * List of all vector primitive collections.
+     * @type {Array<BufferPrimitiveCollection<BufferPrimitive>>}
+     */
     this._collections = [];
 
-    /** @type {Array<Matrix4>} */
+    /**
+     * List of transform matrices for each collection; order matches 'collections'.
+     * @type {Array<Matrix4>}
+     */
     this._collectionLocalMatrices = [];
 
-    /** @type {Map<number, Cesium3DTileVectorFeature>} */
-    this._features = new Map();
+    /**
+     * Maps vector primitive collection -> propertyTableId.
+     * @type {Map<BufferPrimitiveCollection<BufferPrimitive>, number>}
+     */
+    this._collectionFeatureTableIds = new Map();
+
+    /**
+     * Maps propertyTableId -> featureId -> feature. Note that Feature IDs are
+     * unique within their assigned property table, but not globally unique.
+     * @type {Map<number, Map<number, Cesium3DTileVectorFeature>>}
+     */
+    this._featuresByTableId = new Map();
 
     /** @type {ImplicitMetadataView} */
     this._metadata = undefined;
@@ -98,8 +115,8 @@ class VectorGltf3DTileContent {
   }
 
   get featuresLength() {
-    return this._collections.reduce(
-      (acc, collection) => acc + collection.primitiveCount,
+    return this.batchTables.reduce(
+      (acc, batchTable) => acc + batchTable.featuresLength,
       0,
     );
   }
@@ -132,7 +149,11 @@ class VectorGltf3DTileContent {
   }
 
   get batchTableByteLength() {
-    return 0;
+    return this.batchTables.reduce(
+      // @ts-expect-error Missing types.
+      (acc, batchTable) => acc + batchTable.batchTableByteLength,
+      0,
+    );
   }
 
   /** @returns {undefined} */
@@ -189,19 +210,25 @@ class VectorGltf3DTileContent {
 
   /**
    * @param {number} featureId
+   * @param {number} featureTableId
    * @returns {Cesium3DTileVectorFeature}
    */
-  getFeature(featureId) {
-    return this._features.get(featureId);
+  getFeature(featureId, featureTableId) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.number("featureTableId", featureTableId);
+    //>>includeEnd('debug');
+
+    return this._featuresByTableId.get(featureTableId)?.get(featureId);
   }
 
   /**
    * @param {number} featureId
    * @param {string} name
+   * @param {number} featureTableId
    * @returns {boolean}
    */
-  hasProperty(featureId, name) {
-    const feature = this.getFeature(featureId);
+  hasProperty(featureId, name, featureTableId) {
+    const feature = this.getFeature(featureId, featureTableId);
     return feature ? feature.hasProperty(name) : false;
   }
 
@@ -226,9 +253,10 @@ class VectorGltf3DTileContent {
       c instanceof BufferPolygonCollection;
 
     for (const collection of this._collections.filter(isPointCollection)) {
+      const featureTableId = this._collectionFeatureTableIds.get(collection);
       for (let i = 0, il = collection.primitiveCount; i < il; i++) {
         collection.get(i, point);
-        const feature = this.getFeature(point.featureId);
+        const feature = this.getFeature(point.featureId, featureTableId);
 
         point.show = style.show?.evaluate(feature) ?? true;
         style.color?.evaluate(feature, pointMaterial.color);
@@ -241,9 +269,10 @@ class VectorGltf3DTileContent {
     }
 
     for (const collection of this._collections.filter(isPolylineCollection)) {
+      const featureTableId = this._collectionFeatureTableIds.get(collection);
       for (let i = 0, il = collection.primitiveCount; i < il; i++) {
         collection.get(i, polyline);
-        const feature = this.getFeature(polyline.featureId);
+        const feature = this.getFeature(polyline.featureId, featureTableId);
 
         polyline.show = style.show?.evaluate(feature) ?? true;
         style.color?.evaluate(feature, polylineMaterial.color);
@@ -254,9 +283,10 @@ class VectorGltf3DTileContent {
     }
 
     for (const collection of this._collections.filter(isPolygonCollection)) {
+      const featureTableId = this._collectionFeatureTableIds.get(collection);
       for (let i = 0, il = collection.primitiveCount; i < il; i++) {
         collection.get(i, polygon);
-        const feature = this.getFeature(polygon.featureId);
+        const feature = this.getFeature(polygon.featureId, featureTableId);
 
         polygon.show = style.show?.evaluate(feature) ?? true;
         style.color?.evaluate(feature, polygonMaterial.color);
@@ -397,7 +427,8 @@ function initializeVectorPrimitives(content) {
 
   content._collections = result.collections;
   content._collectionLocalMatrices = result.collectionLocalMatrices;
-  content._features = result.features;
+  content._collectionFeatureTableIds = result.collectionFeatureTableIds;
+  content._featuresByTableId = result.featuresByTableId;
 }
 
 export default VectorGltf3DTileContent;

--- a/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
@@ -28,6 +28,10 @@ describe("Scene/VectorGltf3DTileContent", () => {
   afterEach(() => {});
 
   it("featuresLength", () => {
+    // For consistency with other tile content, features are counted from the
+    // batch table, not unique IDs in the geometry, so feature length should be
+    // zero if no batch tables are added. We can change this in the future; the
+    // test is just here to protect against accidental changes.
     content._collections = [
       createBufferPointCollection(),
       createBufferPolylineCollection(),

--- a/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
@@ -1,0 +1,227 @@
+import {
+  BufferPoint,
+  BufferPointCollection,
+  BufferPolyline,
+  BufferPolylineCollection,
+  BufferPolygon,
+  BufferPolygonCollection,
+  Cartesian3,
+  VectorGltf3DTileContent,
+} from "../../index.js";
+
+const scratchPoint = new BufferPoint();
+const scratchPolyline = new BufferPolyline();
+const scratchPolygon = new BufferPolygon();
+
+describe("Scene/VectorGltf3DTileContent", () => {
+  let content;
+
+  beforeAll(() => {});
+
+  afterAll(() => {});
+
+  beforeEach(() => {
+    content = new VectorGltf3DTileContent({}, {}, {});
+    content._model = { _featureTables: [] };
+  });
+
+  afterEach(() => {});
+
+  it("featuresLength", () => {
+    content._collections = [
+      createBufferPointCollection(),
+      createBufferPolylineCollection(),
+    ];
+
+    expect(content.featuresLength).toBe(0);
+
+    content._model._featureTables.push({ featuresLength: 10 });
+    content._model._featureTables.push({ featuresLength: 14 });
+
+    expect(content.featuresLength).toBe(24);
+  });
+
+  it("pointsLength", () => {
+    expect(content.pointsLength).toBe(0);
+
+    const points = createBufferPointCollection();
+    const lines = createBufferPolylineCollection();
+    const polygons = createBufferPolygonCollection();
+    content._collections = [points, lines, polygons];
+
+    expect(content.pointsLength).toBe(points.primitiveCount);
+  });
+
+  it("trianglesLength", () => {
+    expect(content.trianglesLength).toBe(0);
+
+    const points = createBufferPointCollection();
+    const lines = createBufferPolylineCollection();
+    const polygons = createBufferPolygonCollection();
+    content._collections = [points, lines, polygons];
+
+    // Polylines and polygons are triangulated, not points.
+    expect(content.trianglesLength).toBe(
+      2 * lines.primitiveCount + polygons.triangleCount,
+    );
+  });
+
+  it("byteLength", () => {
+    expect(content.geometryByteLength).toBe(0);
+
+    const points = createBufferPointCollection();
+    const lines = createBufferPolylineCollection();
+    const polygons = createBufferPolygonCollection();
+    content._collections = [points, lines, polygons];
+
+    expect(content.geometryByteLength).toBe(
+      points.byteLength + lines.byteLength + polygons.byteLength,
+    );
+  });
+
+  it("texturesByteLength", () => {
+    expect(content.texturesByteLength).toBe(0);
+
+    const points = createBufferPointCollection();
+    const lines = createBufferPolylineCollection();
+    const polygons = createBufferPolygonCollection();
+    content._collections = [points, lines, polygons];
+
+    expect(content.texturesByteLength).toBe(0);
+  });
+
+  it("batchTableByteLength", () => {
+    expect(content.batchTableByteLength).toBe(0);
+
+    content._model._featureTables.push({ batchTableByteLength: 100 });
+    content._model._featureTables.push({ batchTableByteLength: 156 });
+
+    expect(content.batchTableByteLength).toBe(256);
+  });
+
+  it("getFeature", () => {
+    expect(content.getFeature(123, 100)).toBe(undefined);
+
+    const mockFeature1 = { id: 123 };
+    const mockFeature2 = { id: 456 };
+
+    const points = createBufferPointCollection();
+    const lines = createBufferPolylineCollection();
+    const polygons = createBufferPolygonCollection();
+
+    content._collections = [points, lines, polygons];
+    content._collectionFeatureTableIds = new Map([
+      [points, 100],
+      [lines, 101],
+      [polygons, 101],
+    ]);
+    content._featuresByTableId = new Map([
+      [
+        100,
+        new Map([
+          [123, mockFeature1],
+          [456, mockFeature2],
+        ]),
+      ],
+      [101, new Map()],
+    ]);
+
+    expect(content.getFeature(123, 100)).toBe(mockFeature1);
+    expect(content.getFeature(456, 100)).toBe(mockFeature2);
+    expect(content.getFeature(999, 101)).toBe(undefined);
+  });
+
+  it("hasProperty", () => {
+    expect(content.hasProperty(123, "my-prop", 100)).toBe(false);
+
+    const mockFeature1 = { id: 123, hasProperty: (name) => name === "my-prop" };
+    const mockFeature2 = { id: 456, hasProperty: () => false };
+
+    const points = createBufferPointCollection();
+    const lines = createBufferPolylineCollection();
+    const polygons = createBufferPolygonCollection();
+
+    content._collections = [points, lines, polygons];
+    content._collectionFeatureTableIds = new Map([
+      [points, 100],
+      [lines, 101],
+      [polygons, 101],
+    ]);
+    content._featuresByTableId = new Map([
+      [
+        100,
+        new Map([
+          [123, mockFeature1],
+          [456, mockFeature2],
+        ]),
+      ],
+      [101, new Map()],
+    ]);
+
+    expect(content.hasProperty(123, "my-prop", 100)).toBe(true);
+    expect(content.hasProperty(456, "my-prop", 100)).toBe(false);
+    expect(content.hasProperty(999, "my-prop", 101)).toBe(false);
+  });
+});
+
+function createBufferPointCollection() {
+  const collection = new BufferPointCollection();
+  collection.add({ position: Cartesian3.UNIT_X }, scratchPoint);
+  collection.add({ position: Cartesian3.UNIT_Y }, scratchPoint);
+  collection.add({ position: Cartesian3.UNIT_Z }, scratchPoint);
+  return collection;
+}
+
+function createBufferPolylineCollection() {
+  const collection = new BufferPolylineCollection();
+  collection.add(
+    { positions: new Int8Array([0, 0, 0, 1, 1, 1]) },
+    scratchPolyline,
+  );
+  collection.add(
+    { positions: new Int8Array([1, 1, 1, 2, 2, 2]) },
+    scratchPolyline,
+  );
+  collection.add(
+    { positions: new Int8Array([2, 2, 2, 3, 3, 3]) },
+    scratchPolyline,
+  );
+  collection.add(
+    { positions: new Int8Array([3, 3, 3, 4, 4, 4]) },
+    scratchPolyline,
+  );
+  return collection;
+}
+
+function createBufferPolygonCollection() {
+  const collection = new BufferPolygonCollection();
+  collection.add(
+    {
+      positions: new Int8Array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
+      triangles: new Uint8Array([0, 1, 2]),
+    },
+    scratchPolygon,
+  );
+  collection.add(
+    {
+      positions: new Int8Array([1, 1, 1, 2, 2, 2, 3, 3, 3]),
+      triangles: new Uint8Array([0, 1, 2]),
+    },
+    scratchPolygon,
+  );
+  collection.add(
+    {
+      positions: new Int8Array([2, 2, 2, 3, 3, 3, 4, 4, 4]),
+      triangles: new Uint8Array([0, 1, 2]),
+    },
+    scratchPolygon,
+  );
+  collection.add(
+    {
+      positions: new Int8Array([3, 3, 3, 4, 4, 4, 5, 5, 5]),
+      triangles: new Uint8Array([0, 1, 2]),
+    },
+    scratchPolygon,
+  );
+  return collection;
+}


### PR DESCRIPTION
# Description

Additional fixes for https://github.com/CesiumGS/cesium/issues/11683. Affects Vector Tiles only, for now, although similar changes on the Cesium3DTileContent interface will likely be wanted for other 3D Tiles content types at some point. `content.getFeature(...)` and `content.hasProperty(...)` are affected and must take a Table ID, because Feature ID is unique only to a particular property table. A fe

While adding unit tests, I also added or updated implementations of getters for `content.featuresLength`, `content.batchTableByteLength`, which weren't involved in the bug, but are relevant to supporting multiple property tables.

## Issue number and link

- #11683
- #13432

## Testing plan

Unit tests added for VectorGltf3DTileContent. Public data with multiple property tables not yet available — will share a reproduction case by DM.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->









#### PR Dependency Tree


* **PR #13467** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)