### PR TITLE
Compute Gaussian splat 3D tile geometry byte length

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Fixed a bug causing `BufferPointCollection` to not update after changes to point positions. [#13465](https://github.com/CesiumGS/cesium/pull/13465)
+- Fixed Gaussian splat 3D tile `geometryByteLength` reporting zero by estimating unique glTF attribute and cached splat buffer byte lengths. [#13483](https://github.com/CesiumGS/cesium/pull/13483)
 
 ## 1.141 - 2026-05-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -448,3 +448,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jonathan Sullivan](https://github.com/jplusequalt)
 - [Chalabi](https://github.com/chalabi2)
 - [Michal Mitter](https://github.com/mittermichal)
+- [William Liu](https://github.com/WilliamLiu-1997)

--- a/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
+++ b/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
@@ -11,6 +11,36 @@ import deprecationWarning from "../Core/deprecationWarning.js";
 
 /** @import Cesium3DTileContent from "./Cesium3DTileContent.js"; */
 
+function addUniqueBufferByteLength(bufferSet, typedArray) {
+  if (!defined(typedArray) || !defined(typedArray.buffer)) {
+    return 0;
+  }
+
+  const buffer = typedArray.buffer;
+  if (bufferSet.has(buffer)) {
+    return 0;
+  }
+
+  bufferSet.add(buffer);
+  return buffer.byteLength;
+}
+
+function getGltfPrimitiveAttributesByteLength(gltfPrimitive, bufferSet) {
+  if (!defined(gltfPrimitive) || !defined(gltfPrimitive.attributes)) {
+    return 0;
+  }
+
+  let byteLength = 0;
+  const attributes = gltfPrimitive.attributes;
+  for (let i = 0; i < attributes.length; i++) {
+    byteLength += addUniqueBufferByteLength(
+      bufferSet,
+      attributes[i].typedArray,
+    );
+  }
+  return byteLength;
+}
+
 /**
  * Represents the contents of a glTF or glb using the {@link https://github.com/CesiumGS/glTF/tree/draft-splat-spz/extensions/2.0/Khronos/KHR_gaussian_splatting | KHR_gaussian_splatting} and {@link https://github.com/CesiumGS/glTF/tree/draft-splat-spz/extensions/2.0/Khronos/KHR_gaussian_splatting_compression_spz_2 | KHR_gaussian_splatting_compression_spz_2} extensions.
  * <p>
@@ -196,7 +226,19 @@ class GaussianSplat3DTileContent {
    * @readonly
    */
   get geometryByteLength() {
-    return 0;
+    const bufferSet = new Set();
+    let byteLength = getGltfPrimitiveAttributesByteLength(
+      this.gltfPrimitive,
+      bufferSet,
+    );
+    byteLength += addUniqueBufferByteLength(bufferSet, this._positions);
+    byteLength += addUniqueBufferByteLength(bufferSet, this._rotations);
+    byteLength += addUniqueBufferByteLength(bufferSet, this._scales);
+    byteLength += addUniqueBufferByteLength(
+      bufferSet,
+      this._packedSphericalHarmonicsData,
+    );
+    return byteLength;
   }
 
   /**

--- a/packages/engine/Specs/Scene/GaussianSplat3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/GaussianSplat3DTileContentSpec.js
@@ -228,7 +228,7 @@ describe(
       expect(sourceScales[0]).toBe(originalScale);
     });
 
-    it("geometryByteLength returns 0 and is never NaN", async function () {
+    it("geometryByteLength estimates cached splat buffers and is never NaN", async function () {
       const tileset = await Cesium3DTilesTester.loadTileset(
         scene,
         tilesetUrl,
@@ -244,8 +244,29 @@ describe(
       );
       const content = tile.content;
 
-      expect(content.geometryByteLength).toBe(0);
-      expect(isNaN(content.geometryByteLength)).toBe(false);
+      const typedArrays = content.gltfPrimitive.attributes.map(
+        (attribute) => attribute.typedArray,
+      );
+      typedArrays.push(
+        content.positions,
+        content.rotations,
+        content.scales,
+        content.packedSphericalHarmonicsData,
+      );
+
+      const buffers = new Set(
+        typedArrays
+          .filter((typedArray) => typedArray !== undefined)
+          .map((typedArray) => typedArray.buffer),
+      );
+      let expectedByteLength = 0;
+      buffers.forEach((buffer) => {
+        expectedByteLength += buffer.byteLength;
+      });
+
+      expect(content.geometryByteLength).toBe(expectedByteLength);
+      expect(content.geometryByteLength).toBeGreaterThan(0);
+      expect(Number.isNaN(content.geometryByteLength)).toBe(false);
     });
 
     it("texturesByteLength returns 0 when gaussianSplatPrimitive is undefined", async function () {


### PR DESCRIPTION
Count unique underlying buffers for glTF primitive attributes and cached splat data so geometryByteLength returns a non-zero estimate.

<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

GaussianSplat3DTileContent.geometryByteLength previously always returned 0, so Gaussian splat tile memory was not reflected in Cesium3DTileset.totalMemoryUsageInBytes. For large Gaussian splat tilesets, this prevented the existing cache and memory pressure logic from seeing the actual loaded buffer usage, which could allow memory to grow until the browser crashed.

This change estimates geometry memory by summing the unique underlying ArrayBuffers used by the glTF primitive attributes and cached splat data, including transformed positions, rotations, scales, and packed spherical harmonics data. The spec now verifies that geometryByteLength reports a non-zero value and does not double-count shared buffers.


## Issue number and link

https://github.com/CesiumGS/cesium/issues/13483

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

When loading very large Gaussian Splat Tileset, it will not crash anymore, and totalMemoryUsageInBytes will show correct memoryusage now(it was seriously under estimated previously)

## Author checklist

- [ *] I have submitted a Contributor License Agreement
- [* ] I have added my name to `CONTRIBUTORS.md`
- [* ] I have updated `CHANGES.md` with a short summary of my change
- [* ] I have added or updated unit tests to ensure consistent code coverage
- [* ] I have updated the inline documentation, and included code examples where relevant
- [ *] I have performed a self-review of my code

## AI acknowledgment

- [* ] I used AI to generate content in this PR
- [* ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

ChatGPT

If yes, I used the following Model(s):

GPT-5.5 Extra-High
