### PR TITLE
Guard against undefined rectangle in BillboardTexture.loadImage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
 
 - Fixed a bug causing `BufferPointCollection` to not update after changes to point positions. [#13465](https://github.com/CesiumGS/cesium/pull/13465)
 
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixed an unhandled `TypeError` in `BillboardTexture.loadImage` when `TextureAtlas.addImage` resolved with an index whose rectangle slot was still undefined (e.g. after an atlas resize). The billboard texture now transitions to `FAILED` instead of crashing. [#13486](https://github.com/CesiumGS/cesium/issues/13486) [#13487](https://github.com/CesiumGS/cesium/pull/13487)
+
 ## 1.141 - 2026-05-01
 
 ### cesium

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -448,3 +448,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jonathan Sullivan](https://github.com/jplusequalt)
 - [Chalabi](https://github.com/chalabi2)
 - [Michal Mitter](https://github.com/mittermichal)
+- [Daniel Smith](https://github.com/dannydjrs)

--- a/packages/engine/Source/Scene/BillboardTexture.js
+++ b/packages/engine/Source/Scene/BillboardTexture.js
@@ -238,6 +238,24 @@ BillboardTexture.prototype.loadImage = async function (
   billboardTexture._loadState = BillboardLoadState.LOADED;
 
   const rectangle = atlas.rectangles[index];
+  if (!defined(rectangle)) {
+    // The atlas resolved an index but the corresponding rectangle was never
+    // populated (e.g. a queue resize left this slot empty, or the atlas was
+    // recreated between resize and copy). Treat as FAILED rather than
+    // crashing on `rectangle.width`.
+    billboardTexture._loadState = BillboardLoadState.FAILED;
+    billboardTexture._index = -1;
+
+    if (this._id !== id) {
+      // Another load was initiated and resolved before this one. This operation is cancelled.
+      return;
+    }
+
+    this._loadState = BillboardLoadState.FAILED;
+    this._index = -1;
+    return;
+  }
+
   billboardTexture._width = rectangle.width;
   billboardTexture._height = rectangle.height;
 

--- a/packages/engine/Specs/Scene/BillboardTextureSpec.js
+++ b/packages/engine/Specs/Scene/BillboardTextureSpec.js
@@ -1,0 +1,54 @@
+import BillboardTexture from "../../Source/Scene/BillboardTexture.js";
+import BillboardLoadState from "../../Source/Scene/BillboardLoadState.js";
+
+describe("Scene/BillboardTexture", function () {
+  function createMockCollection(atlas) {
+    return {
+      textureAtlas: atlas,
+      billboardTextureCache: new Map(),
+    };
+  }
+
+  it("transitions to FAILED when atlas.addImage resolves to an undefined rectangle", async function () {
+    // Reproduces the crash described at
+    // https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Scene/BillboardTexture.js
+    // where `atlas.addImage` resolves to an index whose rectangle slot is
+    // still unset (e.g. an atlas resize left this slot empty). The previous
+    // behavior dereferenced `rectangle.width` and threw an unhandled
+    // TypeError; the texture should now transition to FAILED instead.
+    const index = 3;
+    const atlas = {
+      rectangles: [], // rectangles[index] is undefined
+      addImage: function () {
+        return Promise.resolve(index);
+      },
+    };
+    const texture = new BillboardTexture(createMockCollection(atlas));
+
+    await expectAsync(
+      texture.loadImage("test-id", new Image(), undefined, undefined),
+    ).toBeResolved();
+
+    expect(texture.loadState).toEqual(BillboardLoadState.FAILED);
+    expect(texture._index).toEqual(-1);
+    expect(texture.ready).toBe(false);
+  });
+
+  it("loads successfully when the rectangle is populated", async function () {
+    const index = 0;
+    const atlas = {
+      rectangles: [{ width: 32, height: 48 }],
+      addImage: function () {
+        return Promise.resolve(index);
+      },
+    };
+    const texture = new BillboardTexture(createMockCollection(atlas));
+
+    await texture.loadImage("ok-id", new Image(), undefined, undefined);
+
+    expect(texture.loadState).toEqual(BillboardLoadState.LOADED);
+    expect(texture.width).toEqual(32);
+    expect(texture.height).toEqual(48);
+    expect(texture.ready).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

`BillboardTexture.loadImage` reads `atlas.rectangles[index].width` after
awaiting `TextureAtlas.addImage`. In some interleavings — most reliably
when the atlas resizes during the frame the image was queued — that slot
can still be `undefined`, and the access escapes as an unhandled rejection:

    Uncaught (in promise) TypeError: Cannot read properties of undefined
    (reading 'width')
        at BillboardTexture.loadImage

This shows up in apps that add/remove billboards rapidly (we hit it
through ol-cesium's `FeatureConverter.csAddBillboard` on a timer-driven
re-render loop).

This change guards the rectangle access and, when it's missing, marks the
texture as `FAILED` — matching the existing pattern in the same method
for `!defined(index) || index === -1`.

## Issue number and link

https://github.com/CesiumGS/cesium/issues/13486

## Testing plan

Added a regression spec covering the case where `TextureAtlas.addImage`
resolves with an index whose rectangle is undefined. The spec asserts the
texture transitions to `BillboardLoadState.FAILED` and `loadImage` does
not reject.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

- Claude

If yes, I used the following Model(s):

- Opus 4.7
