### PR TITLE
BufferPrimitiveCollection: Fix inconsistent test results with explicit blend option

### DIFF
--- a/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
@@ -28,21 +28,21 @@ describe(
     });
 
     beforeEach(function () {
-      collection = new BufferPointCollection({
-        blendOption: BlendOption.OPAQUE,
-      });
       scene.mode = SceneMode.SCENE3D;
       scene.camera = new Camera(scene);
     });
 
     afterEach(function () {
       scene.primitives.removeAll();
-      if (!collection.isDestroyed()) {
-        collection.destroy();
-      }
+      collection?.destroy();
+      collection = undefined;
     });
 
     it("renders points", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const point = new BufferPoint();
       collection.add({ position: new Cartesian3(0, -1000, 0) }, point);
 
@@ -54,7 +54,7 @@ describe(
 
     it("renders points with color", function () {
       collection = new BufferPointCollection({
-        blendOption: BlendOption.TRANSLUCENT, // override beforeEach
+        blendOption: BlendOption.TRANSLUCENT,
       });
 
       const point = new BufferPoint();
@@ -78,6 +78,10 @@ describe(
     });
 
     it("renders points with updated positions", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const point = new BufferPoint();
       const material = new BufferPointMaterial({ size: 8 });
       const position = new Cartesian3(0, -1000, 0);
@@ -99,6 +103,10 @@ describe(
     });
 
     it("renders points with sort order", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const point = new BufferPoint();
 
       collection.add({ position: new Cartesian3(0, -1000, 0) }, point);
@@ -117,6 +125,10 @@ describe(
     });
 
     it("renders points with updated modelMatrix", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const point = new BufferPoint();
       collection.add({ position: new Cartesian3(0, -1000, 0) }, point);
 
@@ -128,6 +140,10 @@ describe(
     });
 
     it("does not render if empty", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
       expect(scene).toRender([0, 0, 0, 255]);
 
       scene.primitives.add(collection);
@@ -135,6 +151,10 @@ describe(
     });
 
     it("does not render if collection.show = false", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const point = new BufferPoint();
       collection.add({ position: new Cartesian3(0, -1000, 0) }, point);
 
@@ -146,6 +166,10 @@ describe(
     });
 
     it("does not render if point.show = false", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const point = new BufferPoint();
       collection.add({ position: new Cartesian3(0, -1000, 0) }, point);
 

--- a/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
@@ -1,4 +1,5 @@
 import {
+  BlendOption,
   BufferPoint,
   BufferPointCollection,
   BufferPointMaterial,
@@ -27,7 +28,9 @@ describe(
     });
 
     beforeEach(function () {
-      collection = new BufferPointCollection();
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
       scene.mode = SceneMode.SCENE3D;
       scene.camera = new Camera(scene);
     });
@@ -50,6 +53,10 @@ describe(
     });
 
     it("renders points with color", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.TRANSLUCENT, // override beforeEach
+      });
+
       const point = new BufferPoint();
       const material = new BufferPointMaterial({ color: Color.RED, size: 8 });
 

--- a/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
@@ -45,10 +45,6 @@ describe(
     });
 
     beforeEach(function () {
-      collection = new BufferPolygonCollection({
-        positionDatatype: ComponentDatatype.INT,
-        blendOption: BlendOption.OPAQUE,
-      });
       scene.mode = SceneMode.SCENE3D;
       scene.camera = new Camera(scene);
       scene.camera.position = new Cartesian3(10.0, 0.0, 0.0);
@@ -58,12 +54,16 @@ describe(
 
     afterEach(function () {
       scene.primitives.removeAll();
-      if (!collection.isDestroyed()) {
-        collection.destroy();
-      }
+      collection?.destroy();
+      collection = undefined;
     });
 
     it("renders polygons", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const polygon = new BufferPolygon();
       collection.add({ positions, triangles }, polygon);
 
@@ -96,6 +96,11 @@ describe(
     });
 
     it("renders polygons with updated positions", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const polygon = new BufferPolygon();
       const material = new BufferPolygonMaterial();
 
@@ -116,6 +121,11 @@ describe(
     });
 
     it("renders polygons with sort order", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const polygon = new BufferPolygon();
 
       collection.add({ positions, triangles }, polygon);
@@ -132,6 +142,11 @@ describe(
     });
 
     it("renders polygons with updated modelMatrix", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const polygon = new BufferPolygon();
       collection.add({ positions, triangles }, polygon);
 
@@ -143,6 +158,11 @@ describe(
     });
 
     it("does not render if empty", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       expect(scene).toRender([0, 0, 0, 255]);
 
       scene.primitives.add(collection);
@@ -150,6 +170,11 @@ describe(
     });
 
     it("does not render if collection.show = false", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const polygon = new BufferPolygon();
       collection.add({ positions, triangles }, polygon);
 
@@ -161,6 +186,11 @@ describe(
     });
 
     it("does not render if polygon.show = false", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const polygon = new BufferPolygon();
       collection.add({ positions, triangles }, polygon);
 

--- a/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
@@ -1,4 +1,5 @@
 import {
+  BlendOption,
   BufferPolygon,
   BufferPolygonCollection,
   BufferPolygonMaterial,
@@ -46,6 +47,7 @@ describe(
     beforeEach(function () {
       collection = new BufferPolygonCollection({
         positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
       });
       scene.mode = SceneMode.SCENE3D;
       scene.camera = new Camera(scene);
@@ -72,6 +74,11 @@ describe(
     });
 
     it("renders polygons with color", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.TRANSLUCENT, // override beforeEach
+      });
+
       const polygon = new BufferPolygon();
       const material = new BufferPolygonMaterial({ color: Color.RED });
       collection.add({ positions, triangles, material }, polygon);

--- a/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
@@ -28,22 +28,22 @@ describe(
     });
 
     beforeEach(function () {
-      collection = new BufferPolylineCollection({
-        positionDatatype: ComponentDatatype.INT,
-        blendOption: BlendOption.OPAQUE,
-      });
       scene.mode = SceneMode.SCENE3D;
       scene.camera = new Camera(scene);
     });
 
     afterEach(function () {
       scene.primitives.removeAll();
-      if (!collection.isDestroyed()) {
-        collection.destroy();
-      }
+      collection?.destroy();
+      collection = undefined;
     });
 
     it("renders polylines", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const line = new BufferPolyline();
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
       collection.add({ positions }, line);
@@ -78,6 +78,11 @@ describe(
     });
 
     it("renders polylines with updated positions", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const line = new BufferPolyline();
       const material = new BufferPolylineMaterial();
 
@@ -101,6 +106,11 @@ describe(
     });
 
     it("renders polylines with sort order", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const line = new BufferPolyline();
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
 
@@ -118,6 +128,11 @@ describe(
     });
 
     it("renders polylines with updated modelMatrix", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const line = new BufferPolyline();
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
       collection.add({ positions }, line);
@@ -130,6 +145,11 @@ describe(
     });
 
     it("does not render if empty", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       expect(scene).toRender([0, 0, 0, 255]);
 
       scene.primitives.add(collection);
@@ -137,6 +157,11 @@ describe(
     });
 
     it("does not render if collection.show = false", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const line = new BufferPolyline();
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
       collection.add({ positions }, line);
@@ -149,6 +174,11 @@ describe(
     });
 
     it("does not render if polyline.show = false", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
       const line = new BufferPolyline();
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
       collection.add({ positions }, line);

--- a/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
@@ -1,4 +1,5 @@
 import {
+  BlendOption,
   BufferPolyline,
   BufferPolylineCollection,
   BufferPolylineMaterial,
@@ -29,6 +30,7 @@ describe(
     beforeEach(function () {
       collection = new BufferPolylineCollection({
         positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
       });
       scene.mode = SceneMode.SCENE3D;
       scene.camera = new Camera(scene);
@@ -53,6 +55,11 @@ describe(
     });
 
     it("renders polylines with color", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.TRANSLUCENT, // override beforeEach
+      });
+
       const line = new BufferPolyline();
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
       const material = new BufferPolylineMaterial({ color: Color.RED });


### PR DESCRIPTION

# Description

Resolves a (local only) test failure for the BufferPrimitiveCollection renderers. Tests were failing locally but not in CI, related to changing the default blend option. With this PR, the blend option is set explicitly for collections under test, and most tests use opaque draws for simplicity.

## Issue number and link

n/a

## Testing plan

No functional change. Unit tests should now pass both locally and in CI. For local tests, try:

```bash
npm run start
```

Then visit:

```
http://localhost:8080/Specs/SpecRunner.html?category=none&spec=Scene%2FrenderBufferPo
```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13510** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)