### PR TITLE
BufferPrimitiveCollection: Allow isolated position buffer updates

### DIFF
--- a/packages/engine/Source/Scene/BufferPoint.js
+++ b/packages/engine/Source/Scene/BufferPoint.js
@@ -123,7 +123,7 @@ class BufferPoint extends BufferPrimitive {
     collection._positionView[vertexOffset * 3 + 1] = position.y;
     collection._positionView[vertexOffset * 3 + 2] = position.z;
 
-    this._dirty = true;
+    collection._makeDirtyPositions(vertexOffset, 1);
     collection._makeDirtyBoundingVolume();
   }
 

--- a/packages/engine/Source/Scene/BufferPolygon.js
+++ b/packages/engine/Source/Scene/BufferPolygon.js
@@ -180,7 +180,7 @@ class BufferPolygon extends BufferPrimitive {
       positionView[(vertexOffset + i) * 3 + 2] = positions[i * 3 + 2];
     }
 
-    this._dirty = true;
+    collection._makeDirtyPositions(vertexOffset, positions.length);
     collection._makeDirtyBoundingVolume();
   }
 

--- a/packages/engine/Source/Scene/BufferPolyline.js
+++ b/packages/engine/Source/Scene/BufferPolyline.js
@@ -160,7 +160,7 @@ class BufferPolyline extends BufferPrimitive {
       positionView[(vertexOffset + i) * 3 + 2] = positions[i * 3 + 2];
     }
 
-    this._dirty = true;
+    collection._makeDirtyPositions(vertexOffset, positions.length);
     collection._makeDirtyBoundingVolume();
   }
 

--- a/packages/engine/Source/Scene/BufferPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/BufferPrimitiveCollection.js
@@ -222,6 +222,18 @@ class BufferPrimitiveCollection {
     this._positionNormalized = options.positionNormalized ?? false;
 
     /**
+     * @type {number}
+     * @ignore
+     */
+    this._positionDirtyOffset = 0;
+
+    /**
+     * @type {number}
+     * @ignore
+     */
+    this._positionDirtyCount = 0;
+
+    /**
      * @type {DataView<ArrayBuffer>}
      * @ignore
      */
@@ -399,6 +411,8 @@ class BufferPrimitiveCollection {
     CollectionClass._replaceBuffers(tmp, this);
     this._dirtyOffset = 0;
     this._dirtyCount = primitiveCount;
+    this._positionDirtyOffset = 0;
+    this._positionDirtyCount = this._positionCount;
 
     return result;
   }
@@ -462,6 +476,8 @@ class BufferPrimitiveCollection {
 
     result._dirtyOffset = 0;
     result._dirtyCount = result.primitiveCount;
+    result._positionDirtyOffset = 0;
+    result._positionDirtyCount = result._positionCount;
 
     collection.boundingVolume.clone(result.boundingVolume);
 
@@ -661,6 +677,31 @@ class BufferPrimitiveCollection {
   }
 
   /**
+   * @param {number} vertexOffset
+   * @param {number} vertexCount
+   * @ignore
+   */
+  _makeDirtyPositions(vertexOffset, vertexCount) {
+    if (this._positionDirtyCount === 0) {
+      this._positionDirtyOffset = vertexOffset;
+      this._positionDirtyCount = vertexCount;
+    } else if (vertexOffset < this._positionDirtyOffset) {
+      this._positionDirtyCount += this._positionDirtyOffset - vertexOffset;
+      this._positionDirtyCount = Math.max(
+        this._positionDirtyCount,
+        vertexCount,
+      );
+      this._positionDirtyOffset = vertexOffset;
+    } else if (
+      vertexOffset + vertexCount >
+      this._positionDirtyOffset + this._positionDirtyCount
+    ) {
+      this._positionDirtyCount =
+        vertexOffset + vertexCount - this._positionDirtyOffset;
+    }
+  }
+
+  /**
    * Marks collection bounding volume as 'dirty', to be updated on next render,
    * if automatic bounding volume updates are enabled.
    * @ignore
@@ -792,6 +833,24 @@ class BufferPrimitiveCollection {
    */
   get positionNormalized() {
     return this._positionNormalized;
+  }
+
+  /**
+   * @param {TypedArray} positions
+   * @param {number} vertexOffset
+   */
+  setPositions(positions, vertexOffset) {
+    //>>includeStart('debug', pragmas.debug);
+    assert(
+      this._positionView.constructor === positions.constructor,
+      "Mismatched position datatype",
+    );
+    //>>includeEnd('debug');
+
+    this._positionView.set(positions, vertexOffset * 3);
+
+    this._makeDirtyPositions(vertexOffset, positions.length / 3);
+    this._makeDirtyBoundingVolume();
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -28,13 +28,13 @@ import BlendOption from "./BlendOption.js";
 
 /**
  * TODO(PR#13211): Need 'keyof' syntax to avoid duplicating attribute names.
- * @typedef {'positionHigh' | 'positionLow' | 'pickColor' | 'showSizeColorAlpha' | 'outlineWidthColorAlpha'} BufferPointAttribute
+ * @typedef {'position' | 'positionHigh' | 'positionLow' | 'pickColor' | 'showSizeColorAlpha' | 'outlineWidthColorAlpha'} BufferPointAttribute
  * @ignore
  */
 
 /**
  * Attribute locations when using 64-bit position precision.
- * @type {Record<BufferPointAttribute, number>}
+ * @type {Partial<Record<BufferPointAttribute, number>>}
  * @ignore
  */
 const BufferPointAttributeLocationsFloat64 = {
@@ -47,7 +47,7 @@ const BufferPointAttributeLocationsFloat64 = {
 
 /**
  * Attribute locations when using <= 32-bit position precision.
- * @type {Record<string, number>}
+ * @type {Partial<Record<BufferPointAttribute, number>>}
  * @ignore
  */
 const BufferPointAttributeLocations = {
@@ -122,17 +122,6 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
         continue;
       }
 
-      if (useFloat64) {
-        point.getPosition(cartesian);
-        EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
-        attributeArrays.positionHigh[i * 3] = encodedCartesian.high.x;
-        attributeArrays.positionHigh[i * 3 + 1] = encodedCartesian.high.y;
-        attributeArrays.positionHigh[i * 3 + 2] = encodedCartesian.high.z;
-        attributeArrays.positionLow[i * 3] = encodedCartesian.low.x;
-        attributeArrays.positionLow[i * 3 + 1] = encodedCartesian.low.y;
-        attributeArrays.positionLow[i * 3 + 2] = encodedCartesian.low.z;
-      }
-
       point.getMaterial(material);
       Color.fromRgba(point._pickId, pickColor);
 
@@ -155,6 +144,28 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       outlineWidthColorAlphaArray[i * 3 + 2] = material.outlineColor.alpha;
 
       point._dirty = false;
+    }
+  }
+
+  // Fast path for position-only updates.
+  if (collection._positionDirtyCount > 0 && useFloat64) {
+    const { attributeArrays } = renderContext;
+
+    const {
+      _positionDirtyOffset: vertexOffset,
+      _positionDirtyCount: vertexCount,
+    } = collection;
+
+    for (let i = vertexOffset, il = vertexOffset + vertexCount; i < il; i++) {
+      // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+      Cartesian3.fromArray(collection._positionView, i * 3, cartesian);
+      EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
+      attributeArrays.positionHigh[i * 3] = encodedCartesian.high.x;
+      attributeArrays.positionHigh[i * 3 + 1] = encodedCartesian.high.y;
+      attributeArrays.positionHigh[i * 3 + 2] = encodedCartesian.high.z;
+      attributeArrays.positionLow[i * 3] = encodedCartesian.low.x;
+      attributeArrays.positionLow[i * 3 + 1] = encodedCartesian.low.y;
+      attributeArrays.positionLow[i * 3 + 2] = encodedCartesian.low.z;
     }
   }
 
@@ -233,6 +244,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       ],
     });
   } else if (collection._dirtyCount > 0) {
+    // Update all vertex attributes.
     for (const key in attributeLocations) {
       if (Object.hasOwn(attributeLocations, key)) {
         const attribute = /** @type {BufferPointAttribute} */ (key);
@@ -243,6 +255,29 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
           collection._dirtyCount,
         );
       }
+    }
+  } else if (collection._positionDirtyCount > 0) {
+    // Fast path, update only vertex positions.
+    if (useFloat64) {
+      renderContext.vertexArray.copyAttributeFromRange(
+        attributeLocations.positionHigh,
+        renderContext.attributeArrays.positionHigh,
+        collection._positionDirtyOffset,
+        collection._positionDirtyCount,
+      );
+      renderContext.vertexArray.copyAttributeFromRange(
+        attributeLocations.positionLow,
+        renderContext.attributeArrays.positionLow,
+        collection._positionDirtyOffset,
+        collection._positionDirtyCount,
+      );
+    } else {
+      renderContext.vertexArray.copyAttributeFromRange(
+        attributeLocations.position,
+        renderContext.attributeArrays.position,
+        collection._positionDirtyOffset,
+        collection._positionDirtyCount,
+      );
     }
   }
 
@@ -303,6 +338,8 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
 
   collection._dirtyCount = 0;
   collection._dirtyOffset = 0;
+  collection._positionDirtyCount = 0;
+  collection._positionDirtyOffset = 0;
 
   return renderContext;
 }


### PR DESCRIPTION
# Description

Proof of concept.

Updates BufferPointCollection such that (1) users can update the entire position buffer in a single call to `collection.setPositions(array)`, and (2) the collection tracks changes to the position buffer and uploads them to the GPU separately from other vertex attributes, a fast path for position-only animation.

A similar approach should be possible for BufferPolylineCollection and BufferPolygonCollection, not yet implemented  here.

## Issue number and link

n/a

## Testing plan

The sandcastle script below animates a large number of points dynamically. Performance results on my laptop (M4 Max), before and after this PR:

| count | before (FPS) | after (FPS) |
|---|---|---|
| 250,000 | 50 fps | 60 fps |
| 500,000 | 25 fps | 60 fps |
| 1,000,000 | 11 fps | 60 fps |
| 2,000,000 | 5 fps | 41 fps |

```javascript
import {
  BufferPoint,
  BufferPointCollection,
  BufferPointMaterial,
  Cartesian3,
  Color,
  ComponentDatatype,
  Viewer,
} from "cesium";

const viewer = new Viewer("cesiumContainer", { shouldAnimate: true });
viewer.scene.debugShowFramesPerSecond = true;

const PRIMITIVE_COUNT = 1_000_000;
const OFFSET_HEIGHT = 500_000;

const collection = new BufferPointCollection({
  primitiveCountMax: PRIMITIVE_COUNT,
  // Use 32-bit precision to reduce overhead from the default (64-bit).
  positionDatatype: ComponentDatatype.FLOAT,
  // Precompute bounding volume, avoiding per-frame calculations.
  boundingVolume: new Cesium.BoundingSphere(
    Cesium.Cartesian3.ZERO,
    7_000_000
  ),
});

const point = new BufferPoint();
const material = new BufferPointMaterial({ size: 6 });

// Scratch.
const position = new Cartesian3();
const positions = new Float32Array(PRIMITIVE_COUNT * 3);

// Fill polyline collection.
for (let i = 0, il = collection.primitiveCountMax; i < il; i++) {
  initializePointPosition(position);
  positions[i * 3] = position.x;
  positions[i * 3 + 1] = position.y;
  positions[i * 3 + 2] = position.z;
  Color.lerp(Color.RED, Color.BLUE, Math.random(), material.color);
  collection.add({ position, material }, point);
}

viewer.scene.primitives.add(collection);
window.collection = collection;

// Update point positions.
viewer.clock.onTick.addEventListener(() => {
  for (let i = 0, il = collection.primitiveCount; i < il; i++) {
    positions[i * 3] += 1000 * (Math.random() * 2 - 1);
    positions[i * 3 + 1] += 1000 * (Math.random() * 2 - 1);
    positions[i * 3 + 2] += 1000 * (Math.random() * 2 - 1);
  }
  // Write positions to collection in bulk.
  collection.setPositions(positions);
});

function initializePointPosition(result) {
  return Cartesian3.fromDegrees(
    Math.random() * 360 - 180,
    Math.random() * 180 - 90,
    Math.random() * OFFSET_HEIGHT,
    undefined,
    result,
  );
}
```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13511** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)