### PR TITLE
Vector Tiles: Fix for tilesets missing EXT_structural_metadata

### DIFF
--- a/packages/engine/Source/Scene/VectorGltf3DTileContent.js
+++ b/packages/engine/Source/Scene/VectorGltf3DTileContent.js
@@ -10,7 +10,6 @@ import BufferPolyline from "./BufferPolyline.js";
 import BufferPolylineCollection from "./BufferPolylineCollection.js";
 import BufferPolylineMaterial from "./BufferPolylineMaterial.js";
 import Cesium3DTileStyle from "./Cesium3DTileStyle.js";
-import Color from "../Core/Color.js";
 import Matrix4 from "../Core/Matrix4.js";
 import Model from "./Model/Model.js";
 import ModelUtility from "./Model/ModelUtility.js";
@@ -19,7 +18,6 @@ import createVectorTileBuffersFromModelComponents from "./Model/createVectorTile
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
-import Check from "../Core/Check.js";
 
 /** @import BufferPrimitive from "./BufferPrimitive.js"; */
 /** @import BufferPrimitiveCollection from "./BufferPrimitiveCollection.js"; */
@@ -29,6 +27,7 @@ import Check from "../Core/Check.js";
 /** @import Cesium3DTileBatchTable from "./Cesium3DTileBatchTable.js"; */
 /** @import Cesium3DTileVectorFeature from "./Cesium3DTileVectorFeature.js";*/
 /** @import Cesium3DTileset from "./Cesium3DTileset.js"; */
+/** @import Color from "../Core/Color.js"; */
 /** @import FrameState from "./FrameState.js"; */
 /** @import ImplicitMetadataView from "./ImplicitMetadataView.js"; */
 /** @import Ray from "../Core/Ray.js"; */
@@ -210,21 +209,17 @@ class VectorGltf3DTileContent {
 
   /**
    * @param {number} featureId
-   * @param {number} featureTableId
+   * @param {number} [featureTableId]
    * @returns {Cesium3DTileVectorFeature}
    */
   getFeature(featureId, featureTableId) {
-    //>>includeStart('debug', pragmas.debug);
-    Check.typeOf.number("featureTableId", featureTableId);
-    //>>includeEnd('debug');
-
     return this._featuresByTableId.get(featureTableId)?.get(featureId);
   }
 
   /**
    * @param {number} featureId
    * @param {string} name
-   * @param {number} featureTableId
+   * @param {number} [featureTableId]
    * @returns {boolean}
    */
   hasProperty(featureId, name, featureTableId) {
@@ -237,8 +232,10 @@ class VectorGltf3DTileContent {
    * @param {Color} color
    */
   applyDebugSettings(enabled, color) {
-    color = enabled ? color : Color.WHITE;
-    this.applyStyle(new Cesium3DTileStyle({ color }));
+    const colorString = enabled
+      ? `color("${color.toCssHexString()}", 1.0)`
+      : 'color("white", 1.0)';
+    this.applyStyle(new Cesium3DTileStyle({ color: colorString }));
   }
 
   /**
@@ -258,11 +255,22 @@ class VectorGltf3DTileContent {
         collection.get(i, point);
         const feature = this.getFeature(point.featureId, featureTableId);
 
-        point.show = style.show?.evaluate(feature) ?? true;
-        style.color?.evaluate(feature, pointMaterial.color);
-        pointMaterial.size = style.pointSize?.evaluate(feature);
-        pointMaterial.outlineWidth = style.pointOutlineWidth?.evaluate(feature);
-        style.pointOutlineColor?.evaluate(feature, pointMaterial.outlineColor);
+        if (defined(style.show)) {
+          point.show = style.show.evaluate(feature);
+        }
+        if (defined(style.color)) {
+          style.color.evaluate(feature, pointMaterial.color);
+        }
+        if (defined(style.pointSize)) {
+          pointMaterial.size = style.pointSize.evaluate(feature);
+        }
+        if (defined(style.pointOutlineWidth)) {
+          pointMaterial.outlineWidth =
+            style.pointOutlineWidth.evaluate(feature);
+        }
+        if (defined(style.pointOutlineColor)) {
+          style.pointOutlineColor.evaluate(feature, pointMaterial.outlineColor);
+        }
 
         point.setMaterial(pointMaterial);
       }
@@ -274,9 +282,15 @@ class VectorGltf3DTileContent {
         collection.get(i, polyline);
         const feature = this.getFeature(polyline.featureId, featureTableId);
 
-        polyline.show = style.show?.evaluate(feature) ?? true;
-        style.color?.evaluate(feature, polylineMaterial.color);
-        polylineMaterial.width = style.lineWidth?.evaluate(feature) ?? 1;
+        if (defined(style.show)) {
+          polyline.show = style.show.evaluate(feature);
+        }
+        if (defined(style.color)) {
+          style.color.evaluate(feature, polylineMaterial.color);
+        }
+        if (defined(style.lineWidth)) {
+          polylineMaterial.width = style.lineWidth.evaluate(feature);
+        }
 
         polyline.setMaterial(polylineMaterial);
       }
@@ -288,8 +302,12 @@ class VectorGltf3DTileContent {
         collection.get(i, polygon);
         const feature = this.getFeature(polygon.featureId, featureTableId);
 
-        polygon.show = style.show?.evaluate(feature) ?? true;
-        style.color?.evaluate(feature, polygonMaterial.color);
+        if (defined(style.show)) {
+          polygon.show = style.show.evaluate(feature);
+        }
+        if (defined(style.color)) {
+          style.color.evaluate(feature, polygonMaterial.color);
+        }
 
         polygon.setMaterial(polygonMaterial);
       }

--- a/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
@@ -1,17 +1,26 @@
 import {
   BufferPoint,
   BufferPointCollection,
+  BufferPointMaterial,
   BufferPolyline,
   BufferPolylineCollection,
+  BufferPolylineMaterial,
   BufferPolygon,
   BufferPolygonCollection,
+  BufferPolygonMaterial,
   Cartesian3,
+  Cesium3DTileStyle,
+  Color,
   VectorGltf3DTileContent,
 } from "../../index.js";
 
 const scratchPoint = new BufferPoint();
 const scratchPolyline = new BufferPolyline();
 const scratchPolygon = new BufferPolygon();
+
+const scratchPointMaterial = new BufferPointMaterial();
+const scratchPolylineMaterial = new BufferPolylineMaterial();
+const scratchPolygonMaterial = new BufferPolygonMaterial();
 
 describe("Scene/VectorGltf3DTileContent", () => {
   let content;
@@ -108,6 +117,7 @@ describe("Scene/VectorGltf3DTileContent", () => {
 
     const mockFeature1 = { id: 123 };
     const mockFeature2 = { id: 456 };
+    const mockFeature3 = { id: 789 };
 
     const points = createBufferPointCollection();
     const lines = createBufferPolylineCollection();
@@ -128,10 +138,12 @@ describe("Scene/VectorGltf3DTileContent", () => {
         ]),
       ],
       [101, new Map()],
+      [undefined, new Map([[789, mockFeature3]])],
     ]);
 
     expect(content.getFeature(123, 100)).toBe(mockFeature1);
     expect(content.getFeature(456, 100)).toBe(mockFeature2);
+    expect(content.getFeature(789, undefined)).toBe(mockFeature3);
     expect(content.getFeature(999, 101)).toBe(undefined);
   });
 
@@ -140,6 +152,7 @@ describe("Scene/VectorGltf3DTileContent", () => {
 
     const mockFeature1 = { id: 123, hasProperty: (name) => name === "my-prop" };
     const mockFeature2 = { id: 456, hasProperty: () => false };
+    const mockFeature3 = { id: 789, hasProperty: () => false };
 
     const points = createBufferPointCollection();
     const lines = createBufferPolylineCollection();
@@ -160,11 +173,111 @@ describe("Scene/VectorGltf3DTileContent", () => {
         ]),
       ],
       [101, new Map()],
+      [undefined, new Map([[789, mockFeature3]])],
     ]);
 
     expect(content.hasProperty(123, "my-prop", 100)).toBe(true);
     expect(content.hasProperty(456, "my-prop", 100)).toBe(false);
+    expect(content.hasProperty(789, "my-prop", undefined)).toBe(false);
     expect(content.hasProperty(999, "my-prop", 101)).toBe(false);
+  });
+
+  it("applyDebugSettings", () => {
+    const points = createBufferPointCollection();
+    const lines = createBufferPolylineCollection();
+    const polygons = createBufferPolygonCollection();
+    content._collections = [points, lines, polygons];
+
+    content.applyDebugSettings(true, Color.RED);
+
+    assertColorAll(points, scratchPoint, scratchPointMaterial, Color.RED);
+    assertColorAll(lines, scratchPolyline, scratchPolylineMaterial, Color.RED);
+    assertColorAll(points, scratchPolygon, scratchPolygonMaterial, Color.RED);
+
+    content.applyDebugSettings(false, Color.RED);
+
+    assertColorAll(points, scratchPoint, scratchPointMaterial, Color.WHITE);
+    assertColorAll(
+      lines,
+      scratchPolyline,
+      scratchPolylineMaterial,
+      Color.WHITE,
+    );
+    assertColorAll(points, scratchPolygon, scratchPolygonMaterial, Color.WHITE);
+  });
+
+  it("applyStyle - points", () => {
+    const points = createBufferPointCollection();
+    content._collections = [points];
+
+    const style = new Cesium3DTileStyle({
+      show: false,
+      color: "color('#ff0000', 0.5)",
+      pointSize: "12",
+      pointOutlineWidth: "2",
+      pointOutlineColor: "color('#00ff00', 0.25)",
+    });
+
+    content.applyStyle(style);
+
+    for (let i = 0; i < points.primitiveCount; i++) {
+      points.get(i, scratchPoint);
+      scratchPoint.getMaterial(scratchPointMaterial);
+
+      expect(scratchPoint.show).toBe(false);
+      expect(scratchPointMaterial.color.toCssHexString()).toEqual("#ff000080");
+      expect(scratchPointMaterial.size).toEqual(12);
+      expect(scratchPointMaterial.outlineWidth).toEqual(2);
+      expect(scratchPointMaterial.outlineColor.toCssHexString()).toEqual(
+        "#00ff0040",
+      );
+    }
+  });
+
+  it("applyStyle - polylines", () => {
+    const lines = createBufferPolylineCollection();
+    content._collections = [lines];
+
+    const style = new Cesium3DTileStyle({
+      show: false,
+      color: "color('#ff0000', 0.5)",
+      lineWidth: "12",
+    });
+
+    content.applyStyle(style);
+
+    for (let i = 0; i < lines.primitiveCount; i++) {
+      lines.get(i, scratchPolyline);
+      scratchPolyline.getMaterial(scratchPolylineMaterial);
+
+      expect(scratchPolyline.show).toBe(false);
+      expect(scratchPolylineMaterial.color.toCssHexString()).toEqual(
+        "#ff000080",
+      );
+      expect(scratchPolylineMaterial.width).toEqual(12);
+    }
+  });
+
+  it("applyStyle - polygons", () => {
+    const polygons = createBufferPolygonCollection();
+    content._collections = [polygons];
+
+    const style = new Cesium3DTileStyle({
+      show: false,
+      color: "color('#ff0000', 0.5)",
+    });
+
+    content.applyStyle(style);
+
+    for (let i = 0; i < polygons.primitiveCount; i++) {
+      polygons.get(i, scratchPolygon);
+      scratchPolygon.getMaterial(scratchPolygonMaterial);
+
+      expect(scratchPolygon.show).toBe(false);
+      expect(scratchPolygonMaterial.color.toCssHexString()).toEqual(
+        "#ff000080",
+      );
+    }
   });
 });
 
@@ -228,4 +341,12 @@ function createBufferPolygonCollection() {
     scratchPolygon,
   );
   return collection;
+}
+
+function assertColorAll(collection, primitive, material, color) {
+  for (let i = 0; i < collection.primitiveCount; i++) {
+    collection.get(i, primitive);
+    primitive.getMaterial(material);
+    expect(material.color).toEqual(color);
+  }
 }


### PR DESCRIPTION

# Description

Fixes a regression on main. Tilesets created without EXT_structural_metadata (i.e. no feature properties) do not have a featureTableId and cannot specify one on calls to `getFeature(featureID, [featureTableId])`, but nevertheless must support picking.

For the second part of the fix, related to applying styles and debug settings, I haven't identified root cause of the regression yet. The changes look reasonable, but I believe it worked before and doesn't now. I'll try to track down what happened there, but if this is how the code 'should' be written then perhaps it doesn't matter. 

## Issue number and link

n/a

## Testing plan

Added unit tests to cover all affected behaviors. I've also merged this fix into the `vector-alpha` branch already, so the fix can be verified here:

https://ci-builds.cesium.com/cesium/vector-alpha/Apps/Sandcastle2/index.html?id=3d-tiles-vector-styling

If the three sample vector datasets in the link above load without crashing the tab, and styles work, then the fix applied correctly.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13507** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)