### PR TITLE
3dgs spz worker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
 
 - Fixed a bug causing `BufferPointCollection` to not update after changes to point positions. [#13465](https://github.com/CesiumGS/cesium/pull/13465)
 
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Improved Gaussian splat SPZ tile loading responsiveness by moving SPZ decoding and spherical harmonics packing to a web worker.
+
 ## 1.141 - 2026-05-01
 
 ### cesium

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -448,3 +448,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jonathan Sullivan](https://github.com/jplusequalt)
 - [Chalabi](https://github.com/chalabi2)
 - [Michal Mitter](https://github.com/mittermichal)
+- [William Liu](https://github.com/WilliamLiu-1997)

--- a/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
+++ b/packages/engine/Source/Scene/GaussianSplat3DTileContent.js
@@ -500,13 +500,16 @@ class GaussianSplat3DTileContent {
         VertexAttributeSemantic.SCALE,
       ).typedArray.slice();
 
-      const { l, n } = degreeAndCoefFromAttributes(
-        this.gltfPrimitive.attributes,
-      );
-      this._sphericalHarmonicsDegree = l;
-      this._sphericalHarmonicsCoefficientCount = n;
-
-      this._packedSphericalHarmonicsData = packSphericalHarmonicsData(this);
+      const packedSphericalHarmonicsAttribute =
+        getPackedSphericalHarmonicsAttribute(this.gltfPrimitive.attributes);
+      if (defined(packedSphericalHarmonicsAttribute)) {
+        this._sphericalHarmonicsDegree =
+          packedSphericalHarmonicsAttribute.sphericalHarmonicsDegree;
+        this._sphericalHarmonicsCoefficientCount =
+          packedSphericalHarmonicsAttribute.sphericalHarmonicsCoefficientCount;
+        this._packedSphericalHarmonicsData =
+          packedSphericalHarmonicsAttribute.packedSphericalHarmonicsData;
+      }
 
       return;
     }
@@ -630,149 +633,15 @@ class GaussianSplat3DTileContent {
   }
 }
 
-function getShAttributePrefix(attribute) {
-  const prefix = attribute.startsWith("KHR_gaussian_splatting:")
-    ? "KHR_gaussian_splatting:"
-    : "_";
-  return `${prefix}SH_DEGREE_`;
-}
-
-/**
- * Determine Spherical Harmonics degree and coefficient count from attributes
- * @param {Attribute[]} attributes - The list of glTF attributes.
- * @returns {object} An object containing the degree (l) and coefficient (n).
- * @private
- */
-function degreeAndCoefFromAttributes(attributes) {
-  const shAttributes = attributes.filter((attr) =>
-    attr.name.includes("SH_DEGREE_"),
-  );
-
-  switch (shAttributes.length) {
-    default:
-    case 0:
-      return { l: 0, n: 0 };
-    case 3:
-      return { l: 1, n: 9 };
-    case 8:
-      return { l: 2, n: 24 };
-    case 15:
-      return { l: 3, n: 45 };
-  }
-}
-
-/**
- * Converts a 32-bit floating point number to a 16-bit floating point number.
- * @param {number} float32 input
- * @returns {number} Half precision float
- * @private
- */
-const buffer = new ArrayBuffer(4);
-const floatView = new Float32Array(buffer);
-const intView = new Uint32Array(buffer);
-
-function float32ToFloat16(float32) {
-  floatView[0] = float32;
-  const bits = intView[0];
-
-  const sign = (bits >> 31) & 0x1;
-  const exponent = (bits >> 23) & 0xff;
-  const mantissa = bits & 0x7fffff;
-
-  let half;
-
-  if (exponent === 0xff) {
-    half = (sign << 15) | (0x1f << 10) | (mantissa ? 0x200 : 0);
-  } else if (exponent === 0) {
-    half = sign << 15;
-  } else {
-    const newExponent = exponent - 127 + 15;
-    if (newExponent >= 31) {
-      half = (sign << 15) | (0x1f << 10);
-    } else if (newExponent <= 0) {
-      half = sign << 15;
-    } else {
-      half = (sign << 15) | (newExponent << 10) | (mantissa >>> 13);
+function getPackedSphericalHarmonicsAttribute(attributes) {
+  for (let i = 0; i < attributes.length; i++) {
+    const attribute = attributes[i];
+    if (defined(attribute.packedSphericalHarmonicsData)) {
+      return attribute;
     }
   }
 
-  return half;
-}
-
-/**
- * Extracts the spherical harmonic degree and coefficient from the attribute name.
- * @param {string} attribute - The attribute name.
- * @returns {object} An object containing the degree (l) and coefficient (n).
- * @private
- */
-function extractSHDegreeAndCoef(attribute) {
-  const prefix = getShAttributePrefix(attribute);
-  const separator = "_COEF_";
-
-  const lStart = prefix.length;
-  const coefIndex = attribute.indexOf(separator, lStart);
-
-  const l = parseInt(attribute.slice(lStart, coefIndex), 10);
-  const n = parseInt(attribute.slice(coefIndex + separator.length), 10);
-
-  return { l, n };
-}
-
-/**
- * Packs spherical harmonic data into half-precision floats.
- * @param {GaussianSplat3DTileContent} tileContent - The tile content containing the spherical harmonic data.
- * @returns {Uint32Array} - The Float16 packed spherical harmonic data.
- * @private
- */
-function packSphericalHarmonicsData(tileContent) {
-  const degree = tileContent.sphericalHarmonicsDegree;
-  const coefs = tileContent.sphericalHarmonicsCoefficientCount;
-  const totalLength = tileContent.pointsLength * (coefs * (2 / 3)); //3 packs into 2
-  const packedData = new Uint32Array(totalLength);
-
-  const shAttributes = tileContent.gltfPrimitive.attributes.filter((attr) =>
-    attr.name.includes("SH_DEGREE_"),
-  );
-  let stride = 0;
-  const base = [0, 9, 24];
-  switch (degree) {
-    case 1:
-      stride = 9;
-      break;
-    case 2:
-      stride = 24;
-      break;
-    case 3:
-      stride = 45;
-      break;
-  }
-  shAttributes.sort((a, b) => {
-    if (a.name < b.name) {
-      return -1;
-    }
-    if (a.name > b.name) {
-      return 1;
-    }
-
-    return 0;
-  });
-  const packedStride = stride * (2 / 3);
-  for (let i = 0; i < shAttributes.length; i++) {
-    const { l, n } = extractSHDegreeAndCoef(shAttributes[i].name);
-    for (let j = 0; j < tileContent.pointsLength; j++) {
-      //interleave the data
-      const packedBase = (base[l - 1] * 2) / 3;
-      const idx = j * packedStride + packedBase + n * 2;
-      const src = j * 3;
-      packedData[idx] =
-        float32ToFloat16(shAttributes[i].typedArray[src]) |
-        (float32ToFloat16(shAttributes[i].typedArray[src + 1]) << 16);
-      packedData[idx + 1] = float32ToFloat16(
-        shAttributes[i].typedArray[src + 2],
-      );
-    }
-  }
-  return packedData;
+  return undefined;
 }
 
 export default GaussianSplat3DTileContent;

--- a/packages/engine/Source/Scene/GltfLoader.js
+++ b/packages/engine/Source/Scene/GltfLoader.js
@@ -1155,6 +1155,16 @@ function finalizeSpzAttribute(
   attribute.byteOffset = 0;
   attribute.byteStride = undefined;
 
+  const packedSphericalHarmonicsData =
+    vertexBufferLoader.spzPackedSphericalHarmonicsData;
+  if (defined(packedSphericalHarmonicsData)) {
+    attribute.packedSphericalHarmonicsData = packedSphericalHarmonicsData;
+    attribute.sphericalHarmonicsDegree =
+      vertexBufferLoader.spzSphericalHarmonicsDegree;
+    attribute.sphericalHarmonicsCoefficientCount =
+      vertexBufferLoader.spzSphericalHarmonicsCoefficientCount;
+  }
+
   if (loadBuffer) {
     attribute.buffer = vertexBufferLoader.buffer;
   }

--- a/packages/engine/Source/Scene/GltfSpzDecoder.js
+++ b/packages/engine/Source/Scene/GltfSpzDecoder.js
@@ -1,0 +1,54 @@
+import defined from "../Core/defined.js";
+import FeatureDetection from "../Core/FeatureDetection.js";
+import TaskProcessor from "../Core/TaskProcessor.js";
+
+/**
+ * Schedules SPZ decode work on a task processor worker.
+ *
+ * @private
+ */
+function GltfSpzDecoder() {}
+
+GltfSpzDecoder._maximumDecodingConcurrency = Math.max(
+  FeatureDetection.hardwareConcurrency - 1,
+  1,
+);
+GltfSpzDecoder._taskProcessor = undefined;
+
+GltfSpzDecoder._getTaskProcessor = function () {
+  if (!defined(GltfSpzDecoder._taskProcessor)) {
+    GltfSpzDecoder._taskProcessor = new TaskProcessor(
+      "decodeSpz",
+      GltfSpzDecoder._maximumDecodingConcurrency,
+    );
+  }
+
+  return GltfSpzDecoder._taskProcessor;
+};
+
+function copyForTransfer(bufferViewTypedArray) {
+  const buffer = new Uint8Array(bufferViewTypedArray.byteLength);
+  buffer.set(bufferViewTypedArray);
+  return buffer;
+}
+
+/**
+ * Decodes an SPZ buffer view. Returns undefined if the worker queue is full.
+ *
+ * @param {Uint8Array} bufferViewTypedArray The compressed SPZ buffer view.
+ * @returns {Promise<object>|undefined} The decoded Gaussian cloud promise.
+ * @private
+ */
+GltfSpzDecoder.decode = function (bufferViewTypedArray) {
+  const taskProcessor = GltfSpzDecoder._getTaskProcessor();
+  if (
+    taskProcessor._activeTasks >= GltfSpzDecoder._maximumDecodingConcurrency
+  ) {
+    return undefined;
+  }
+
+  const buffer = copyForTransfer(bufferViewTypedArray);
+  return taskProcessor.scheduleTask({ buffer: buffer }, [buffer.buffer]);
+};
+
+export default GltfSpzDecoder;

--- a/packages/engine/Source/Scene/GltfSpzLoader.js
+++ b/packages/engine/Source/Scene/GltfSpzLoader.js
@@ -4,7 +4,7 @@ import defined from "../Core/defined.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import ResourceLoader from "./ResourceLoader.js";
 import ResourceLoaderState from "./ResourceLoaderState.js";
-import { loadSpz } from "@spz-loader/core";
+import GltfSpzDecoder from "./GltfSpzDecoder.js";
 
 // Cumulative number of SH coefficient floats per splat per channel for each
 // degree. Degree 0 has no extra SH data (base color is stored separately in
@@ -234,15 +234,15 @@ class GltfSpzLoader extends ResourceLoader {
       }
     }
 
-    const decodePromise = loadSpz(this._bufferViewTypedArray, {
-      unpackOptions: { coordinateSystem: "UNSPECIFIED" },
-    });
+    const decodePromise = GltfSpzDecoder.decode(this._bufferViewTypedArray);
 
     if (!defined(decodePromise)) {
       return false;
     }
 
+    this._bufferViewTypedArray = undefined;
     this._decodePromise = processDecode(this, decodePromise);
+    return false;
   }
 
   /**

--- a/packages/engine/Source/Scene/GltfVertexBufferLoader.js
+++ b/packages/engine/Source/Scene/GltfVertexBufferLoader.js
@@ -128,6 +128,9 @@ class GltfVertexBufferLoader extends ResourceLoader {
     this._quantization = undefined;
     this._typedArray = undefined;
     this._buffer = undefined;
+    this._spzPackedSphericalHarmonicsData = undefined;
+    this._spzSphericalHarmonicsDegree = 0;
+    this._spzSphericalHarmonicsCoefficientCount = 0;
     this._state = ResourceLoaderState.UNLOADED;
     this._promise = undefined;
   }
@@ -178,6 +181,39 @@ class GltfVertexBufferLoader extends ResourceLoader {
    */
   get quantization() {
     return this._quantization;
+  }
+
+  /**
+   * The packed spherical harmonics data decoded from SPZ.
+   *
+   * @type {Uint32Array|undefined}
+   * @readonly
+   * @private
+   */
+  get spzPackedSphericalHarmonicsData() {
+    return this._spzPackedSphericalHarmonicsData;
+  }
+
+  /**
+   * The spherical harmonics degree decoded from SPZ.
+   *
+   * @type {number}
+   * @readonly
+   * @private
+   */
+  get spzSphericalHarmonicsDegree() {
+    return this._spzSphericalHarmonicsDegree;
+  }
+
+  /**
+   * The spherical harmonics coefficient count decoded from SPZ.
+   *
+   * @type {number}
+   * @readonly
+   * @private
+   */
+  get spzSphericalHarmonicsCoefficientCount() {
+    return this._spzSphericalHarmonicsCoefficientCount;
   }
 
   /**
@@ -254,6 +290,11 @@ class GltfVertexBufferLoader extends ResourceLoader {
 
     let buffer;
     const typedArray = this._typedArray;
+    const spzPackedSphericalHarmonicsData =
+      this._spzPackedSphericalHarmonicsData;
+    const spzSphericalHarmonicsDegree = this._spzSphericalHarmonicsDegree;
+    const spzSphericalHarmonicsCoefficientCount =
+      this._spzSphericalHarmonicsCoefficientCount;
     if (this._loadBuffer && this._asynchronous) {
       const vertexBufferJob = scratchVertexBufferJob;
       vertexBufferJob.set(typedArray, frameState.context);
@@ -272,6 +313,10 @@ class GltfVertexBufferLoader extends ResourceLoader {
 
     this._buffer = buffer;
     this._typedArray = this._loadTypedArray ? typedArray : undefined;
+    this._spzPackedSphericalHarmonicsData = spzPackedSphericalHarmonicsData;
+    this._spzSphericalHarmonicsDegree = spzSphericalHarmonicsDegree;
+    this._spzSphericalHarmonicsCoefficientCount =
+      spzSphericalHarmonicsCoefficientCount;
     this._state = ResourceLoaderState.READY;
     this._resourceCache.statistics.addGeometryLoader(this);
     return true;
@@ -308,6 +353,9 @@ class GltfVertexBufferLoader extends ResourceLoader {
     this._spzLoader = undefined;
     this._typedArray = undefined;
     this._buffer = undefined;
+    this._spzPackedSphericalHarmonicsData = undefined;
+    this._spzSphericalHarmonicsDegree = 0;
+    this._spzSphericalHarmonicsCoefficientCount = 0;
     this._gltf = undefined;
     this._primitive = undefined;
   }
@@ -399,31 +447,17 @@ async function loadFromSpz(vertexBufferLoader) {
   }
 }
 
-function getShAttributePrefix(attribute) {
-  const prefix = attribute.startsWith("KHR_gaussian_splatting:")
-    ? "KHR_gaussian_splatting:"
-    : "_";
-  return `${prefix}SH_DEGREE_`;
-}
-
-function extractSHDegreeAndCoef(attribute) {
-  const prefix = getShAttributePrefix(attribute);
-  const separator = "_COEF_";
-
-  const lStart = prefix.length;
-  const coefIndex = attribute.indexOf(separator, lStart);
-
-  const l = parseInt(attribute.slice(lStart, coefIndex), 10);
-  const n = parseInt(attribute.slice(coefIndex + separator.length), 10);
-
-  return { l, n };
-}
-
 function processSpz(vertexBufferLoader) {
   vertexBufferLoader._state = ResourceLoaderState.PROCESSING;
   const spzLoader = vertexBufferLoader._spzLoader;
 
   const gcloudData = spzLoader.decodedData.gcloud;
+  vertexBufferLoader._spzPackedSphericalHarmonicsData =
+    gcloudData.packedSphericalHarmonicsData;
+  vertexBufferLoader._spzSphericalHarmonicsDegree =
+    gcloudData.sphericalHarmonicsDegree ?? gcloudData.shDegree ?? 0;
+  vertexBufferLoader._spzSphericalHarmonicsCoefficientCount =
+    gcloudData.sphericalHarmonicsCoefficientCount ?? 0;
 
   if (vertexBufferLoader._attributeSemantic === "POSITION") {
     vertexBufferLoader._typedArray = gcloudData.positions;
@@ -463,33 +497,6 @@ function processSpz(vertexBufferLoader) {
         0.0,
         255.0,
       );
-    }
-  } else if (vertexBufferLoader._attributeSemantic.includes("SH_DEGREE_")) {
-    const { l, n } = extractSHDegreeAndCoef(
-      vertexBufferLoader._attributeSemantic,
-    );
-    const sphericalHarmonicDegree = gcloudData.shDegree;
-    let stride = 0;
-    const base = [0, 9, 24];
-    switch (sphericalHarmonicDegree) {
-      case 1:
-        stride = 9;
-        break;
-      case 2:
-        stride = 24;
-        break;
-      case 3:
-        stride = 45;
-        break;
-    }
-    const count = gcloudData.numPoints;
-    const sh = gcloudData.sh;
-    vertexBufferLoader._typedArray = new Float32Array(count * 3);
-    for (let i = 0; i < count; i++) {
-      const idx = i * stride + base[l - 1] + n * 3;
-      vertexBufferLoader._typedArray[i * 3] = sh[idx];
-      vertexBufferLoader._typedArray[i * 3 + 1] = sh[idx + 1];
-      vertexBufferLoader._typedArray[i * 3 + 2] = sh[idx + 2];
     }
   }
 }

--- a/packages/engine/Source/Scene/ModelComponents.js
+++ b/packages/engine/Source/Scene/ModelComponents.js
@@ -270,6 +270,30 @@ export class Attribute {
     this.typedArray = undefined;
 
     /**
+     * Packed spherical harmonics data produced while decoding SPZ data.
+     *
+     * @type {Uint32Array|undefined}
+     * @ignore
+     */
+    this.packedSphericalHarmonicsData = undefined;
+
+    /**
+     * Spherical harmonics degree for packed SPZ data.
+     *
+     * @type {number}
+     * @ignore
+     */
+    this.sphericalHarmonicsDegree = 0;
+
+    /**
+     * Spherical harmonics coefficient count for packed SPZ data.
+     *
+     * @type {number}
+     * @ignore
+     */
+    this.sphericalHarmonicsCoefficientCount = 0;
+
+    /**
      * A vertex buffer. Attribute values are accessed using byteOffset and byteStride.
      *
      * @type {Buffer}

--- a/packages/engine/Source/Workers/decodeSpz.js
+++ b/packages/engine/Source/Workers/decodeSpz.js
@@ -1,0 +1,119 @@
+import createTaskProcessorWorker from "./createTaskProcessorWorker.js";
+import defined from "../Core/defined.js";
+import { loadSpz } from "@spz-loader/core";
+
+function transferTypedArray(transferableObjects, typedArray) {
+  if (defined(typedArray)) {
+    transferableObjects.push(typedArray.buffer);
+  }
+}
+
+const scratchFloatBuffer = new ArrayBuffer(4);
+const scratchFloatView = new Float32Array(scratchFloatBuffer);
+const scratchIntView = new Uint32Array(scratchFloatBuffer);
+
+function float32ToFloat16(float32) {
+  scratchFloatView[0] = float32;
+  const bits = scratchIntView[0];
+
+  const sign = (bits >> 31) & 0x1;
+  const exponent = (bits >> 23) & 0xff;
+  const mantissa = bits & 0x7fffff;
+
+  if (exponent === 0xff) {
+    return (sign << 15) | (0x1f << 10) | (mantissa ? 0x200 : 0);
+  }
+
+  if (exponent === 0) {
+    return sign << 15;
+  }
+
+  const newExponent = exponent - 127 + 15;
+  if (newExponent >= 31) {
+    return (sign << 15) | (0x1f << 10);
+  }
+
+  if (newExponent <= 0) {
+    return sign << 15;
+  }
+
+  return (sign << 15) | (newExponent << 10) | (mantissa >>> 13);
+}
+
+function getSphericalHarmonicsCoefficientCount(degree) {
+  switch (degree) {
+    case 1:
+      return 9;
+    case 2:
+      return 24;
+    case 3:
+      return 45;
+    default:
+      return 0;
+  }
+}
+
+function packSphericalHarmonicsData(gcloud) {
+  const sphericalHarmonics = gcloud.sh;
+  const degree = gcloud.shDegree;
+  const coefs = getSphericalHarmonicsCoefficientCount(degree);
+  if (!defined(sphericalHarmonics) || coefs === 0) {
+    return undefined;
+  }
+
+  const pointsLength = gcloud.numPoints ?? gcloud.positions.length / 3;
+  const packedStride = (coefs / 3) * 2;
+  const packedData = new Uint32Array(pointsLength * packedStride);
+  const base = [0, 9, 24];
+
+  for (let point = 0; point < pointsLength; point++) {
+    const sourcePointOffset = point * coefs;
+    const packedPointOffset = point * packedStride;
+
+    for (let l = 1; l <= degree; l++) {
+      const coefficientCount = l * 2 + 1;
+      const sourceBase = base[l - 1];
+      const packedBase = (sourceBase / 3) * 2;
+
+      for (let n = 0; n < coefficientCount; n++) {
+        const sourceIndex = sourcePointOffset + sourceBase + n * 3;
+        const packedIndex = packedPointOffset + packedBase + n * 2;
+        packedData[packedIndex] =
+          float32ToFloat16(sphericalHarmonics[sourceIndex]) |
+          (float32ToFloat16(sphericalHarmonics[sourceIndex + 1]) << 16);
+        packedData[packedIndex + 1] = float32ToFloat16(
+          sphericalHarmonics[sourceIndex + 2],
+        );
+      }
+    }
+  }
+
+  return packedData;
+}
+
+async function decodeSpz(parameters, transferableObjects) {
+  const gcloud = await loadSpz(parameters.buffer, {
+    unpackOptions: { coordinateSystem: "UNSPECIFIED" },
+  });
+
+  const packedSphericalHarmonicsData = packSphericalHarmonicsData(gcloud);
+  if (defined(packedSphericalHarmonicsData)) {
+    gcloud.packedSphericalHarmonicsData = packedSphericalHarmonicsData;
+    gcloud.sphericalHarmonicsDegree = gcloud.shDegree;
+    gcloud.sphericalHarmonicsCoefficientCount =
+      getSphericalHarmonicsCoefficientCount(gcloud.shDegree);
+    gcloud.sh = undefined;
+  }
+
+  transferTypedArray(transferableObjects, gcloud.positions);
+  transferTypedArray(transferableObjects, gcloud.scales);
+  transferTypedArray(transferableObjects, gcloud.rotations);
+  transferTypedArray(transferableObjects, gcloud.alphas);
+  transferTypedArray(transferableObjects, gcloud.colors);
+  transferTypedArray(transferableObjects, gcloud.sh);
+  transferTypedArray(transferableObjects, gcloud.packedSphericalHarmonicsData);
+
+  return gcloud;
+}
+
+export default createTaskProcessorWorker(decodeSpz);


### PR DESCRIPTION
# Description

This PR moves SPZ decoding for Gaussian Splat content off the main thread and into a task processor worker.

Previously, loading SPZ-compressed Gaussian Splat tiles could cause severe main-thread stalls. The expensive work included:

- decoding the SPZ payload with `@spz-loader/core`
- extracting decoded Gaussian attributes
- packing spherical harmonics data into half-float `Uint32Array` buffers for shader/texture use

For large tiles, especially tiles with SH degree 2 or 3, this could block rendering and make camera interaction freeze or stutter while tiles were loading.

This change adds a `decodeSpz` worker and routes SPZ decoding through `GltfSpzDecoder`. The worker now decodes the SPZ buffer, packs spherical harmonics data, transfers decoded typed arrays back to the main thread, and stores the packed SH data on model attributes so `GaussianSplat3DTileContent` can consume it without doing the packing work on the main thread.

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/13489

## Testing plan

Tested by loading Gaussian Splat tiles with spherical harmonics data and navigating while tiles streamed in.

Before this change:

1. Load a Gaussian Splat 3D Tiles tileset.
2. Navigate the scene so new tiles are requested.
3. Observe visible frame stalls and camera interaction freezes while SPZ tiles load.
4. Browser performance profiling shows long main-thread tasks during SPZ decode and SH packing.

After this change:

1. Load the same tileset.
2. Navigate while tiles stream in.
3. SPZ decode and SH packing are scheduled on the `decodeSpz` worker.
4. The main thread remains more responsive during tile loading.
5. Decoded attributes and packed spherical harmonics data are still available to `GaussianSplat3DTileContent`.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

ChatGPT

If yes, I used the following Model(s):

GPT-5.5 Extra-High
