### PR TITLE
Skip hidden model animation updates

### DIFF
--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -2521,7 +2521,7 @@ function updateSceneGraph(model, frameState) {
 
   let updateForAnimations = false;
   // Animations are disabled for classification models.
-  if (!defined(model.classificationType)) {
+  if (!defined(model.classificationType) && model._show) {
     updateForAnimations =
       model._userAnimationDirty || model._activeAnimations.update(frameState);
   }

--- a/packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js
@@ -718,6 +718,37 @@ describe(
       });
     });
 
+    it("does not animate when the model is hidden", function () {
+      return loadAndZoomToModelAsync(
+        {
+          gltf: animatedTriangleUrl,
+        },
+        scene,
+      ).then(function (model) {
+        const time = defaultDate;
+        const animation = model.activeAnimations.add({
+          index: 0,
+        });
+
+        const spyUpdate = jasmine.createSpy("listener");
+        animation.update.addEventListener(spyUpdate);
+
+        scene.renderForSpecs(time);
+        model.show = false;
+        scene.renderForSpecs(
+          JulianDate.addSeconds(time, 1.0, scratchJulianDate),
+        );
+        model.show = true;
+        scene.renderForSpecs(
+          JulianDate.addSeconds(time, 2.0, scratchJulianDate),
+        );
+
+        expect(spyUpdate.calls.count()).toEqual(2);
+        expect(spyUpdate.calls.argsFor(0)[2]).toEqual(0.0);
+        expect(spyUpdate.calls.argsFor(1)[2]).toEqual(1.0);
+      });
+    });
+
     it("animates while paused with an explicit animation time", function () {
       return loadAndZoomToModelAsync(
         {


### PR DESCRIPTION
# Description

Model scene graph updates now skip active animation updates while the model is hidden, which prevents unavailable entity-backed models from continuing to spend frame time on animations after their visibility has ended. A regression spec covers the hidden-model case and verifies animations resume when the model is shown again.

## Issue number and link

Fixes #12633

## Testing plan

- `npx prettier --check packages/engine/Source/Scene/Model/Model.js packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js`
- `git diff --check`
- `npx eslint packages/engine/Source/Scene/Model/Model.js packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js --quiet` could not run in this shallow checkout because dependencies are not installed; `npx` attempted to fetch ESLint and then failed loading the repository config dependency `globals`.

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):


If yes, I used the following Model(s):


