### PR TITLE
BufferPolylineCollection: Fix culled line segments clamped to origin

### DIFF
--- a/packages/engine/Source/Shaders/PolylineCommon.glsl
+++ b/packages/engine/Source/Shaders/PolylineCommon.glsl
@@ -103,7 +103,7 @@ vec4 getPolylineWindowCoordinatesEC(vec4 positionEC, vec4 prevEC, vec4 nextEC, f
     vec4 clippedPositionWC, clippedPositionEC;
     clipLineSegmentToNearPlane(positionEC.xyz, usePrevious ? prevEC.xyz : nextEC.xyz, clippedPositionWC, segmentClipped, segmentCulled, clippedPositionEC);
 
-    if (segmentCulled)
+    if (prevSegmentCulled && nextSegmentCulled)
     {
         return vec4(0.0, 0.0, 0.0, 1.0);
     }


### PR DESCRIPTION
# Description

Work in progress fix for a rendering issue affecting BufferPolylineCollection, and possibly other users of PolylineCommon.glsl. When the camera is located so that a segment of a polyline intersects with the camera near plane in a specific way, the near end of the polygon is moved to the screen-space lower-left corner, creating an unwanted diagonal line across the screen. Example:

<img width="1453" height="857" alt="polyline-cull-to-origin" src="https://github.com/user-attachments/assets/e481d7ae-3e39-4b2c-8318-3951604b873c" />

All lines shown above should continue straight, not bend toward the lower-left of the screen.

As best as I can tell, this happens because the `getPolylineWindowCoordinatesEC` function believes that segment of the line should be culled, and tries to collapse the segment to the origin, presumably assuming that the same will happen for the other vertex on the segment. When that doesn't happen, we see a diagonal line for the 'culled' segment.

I have a plausible-looking fix in this PR, but I'm not sure I understand the cause or the fix deeply enough quite yet.

It is probably worth mentioning that BufferPolylineCollection draws two triangles per line segment, with adjacent segments sharing vertices:

```plaintext
0 - 2 - 4 - 6 - 8
| \ | \ | \ | \ | ...
1 - 3 - 5 - 7 - 9
```

I believe the older `Cesium.PolylineCollection` code uses more vertices than this (needs confirmation?) and I'm not sure why, but that could be related to the bug, if `Cesium.BufferPolylineCollection` is structuring the geometry differently.

## Issue number and link

- #13444
- #8600
- #8689

## Testing plan

Sandcastle below. I just traced a few streets on https://geojson.io/#map=14.81/37.78294/-122.4168 and exported to GeoJSON. You may need to zoom in just a bit to see the bug occur.

```javascript
import * as Cesium from "cesium";

const viewer = new Cesium.Viewer("cesiumContainer");

const prim = new Cesium.GeoJsonPrimitive({
  geoJson: {
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [
          [-122.41747314374474, 37.79101090764081],
          [-122.41708061695125, 37.78914971567356],
          [-122.41666355723294, 37.787249700518615],
          [-122.41629556336358, 37.78538841381648],
          [-122.41590303656972, 37.78360463673772],
          [-122.4155350427007, 37.781588141242054],
          [-122.41499531835925, 37.77900927356947]
        ],
        "type": "LineString"
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [
          [-122.41575583902211, 37.79124355334041],
          [-122.4153878451531, 37.7893242044119],
          [-122.41499531835925, 37.78742419374345],
          [-122.4146763903392, 37.78564046580172],
          [-122.41421026477155, 37.78379852763621],
          [-122.41391586967634, 37.78191776445976],
          [-122.41376867212873, 37.78094828021223]
        ],
        "type": "LineString"
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [
          [-122.41413666599775, 37.79147619830805],
          [-122.41369507335494, 37.78949869273826],
          [-122.41340067825936, 37.787656850735615],
          [-122.41300815146589, 37.785776185744936],
          [-122.4126401575965, 37.78395363998841],
          [-122.41224763080265, 37.78213104928743],
          [-122.41205136740611, 37.78121973708299]
        ],
        "type": "LineString"
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [
          [-122.40748824342823, 37.78356585849724],
          [-122.4132044148628, 37.77893171224564]
        ],
        "type": "LineString"
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [
          [-122.40780717144827, 37.782635174616246],
          [-122.4101868651355, 37.78065743245848]
        ],
        "type": "LineString"
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [
          [-122.40650692644397, 37.78275151074217],
          [-122.40871488965874, 37.78089011075305],
          [-122.41092285287387, 37.779125615402336],
          [-122.41237029542577, 37.7780979228767],
          [-122.41317988193796, 37.77747742235887],
          [-122.41477452203785, 37.77619762359221]
        ],
        "type": "LineString"
      }
    }
  ]
}
});

viewer.scene.primitives.add(prim);

const line = new Cesium.BufferPolyline();
const material = new Cesium.BufferPolylineMaterial({
  color: Cesium.Color.ORANGE,
  width: 4
});
for (let i = 0, il = prim.polylines.primitiveCount; i < il; i++) {
  prim.polylines.get(i, line);
  line.setMaterial(material)
}

viewer.zoomTo(prim.polylines);
```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13516** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)