### PR TITLE
Buffer*Collection gpu normalized

### DIFF
--- a/packages/engine/Source/Core/ComponentDatatype.d.ts
+++ b/packages/engine/Source/Core/ComponentDatatype.d.ts
@@ -23,6 +23,18 @@ declare namespace ComponentDatatype {
     value: number,
     componentDatatype: ComponentDatatype,
   ): number;
+  function createTypedArray(
+    componentDatatype: ComponentDatatype,
+    valuesOrLength: number | ArrayLike<number>,
+  ):
+    | Int8Array
+    | Uint8Array
+    | Int16Array
+    | Uint16Array
+    | Int32Array
+    | Uint32Array
+    | Float32Array
+    | Float64Array;
 }
 
 export default ComponentDatatype;

--- a/packages/engine/Source/Scene/BufferPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/BufferPrimitiveCollection.js
@@ -292,50 +292,11 @@ class BufferPrimitiveCollection {
    * @ignore
    */
   _allocatePositionBuffer(datatype) {
-    // @ts-expect-error Requires https://github.com/CesiumGS/cesium/pull/13203.
     this._positionView = ComponentDatatype.createTypedArray(
       datatype,
       this._positionCountMax * 3,
     );
     this._positionDatatype = datatype;
-  }
-
-  /**
-   * When {@link positionNormalized} is <code>true</code>, de-normalizes the
-   * given cartesian in-place: converts integer values to floats in the range
-   * [-1, 1] or [0, 1] following WebGL normalization conventions. When
-   * <code>positionNormalized</code> is <code>false</code>, this is a no-op.
-   *
-   * The caller is responsible for applying the collection's modelMatrix to
-   * transform the result from local space to world-space (ECEF).
-   *
-   * @param {Cartesian3} cartesian The cartesian to modify in-place.
-   * @returns {Cartesian3} The modified cartesian.
-   * @ignore
-   */
-  _denormalizePosition(cartesian) {
-    if (!this._positionNormalized) {
-      return cartesian;
-    }
-    const datatype = this._positionDatatype;
-    cartesian.x = ComponentDatatype.dequantize(cartesian.x, datatype);
-    cartesian.y = ComponentDatatype.dequantize(cartesian.y, datatype);
-    cartesian.z = ComponentDatatype.dequantize(cartesian.z, datatype);
-    return cartesian;
-  }
-
-  /**
-   * Returns the modelMatrix to use for the GPU DrawCommand. When
-   * {@link positionNormalized} is <code>true</code>, positions are already
-   * transformed to world-space ECEF on the CPU, so the DrawCommand must use
-   * {@link Matrix4.IDENTITY} to avoid a double-transform. Otherwise returns
-   * the collection's modelMatrix.
-   *
-   * @returns {Matrix4}
-   * @ignore
-   */
-  get _commandModelMatrix() {
-    return this._positionNormalized ? Matrix4.IDENTITY : this.modelMatrix;
   }
 
   /**

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -281,7 +281,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [BufferPointMaterialVS],
-        defines: useLocalSpace ? ["LOCAL_POSITION"] : [],
+        defines: useFloat64 ? ["USE_FLOAT64"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPointMaterialFS],

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -18,7 +18,6 @@ import PrimitiveType from "../Core/PrimitiveType.js";
 import BufferPointMaterialVS from "../Shaders/BufferPointMaterialVS.js";
 import BufferPointMaterialFS from "../Shaders/BufferPointMaterialFS.js";
 import EncodedCartesian3 from "../Core/EncodedCartesian3.js";
-import Matrix4 from "../Core/Matrix4.js";
 import AttributeCompression from "../Core/AttributeCompression.js";
 import BufferPointMaterial from "./BufferPointMaterial.js";
 
@@ -45,9 +44,23 @@ const BufferPointAttributeLocations = {
 };
 
 /**
+ * Attribute locations for the quantized GPU path ({@link positionNormalized}=true).
+ * A single normalized vec3 position replaces the high/low float pair.
+ * Material attributes retain their original indices.
+ * @type {Record<string, number>}
+ * @ignore
+ */
+const BufferPointQuantizedAttributeLocations = {
+  position: 0,
+  pickColor: 2,
+  showSizeAndColor: 3,
+  outlineWidthAndOutlineColor: 4,
+};
+
+/**
  * @typedef {object} BufferPointRenderContext
  * @property {VertexArray} [vertexArray]
- * @property {Record<BufferPointAttribute, TypedArray>} [attributeArrays]
+ * @property {Record<string, TypedArray>} [attributeArrays]
  * @property {RenderState} [renderState]
  * @property {ShaderProgram} [shaderProgram]
  * @property {DrawCommand} [command]
@@ -72,24 +85,29 @@ const encodedCartesian = new EncodedCartesian3();
 function renderBufferPointCollection(collection, frameState, renderContext) {
   const context = frameState.context;
   renderContext = renderContext || { destroy: destroyRenderContext };
+  const useQuantized = collection._positionNormalized;
 
   if (!defined(renderContext.attributeArrays)) {
     const featureCountMax = collection.primitiveCountMax;
 
-    renderContext.attributeArrays = {
-      positionHigh: new Float32Array(featureCountMax * 3),
-      positionLow: new Float32Array(featureCountMax * 3),
-      pickColor: new Uint8Array(featureCountMax * 4),
-      showSizeAndColor: new Float32Array(featureCountMax * 3),
-      outlineWidthAndOutlineColor: new Float32Array(featureCountMax * 2),
-    };
+    renderContext.attributeArrays = useQuantized
+      ? {
+          pickColor: new Uint8Array(featureCountMax * 4),
+          showSizeAndColor: new Float32Array(featureCountMax * 3),
+          outlineWidthAndOutlineColor: new Float32Array(featureCountMax * 2),
+        }
+      : {
+          positionHigh: new Float32Array(featureCountMax * 3),
+          positionLow: new Float32Array(featureCountMax * 3),
+          pickColor: new Uint8Array(featureCountMax * 4),
+          showSizeAndColor: new Float32Array(featureCountMax * 3),
+          outlineWidthAndOutlineColor: new Float32Array(featureCountMax * 2),
+        };
   }
 
   if (collection._dirtyCount > 0) {
     const { attributeArrays } = renderContext;
 
-    const positionHighArray = attributeArrays.positionHigh;
-    const positionLowArray = attributeArrays.positionLow;
     const pickColorArray = attributeArrays.pickColor;
     const showSizeAndColorArray = attributeArrays.showSizeAndColor;
     const outlineWidthAndOutlineColorArray =
@@ -104,22 +122,19 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
         continue;
       }
 
-      point.getPosition(cartesian);
-      collection._denormalizePosition(cartesian);
-      if (collection._positionNormalized) {
-        Matrix4.multiplyByPoint(collection.modelMatrix, cartesian, cartesian);
+      if (!useQuantized) {
+        point.getPosition(cartesian);
+        EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
+        attributeArrays.positionHigh[i * 3] = encodedCartesian.high.x;
+        attributeArrays.positionHigh[i * 3 + 1] = encodedCartesian.high.y;
+        attributeArrays.positionHigh[i * 3 + 2] = encodedCartesian.high.z;
+        attributeArrays.positionLow[i * 3] = encodedCartesian.low.x;
+        attributeArrays.positionLow[i * 3 + 1] = encodedCartesian.low.y;
+        attributeArrays.positionLow[i * 3 + 2] = encodedCartesian.low.z;
       }
-      EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
+
       point.getMaterial(material);
       Color.fromRgba(point._pickId, pickColor);
-
-      positionHighArray[i * 3] = encodedCartesian.high.x;
-      positionHighArray[i * 3 + 1] = encodedCartesian.high.y;
-      positionHighArray[i * 3 + 2] = encodedCartesian.high.z;
-
-      positionLowArray[i * 3] = encodedCartesian.low.x;
-      positionLowArray[i * 3 + 1] = encodedCartesian.low.y;
-      positionLowArray[i * 3 + 2] = encodedCartesian.low.z;
 
       pickColorArray[i * 4] = Color.floatToByte(pickColor.red);
       pickColorArray[i * 4 + 1] = Color.floatToByte(pickColor.green);
@@ -142,32 +157,51 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
 
   if (!defined(renderContext.vertexArray)) {
     const { attributeArrays } = renderContext;
+    const locations = useQuantized
+      ? BufferPointQuantizedAttributeLocations
+      : BufferPointAttributeLocations;
 
     renderContext.vertexArray = new VertexArray({
       context,
       attributes: [
+        ...(useQuantized
+          ? [
+              {
+                index: BufferPointQuantizedAttributeLocations.position,
+                componentDatatype: collection._positionDatatype,
+                componentsPerAttribute: 3,
+                normalize: true,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: collection._positionView,
+                  context,
+                  usage: BufferUsage.DYNAMIC_DRAW,
+                }),
+              },
+            ]
+          : [
+              {
+                index: BufferPointAttributeLocations.positionHigh,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.positionHigh,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPointAttributeLocations.positionLow,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.positionLow,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+            ]),
         {
-          index: BufferPointAttributeLocations.positionHigh,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.positionHigh,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPointAttributeLocations.positionLow,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.positionLow,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPointAttributeLocations.pickColor,
+          index: locations.pickColor,
           componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
           componentsPerAttribute: 4,
           vertexBuffer: Buffer.createVertexBuffer({
@@ -177,7 +211,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
           }),
         },
         {
-          index: BufferPointAttributeLocations.showSizeAndColor,
+          index: locations.showSizeAndColor,
           componentDatatype: ComponentDatatype.FLOAT,
           componentsPerAttribute: 3,
           vertexBuffer: Buffer.createVertexBuffer({
@@ -187,7 +221,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
           }),
         },
         {
-          index: BufferPointAttributeLocations.outlineWidthAndOutlineColor,
+          index: locations.outlineWidthAndOutlineColor,
           componentDatatype: ComponentDatatype.FLOAT,
           componentsPerAttribute: 2,
           vertexBuffer: Buffer.createVertexBuffer({
@@ -199,15 +233,37 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       ],
     });
   } else if (collection._dirtyCount > 0) {
-    for (const key in BufferPointAttributeLocations) {
-      if (Object.hasOwn(BufferPointAttributeLocations, key)) {
-        const attribute = /** @type {BufferPointAttribute} */ (key);
+    if (useQuantized) {
+      renderContext.vertexArray.copyAttributeFromRange(
+        0, // array index 0 = position
+        collection._positionView,
+        collection._dirtyOffset,
+        collection._dirtyCount,
+      );
+      const materialKeys = [
+        "pickColor",
+        "showSizeAndColor",
+        "outlineWidthAndOutlineColor",
+      ];
+      for (let ai = 0; ai < materialKeys.length; ai++) {
         renderContext.vertexArray.copyAttributeFromRange(
-          BufferPointAttributeLocations[attribute],
-          renderContext.attributeArrays[attribute],
+          ai + 1, // array indices 1, 2, 3
+          renderContext.attributeArrays[materialKeys[ai]],
           collection._dirtyOffset,
           collection._dirtyCount,
         );
+      }
+    } else {
+      for (const key in BufferPointAttributeLocations) {
+        if (Object.hasOwn(BufferPointAttributeLocations, key)) {
+          const attribute = /** @type {BufferPointAttribute} */ (key);
+          renderContext.vertexArray.copyAttributeFromRange(
+            BufferPointAttributeLocations[attribute],
+            renderContext.attributeArrays[attribute],
+            collection._dirtyOffset,
+            collection._dirtyCount,
+          );
+        }
       }
     }
   }
@@ -224,11 +280,14 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [BufferPointMaterialVS],
+        defines: useQuantized ? ["QUANTIZED_POSITIONS"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPointMaterialFS],
       }),
-      attributeLocations: BufferPointAttributeLocations,
+      attributeLocations: useQuantized
+        ? BufferPointQuantizedAttributeLocations
+        : BufferPointAttributeLocations,
     });
   }
 
@@ -242,7 +301,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: collection.primitiveCount,
-      modelMatrix: collection._commandModelMatrix,
+      modelMatrix: collection.modelMatrix,
       boundingVolume: collection.boundingVolumeWC, // shared reference
       debugShowBoundingVolume: collection.debugShowBoundingVolume,
     });

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -44,13 +44,13 @@ const BufferPointAttributeLocations = {
 };
 
 /**
- * Attribute locations for the quantized GPU path ({@link positionNormalized}=true).
- * A single normalized vec3 position replaces the high/low float pair.
+ * Attribute locations for the GPU position path (float32 or normalized integer inputs).
+ * A single vec3 position replaces the high/low float pair.
  * Material attributes retain their original indices.
  * @type {Record<string, number>}
  * @ignore
  */
-const BufferPointQuantizedAttributeLocations = {
+const BufferPointLocalSpaceAttributeLocations = {
   position: 0,
   pickColor: 2,
   showSizeAndColor: 3,
@@ -85,12 +85,13 @@ const encodedCartesian = new EncodedCartesian3();
 function renderBufferPointCollection(collection, frameState, renderContext) {
   const context = frameState.context;
   renderContext = renderContext || { destroy: destroyRenderContext };
-  const useQuantized = collection._positionNormalized;
+  const useFloat64 = collection._positionDatatype === ComponentDatatype.DOUBLE;
+  const useLocalSpace = !useFloat64;
 
   if (!defined(renderContext.attributeArrays)) {
     const featureCountMax = collection.primitiveCountMax;
 
-    renderContext.attributeArrays = useQuantized
+    renderContext.attributeArrays = useLocalSpace
       ? {
           pickColor: new Uint8Array(featureCountMax * 4),
           showSizeAndColor: new Float32Array(featureCountMax * 3),
@@ -122,7 +123,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
         continue;
       }
 
-      if (!useQuantized) {
+      if (useFloat64) {
         point.getPosition(cartesian);
         EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
         attributeArrays.positionHigh[i * 3] = encodedCartesian.high.x;
@@ -157,20 +158,20 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
 
   if (!defined(renderContext.vertexArray)) {
     const { attributeArrays } = renderContext;
-    const locations = useQuantized
-      ? BufferPointQuantizedAttributeLocations
+    const locations = useLocalSpace
+      ? BufferPointLocalSpaceAttributeLocations
       : BufferPointAttributeLocations;
 
     renderContext.vertexArray = new VertexArray({
       context,
       attributes: [
-        ...(useQuantized
+        ...(useLocalSpace
           ? [
               {
-                index: BufferPointQuantizedAttributeLocations.position,
+                index: BufferPointLocalSpaceAttributeLocations.position,
                 componentDatatype: collection._positionDatatype,
                 componentsPerAttribute: 3,
-                normalize: true,
+                normalize: collection._positionNormalized,
                 vertexBuffer: Buffer.createVertexBuffer({
                   typedArray: collection._positionView,
                   context,
@@ -233,7 +234,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       ],
     });
   } else if (collection._dirtyCount > 0) {
-    if (useQuantized) {
+    if (useLocalSpace) {
       renderContext.vertexArray.copyAttributeFromRange(
         0, // array index 0 = position
         collection._positionView,
@@ -280,13 +281,13 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [BufferPointMaterialVS],
-        defines: useQuantized ? ["QUANTIZED_POSITIONS"] : [],
+        defines: useLocalSpace ? ["LOCAL_POSITION"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPointMaterialFS],
       }),
-      attributeLocations: useQuantized
-        ? BufferPointQuantizedAttributeLocations
+      attributeLocations: useLocalSpace
+        ? BufferPointLocalSpaceAttributeLocations
         : BufferPointAttributeLocations,
     });
   }

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -18,7 +18,6 @@ import PrimitiveType from "../Core/PrimitiveType.js";
 import BufferPolygonMaterialVS from "../Shaders/BufferPolygonMaterialVS.js";
 import BufferPolygonMaterialFS from "../Shaders/BufferPolygonMaterialFS.js";
 import EncodedCartesian3 from "../Core/EncodedCartesian3.js";
-import Matrix4 from "../Core/Matrix4.js";
 import AttributeCompression from "../Core/AttributeCompression.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
 import BufferPolygonMaterial from "./BufferPolygonMaterial.js";
@@ -45,9 +44,22 @@ const BufferPolygonAttributeLocations = {
 };
 
 /**
+ * Attribute locations for the quantized GPU path ({@link positionNormalized}=true).
+ * A single normalized vec3 position replaces the high/low float pair.
+ * Material attributes retain their original indices.
+ * @type {Record<string, number>}
+ * @ignore
+ */
+const BufferPolygonQuantizedAttributeLocations = {
+  position: 0,
+  pickColor: 2,
+  showAndColor: 3,
+};
+
+/**
  * @typedef {object} BufferPolygonRenderContext
  * @property {VertexArray} [vertexArray]
- * @property {Record<BufferPolygonAttribute, TypedArray>} [attributeArrays]
+ * @property {Record<string, TypedArray>} [attributeArrays]
  * @property {TypedArray} [indexArray]
  * @property {RenderState} [renderState]
  * @property {ShaderProgram} [shaderProgram]
@@ -73,6 +85,7 @@ const encodedCartesian = new EncodedCartesian3();
 function renderBufferPolygonCollection(collection, frameState, renderContext) {
   const context = frameState.context;
   renderContext = renderContext || { destroy: destroyRenderContext };
+  const useQuantized = collection._positionNormalized;
 
   if (
     !defined(renderContext.attributeArrays) ||
@@ -86,12 +99,17 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       triangleCountMax * 3,
     );
 
-    renderContext.attributeArrays = {
-      positionHigh: new Float32Array(vertexCountMax * 3),
-      positionLow: new Float32Array(vertexCountMax * 3),
-      pickColor: new Uint8Array(vertexCountMax * 4),
-      showAndColor: new Float32Array(vertexCountMax * 2),
-    };
+    renderContext.attributeArrays = useQuantized
+      ? {
+          pickColor: new Uint8Array(vertexCountMax * 4),
+          showAndColor: new Float32Array(vertexCountMax * 2),
+        }
+      : {
+          positionHigh: new Float32Array(vertexCountMax * 3),
+          positionLow: new Float32Array(vertexCountMax * 3),
+          pickColor: new Uint8Array(vertexCountMax * 4),
+          showAndColor: new Float32Array(vertexCountMax * 2),
+        };
   }
 
   if (collection._dirtyCount > 0) {
@@ -99,8 +117,6 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
     const { _dirtyOffset, _dirtyCount } = collection;
 
     const indexArray = renderContext.indexArray;
-    const positionHighArray = attributeArrays.positionHigh;
-    const positionLowArray = attributeArrays.positionLow;
     const pickColorArray = attributeArrays.pickColor;
     const showAndColorArray = attributeArrays.showAndColor;
 
@@ -126,28 +142,28 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       }
 
       const show = polygon.show;
-      const cartesianArray = polygon.getPositions();
+      const cartesianArray = useQuantized ? null : polygon.getPositions();
       polygon.getMaterial(material);
       const encodedColor = AttributeCompression.encodeRGB8(material.color);
       Color.fromRgba(polygon._pickId, pickColor);
 
       // Update vertex arrays.
       for (let j = 0, jl = polygon.vertexCount; j < jl; j++) {
-        // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-        Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
-        collection._denormalizePosition(cartesian);
-        if (collection._positionNormalized) {
-          Matrix4.multiplyByPoint(collection.modelMatrix, cartesian, cartesian);
+        if (!useQuantized) {
+          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+          Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
+          EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
+
+          attributeArrays.positionHigh[vOffset * 3] = encodedCartesian.high.x;
+          attributeArrays.positionHigh[vOffset * 3 + 1] =
+            encodedCartesian.high.y;
+          attributeArrays.positionHigh[vOffset * 3 + 2] =
+            encodedCartesian.high.z;
+
+          attributeArrays.positionLow[vOffset * 3] = encodedCartesian.low.x;
+          attributeArrays.positionLow[vOffset * 3 + 1] = encodedCartesian.low.y;
+          attributeArrays.positionLow[vOffset * 3 + 2] = encodedCartesian.low.z;
         }
-        EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
-
-        positionHighArray[vOffset * 3] = encodedCartesian.high.x;
-        positionHighArray[vOffset * 3 + 1] = encodedCartesian.high.y;
-        positionHighArray[vOffset * 3 + 2] = encodedCartesian.high.z;
-
-        positionLowArray[vOffset * 3] = encodedCartesian.low.x;
-        positionLowArray[vOffset * 3 + 1] = encodedCartesian.low.y;
-        positionLowArray[vOffset * 3 + 2] = encodedCartesian.low.z;
 
         pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);
         pickColorArray[vOffset * 4 + 1] = Color.floatToByte(pickColor.green);
@@ -166,6 +182,9 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
 
   if (!defined(renderContext.vertexArray)) {
     const { attributeArrays } = renderContext;
+    const locations = useQuantized
+      ? BufferPolygonQuantizedAttributeLocations
+      : BufferPolygonAttributeLocations;
 
     renderContext.vertexArray = new VertexArray({
       context,
@@ -179,28 +198,44 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       }),
 
       attributes: [
+        ...(useQuantized
+          ? [
+              {
+                index: BufferPolygonQuantizedAttributeLocations.position,
+                componentDatatype: collection._positionDatatype,
+                componentsPerAttribute: 3,
+                normalize: true,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: collection._positionView,
+                  context,
+                  usage: BufferUsage.DYNAMIC_DRAW,
+                }),
+              },
+            ]
+          : [
+              {
+                index: BufferPolygonAttributeLocations.positionHigh,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.positionHigh,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolygonAttributeLocations.positionLow,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.positionLow,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+            ]),
         {
-          index: BufferPolygonAttributeLocations.positionHigh,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.positionHigh,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPolygonAttributeLocations.positionLow,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.positionLow,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPolygonAttributeLocations.pickColor,
+          index: locations.pickColor,
           componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
           componentsPerAttribute: 4,
           vertexBuffer: Buffer.createVertexBuffer({
@@ -210,7 +245,7 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
           }),
         },
         {
-          index: BufferPolygonAttributeLocations.showAndColor,
+          index: locations.showAndColor,
           componentDatatype: ComponentDatatype.FLOAT,
           componentsPerAttribute: 2,
           vertexBuffer: Buffer.createVertexBuffer({
@@ -231,15 +266,33 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       indexCount,
     );
 
-    for (const key in BufferPolygonAttributeLocations) {
-      if (Object.hasOwn(BufferPolygonAttributeLocations, key)) {
-        const attribute = /** @type {BufferPolygonAttribute} */ (key);
+    if (useQuantized) {
+      renderContext.vertexArray.copyAttributeFromRange(
+        0, // array index 0 = position
+        collection._positionView,
+        vertexOffset,
+        vertexCount,
+      );
+      const materialKeys = ["pickColor", "showAndColor"];
+      for (let ai = 0; ai < materialKeys.length; ai++) {
         renderContext.vertexArray.copyAttributeFromRange(
-          BufferPolygonAttributeLocations[attribute],
-          renderContext.attributeArrays[attribute],
+          ai + 1, // array indices 1, 2
+          renderContext.attributeArrays[materialKeys[ai]],
           vertexOffset,
           vertexCount,
         );
+      }
+    } else {
+      for (const key in BufferPolygonAttributeLocations) {
+        if (Object.hasOwn(BufferPolygonAttributeLocations, key)) {
+          const attribute = /** @type {BufferPolygonAttribute} */ (key);
+          renderContext.vertexArray.copyAttributeFromRange(
+            BufferPolygonAttributeLocations[attribute],
+            renderContext.attributeArrays[attribute],
+            vertexOffset,
+            vertexCount,
+          );
+        }
       }
     }
   }
@@ -256,11 +309,14 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [BufferPolygonMaterialVS],
+        defines: useQuantized ? ["QUANTIZED_POSITIONS"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolygonMaterialFS],
       }),
-      attributeLocations: BufferPolygonAttributeLocations,
+      attributeLocations: useQuantized
+        ? BufferPolygonQuantizedAttributeLocations
+        : BufferPolygonAttributeLocations,
     });
   }
 
@@ -276,7 +332,7 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: drawCount,
-      modelMatrix: collection._commandModelMatrix,
+      modelMatrix: collection.modelMatrix,
       boundingVolume: collection.boundingVolumeWC, // shared reference
       debugShowBoundingVolume: collection.debugShowBoundingVolume,
     });

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -310,7 +310,7 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [BufferPolygonMaterialVS],
-        defines: useLocalSpace ? ["LOCAL_POSITION"] : [],
+        defines: useFloat64 ? ["USE_FLOAT64"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolygonMaterialFS],

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -44,13 +44,13 @@ const BufferPolygonAttributeLocations = {
 };
 
 /**
- * Attribute locations for the quantized GPU path ({@link positionNormalized}=true).
- * A single normalized vec3 position replaces the high/low float pair.
+ * Attribute locations for the GPU position path (float32 or normalized integer inputs).
+ * A single vec3 position replaces the high/low float pair.
  * Material attributes retain their original indices.
  * @type {Record<string, number>}
  * @ignore
  */
-const BufferPolygonQuantizedAttributeLocations = {
+const BufferPolygonLocalSpaceAttributeLocations = {
   position: 0,
   pickColor: 2,
   showAndColor: 3,
@@ -85,7 +85,8 @@ const encodedCartesian = new EncodedCartesian3();
 function renderBufferPolygonCollection(collection, frameState, renderContext) {
   const context = frameState.context;
   renderContext = renderContext || { destroy: destroyRenderContext };
-  const useQuantized = collection._positionNormalized;
+  const useFloat64 = collection._positionDatatype === ComponentDatatype.DOUBLE;
+  const useLocalSpace = !useFloat64;
 
   if (
     !defined(renderContext.attributeArrays) ||
@@ -99,7 +100,7 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       triangleCountMax * 3,
     );
 
-    renderContext.attributeArrays = useQuantized
+    renderContext.attributeArrays = useLocalSpace
       ? {
           pickColor: new Uint8Array(vertexCountMax * 4),
           showAndColor: new Float32Array(vertexCountMax * 2),
@@ -142,14 +143,14 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       }
 
       const show = polygon.show;
-      const cartesianArray = useQuantized ? null : polygon.getPositions();
+      const cartesianArray = useLocalSpace ? null : polygon.getPositions();
       polygon.getMaterial(material);
       const encodedColor = AttributeCompression.encodeRGB8(material.color);
       Color.fromRgba(polygon._pickId, pickColor);
 
       // Update vertex arrays.
       for (let j = 0, jl = polygon.vertexCount; j < jl; j++) {
-        if (!useQuantized) {
+        if (useFloat64) {
           // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
           Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
           EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
@@ -182,8 +183,8 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
 
   if (!defined(renderContext.vertexArray)) {
     const { attributeArrays } = renderContext;
-    const locations = useQuantized
-      ? BufferPolygonQuantizedAttributeLocations
+    const locations = useLocalSpace
+      ? BufferPolygonLocalSpaceAttributeLocations
       : BufferPolygonAttributeLocations;
 
     renderContext.vertexArray = new VertexArray({
@@ -198,13 +199,13 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       }),
 
       attributes: [
-        ...(useQuantized
+        ...(useLocalSpace
           ? [
               {
-                index: BufferPolygonQuantizedAttributeLocations.position,
+                index: BufferPolygonLocalSpaceAttributeLocations.position,
                 componentDatatype: collection._positionDatatype,
                 componentsPerAttribute: 3,
-                normalize: true,
+                normalize: collection._positionNormalized,
                 vertexBuffer: Buffer.createVertexBuffer({
                   typedArray: collection._positionView,
                   context,
@@ -266,7 +267,7 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       indexCount,
     );
 
-    if (useQuantized) {
+    if (useLocalSpace) {
       renderContext.vertexArray.copyAttributeFromRange(
         0, // array index 0 = position
         collection._positionView,
@@ -309,13 +310,13 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [BufferPolygonMaterialVS],
-        defines: useQuantized ? ["QUANTIZED_POSITIONS"] : [],
+        defines: useLocalSpace ? ["LOCAL_POSITION"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolygonMaterialFS],
       }),
-      attributeLocations: useQuantized
-        ? BufferPolygonQuantizedAttributeLocations
+      attributeLocations: useLocalSpace
+        ? BufferPolygonLocalSpaceAttributeLocations
         : BufferPolygonAttributeLocations,
     });
   }

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -49,13 +49,13 @@ const BufferPolylineAttributeLocations = {
 };
 
 /**
- * Attribute locations for the quantized GPU path ({@link positionNormalized}=true).
- * Three normalized int vec3 attributes replace the six high/low float pairs.
+ * Attribute locations for the GPU position path (float32 or normalized integer inputs).
+ * Three vec3 attributes replace the six high/low float pairs.
  * Material attributes retain their original indices.
  * @type {Record<string, number>}
  * @ignore
  */
-const BufferPolylineQuantizedAttributeLocations = {
+const BufferPolylineLocalSpaceAttributeLocations = {
   position: 0,
   prevPosition: 2,
   nextPosition: 4,
@@ -109,7 +109,8 @@ const nextCartesianEnc = new EncodedCartesian3();
 function renderBufferPolylineCollection(collection, frameState, renderContext) {
   const context = frameState.context;
   renderContext = renderContext || { destroy: destroyRenderContext };
-  const useQuantized = collection._positionNormalized;
+  const useFloat64 = collection._positionDatatype === ComponentDatatype.DOUBLE;
+  const useLocalSpace = !useFloat64;
 
   if (
     !defined(renderContext.attributeArrays) ||
@@ -127,7 +128,7 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       segmentCountMax * 6,
     );
 
-    renderContext.attributeArrays = useQuantized
+    renderContext.attributeArrays = useLocalSpace
       ? {
           position: ComponentDatatype.createTypedArray(
             collection._positionDatatype,
@@ -182,7 +183,7 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
 
       const jl = polyline.vertexCount;
 
-      if (useQuantized) {
+      if (useLocalSpace) {
         const posView = collection._positionView;
         const posStart = polyline.vertexOffset * 3;
         const posArray = attributeArrays.position;
@@ -378,8 +379,8 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
 
   if (!defined(renderContext.vertexArray)) {
     const attributeArrays = renderContext.attributeArrays;
-    const locations = useQuantized
-      ? BufferPolylineQuantizedAttributeLocations
+    const locations = useLocalSpace
+      ? BufferPolylineLocalSpaceAttributeLocations
       : BufferPolylineAttributeLocations;
 
     renderContext.vertexArray = new VertexArray({
@@ -394,13 +395,13 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       }),
 
       attributes: [
-        ...(useQuantized
+        ...(useLocalSpace
           ? [
               {
-                index: BufferPolylineQuantizedAttributeLocations.position,
+                index: BufferPolylineLocalSpaceAttributeLocations.position,
                 componentDatatype: collection._positionDatatype,
                 componentsPerAttribute: 3,
-                normalize: true,
+                normalize: collection._positionNormalized,
                 vertexBuffer: Buffer.createVertexBuffer({
                   typedArray: attributeArrays.position,
                   context,
@@ -408,10 +409,10 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
                 }),
               },
               {
-                index: BufferPolylineQuantizedAttributeLocations.prevPosition,
+                index: BufferPolylineLocalSpaceAttributeLocations.prevPosition,
                 componentDatatype: collection._positionDatatype,
                 componentsPerAttribute: 3,
-                normalize: true,
+                normalize: collection._positionNormalized,
                 vertexBuffer: Buffer.createVertexBuffer({
                   typedArray: attributeArrays.prevPosition,
                   context,
@@ -419,10 +420,10 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
                 }),
               },
               {
-                index: BufferPolylineQuantizedAttributeLocations.nextPosition,
+                index: BufferPolylineLocalSpaceAttributeLocations.nextPosition,
                 componentDatatype: collection._positionDatatype,
                 componentsPerAttribute: 3,
-                normalize: true,
+                normalize: collection._positionNormalized,
                 vertexBuffer: Buffer.createVertexBuffer({
                   typedArray: attributeArrays.nextPosition,
                   context,
@@ -524,19 +525,19 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       indexCount,
     );
 
-    if (useQuantized) {
+    if (useLocalSpace) {
       // Use sequential array indices (0,1,2,3,4), NOT shader location values.
-      const quantizedAttrs = [
+      const localSpaceAttrs = [
         "position",
         "prevPosition",
         "nextPosition",
         "pickColor",
         "showColorWidthAndTexCoord",
       ];
-      for (let ai = 0; ai < quantizedAttrs.length; ai++) {
+      for (let ai = 0; ai < localSpaceAttrs.length; ai++) {
         renderContext.vertexArray.copyAttributeFromRange(
           ai,
-          renderContext.attributeArrays[quantizedAttrs[ai]],
+          renderContext.attributeArrays[localSpaceAttrs[ai]],
           vertexOffset,
           vertexCount,
         );
@@ -568,13 +569,13 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [PolylineCommon, BufferPolylineMaterialVS],
-        defines: useQuantized ? ["QUANTIZED_POSITIONS"] : [],
+        defines: useLocalSpace ? ["LOCAL_POSITION"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolylineMaterialFS],
       }),
-      attributeLocations: useQuantized
-        ? BufferPolylineQuantizedAttributeLocations
+      attributeLocations: useLocalSpace
+        ? BufferPolylineLocalSpaceAttributeLocations
         : BufferPolylineAttributeLocations,
     });
   }

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -569,7 +569,7 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [PolylineCommon, BufferPolylineMaterialVS],
-        defines: useLocalSpace ? ["LOCAL_POSITION"] : [],
+        defines: useFloat64 ? ["USE_FLOAT64"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolylineMaterialFS],

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -18,7 +18,6 @@ import PrimitiveType from "../Core/PrimitiveType.js";
 import BufferPolylineMaterialVS from "../Shaders/BufferPolylineMaterialVS.js";
 import BufferPolylineMaterialFS from "../Shaders/BufferPolylineMaterialFS.js";
 import EncodedCartesian3 from "../Core/EncodedCartesian3.js";
-import Matrix4 from "../Core/Matrix4.js";
 import AttributeCompression from "../Core/AttributeCompression.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
 import PolylineCommon from "../Shaders/PolylineCommon.js";
@@ -50,9 +49,24 @@ const BufferPolylineAttributeLocations = {
 };
 
 /**
+ * Attribute locations for the quantized GPU path ({@link positionNormalized}=true).
+ * Three normalized int vec3 attributes replace the six high/low float pairs.
+ * Material attributes retain their original indices.
+ * @type {Record<string, number>}
+ * @ignore
+ */
+const BufferPolylineQuantizedAttributeLocations = {
+  position: 0,
+  prevPosition: 2,
+  nextPosition: 4,
+  pickColor: 6,
+  showColorWidthAndTexCoord: 7,
+};
+
+/**
  * @typedef {object} BufferPolylineRenderContext
  * @property {VertexArray} [vertexArray]
- * @property {Record<BufferPolylineAttribute, TypedArray>} [attributeArrays]
+ * @property {Record<string, TypedArray>} [attributeArrays]
  * @property {TypedArray} [indexArray]
  * @property {RenderState} [renderState]
  * @property {ShaderProgram} [shaderProgram]
@@ -95,6 +109,7 @@ const nextCartesianEnc = new EncodedCartesian3();
 function renderBufferPolylineCollection(collection, frameState, renderContext) {
   const context = frameState.context;
   renderContext = renderContext || { destroy: destroyRenderContext };
+  const useQuantized = collection._positionNormalized;
 
   if (
     !defined(renderContext.attributeArrays) ||
@@ -112,16 +127,33 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       segmentCountMax * 6,
     );
 
-    renderContext.attributeArrays = {
-      positionHigh: new Float32Array(vertexCountMax * 3),
-      positionLow: new Float32Array(vertexCountMax * 3),
-      prevPositionHigh: new Float32Array(vertexCountMax * 3),
-      prevPositionLow: new Float32Array(vertexCountMax * 3),
-      nextPositionHigh: new Float32Array(vertexCountMax * 3),
-      nextPositionLow: new Float32Array(vertexCountMax * 3),
-      pickColor: new Uint8Array(vertexCountMax * 4),
-      showColorWidthAndTexCoord: new Float32Array(vertexCountMax * 4),
-    };
+    renderContext.attributeArrays = useQuantized
+      ? {
+          position: ComponentDatatype.createTypedArray(
+            collection._positionDatatype,
+            vertexCountMax * 3,
+          ),
+          prevPosition: ComponentDatatype.createTypedArray(
+            collection._positionDatatype,
+            vertexCountMax * 3,
+          ),
+          nextPosition: ComponentDatatype.createTypedArray(
+            collection._positionDatatype,
+            vertexCountMax * 3,
+          ),
+          pickColor: new Uint8Array(vertexCountMax * 4),
+          showColorWidthAndTexCoord: new Float32Array(vertexCountMax * 4),
+        }
+      : {
+          positionHigh: new Float32Array(vertexCountMax * 3),
+          positionLow: new Float32Array(vertexCountMax * 3),
+          prevPositionHigh: new Float32Array(vertexCountMax * 3),
+          prevPositionLow: new Float32Array(vertexCountMax * 3),
+          nextPositionHigh: new Float32Array(vertexCountMax * 3),
+          nextPositionLow: new Float32Array(vertexCountMax * 3),
+          pickColor: new Uint8Array(vertexCountMax * 4),
+          showColorWidthAndTexCoord: new Float32Array(vertexCountMax * 4),
+        };
   }
 
   if (collection._dirtyCount > 0) {
@@ -129,12 +161,6 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
     const { attributeArrays } = renderContext;
 
     const indexArray = renderContext.indexArray;
-    const positionHighArray = attributeArrays.positionHigh;
-    const positionLowArray = attributeArrays.positionLow;
-    const prevPositionHighArray = attributeArrays.prevPositionHigh;
-    const prevPositionLowArray = attributeArrays.prevPositionLow;
-    const nextPositionHighArray = attributeArrays.nextPositionHigh;
-    const nextPositionLowArray = attributeArrays.nextPositionLow;
     const pickColorArray = attributeArrays.pickColor;
     const showColorWidthAndTexCoordArray =
       attributeArrays.showColorWidthAndTexCoord;
@@ -146,7 +172,6 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
         continue;
       }
 
-      const cartesianArray = polyline.getPositions();
       polyline.getMaterial(material);
       const encodedColor = AttributeCompression.encodeRGB8(material.color);
       Color.fromRgba(polyline._pickId, pickColor);
@@ -155,107 +180,195 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       let vOffset = polyline.vertexOffset * 2; // vertex offset
       let iOffset = (polyline.vertexOffset - i) * 6; // index offset
 
-      for (let j = 0, jl = polyline.vertexCount; j < jl; j++) {
-        const isFirstSegment = j === 0;
-        const isLastSegment = j === jl - 1;
+      const jl = polyline.vertexCount;
 
-        // For first/last vertices, infer missing vertices by mirroring the segment.
-        // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-        Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
-        if (isFirstSegment) {
-          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-          Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
-          Cartesian3.subtract(cartesian, nextCartesian, prevCartesian);
-          Cartesian3.add(cartesian, prevCartesian, prevCartesian);
-        } else if (isLastSegment) {
-          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-          Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
-          Cartesian3.subtract(cartesian, prevCartesian, nextCartesian);
-          Cartesian3.add(cartesian, nextCartesian, nextCartesian);
-        } else {
-          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-          Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
-          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-          Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
+      if (useQuantized) {
+        const posView = collection._positionView;
+        const posStart = polyline.vertexOffset * 3;
+        const posArray = attributeArrays.position;
+        const prevPosArray = attributeArrays.prevPosition;
+        const nextPosArray = attributeArrays.nextPosition;
+
+        for (let j = 0; j < jl; j++) {
+          const isFirstSegment = j === 0;
+          const isLastSegment = j === jl - 1;
+
+          const cx = posView[posStart + j * 3];
+          const cy = posView[posStart + j * 3 + 1];
+          const cz = posView[posStart + j * 3 + 2];
+
+          let px, py, pz, nx, ny, nz;
+
+          if (isFirstSegment) {
+            nx = posView[posStart + 1 * 3];
+            ny = posView[posStart + 1 * 3 + 1];
+            nz = posView[posStart + 1 * 3 + 2];
+            // Mirror current over next to get synthetic prev.
+            px = 2 * cx - nx;
+            py = 2 * cy - ny;
+            pz = 2 * cz - nz;
+          } else if (isLastSegment) {
+            px = posView[posStart + (j - 1) * 3];
+            py = posView[posStart + (j - 1) * 3 + 1];
+            pz = posView[posStart + (j - 1) * 3 + 2];
+            // Mirror current over prev to get synthetic next.
+            nx = 2 * cx - px;
+            ny = 2 * cy - py;
+            nz = 2 * cz - pz;
+          } else {
+            px = posView[posStart + (j - 1) * 3];
+            py = posView[posStart + (j - 1) * 3 + 1];
+            pz = posView[posStart + (j - 1) * 3 + 2];
+            nx = posView[posStart + (j + 1) * 3];
+            ny = posView[posStart + (j + 1) * 3 + 1];
+            nz = posView[posStart + (j + 1) * 3 + 2];
+          }
+
+          if (!isLastSegment) {
+            indexArray[iOffset] = vOffset;
+            indexArray[iOffset + 1] = vOffset + 1;
+            indexArray[iOffset + 2] = vOffset + 2;
+            indexArray[iOffset + 3] = vOffset + 2;
+            indexArray[iOffset + 4] = vOffset + 1;
+            indexArray[iOffset + 5] = vOffset + 3;
+            iOffset += 6;
+          }
+
+          // Write each vertex twice for the quad.
+          for (let k = 0; k < 2; k++) {
+            posArray[vOffset * 3] = cx;
+            posArray[vOffset * 3 + 1] = cy;
+            posArray[vOffset * 3 + 2] = cz;
+
+            prevPosArray[vOffset * 3] = px;
+            prevPosArray[vOffset * 3 + 1] = py;
+            prevPosArray[vOffset * 3 + 2] = pz;
+
+            nextPosArray[vOffset * 3] = nx;
+            nextPosArray[vOffset * 3 + 1] = ny;
+            nextPosArray[vOffset * 3 + 2] = nz;
+
+            pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);
+            pickColorArray[vOffset * 4 + 1] = Color.floatToByte(
+              pickColor.green,
+            );
+            pickColorArray[vOffset * 4 + 2] = Color.floatToByte(pickColor.blue);
+            pickColorArray[vOffset * 4 + 3] = Color.floatToByte(
+              pickColor.alpha,
+            );
+
+            showColorWidthAndTexCoordArray[vOffset * 4] = show ? 1 : 0;
+            showColorWidthAndTexCoordArray[vOffset * 4 + 1] = encodedColor;
+            showColorWidthAndTexCoordArray[vOffset * 4 + 2] = material.width;
+            showColorWidthAndTexCoordArray[vOffset * 4 + 3] = j / (jl - 1);
+
+            vOffset++;
+          }
         }
+      } else {
+        const cartesianArray = polyline.getPositions();
 
-        collection._denormalizePosition(cartesian);
-        collection._denormalizePosition(prevCartesian);
-        collection._denormalizePosition(nextCartesian);
-        if (collection._positionNormalized) {
-          Matrix4.multiplyByPoint(collection.modelMatrix, cartesian, cartesian);
-          Matrix4.multiplyByPoint(
-            collection.modelMatrix,
-            prevCartesian,
-            prevCartesian,
-          );
-          Matrix4.multiplyByPoint(
-            collection.modelMatrix,
-            nextCartesian,
-            nextCartesian,
-          );
-        }
+        for (let j = 0; j < jl; j++) {
+          const isFirstSegment = j === 0;
+          const isLastSegment = j === jl - 1;
 
-        // For each segment, draw two triangles.
-        if (!isLastSegment) {
-          indexArray[iOffset] = vOffset;
-          indexArray[iOffset + 1] = vOffset + 1;
-          indexArray[iOffset + 2] = vOffset + 2;
+          // For first/last vertices, infer missing vertices by mirroring the segment.
+          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+          Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
+          if (isFirstSegment) {
+            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+            Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
+            Cartesian3.subtract(cartesian, nextCartesian, prevCartesian);
+            Cartesian3.add(cartesian, prevCartesian, prevCartesian);
+          } else if (isLastSegment) {
+            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+            Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
+            Cartesian3.subtract(cartesian, prevCartesian, nextCartesian);
+            Cartesian3.add(cartesian, nextCartesian, nextCartesian);
+          } else {
+            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+            Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
+            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+            Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
+          }
 
-          indexArray[iOffset + 3] = vOffset + 2;
-          indexArray[iOffset + 4] = vOffset + 1;
-          indexArray[iOffset + 5] = vOffset + 3;
+          // For each segment, draw two triangles.
+          if (!isLastSegment) {
+            indexArray[iOffset] = vOffset;
+            indexArray[iOffset + 1] = vOffset + 1;
+            indexArray[iOffset + 2] = vOffset + 2;
 
-          iOffset += 6;
-        }
+            indexArray[iOffset + 3] = vOffset + 2;
+            indexArray[iOffset + 4] = vOffset + 1;
+            indexArray[iOffset + 5] = vOffset + 3;
 
-        EncodedCartesian3.fromCartesian(cartesian, cartesianEnc);
-        EncodedCartesian3.fromCartesian(prevCartesian, prevCartesianEnc);
-        EncodedCartesian3.fromCartesian(nextCartesian, nextCartesianEnc);
+            iOffset += 6;
+          }
 
-        // TODO(donmccurdy): Diverging from PolylineCollection.js, which writes
-        // internal vertices to buffer 4x, not 2x. Not sure that's needed?
-        for (let k = 0; k < 2; k++) {
-          // Position.
-          positionHighArray[vOffset * 3] = cartesianEnc.high.x;
-          positionHighArray[vOffset * 3 + 1] = cartesianEnc.high.y;
-          positionHighArray[vOffset * 3 + 2] = cartesianEnc.high.z;
+          EncodedCartesian3.fromCartesian(cartesian, cartesianEnc);
+          EncodedCartesian3.fromCartesian(prevCartesian, prevCartesianEnc);
+          EncodedCartesian3.fromCartesian(nextCartesian, nextCartesianEnc);
 
-          positionLowArray[vOffset * 3] = cartesianEnc.low.x;
-          positionLowArray[vOffset * 3 + 1] = cartesianEnc.low.y;
-          positionLowArray[vOffset * 3 + 2] = cartesianEnc.low.z;
+          // TODO(donmccurdy): Diverging from PolylineCollection.js, which writes
+          // internal vertices to buffer 4x, not 2x. Not sure that's needed?
+          for (let k = 0; k < 2; k++) {
+            // Position.
+            attributeArrays.positionHigh[vOffset * 3] = cartesianEnc.high.x;
+            attributeArrays.positionHigh[vOffset * 3 + 1] = cartesianEnc.high.y;
+            attributeArrays.positionHigh[vOffset * 3 + 2] = cartesianEnc.high.z;
 
-          // Previous position.
-          prevPositionHighArray[vOffset * 3] = prevCartesianEnc.high.x;
-          prevPositionHighArray[vOffset * 3 + 1] = prevCartesianEnc.high.y;
-          prevPositionHighArray[vOffset * 3 + 2] = prevCartesianEnc.high.z;
+            attributeArrays.positionLow[vOffset * 3] = cartesianEnc.low.x;
+            attributeArrays.positionLow[vOffset * 3 + 1] = cartesianEnc.low.y;
+            attributeArrays.positionLow[vOffset * 3 + 2] = cartesianEnc.low.z;
 
-          prevPositionLowArray[vOffset * 3] = prevCartesianEnc.low.x;
-          prevPositionLowArray[vOffset * 3 + 1] = prevCartesianEnc.low.y;
-          prevPositionLowArray[vOffset * 3 + 2] = prevCartesianEnc.low.z;
+            // Previous position.
+            attributeArrays.prevPositionHigh[vOffset * 3] =
+              prevCartesianEnc.high.x;
+            attributeArrays.prevPositionHigh[vOffset * 3 + 1] =
+              prevCartesianEnc.high.y;
+            attributeArrays.prevPositionHigh[vOffset * 3 + 2] =
+              prevCartesianEnc.high.z;
 
-          // Next position.
-          nextPositionHighArray[vOffset * 3] = nextCartesianEnc.high.x;
-          nextPositionHighArray[vOffset * 3 + 1] = nextCartesianEnc.high.y;
-          nextPositionHighArray[vOffset * 3 + 2] = nextCartesianEnc.high.z;
+            attributeArrays.prevPositionLow[vOffset * 3] =
+              prevCartesianEnc.low.x;
+            attributeArrays.prevPositionLow[vOffset * 3 + 1] =
+              prevCartesianEnc.low.y;
+            attributeArrays.prevPositionLow[vOffset * 3 + 2] =
+              prevCartesianEnc.low.z;
 
-          nextPositionLowArray[vOffset * 3] = nextCartesianEnc.low.x;
-          nextPositionLowArray[vOffset * 3 + 1] = nextCartesianEnc.low.y;
-          nextPositionLowArray[vOffset * 3 + 2] = nextCartesianEnc.low.z;
+            // Next position.
+            attributeArrays.nextPositionHigh[vOffset * 3] =
+              nextCartesianEnc.high.x;
+            attributeArrays.nextPositionHigh[vOffset * 3 + 1] =
+              nextCartesianEnc.high.y;
+            attributeArrays.nextPositionHigh[vOffset * 3 + 2] =
+              nextCartesianEnc.high.z;
 
-          // Pick ID.
-          pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);
-          pickColorArray[vOffset * 4 + 1] = Color.floatToByte(pickColor.green);
-          pickColorArray[vOffset * 4 + 2] = Color.floatToByte(pickColor.blue);
-          pickColorArray[vOffset * 4 + 3] = Color.floatToByte(pickColor.alpha);
+            attributeArrays.nextPositionLow[vOffset * 3] =
+              nextCartesianEnc.low.x;
+            attributeArrays.nextPositionLow[vOffset * 3 + 1] =
+              nextCartesianEnc.low.y;
+            attributeArrays.nextPositionLow[vOffset * 3 + 2] =
+              nextCartesianEnc.low.z;
 
-          // Properties.
-          showColorWidthAndTexCoordArray[vOffset * 4] = show ? 1 : 0;
-          showColorWidthAndTexCoordArray[vOffset * 4 + 1] = encodedColor;
-          showColorWidthAndTexCoordArray[vOffset * 4 + 2] = material.width;
-          showColorWidthAndTexCoordArray[vOffset * 4 + 3] = j / (jl - 1); // texcoord.s
+            // Pick ID.
+            pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);
+            pickColorArray[vOffset * 4 + 1] = Color.floatToByte(
+              pickColor.green,
+            );
+            pickColorArray[vOffset * 4 + 2] = Color.floatToByte(pickColor.blue);
+            pickColorArray[vOffset * 4 + 3] = Color.floatToByte(
+              pickColor.alpha,
+            );
 
-          vOffset++;
+            // Properties.
+            showColorWidthAndTexCoordArray[vOffset * 4] = show ? 1 : 0;
+            showColorWidthAndTexCoordArray[vOffset * 4 + 1] = encodedColor;
+            showColorWidthAndTexCoordArray[vOffset * 4 + 2] = material.width;
+            showColorWidthAndTexCoordArray[vOffset * 4 + 3] = j / (jl - 1); // texcoord.s
+
+            vOffset++;
+          }
         }
       }
 
@@ -265,6 +378,9 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
 
   if (!defined(renderContext.vertexArray)) {
     const attributeArrays = renderContext.attributeArrays;
+    const locations = useQuantized
+      ? BufferPolylineQuantizedAttributeLocations
+      : BufferPolylineAttributeLocations;
 
     renderContext.vertexArray = new VertexArray({
       context,
@@ -278,70 +394,106 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       }),
 
       attributes: [
+        ...(useQuantized
+          ? [
+              {
+                index: BufferPolylineQuantizedAttributeLocations.position,
+                componentDatatype: collection._positionDatatype,
+                componentsPerAttribute: 3,
+                normalize: true,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.position,
+                  context,
+                  usage: BufferUsage.DYNAMIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolylineQuantizedAttributeLocations.prevPosition,
+                componentDatatype: collection._positionDatatype,
+                componentsPerAttribute: 3,
+                normalize: true,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.prevPosition,
+                  context,
+                  usage: BufferUsage.DYNAMIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolylineQuantizedAttributeLocations.nextPosition,
+                componentDatatype: collection._positionDatatype,
+                componentsPerAttribute: 3,
+                normalize: true,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.nextPosition,
+                  context,
+                  usage: BufferUsage.DYNAMIC_DRAW,
+                }),
+              },
+            ]
+          : [
+              {
+                index: BufferPolylineAttributeLocations.positionHigh,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.positionHigh,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolylineAttributeLocations.positionLow,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.positionLow,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolylineAttributeLocations.prevPositionHigh,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.prevPositionHigh,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolylineAttributeLocations.prevPositionLow,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.prevPositionLow,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolylineAttributeLocations.nextPositionHigh,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.nextPositionHigh,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+              {
+                index: BufferPolylineAttributeLocations.nextPositionLow,
+                componentDatatype: ComponentDatatype.FLOAT,
+                componentsPerAttribute: 3,
+                vertexBuffer: Buffer.createVertexBuffer({
+                  typedArray: attributeArrays.nextPositionLow,
+                  context,
+                  usage: BufferUsage.STATIC_DRAW,
+                }),
+              },
+            ]),
         {
-          index: BufferPolylineAttributeLocations.positionHigh,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.positionHigh,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPolylineAttributeLocations.positionLow,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.positionLow,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-
-        {
-          index: BufferPolylineAttributeLocations.prevPositionHigh,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.prevPositionHigh,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPolylineAttributeLocations.prevPositionLow,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.prevPositionLow,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-
-        {
-          index: BufferPolylineAttributeLocations.nextPositionHigh,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.nextPositionHigh,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPolylineAttributeLocations.nextPositionLow,
-          componentDatatype: ComponentDatatype.FLOAT,
-          componentsPerAttribute: 3,
-          vertexBuffer: Buffer.createVertexBuffer({
-            typedArray: attributeArrays.nextPositionLow,
-            context,
-            usage: BufferUsage.STATIC_DRAW,
-          }),
-        },
-        {
-          index: BufferPolylineAttributeLocations.pickColor,
+          index: locations.pickColor,
           componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
           componentsPerAttribute: 4,
           vertexBuffer: Buffer.createVertexBuffer({
@@ -351,7 +503,7 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
           }),
         },
         {
-          index: BufferPolylineAttributeLocations.showColorWidthAndTexCoord,
+          index: locations.showColorWidthAndTexCoord,
           componentDatatype: ComponentDatatype.FLOAT,
           componentsPerAttribute: 4,
           vertexBuffer: Buffer.createVertexBuffer({
@@ -372,15 +524,34 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       indexCount,
     );
 
-    for (const key in BufferPolylineAttributeLocations) {
-      if (Object.hasOwn(BufferPolylineAttributeLocations, key)) {
-        const attribute = /** @type {BufferPolylineAttribute} */ (key);
+    if (useQuantized) {
+      // Use sequential array indices (0,1,2,3,4), NOT shader location values.
+      const quantizedAttrs = [
+        "position",
+        "prevPosition",
+        "nextPosition",
+        "pickColor",
+        "showColorWidthAndTexCoord",
+      ];
+      for (let ai = 0; ai < quantizedAttrs.length; ai++) {
         renderContext.vertexArray.copyAttributeFromRange(
-          BufferPolylineAttributeLocations[attribute],
-          renderContext.attributeArrays[attribute],
+          ai,
+          renderContext.attributeArrays[quantizedAttrs[ai]],
           vertexOffset,
           vertexCount,
         );
+      }
+    } else {
+      for (const key in BufferPolylineAttributeLocations) {
+        if (Object.hasOwn(BufferPolylineAttributeLocations, key)) {
+          const attribute = /** @type {BufferPolylineAttribute} */ (key);
+          renderContext.vertexArray.copyAttributeFromRange(
+            BufferPolylineAttributeLocations[attribute],
+            renderContext.attributeArrays[attribute],
+            vertexOffset,
+            vertexCount,
+          );
+        }
       }
     }
   }
@@ -397,11 +568,14 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       context,
       vertexShaderSource: new ShaderSource({
         sources: [PolylineCommon, BufferPolylineMaterialVS],
+        defines: useQuantized ? ["QUANTIZED_POSITIONS"] : [],
       }),
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolylineMaterialFS],
       }),
-      attributeLocations: BufferPolylineAttributeLocations,
+      attributeLocations: useQuantized
+        ? BufferPolylineQuantizedAttributeLocations
+        : BufferPolylineAttributeLocations,
     });
   }
 
@@ -417,7 +591,7 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: drawCount,
-      modelMatrix: collection._commandModelMatrix,
+      modelMatrix: collection.modelMatrix,
       boundingVolume: collection.boundingVolumeWC, // shared reference
       debugShowBoundingVolume: collection.debugShowBoundingVolume,
     });

--- a/packages/engine/Source/Shaders/BufferPointMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPointMaterialVS.glsl
@@ -1,5 +1,9 @@
+#ifdef QUANTIZED_POSITIONS
+in vec3 position;
+#else
 in vec3 positionHigh;
 in vec3 positionLow;
+#endif
 in vec4 pickColor;
 in vec3 showPixelSizeAndColor;
 in vec2 outlineWidthAndOutlineColor;
@@ -25,8 +29,13 @@ void main()
 
     ///////////////////////////////////////////////////////////////////////////
 
+#ifdef QUANTIZED_POSITIONS
+    // Normalized integer positions are hardware-decoded to [-1, 1] by the attribute pipeline.
+    vec4 positionEC = czm_modelView * vec4(position, 1.0);
+#else
     vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);
     vec4 positionEC = czm_modelViewRelativeToEye * p;
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
 

--- a/packages/engine/Source/Shaders/BufferPointMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPointMaterialVS.glsl
@@ -1,8 +1,8 @@
-#ifdef LOCAL_POSITION
-in vec3 position;
-#else
+#ifdef USE_FLOAT64
 in vec3 positionHigh;
 in vec3 positionLow;
+#else
+in vec3 position;
 #endif
 in vec4 pickColor;
 in vec3 showPixelSizeAndColor;
@@ -29,12 +29,11 @@ void main()
 
     ///////////////////////////////////////////////////////////////////////////
 
-#ifdef LOCAL_POSITION
-    // Positions are in local space; czm_modelView transforms to eye space.
-    vec4 positionEC = czm_modelView * vec4(position, 1.0);
-#else
+#ifdef USE_FLOAT64
     vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);
     vec4 positionEC = czm_modelViewRelativeToEye * p;
+#else
+    vec4 positionEC = czm_modelView * vec4(position, 1.0);
 #endif
 
     ///////////////////////////////////////////////////////////////////////////

--- a/packages/engine/Source/Shaders/BufferPointMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPointMaterialVS.glsl
@@ -1,4 +1,4 @@
-#ifdef QUANTIZED_POSITIONS
+#ifdef LOCAL_POSITION
 in vec3 position;
 #else
 in vec3 positionHigh;
@@ -29,8 +29,8 @@ void main()
 
     ///////////////////////////////////////////////////////////////////////////
 
-#ifdef QUANTIZED_POSITIONS
-    // Normalized integer positions are hardware-decoded to [-1, 1] by the attribute pipeline.
+#ifdef LOCAL_POSITION
+    // Positions are in local space; czm_modelView transforms to eye space.
     vec4 positionEC = czm_modelView * vec4(position, 1.0);
 #else
     vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);

--- a/packages/engine/Source/Shaders/BufferPolygonMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolygonMaterialVS.glsl
@@ -1,4 +1,4 @@
-#ifdef QUANTIZED_POSITIONS
+#ifdef LOCAL_POSITION
 in vec3 position;
 #else
 in vec3 positionHigh;
@@ -17,8 +17,8 @@ void main()
 
     ///////////////////////////////////////////////////////////////////////////
 
-#ifdef QUANTIZED_POSITIONS
-    // Normalized integer positions are hardware-decoded to [-1, 1] by the attribute pipeline.
+#ifdef LOCAL_POSITION
+    // Positions are in local space; czm_modelView transforms to eye space.
     vec4 positionEC = czm_modelView * vec4(position, 1.0);
 #else
     vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);

--- a/packages/engine/Source/Shaders/BufferPolygonMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolygonMaterialVS.glsl
@@ -1,5 +1,9 @@
+#ifdef QUANTIZED_POSITIONS
+in vec3 position;
+#else
 in vec3 positionHigh;
 in vec3 positionLow;
+#endif
 in vec4 pickColor;
 in vec2 showAndColor;
 
@@ -13,8 +17,13 @@ void main()
 
     ///////////////////////////////////////////////////////////////////////////
 
+#ifdef QUANTIZED_POSITIONS
+    // Normalized integer positions are hardware-decoded to [-1, 1] by the attribute pipeline.
+    vec4 positionEC = czm_modelView * vec4(position, 1.0);
+#else
     vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);
     vec4 positionEC = czm_modelViewRelativeToEye * p;
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
 

--- a/packages/engine/Source/Shaders/BufferPolygonMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolygonMaterialVS.glsl
@@ -1,8 +1,8 @@
-#ifdef LOCAL_POSITION
-in vec3 position;
-#else
+#ifdef USE_FLOAT64
 in vec3 positionHigh;
 in vec3 positionLow;
+#else
+in vec3 position;
 #endif
 in vec4 pickColor;
 in vec2 showAndColor;
@@ -17,12 +17,11 @@ void main()
 
     ///////////////////////////////////////////////////////////////////////////
 
-#ifdef LOCAL_POSITION
-    // Positions are in local space; czm_modelView transforms to eye space.
-    vec4 positionEC = czm_modelView * vec4(position, 1.0);
-#else
+#ifdef USE_FLOAT64
     vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);
     vec4 positionEC = czm_modelViewRelativeToEye * p;
+#else
+    vec4 positionEC = czm_modelView * vec4(position, 1.0);
 #endif
 
     ///////////////////////////////////////////////////////////////////////////

--- a/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
@@ -1,4 +1,4 @@
-#ifdef QUANTIZED_POSITIONS
+#ifdef LOCAL_POSITION
 in vec3 position;
 in vec3 prevPosition;
 in vec3 nextPosition;
@@ -32,8 +32,8 @@ void main()
     float expandDir = gl_VertexID % 2 == 1 ? 1.0 : -1.0;
     float polylineAngle;
 
-#ifdef QUANTIZED_POSITIONS
-    // Normalized integer positions are hardware-decoded to [-1, 1] by the attribute pipeline.
+#ifdef LOCAL_POSITION
+    // Positions are in local space; czm_modelView transforms to eye space.
     vec4 positionEC = czm_modelView * vec4(position, 1.0);
     vec4 prevPositionEC = czm_modelView * vec4(prevPosition, 1.0);
     vec4 nextPositionEC = czm_modelView * vec4(nextPosition, 1.0);

--- a/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
@@ -1,9 +1,15 @@
+#ifdef QUANTIZED_POSITIONS
+in vec3 position;
+in vec3 prevPosition;
+in vec3 nextPosition;
+#else
 in vec3 positionHigh;
 in vec3 positionLow;
 in vec3 prevPositionHigh;
 in vec3 prevPositionLow;
 in vec3 nextPositionHigh;
 in vec3 nextPositionLow;
+#endif
 in vec4 pickColor;
 in vec4 showColorWidthAndTexCoord;
 
@@ -26,11 +32,19 @@ void main()
     float expandDir = gl_VertexID % 2 == 1 ? 1.0 : -1.0;
     float polylineAngle;
 
+#ifdef QUANTIZED_POSITIONS
+    // Normalized integer positions are hardware-decoded to [-1, 1] by the attribute pipeline.
+    vec4 positionEC = czm_modelView * vec4(position, 1.0);
+    vec4 prevPositionEC = czm_modelView * vec4(prevPosition, 1.0);
+    vec4 nextPositionEC = czm_modelView * vec4(nextPosition, 1.0);
+    // Positions are already in eye space; use the EC variant to skip the redundant transform.
+    vec4 positionWC = getPolylineWindowCoordinatesEC(positionEC, prevPositionEC, nextPositionEC, expandDir, width, usePrevious, polylineAngle);
+#else
     vec4 positionEC = czm_translateRelativeToEye(positionHigh, positionLow);
     vec4 prevPositionEC = czm_translateRelativeToEye(prevPositionHigh, prevPositionLow);
     vec4 nextPositionEC = czm_translateRelativeToEye(nextPositionHigh, nextPositionLow);
-
     vec4 positionWC = getPolylineWindowCoordinates(positionEC, prevPositionEC, nextPositionEC, expandDir, width, usePrevious, polylineAngle);
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
 

--- a/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
@@ -1,14 +1,14 @@
-#ifdef LOCAL_POSITION
-in vec3 position;
-in vec3 prevPosition;
-in vec3 nextPosition;
-#else
+#ifdef USE_FLOAT64
 in vec3 positionHigh;
 in vec3 positionLow;
 in vec3 prevPositionHigh;
 in vec3 prevPositionLow;
 in vec3 nextPositionHigh;
 in vec3 nextPositionLow;
+#else
+in vec3 position;
+in vec3 prevPosition;
+in vec3 nextPosition;
 #endif
 in vec4 pickColor;
 in vec4 showColorWidthAndTexCoord;
@@ -32,18 +32,17 @@ void main()
     float expandDir = gl_VertexID % 2 == 1 ? 1.0 : -1.0;
     float polylineAngle;
 
-#ifdef LOCAL_POSITION
-    // Positions are in local space; czm_modelView transforms to eye space.
+#ifdef USE_FLOAT64
+    vec4 positionEC = czm_translateRelativeToEye(positionHigh, positionLow);
+    vec4 prevPositionEC = czm_translateRelativeToEye(prevPositionHigh, prevPositionLow);
+    vec4 nextPositionEC = czm_translateRelativeToEye(nextPositionHigh, nextPositionLow);
+    vec4 positionWC = getPolylineWindowCoordinates(positionEC, prevPositionEC, nextPositionEC, expandDir, width, usePrevious, polylineAngle);
+#else
     vec4 positionEC = czm_modelView * vec4(position, 1.0);
     vec4 prevPositionEC = czm_modelView * vec4(prevPosition, 1.0);
     vec4 nextPositionEC = czm_modelView * vec4(nextPosition, 1.0);
     // Positions are already in eye space; use the EC variant to skip the redundant transform.
     vec4 positionWC = getPolylineWindowCoordinatesEC(positionEC, prevPositionEC, nextPositionEC, expandDir, width, usePrevious, polylineAngle);
-#else
-    vec4 positionEC = czm_translateRelativeToEye(positionHigh, positionLow);
-    vec4 prevPositionEC = czm_translateRelativeToEye(prevPositionHigh, prevPositionLow);
-    vec4 nextPositionEC = czm_translateRelativeToEye(nextPositionHigh, nextPositionLow);
-    vec4 positionWC = getPolylineWindowCoordinates(positionEC, prevPositionEC, nextPositionEC, expandDir, width, usePrevious, polylineAngle);
 #endif
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Extends the `positionNormalized` API introduced in #13462 by moving position
dequantization entirely to the GPU, eliminating per-frame CPU work.

Previously, when `positionNormalized: true` was set, the CPU decoded each
int16 position to a float64 Cartesian3, applied `modelMatrix`, then
re-encoded to high/low float32 pairs before upload. This PR replaces that
path by keeping integer data in the vertex buffer and relying on WebGL's
built-in `normalize` attribute flag to decode to `[-1, 1]` on the GPU.

## Changes

- **Shaders** (`Buffer{Point,Polyline,Polygon}MaterialVS.glsl`): added
  `#ifdef QUANTIZED_POSITIONS` path using `czm_modelView * vec4(position, 1.0)`
  in place of the RTE `positionHigh`/`positionLow` path.
- **Renderers** (`renderBuffer{Point,Polyline,Polygon}Collection.js`): added
  `useQuantized` branch that reads `_positionView` (int16) directly and writes
  to typed attribute arrays; vertex buffers are created with `normalize: true`.
- **BufferPrimitiveCollection**: removed `_denormalizePosition()` and
  `_commandModelMatrix` (CPU-era artifacts); all draw commands now pass
  `collection.modelMatrix` directly.
<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link
https://github.com/CesiumGS/cesium/pull/13462
https://github.com/CesiumGS/cesium/issues/13444
<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
