### PR TITLE
Add EXT_structural_metadata support to MVT vector tiles

### DIFF
--- a/packages/engine/Source/Scene/MVTDataProvider.js
+++ b/packages/engine/Source/Scene/MVTDataProvider.js
@@ -173,8 +173,15 @@ async function fetchMvtMetadata(urlTemplate) {
     return undefined;
   }
 
-  const metadataResource = Resource.createIfNeeded(getAbsoluteUri(metadataUrl));
-  return metadataResource.fetchJson();
+  try {
+    const metadataResource = Resource.createIfNeeded(
+      getAbsoluteUri(metadataUrl),
+    );
+    return await metadataResource.fetchJson();
+  } catch {
+    // metadata.json is optional; return undefined if not available.
+    return undefined;
+  }
 }
 
 function resolveMetadataUrl(templateUrl) {

--- a/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
+++ b/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
@@ -474,7 +474,7 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
 
     for (const props of featureProperties.values()) {
       for (const [key, value] of Object.entries(props)) {
-        if (value === null || value === undefined) {
+        if (!defined(value)) {
           continue;
         }
         const jsType = typeof value;

--- a/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
+++ b/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
@@ -85,7 +85,7 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
   const featureIdLookup = new Map();
 
   // Maps featureId -> properties object (first-seen wins for ID collisions).
-  /** @type {Map<number, Record<string, *>>} */
+  /** @type {Map<number, Object.<string, *>>} */
   const featureProperties = new Map();
 
   /** @type {number[]} */
@@ -133,7 +133,7 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
         currentFeatureId !== nullFeatureId &&
         !featureProperties.has(currentFeatureId)
       ) {
-        /** @type {Record<string, *>} */
+        /** @type {Object.<string, *>} */
         const props = Object.assign({}, feature.properties);
         props["_layer"] = layer.name ?? "";
         featureProperties.set(currentFeatureId, props);
@@ -504,7 +504,7 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
     }
 
     // 2. Build schema class properties.
-    /** @type {Record<string, *>} */
+    /** @type {Object.<string, *>} */
     const classProperties = {};
     for (const [name, type] of propertyTypes) {
       if (type === "SCALAR") {
@@ -524,7 +524,7 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
     }
 
     // 3. Encode property values into binary buffers.
-    /** @type {Record<string, *>} */
+    /** @type {Object.<string, *>} */
     const tableProperties = {};
     const count = featureCount;
 
@@ -811,10 +811,11 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
         byteLength: binaryChunk.byteLength,
       },
     ],
+    extensions: /** @type {Object|undefined} */ (undefined),
   };
 
   if (defined(structuralMetadata)) {
-    /** @type {*} */ (gltfJson).extensions = {
+    gltfJson.extensions = {
       EXT_structural_metadata: structuralMetadata,
     };
   }

--- a/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
+++ b/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
@@ -35,6 +35,7 @@ const scratchLocal = new Cartesian3();
 
 /**
  * @typedef {object} VectorTileLayer
+ * @property {string} name
  * @property {number} extent
  * @property {VectorTileFeature[]} features
  * @ignore
@@ -83,6 +84,10 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
   // Maps a property value (or auto-increment key) to a compact integer feature ID.
   const featureIdLookup = new Map();
 
+  // Maps featureId -> properties object (first-seen wins for ID collisions).
+  /** @type {Map<number, Record<string, *>>} */
+  const featureProperties = new Map();
+
   /** @type {number[]} */
   const pointPositions = [];
   /** @type {number[]} */
@@ -122,6 +127,17 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
             featureIdLookup,
           ) ?? nullFeatureId)
         : getOrAssignAutoFeatureId(feature, featureIdLookup);
+
+      // Collect properties for the property table (first-seen wins).
+      if (
+        currentFeatureId !== nullFeatureId &&
+        !featureProperties.has(currentFeatureId)
+      ) {
+        /** @type {Record<string, *>} */
+        const props = Object.assign({}, feature.properties);
+        props["_layer"] = layer.name ?? "";
+        featureProperties.set(currentFeatureId, props);
+      }
 
       if (feature.type === "Point") {
         const points = /** @type {VectorTilePoint[]} */ (feature.geometry);
@@ -401,12 +417,206 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
       target: WebGLConstants.ARRAY_BUFFER,
     });
     attributes._FEATURE_ID_0 = featureAccessor;
+    /** @type {*} */
+    const featureIdDef = {
+      featureCount: featureCount,
+      nullFeatureId: nullFeatureId,
+      attribute: 0,
+    };
+    if (featureProperties.size > 0) {
+      featureIdDef.propertyTable = 0;
+    }
     extensions.EXT_mesh_features = {
-      featureIds: [
+      featureIds: [featureIdDef],
+    };
+  }
+
+  /**
+   * Adds a raw buffer view for metadata (no accessor target).
+   * @param {Uint8Array} bytes
+   * @param {number} [alignment=4] Required byte alignment (e.g., 8 for Float64).
+   * @returns {number} bufferView index
+   */
+  function addMetadataBufferView(bytes, alignment) {
+    alignment = alignment ?? 4;
+    // Align to the required boundary.
+    const pad = (alignment - (byteLength % alignment)) % alignment;
+    if (pad > 0) {
+      chunks.push(new Uint8Array(pad));
+      byteLength += pad;
+    }
+    const byteOffset = byteLength;
+    chunks.push(bytes);
+    byteLength += bytes.byteLength;
+    const bufferViewIndex = bufferViews.length;
+    bufferViews.push({
+      buffer: 0,
+      byteOffset: byteOffset,
+      byteLength: bytes.byteLength,
+    });
+    return bufferViewIndex;
+  }
+
+  /**
+   * Builds the EXT_structural_metadata extension object with schema and
+   * property table from the collected feature properties.
+   * @returns {object|undefined}
+   */
+  function buildStructuralMetadata() {
+    if (featureProperties.size === 0) {
+      return undefined;
+    }
+
+    // 1. Determine union of all property names and infer types.
+    /** @type {Map<string, string>} propertyName -> "STRING"|"SCALAR"|"BOOLEAN" */
+    const propertyTypes = new Map();
+
+    for (const props of featureProperties.values()) {
+      for (const [key, value] of Object.entries(props)) {
+        if (value === null || value === undefined) {
+          continue;
+        }
+        const jsType = typeof value;
+        let metaType;
+        if (jsType === "string") {
+          metaType = "STRING";
+        } else if (jsType === "number") {
+          metaType = "SCALAR";
+        } else if (jsType === "boolean") {
+          metaType = "BOOLEAN";
+        } else {
+          // Objects/arrays: coerce to string
+          metaType = "STRING";
+        }
+
+        const existing = propertyTypes.get(key);
+        if (!defined(existing)) {
+          propertyTypes.set(key, metaType);
+        } else if (existing !== metaType) {
+          // Mixed types: coerce to STRING
+          propertyTypes.set(key, "STRING");
+        }
+      }
+    }
+
+    if (propertyTypes.size === 0) {
+      return undefined;
+    }
+
+    // 2. Build schema class properties.
+    /** @type {Record<string, *>} */
+    const classProperties = {};
+    for (const [name, type] of propertyTypes) {
+      if (type === "SCALAR") {
+        classProperties[name] = {
+          type: "SCALAR",
+          componentType: "FLOAT64",
+        };
+      } else if (type === "BOOLEAN") {
+        classProperties[name] = {
+          type: "BOOLEAN",
+        };
+      } else {
+        classProperties[name] = {
+          type: "STRING",
+        };
+      }
+    }
+
+    // 3. Encode property values into binary buffers.
+    /** @type {Record<string, *>} */
+    const tableProperties = {};
+    const count = featureCount;
+
+    for (const [name, type] of propertyTypes) {
+      if (type === "SCALAR") {
+        const values = new Float64Array(count);
+        for (let i = 0; i < count; i++) {
+          const props = featureProperties.get(i);
+          const raw = props?.[name];
+          values[i] =
+            typeof raw === "number" && Number.isFinite(raw) ? raw : NaN;
+        }
+        const bvIndex = addMetadataBufferView(
+          new Uint8Array(values.buffer, values.byteOffset, values.byteLength),
+          8,
+        );
+        tableProperties[name] = { values: bvIndex };
+      } else if (type === "BOOLEAN") {
+        const byteCount = Math.ceil(count / 8);
+        const values = new Uint8Array(byteCount);
+        for (let i = 0; i < count; i++) {
+          const props = featureProperties.get(i);
+          const raw = props?.[name];
+          if (raw) {
+            values[i >> 3] |= 1 << (i & 7);
+          }
+        }
+        const bvIndex = addMetadataBufferView(values);
+        tableProperties[name] = { values: bvIndex };
+      } else {
+        // STRING encoding: values (UTF-8 bytes) + stringOffsets (Uint32)
+        const encoder = new TextEncoder();
+        /** @type {Uint8Array[]} */
+        const stringParts = [];
+        const offsets = new Uint32Array(count + 1);
+        let totalBytes = 0;
+
+        for (let i = 0; i < count; i++) {
+          offsets[i] = totalBytes;
+          const props = featureProperties.get(i);
+          const raw = props?.[name];
+          let str;
+          if (raw === null || raw === undefined) {
+            str = "";
+          } else if (typeof raw === "string") {
+            str = raw;
+          } else {
+            str = String(raw);
+          }
+          const encoded = encoder.encode(str);
+          stringParts.push(encoded);
+          totalBytes += encoded.byteLength;
+        }
+        offsets[count] = totalBytes;
+
+        // Concatenate string bytes
+        const valuesBuffer = new Uint8Array(totalBytes);
+        let writeOffset = 0;
+        for (const part of stringParts) {
+          valuesBuffer.set(part, writeOffset);
+          writeOffset += part.byteLength;
+        }
+
+        const valuesBv = addMetadataBufferView(valuesBuffer);
+        const offsetsBv = addMetadataBufferView(
+          new Uint8Array(
+            offsets.buffer,
+            offsets.byteOffset,
+            offsets.byteLength,
+          ),
+        );
+        tableProperties[name] = {
+          values: valuesBv,
+          stringOffsets: offsetsBv,
+          stringOffsetType: "UINT32",
+        };
+      }
+    }
+
+    return {
+      schema: {
+        classes: {
+          mvt_feature: {
+            properties: classProperties,
+          },
+        },
+      },
+      propertyTables: [
         {
-          featureCount: featureCount,
-          nullFeatureId: nullFeatureId,
-          attribute: 0,
+          class: "mvt_feature",
+          count: count,
+          properties: tableProperties,
         },
       ],
     };
@@ -559,11 +769,17 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
     return undefined;
   }
 
+  // Build property table AFTER primitives (adds metadata buffer views).
+  const structuralMetadata = buildStructuralMetadata();
+
   const binaryChunk = concatChunks(chunks, byteLength);
   const translation = [origin.x, origin.y, origin.z];
   const extensionsUsed = ["CESIUM_mesh_vector"];
   if (featureCount > 0) {
     extensionsUsed.push("EXT_mesh_features");
+  }
+  if (defined(structuralMetadata)) {
+    extensionsUsed.push("EXT_structural_metadata");
   }
 
   const gltfJson = {
@@ -596,6 +812,12 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
       },
     ],
   };
+
+  if (defined(structuralMetadata)) {
+    /** @type {*} */ (gltfJson).extensions = {
+      EXT_structural_metadata: structuralMetadata,
+    };
+  }
 
   return buildGlb(gltfJson, binaryChunk);
 }

--- a/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
+++ b/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
@@ -468,7 +468,8 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
     }
 
     // 1. Determine union of all property names and infer types.
-    /** @type {Map<string, string>} propertyName -> "STRING"|"SCALAR"|"BOOLEAN" */
+    // propertyName -> "STRING"|"SCALAR"|"BOOLEAN"
+    /** @type {Map<string, string>} */
     const propertyTypes = new Map();
 
     for (const props of featureProperties.values()) {

--- a/packages/engine/Specs/Scene/buildVectorGltfFromMVTSpec.js
+++ b/packages/engine/Specs/Scene/buildVectorGltfFromMVTSpec.js
@@ -24,6 +24,7 @@ describe("Scene/buildVectorGltfFromMVT", function () {
     const decoded = {
       layers: [
         {
+          name: "empty",
           extent: 4096,
           features: [],
         },
@@ -38,6 +39,7 @@ describe("Scene/buildVectorGltfFromMVT", function () {
     const decoded = {
       layers: [
         {
+          name: "testlayer",
           extent: 4096,
           features: [
             {
@@ -79,10 +81,9 @@ describe("Scene/buildVectorGltfFromMVT", function () {
     expect(glb instanceof Uint8Array).toBe(true);
 
     const gltf = parseGlbJson(glb);
-    expect(gltf.extensionsUsed).toEqual([
-      "CESIUM_mesh_vector",
-      "EXT_mesh_features",
-    ]);
+    expect(gltf.extensionsUsed).toContain("CESIUM_mesh_vector");
+    expect(gltf.extensionsUsed).toContain("EXT_mesh_features");
+    expect(gltf.extensionsUsed).toContain("EXT_structural_metadata");
     expect(gltf.extensionsRequired).toBeUndefined();
 
     const primitives = gltf.meshes[0].primitives;
@@ -115,5 +116,169 @@ describe("Scene/buildVectorGltfFromMVT", function () {
     expect(pointPrimitive.extensions.EXT_mesh_features).toBeDefined();
     expect(linePrimitive.extensions.EXT_mesh_features).toBeDefined();
     expect(polygonPrimitive.extensions.EXT_mesh_features).toBeDefined();
+  });
+
+  it("encodes feature properties into EXT_structural_metadata", function () {
+    const decoded = {
+      layers: [
+        {
+          name: "roads",
+          extent: 4096,
+          features: [
+            {
+              type: "LineString",
+              geometry: [
+                [
+                  { x: 100, y: 100 },
+                  { x: 200, y: 200 },
+                ],
+              ],
+              properties: { name: "Main St", lanes: 4, oneway: true },
+            },
+            {
+              type: "LineString",
+              geometry: [
+                [
+                  { x: 300, y: 300 },
+                  { x: 400, y: 400 },
+                ],
+              ],
+              properties: { name: "Oak Ave", lanes: 2, oneway: false },
+            },
+          ],
+        },
+        {
+          name: "buildings",
+          extent: 4096,
+          features: [
+            {
+              type: "Polygon",
+              geometry: [
+                [
+                  { x: 500, y: 500 },
+                  { x: 600, y: 500 },
+                  { x: 600, y: 600 },
+                  { x: 500, y: 600 },
+                  { x: 500, y: 500 },
+                ],
+              ],
+              properties: { name: "Tower", height: 120.5 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const glb = buildVectorGltfFromMVT(decoded, tileCoordinates);
+    expect(glb).toBeDefined();
+
+    const gltf = parseGlbJson(glb);
+
+    // Extension is declared
+    expect(gltf.extensionsUsed).toContain("EXT_structural_metadata");
+
+    // Root extension is present
+    const metadata = gltf.extensions.EXT_structural_metadata;
+    expect(metadata).toBeDefined();
+
+    // Schema has the expected class
+    const schema = metadata.schema;
+    expect(schema.classes.mvt_feature).toBeDefined();
+
+    const classProps = schema.classes.mvt_feature.properties;
+    expect(classProps._layer.type).toBe("STRING");
+    expect(classProps.name.type).toBe("STRING");
+    expect(classProps.lanes.type).toBe("SCALAR");
+    expect(classProps.lanes.componentType).toBe("FLOAT64");
+    expect(classProps.oneway.type).toBe("BOOLEAN");
+    expect(classProps.height.type).toBe("SCALAR");
+    expect(classProps.height.componentType).toBe("FLOAT64");
+
+    // Property table has correct count (3 unique features)
+    const table = metadata.propertyTables[0];
+    expect(table.class).toBe("mvt_feature");
+    expect(table.count).toBe(3);
+
+    // Table properties reference bufferViews
+    expect(table.properties._layer.values).toBeDefined();
+    expect(table.properties._layer.stringOffsets).toBeDefined();
+    expect(table.properties.name.values).toBeDefined();
+    expect(table.properties.name.stringOffsets).toBeDefined();
+    expect(table.properties.lanes.values).toBeDefined();
+    expect(table.properties.oneway.values).toBeDefined();
+    expect(table.properties.height.values).toBeDefined();
+
+    // EXT_mesh_features links to propertyTable 0
+    const primitives = gltf.meshes[0].primitives;
+    for (const prim of primitives) {
+      if (prim.extensions.EXT_mesh_features) {
+        expect(
+          prim.extensions.EXT_mesh_features.featureIds[0].propertyTable,
+        ).toBe(0);
+      }
+    }
+  });
+
+  it("encodes string properties with binary values and offsets", function () {
+    const decoded = {
+      layers: [
+        {
+          name: "places",
+          extent: 4096,
+          features: [
+            {
+              type: "Point",
+              geometry: [{ x: 1000, y: 1000 }],
+              properties: { name: "Hello" },
+            },
+            {
+              type: "Point",
+              geometry: [{ x: 2000, y: 2000 }],
+              properties: { name: "World" },
+            },
+          ],
+        },
+      ],
+    };
+
+    const glb = buildVectorGltfFromMVT(decoded, tileCoordinates);
+    const gltf = parseGlbJson(glb);
+    const metadata = gltf.extensions.EXT_structural_metadata;
+    const table = metadata.propertyTables[0];
+
+    // Verify string property has both values and stringOffsets
+    expect(table.properties.name.values).toBeDefined();
+    expect(table.properties.name.stringOffsets).toBeDefined();
+    expect(table.properties.name.stringOffsetType).toBe("UINT32");
+
+    // Verify _layer property
+    expect(table.properties._layer.values).toBeDefined();
+    expect(table.properties._layer.stringOffsets).toBeDefined();
+  });
+
+  it("handles features with no properties gracefully", function () {
+    const decoded = {
+      layers: [
+        {
+          name: "minimal",
+          extent: 4096,
+          features: [
+            {
+              type: "Point",
+              geometry: [{ x: 500, y: 500 }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const glb = buildVectorGltfFromMVT(decoded, tileCoordinates);
+    expect(glb).toBeDefined();
+
+    const gltf = parseGlbJson(glb);
+    // Should still have _layer property
+    const metadata = gltf.extensions.EXT_structural_metadata;
+    expect(metadata).toBeDefined();
+    expect(metadata.schema.classes.mvt_feature.properties._layer).toBeDefined();
   });
 });


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Adds per-feature property support to the MVT→glTF pipeline by encoding feature properties as `EXT_structural_metadata` and linking them via `EXT_mesh_features`. 
<img width="1486" height="907" alt="image" src="https://github.com/user-attachments/assets/c8459295-1d43-4b05-85ed-302c15d4432d" />

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan
[us_states_20m_mvt.zip](https://github.com/user-attachments/files/27975787/us_states_20m_mvt.zip)

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
