### PR TITLE
Improve default voxel shader for common metadata types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 #### Fixes :wrench:
 
 - Fixed a bug causing `BufferPointCollection` to not update after changes to point positions. [#13465](https://github.com/CesiumGS/cesium/pull/13465)
+- Improved the default voxel shader for common metadata types. [#13517](https://github.com/CesiumGS/cesium/pull/13517)
 
 ## 1.141 - 2026-05-01
 

--- a/packages/engine/Source/Core/createColorRamp.js
+++ b/packages/engine/Source/Core/createColorRamp.js
@@ -1,0 +1,37 @@
+// @ts-check
+
+/** @import Color from "./Color.js"; */
+
+/**
+ * Creates a color ramp that linearly interpolates between the given colors.
+ *
+ * @param {Color[]} colors The array of colors to use for the color ramp.
+ * @param {number} rampLength The length (in number of samples) of the color ramp to create.
+ * @returns {Uint8Array} A typed array representing the color ramp.
+ *
+ * @private
+ */
+function createColorRamp(colors, rampLength) {
+  const ramp = document.createElement("canvas");
+  ramp.width = rampLength;
+  ramp.height = 1;
+  const ctx = ramp.getContext("2d");
+  const grd = ctx.createLinearGradient(0, 0, ramp.width, 0);
+
+  const stepSize = 1 / (colors.length - 1);
+  for (let i = 0; i < colors.length; i++) {
+    const color = colors[i];
+    const stop = i * stepSize;
+    const cssColor = color.toCssColorString();
+    grd.addColorStop(stop, cssColor);
+  }
+
+  ctx.fillStyle = grd;
+  ctx.fillRect(0, 0, ramp.width, ramp.height);
+
+  const imageData = ctx.getImageData(0, 0, ramp.width, ramp.height);
+  const array = new Uint8Array(imageData.data.buffer);
+  return array;
+}
+
+export default createColorRamp;

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -105,6 +105,8 @@ function VoxelPrimitive(options) {
 
   /**
    * @type {Cartesian3}
+   * @readonly
+   * @constant
    * @private
    */
   this._dimensions = Cartesian3.clone(dimensions);
@@ -409,10 +411,10 @@ function VoxelPrimitive(options) {
     octreeLeafNodeTexelSizeUv: new Cartesian2(),
     megatextureTextures: [],
     megatextureTileCounts: new Cartesian3(),
-    dimensions: this._dimensions.clone(),
-    inputDimensions: this._inputDimensions.clone(),
-    paddingBefore: this._paddingBefore.clone(),
-    paddingAfter: this._paddingAfter.clone(),
+    dimensions: this._dimensions,
+    inputDimensions: this._inputDimensions,
+    paddingBefore: this._paddingBefore,
+    paddingAfter: this._paddingAfter,
     transformPositionViewToLocal: new Matrix4(),
     transformDirectionViewToLocal: new Matrix3(),
     cameraPositionLocal: new Cartesian3(),
@@ -602,6 +604,15 @@ function computeInputDimensions(
   return inputDimensions;
 }
 
+/**
+ * Combine uniforms from the shape with the primitive uniform map, and
+ * setup change tracking for shape defines to know when to rebuild the shader.
+ *
+ * @param {VoxelPrimitive} primitive The primitive with which the shape uniforms are associated.
+ * @param {VoxelShape} shape The shape from which to pull the shader uniforms and defines.
+ *
+ * @private
+ */
 function setupShapeUniformsAndDefines(primitive, shape) {
   const uniformMap = primitive._uniformMap;
   const { shaderUniforms, shaderDefines } = shape;
@@ -718,6 +729,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
    * @memberof VoxelPrimitive.prototype
    * @type {Cartesian3}
    * @readonly
+   * @constant
    */
   dimensions: {
     get: function () {
@@ -731,6 +743,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
    * @memberof VoxelPrimitive.prototype
    * @type {Cartesian3}
    * @readonly
+   * @constant
    */
   inputDimensions: {
     get: function () {
@@ -744,6 +757,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
    * @memberof VoxelPrimitive.prototype
    * @type {Cartesian3}
    * @readonly
+   * @constant
    */
   paddingBefore: {
     get: function () {
@@ -757,6 +771,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
    * @memberof VoxelPrimitive.prototype
    * @type {Cartesian3}
    * @readonly
+   * @constant
    */
   paddingAfter: {
     get: function () {
@@ -770,6 +785,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
    * @memberof VoxelPrimitive.prototype
    * @type {number[][]}
    * @readonly
+   * @constant
    */
   minimumValues: {
     get: function () {
@@ -783,6 +799,7 @@ Object.defineProperties(VoxelPrimitive.prototype, {
    * @memberof VoxelPrimitive.prototype
    * @type {number[][]}
    * @readonly
+   * @constant
    */
   maximumValues: {
     get: function () {

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -1,3 +1,4 @@
+import buildVoxelCustomShader from "./buildVoxelCustomShader.js";
 import buildVoxelDrawCommands from "./buildVoxelDrawCommands.js";
 import Cartesian2 from "../Core/Cartesian2.js";
 import Cartesian3 from "../Core/Cartesian3.js";
@@ -9,7 +10,6 @@ import Check from "../Core/Check.js";
 import Color from "../Core/Color.js";
 import ClippingPlaneCollection from "./ClippingPlaneCollection.js";
 import clone from "../Core/clone.js";
-import CustomShader from "./Model/CustomShader.js";
 import Frozen from "../Core/Frozen.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
@@ -54,7 +54,7 @@ function VoxelPrimitive(options) {
   const {
     provider = VoxelPrimitive.DefaultProvider,
     modelMatrix = Matrix4.IDENTITY,
-    customShader = VoxelPrimitive.DefaultCustomShader,
+    customShader = buildVoxelCustomShader(provider),
     clock,
     calculateStatistics = false,
   } = options;
@@ -2070,23 +2070,6 @@ function debugDraw(that, frameState) {
 
   polylines.update(frameState);
 }
-
-/**
- * The default custom shader used by the primitive.
- *
- * @type {CustomShader}
- * @constant
- * @readonly
- *
- * @private
- */
-VoxelPrimitive.DefaultCustomShader = new CustomShader({
-  fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
-{
-    material.diffuse = vec3(1.0);
-    material.alpha = 1.0;
-}`,
-});
 
 function DefaultVoxelProvider() {
   this.shape = VoxelShapeType.BOX;

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -10,6 +10,7 @@ import Check from "../Core/Check.js";
 import Color from "../Core/Color.js";
 import ClippingPlaneCollection from "./ClippingPlaneCollection.js";
 import clone from "../Core/clone.js";
+import CustomShader from "./Model/CustomShader.js";
 import Frozen from "../Core/Frozen.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
@@ -253,7 +254,7 @@ function VoxelPrimitive(options) {
    * @type {CustomShader}
    * @private
    */
-  this._customShader = customShader;
+  this._customShader = customShader ?? VoxelPrimitive.DefaultCustomShader;
 
   /**
    * @type {Event}
@@ -1055,7 +1056,8 @@ Object.defineProperties(VoxelPrimitive.prototype, {
   },
 
   /**
-   * Gets or sets the custom shader. If undefined, {@link VoxelPrimitive.DefaultCustomShader} is set.
+   * Gets or sets the custom shader. If undefined, attempt to build a default custom shader
+   * appropriate to the metadata type. If that fails, use {@link VoxelPrimitive.DefaultCustomShader}.
    *
    * @memberof VoxelPrimitive.prototype
    * @type {CustomShader}
@@ -1081,7 +1083,9 @@ Object.defineProperties(VoxelPrimitive.prototype, {
       }
 
       if (!defined(customShader)) {
-        this._customShader = VoxelPrimitive.DefaultCustomShader;
+        const defaultShader = buildVoxelCustomShader(this._provider);
+        this._customShader =
+          defaultShader ?? VoxelPrimitive.DefaultCustomShader;
       } else {
         this._customShader = customShader;
       }
@@ -2070,6 +2074,26 @@ function debugDraw(that, frameState) {
 
   polylines.update(frameState);
 }
+
+/**
+ * The default custom shader used by the primitive.
+ *
+ * @type {CustomShader}
+ * @constant
+ * @readonly
+ *
+ * @private
+ */
+VoxelPrimitive.DefaultCustomShader = new CustomShader({
+  fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+{
+    vec3 voxelNormal = fsInput.attributes.normalEC;
+    float diffuse = max(0.0, dot(voxelNormal, czm_lightDirectionEC));
+    float lighting = 0.5 + 0.5 * diffuse;
+    material.diffuse = vec3(lighting);
+    material.alpha = 1.0;
+}`,
+});
 
 function DefaultVoxelProvider() {
   this.shape = VoxelShapeType.BOX;

--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -51,6 +51,13 @@ import VoxelMetadataOrder from "./VoxelMetadataOrder.js";
  */
 function VoxelPrimitive(options) {
   options = options ?? Frozen.EMPTY_OBJECT;
+  const {
+    provider = VoxelPrimitive.DefaultProvider,
+    modelMatrix = Matrix4.IDENTITY,
+    customShader = VoxelPrimitive.DefaultCustomShader,
+    clock,
+    calculateStatistics = false,
+  } = options;
 
   /**
    * @type {boolean}
@@ -62,10 +69,10 @@ function VoxelPrimitive(options) {
    * @type {VoxelProvider}
    * @private
    */
-  this._provider = options.provider ?? VoxelPrimitive.DefaultProvider;
+  this._provider = provider;
 
   /**
-   * This member is not created until the provider and shape are ready.
+   * This member is not created until the first update loop.
    *
    * @type {VoxelTraversal}
    * @private
@@ -82,73 +89,62 @@ function VoxelPrimitive(options) {
    * @type {boolean}
    * @private
    */
-  this._calculateStatistics = options.calculateStatistics ?? false;
+  this._calculateStatistics = calculateStatistics;
+
+  const {
+    shape: shapeType,
+    minBounds = VoxelShapeType.getMinBounds(shapeType),
+    maxBounds = VoxelShapeType.getMaxBounds(shapeType),
+    dimensions,
+    paddingBefore = Cartesian3.ZERO,
+    paddingAfter = Cartesian3.ZERO,
+    metadataOrder,
+    availableLevels = 1,
+  } = provider;
 
   /**
-   * This member is not created until the provider is ready.
-   *
-   * @type {VoxelShape}
-   * @private
-   */
-  this._shape = undefined;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this._shapeVisible = false;
-
-  /**
-   * This member is not created until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._dimensions = new Cartesian3();
+  this._dimensions = Cartesian3.clone(dimensions);
 
   /**
-   * This member is not created until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._inputDimensions = new Cartesian3();
+  this._paddingBefore = Cartesian3.clone(paddingBefore);
 
   /**
-   * This member is not created until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._paddingBefore = new Cartesian3();
+  this._paddingAfter = Cartesian3.clone(paddingAfter);
 
   /**
-   * This member is not created until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._paddingAfter = new Cartesian3();
+  this._inputDimensions = computeInputDimensions(
+    dimensions,
+    paddingBefore,
+    paddingAfter,
+    metadataOrder,
+  );
 
   /**
-   * This member is not known until the provider is ready.
-   *
    * @type {number}
    * @private
    */
-  this._availableLevels = 1;
+  this._availableLevels = availableLevels;
 
   /**
-   * This member is not known until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._minBounds = new Cartesian3();
+  this._minBounds = minBounds.clone();
 
   /**
    * Used to detect if the shape is dirty.
-   * This member is not known until the provider is ready.
    *
    * @type {Cartesian3}
    * @private
@@ -156,16 +152,13 @@ function VoxelPrimitive(options) {
   this._minBoundsOld = new Cartesian3();
 
   /**
-   * This member is not known until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._maxBounds = new Cartesian3();
+  this._maxBounds = maxBounds.clone();
 
   /**
    * Used to detect if the shape is dirty.
-   * This member is not known until the provider is ready.
    *
    * @type {Cartesian3}
    * @private
@@ -173,16 +166,13 @@ function VoxelPrimitive(options) {
   this._maxBoundsOld = new Cartesian3();
 
   /**
-   * This member is not known until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._minClippingBounds = new Cartesian3();
+  this._minClippingBounds = minBounds.clone();
 
   /**
    * Used to detect if the clipping is dirty.
-   * This member is not known until the provider is ready.
    *
    * @type {Cartesian3}
    * @private
@@ -190,16 +180,13 @@ function VoxelPrimitive(options) {
   this._minClippingBoundsOld = new Cartesian3();
 
   /**
-   * This member is not known until the provider is ready.
-   *
    * @type {Cartesian3}
    * @private
    */
-  this._maxClippingBounds = new Cartesian3();
+  this._maxClippingBounds = maxBounds.clone();
 
   /**
    * Used to detect if the clipping is dirty.
-   * This member is not known until the provider is ready.
    *
    * @type {Cartesian3}
    * @private
@@ -252,7 +239,7 @@ function VoxelPrimitive(options) {
    * @type {Matrix4}
    * @private
    */
-  this._modelMatrix = Matrix4.clone(options.modelMatrix ?? Matrix4.IDENTITY);
+  this._modelMatrix = Matrix4.clone(modelMatrix);
 
   /**
    * Used to detect if the model matrix is dirty.
@@ -266,8 +253,7 @@ function VoxelPrimitive(options) {
    * @type {CustomShader}
    * @private
    */
-  this._customShader =
-    options.customShader ?? VoxelPrimitive.DefaultCustomShader;
+  this._customShader = customShader;
 
   /**
    * @type {Event}
@@ -303,7 +289,7 @@ function VoxelPrimitive(options) {
    * @type {Clock}
    * @private
    */
-  this._clock = options.clock;
+  this._clock = clock;
 
   // Transforms and other values that are computed when the shape changes
   /**
@@ -393,6 +379,22 @@ function VoxelPrimitive(options) {
    */
   this._disableUpdate = false;
 
+  const ShapeConstructor = VoxelShapeType.getShapeConstructor(shapeType);
+
+  /**
+   * @type {VoxelShape}
+   * @private
+   */
+  this._shape = new ShapeConstructor();
+
+  checkTransformAndBounds(this);
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this._shapeVisible = updateShapeAndTransforms(this);
+
   /**
    * @type {Object<string, any>}
    * @private
@@ -406,10 +408,10 @@ function VoxelPrimitive(options) {
     octreeLeafNodeTexelSizeUv: new Cartesian2(),
     megatextureTextures: [],
     megatextureTileCounts: new Cartesian3(),
-    dimensions: new Cartesian3(),
-    inputDimensions: new Cartesian3(),
-    paddingBefore: new Cartesian3(),
-    paddingAfter: new Cartesian3(),
+    dimensions: this._dimensions.clone(),
+    inputDimensions: this._inputDimensions.clone(),
+    paddingBefore: this._paddingBefore.clone(),
+    paddingAfter: this._paddingAfter.clone(),
     transformPositionViewToLocal: new Matrix4(),
     transformDirectionViewToLocal: new Matrix3(),
     cameraPositionLocal: new Cartesian3(),
@@ -420,7 +422,7 @@ function VoxelPrimitive(options) {
     clippingPlanesTexture: undefined,
     clippingPlanesMatrix: new Matrix4(),
     renderBoundPlanesTexture: undefined,
-    stepSize: 0,
+    stepSize: this._stepSizeMultiplier,
     pickColor: new Color(),
   };
 
@@ -448,6 +450,8 @@ function VoxelPrimitive(options) {
       };
     }
   }
+
+  setupShapeUniformsAndDefines(this, this._shape);
 
   /**
    * The event fired to indicate that a tile's content was loaded.
@@ -565,31 +569,59 @@ function VoxelPrimitive(options) {
    * @see Cesium3DTileset#allTilesLoaded
    */
   this.initialTilesLoaded = new Event();
-
-  // If the provider fails to initialize the primitive will fail too.
-  const provider = this._provider;
-  initialize(this, provider);
 }
 
-function initialize(primitive, provider) {
-  // Set the bounds
-  const {
-    shape: shapeType,
-    minBounds = VoxelShapeType.getMinBounds(shapeType),
-    maxBounds = VoxelShapeType.getMaxBounds(shapeType),
-  } = provider;
+/**
+ * Computes the dimensions of the input voxel data, including padding and in the input orientation.
+ *
+ * @param {Cartesian3} dimensions The dimensions of the voxel data, not including padding, in z-up orientation.
+ * @param {Cartesian3} paddingBefore The padding before the voxel data.
+ * @param {Cartesian3} paddingAfter The padding after the voxel data.
+ * @param {VoxelMetadataOrder} metadataOrder The ordering of the input metadata dimensions.
+ *
+ * @private
+ */
+function computeInputDimensions(
+  dimensions,
+  paddingBefore,
+  paddingAfter,
+  metadataOrder,
+) {
+  const inputDimensions = Cartesian3.add(
+    dimensions,
+    paddingBefore,
+    new Cartesian3(),
+  );
+  Cartesian3.add(inputDimensions, paddingAfter, inputDimensions);
+  if (metadataOrder === VoxelMetadataOrder.Y_UP) {
+    const inputDimensionsY = inputDimensions.y;
+    inputDimensions.y = inputDimensions.z;
+    inputDimensions.z = inputDimensionsY;
+  }
+  return inputDimensions;
+}
 
-  primitive.minBounds = minBounds;
-  primitive.maxBounds = maxBounds;
-  primitive.minClippingBounds = minBounds.clone();
-  primitive.maxClippingBounds = maxBounds.clone();
+function setupShapeUniformsAndDefines(primitive, shape) {
+  const uniformMap = primitive._uniformMap;
+  const { shaderUniforms, shaderDefines } = shape;
+  for (const uniformName in shaderUniforms) {
+    if (shaderUniforms.hasOwnProperty(uniformName)) {
+      const name = `u_${uniformName}`;
 
-  checkTransformAndBounds(primitive);
+      //>>includeStart('debug', pragmas.debug);
+      if (defined(uniformMap[name])) {
+        oneTimeWarning(
+          `VoxelPrimitive: Uniform name "${name}" is already defined`,
+        );
+      }
+      //>>includeEnd('debug');
 
-  // Create the shape object, and update it so it is valid for VoxelTraversal
-  const ShapeConstructor = VoxelShapeType.getShapeConstructor(shapeType);
-  primitive._shape = new ShapeConstructor();
-  primitive._shapeVisible = updateShapeAndTransforms(primitive);
+      uniformMap[name] = function () {
+        return shaderUniforms[uniformName];
+      };
+    }
+  }
+  primitive._shapeDefinesOld = clone(shaderDefines, true);
 }
 
 Object.defineProperties(VoxelPrimitive.prototype, {
@@ -1034,28 +1066,26 @@ Object.defineProperties(VoxelPrimitive.prototype, {
       return this._customShader;
     },
     set: function (customShader) {
-      if (this._customShader !== customShader) {
-        // Delete old custom shader entries from the uniform map
-        const uniformMap = this._uniformMap;
-        const oldCustomShader = this._customShader;
-        const oldCustomShaderUniformMap = oldCustomShader.uniformMap;
-        for (const uniformName in oldCustomShaderUniformMap) {
-          if (oldCustomShaderUniformMap.hasOwnProperty(uniformName)) {
-            // If the custom shader was set but the voxel shader was never
-            // built, the custom shader uniforms wouldn't have been added to
-            // the uniform map. But it doesn't matter because the delete
-            // operator ignores if the key doesn't exist.
-            delete uniformMap[uniformName];
-          }
-        }
-
-        if (!defined(customShader)) {
-          this._customShader = VoxelPrimitive.DefaultCustomShader;
-        } else {
-          this._customShader = customShader;
-        }
-        this._shaderDirty = true;
+      if (customShader === this._customShader) {
+        return;
       }
+      // Delete old custom shader entries from the uniform map
+      // (they were added in VoxelRenderResources when the shader was built)
+      const uniformMap = this._uniformMap;
+      const oldCustomShader = this._customShader;
+      const oldCustomShaderUniformMap = oldCustomShader.uniformMap;
+      for (const uniformName in oldCustomShaderUniformMap) {
+        if (oldCustomShaderUniformMap.hasOwnProperty(uniformName)) {
+          delete uniformMap[uniformName];
+        }
+      }
+
+      if (!defined(customShader)) {
+        this._customShader = VoxelPrimitive.DefaultCustomShader;
+      } else {
+        this._customShader = customShader;
+      }
+      this._shaderDirty = true;
     },
   },
 
@@ -1073,8 +1103,8 @@ Object.defineProperties(VoxelPrimitive.prototype, {
   },
 
   /**
-   *  Loading and rendering information for requested content
-   * To use `visited` and `numberOfTilesWithContentReady` statistics, set options._calculateStatistics` to `true` in the constructor.
+   * Loading and rendering information for requested content.
+   * To use `visited` and `numberOfTilesWithContentReady` statistics, set options.calculateStatistics` to `true` in the constructor.
    * @type {Cesium3DTilesetStatistics}
    * @readonly
    * @private
@@ -1106,12 +1136,13 @@ VoxelPrimitive.prototype.update = function (frameState) {
   // Update the custom shader in case it has texture uniforms.
   this._customShader.update(frameState);
 
-  // Initialize from the ready provider. This only happens once.
+  // Initialize from the provider. This only happens once.
   const context = frameState.context;
   if (!this._ready) {
-    initFromProvider(this, provider, context);
-    // Set the primitive as ready after the first frame render since the user might set up events subscribed to
-    // the post render event, and the primitive may not be ready for those past the first frame.
+    initializeFromContext(this, provider, context);
+    // Set the primitive as ready after the first frame render since
+    // the user might set up events subscribed to the post render event,
+    // and the primitive may not be ready for those past the first frame.
     frameState.afterRender.push(() => {
       this._ready = true;
       return true;
@@ -1368,81 +1399,11 @@ function updateVerticalExaggeration(primitive, frameState) {
  * @param {Context} context
  * @private
  */
-function initFromProvider(primitive, provider, context) {
+function initializeFromContext(primitive, provider, context) {
   const uniforms = primitive._uniforms;
 
   primitive._pickId = context.createPickId({ primitive });
   uniforms.pickColor = Color.clone(primitive._pickId.color, uniforms.pickColor);
-
-  const { shaderDefines, shaderUniforms: shapeUniforms } = primitive._shape;
-  primitive._shapeDefinesOld = clone(shaderDefines, true);
-
-  // Add shape uniforms to the uniform map
-  const uniformMap = primitive._uniformMap;
-  for (const key in shapeUniforms) {
-    if (shapeUniforms.hasOwnProperty(key)) {
-      const name = `u_${key}`;
-
-      //>>includeStart('debug', pragmas.debug);
-      if (defined(uniformMap[name])) {
-        oneTimeWarning(
-          `VoxelPrimitive: Uniform name "${name}" is already defined`,
-        );
-      }
-      //>>includeEnd('debug');
-
-      uniformMap[name] = function () {
-        return shapeUniforms[key];
-      };
-    }
-  }
-
-  // Set uniforms that come from the provider.
-  // Note that minBounds and maxBounds can be set dynamically, so their uniforms aren't set here.
-  primitive._dimensions = Cartesian3.clone(
-    provider.dimensions,
-    primitive._dimensions,
-  );
-  uniforms.dimensions = Cartesian3.clone(
-    primitive._dimensions,
-    uniforms.dimensions,
-  );
-  primitive._paddingBefore = Cartesian3.clone(
-    provider.paddingBefore ?? Cartesian3.ZERO,
-    primitive._paddingBefore,
-  );
-  uniforms.paddingBefore = Cartesian3.clone(
-    primitive._paddingBefore,
-    uniforms.paddingBefore,
-  );
-  primitive._paddingAfter = Cartesian3.clone(
-    provider.paddingAfter ?? Cartesian3.ZERO,
-    primitive._paddingAfter,
-  );
-  uniforms.paddingAfter = Cartesian3.clone(
-    primitive._paddingAfter,
-    uniforms.paddingAfter,
-  );
-  primitive._inputDimensions = Cartesian3.add(
-    primitive._dimensions,
-    primitive._paddingBefore,
-    primitive._inputDimensions,
-  );
-  primitive._inputDimensions = Cartesian3.add(
-    primitive._inputDimensions,
-    primitive._paddingAfter,
-    primitive._inputDimensions,
-  );
-  if (provider.metadataOrder === VoxelMetadataOrder.Y_UP) {
-    const inputDimensionsY = primitive._inputDimensions.y;
-    primitive._inputDimensions.y = primitive._inputDimensions.z;
-    primitive._inputDimensions.z = inputDimensionsY;
-  }
-  uniforms.inputDimensions = Cartesian3.clone(
-    primitive._inputDimensions,
-    uniforms.inputDimensions,
-  );
-  primitive._availableLevels = provider.availableLevels ?? 1;
 
   // Create the VoxelTraversal, and set related uniforms
   const keyframeCount = provider.keyframeCount ?? 1;
@@ -2128,7 +2089,6 @@ VoxelPrimitive.DefaultCustomShader = new CustomShader({
 });
 
 function DefaultVoxelProvider() {
-  this.ready = true;
   this.shape = VoxelShapeType.BOX;
   this.dimensions = new Cartesian3(1, 1, 1);
   this.names = ["data"];

--- a/packages/engine/Source/Scene/VoxelProvider.js
+++ b/packages/engine/Source/Scene/VoxelProvider.js
@@ -14,9 +14,6 @@ import DeveloperError from "../Core/DeveloperError.js";
  * Provides voxel data. Intended to be used with {@link VoxelPrimitive}.
  * This type describes an interface and is not intended to be instantiated directly.
  *
- * @alias VoxelProvider
- * @constructor
- *
  * @see Cesium3DTilesVoxelProvider
  * @see VoxelPrimitive
  * @see VoxelShapeType
@@ -49,6 +46,7 @@ class VoxelProvider {
    * @type {Matrix4}
    * @default Matrix4.IDENTITY
    * @readonly
+   * @constant
    */
   globalTransform;
 
@@ -58,6 +56,7 @@ class VoxelProvider {
    * @type {Matrix4}
    * @default Matrix4.IDENTITY
    * @readonly
+   * @constant
    */
   shapeTransform;
 
@@ -66,6 +65,7 @@ class VoxelProvider {
    *
    * @type {VoxelShapeType}
    * @readonly
+   * @constant
    */
   shape;
 
@@ -75,6 +75,7 @@ class VoxelProvider {
    *
    * @type {Cartesian3|undefined}
    * @readonly
+   * @constant
    */
   minBounds;
 
@@ -84,6 +85,7 @@ class VoxelProvider {
    *
    * @type {Cartesian3|undefined}
    * @readonly
+   * @constant
    */
   maxBounds;
 
@@ -92,6 +94,7 @@ class VoxelProvider {
    *
    * @type {Cartesian3}
    * @readonly
+   * @constant
    */
   dimensions;
 
@@ -101,6 +104,7 @@ class VoxelProvider {
    * @type {Cartesian3}
    * @default Cartesian3.ZERO
    * @readonly
+   * @constant
    */
   paddingBefore;
 
@@ -110,6 +114,7 @@ class VoxelProvider {
    * @type {Cartesian3}
    * @default Cartesian3.ZERO
    * @readonly
+   * @constant
    */
   paddingAfter;
 
@@ -118,6 +123,7 @@ class VoxelProvider {
    *
    * @type {string[]}
    * @readonly
+   * @constant
    */
   names;
 
@@ -126,6 +132,7 @@ class VoxelProvider {
    *
    * @type {MetadataType[]}
    * @readonly
+   * @constant
    */
   types;
 
@@ -134,6 +141,7 @@ class VoxelProvider {
    *
    * @type {MetadataComponentType[]}
    * @readonly
+   * @constant
    */
   componentTypes;
 
@@ -142,6 +150,7 @@ class VoxelProvider {
    *
    * @type {number[][]|undefined}
    * @readonly
+   * @constant
    */
   minimumValues;
 
@@ -150,6 +159,7 @@ class VoxelProvider {
    *
    * @type {number[][]|undefined}
    * @readonly
+   * @constant
    */
   maximumValues;
 
@@ -160,6 +170,7 @@ class VoxelProvider {
    *
    * @type {number|undefined}
    * @readonly
+   * @constant
    */
   maximumTileCount;
 
@@ -168,6 +179,7 @@ class VoxelProvider {
    *
    * @type {number|undefined}
    * @readonly
+   * @constant
    */
   availableLevels;
 
@@ -176,6 +188,7 @@ class VoxelProvider {
    *
    * @type {number|undefined}
    * @readonly
+   * @constant
    * @private
    */
   keyframeCount;
@@ -186,6 +199,7 @@ class VoxelProvider {
    *
    * @type {TimeIntervalCollection|undefined}
    * @readonly
+   * @constant
    * @private
    */
   timeIntervalCollection;

--- a/packages/engine/Source/Scene/VoxelProvider.js
+++ b/packages/engine/Source/Scene/VoxelProvider.js
@@ -1,4 +1,14 @@
+// @ts-check
+
 import DeveloperError from "../Core/DeveloperError.js";
+
+/** @import Cartesian3 from "../Core/Cartesian3.js"; */
+/** @import Matrix4 from "../Core/Matrix4.js"; */
+/** @import MetadataComponentType from "./MetadataComponentType.js"; */
+/** @import MetadataType from "./MetadataType.js"; */
+/** @import TimeIntervalCollection from "../Core/TimeIntervalCollection.js"; */
+/** @import VoxelContent from "./VoxelContent.js"; */
+/** @import VoxelShapeType from "./VoxelShapeType.js"; */
 
 /**
  * Provides voxel data. Intended to be used with {@link VoxelPrimitive}.
@@ -13,223 +23,172 @@ import DeveloperError from "../Core/DeveloperError.js";
  *
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
  */
-function VoxelProvider() {
-  DeveloperError.throwInstantiationError();
-}
+class VoxelProvider {
+  constructor() {
+    DeveloperError.throwInstantiationError();
+  }
 
-Object.defineProperties(VoxelProvider.prototype, {
+  /**
+   * Requests the data for a given tile.
+   *
+   * @param {object} [options] Object with the following properties:
+   * @param {number} [options.tileLevel=0] The tile's level.
+   * @param {number} [options.tileX=0] The tile's X coordinate.
+   * @param {number} [options.tileY=0] The tile's Y coordinate.
+   * @param {number} [options.tileZ=0] The tile's Z coordinate.
+   * @privateparam {number} [options.keyframe=0] The requested keyframe.
+   * @returns {Promise<VoxelContent>|undefined} A promise resolving to a VoxelContent containing the data for the tile, or undefined if the request could not be scheduled this frame.
+   */
+  requestData(options) {
+    DeveloperError.throwInstantiationError();
+  }
+
   /**
    * A transform from local space to global space.
    *
-   * @memberof VoxelProvider.prototype
    * @type {Matrix4}
    * @default Matrix4.IDENTITY
    * @readonly
    */
-  globalTransform: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  globalTransform;
 
   /**
    * A transform from shape space to local space.
    *
-   * @memberof VoxelProvider.prototype
    * @type {Matrix4}
    * @default Matrix4.IDENTITY
    * @readonly
    */
-  shapeTransform: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  shapeTransform;
 
   /**
    * Gets the {@link VoxelShapeType}
    *
-   * @memberof VoxelProvider.prototype
    * @type {VoxelShapeType}
    * @readonly
    */
-  shape: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  shape;
 
   /**
    * Gets the minimum bounds.
    * If undefined, the shape's default minimum bounds will be used instead.
    *
-   * @memberof VoxelProvider.prototype
    * @type {Cartesian3|undefined}
    * @readonly
    */
-  minBounds: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  minBounds;
 
   /**
    * Gets the maximum bounds.
    * If undefined, the shape's default maximum bounds will be used instead.
    *
-   * @memberof VoxelProvider.prototype
    * @type {Cartesian3|undefined}
    * @readonly
    */
-  maxBounds: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  maxBounds;
 
   /**
    * Gets the number of voxels per dimension of a tile. This is the same for all tiles in the dataset.
    *
-   * @memberof VoxelProvider.prototype
    * @type {Cartesian3}
    * @readonly
    */
-  dimensions: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  dimensions;
 
   /**
    * Gets the number of padding voxels before the tile. This improves rendering quality when sampling the edge of a tile, but it increases memory usage.
    *
-   * @memberof VoxelProvider.prototype
    * @type {Cartesian3}
    * @default Cartesian3.ZERO
    * @readonly
    */
-  paddingBefore: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  paddingBefore;
 
   /**
    * Gets the number of padding voxels after the tile. This improves rendering quality when sampling the edge of a tile, but it increases memory usage.
    *
-   * @memberof VoxelProvider.prototype
    * @type {Cartesian3}
    * @default Cartesian3.ZERO
    * @readonly
    */
-  paddingAfter: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  paddingAfter;
 
   /**
    * Gets the metadata names.
    *
-   * @memberof VoxelProvider.prototype
    * @type {string[]}
    * @readonly
    */
-  names: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  names;
 
   /**
    * Gets the metadata types.
    *
-   * @memberof VoxelProvider.prototype
    * @type {MetadataType[]}
    * @readonly
    */
-  types: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  types;
 
   /**
    * Gets the metadata component types.
    *
-   * @memberof VoxelProvider.prototype
    * @type {MetadataComponentType[]}
    * @readonly
    */
-  componentTypes: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  componentTypes;
 
   /**
    * Gets the metadata minimum values.
    *
-   * @memberof VoxelProvider.prototype
    * @type {number[][]|undefined}
    * @readonly
    */
-  minimumValues: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  minimumValues;
 
   /**
    * Gets the metadata maximum values.
    *
-   * @memberof VoxelProvider.prototype
    * @type {number[][]|undefined}
    * @readonly
    */
-  maximumValues: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  maximumValues;
 
   /**
    * The maximum number of tiles that exist for this provider.
    * This value is used as a hint to the voxel renderer to allocate an appropriate amount of GPU memory.
    * If this value is not known it can be undefined.
    *
-   * @memberof VoxelProvider.prototype
    * @type {number|undefined}
    * @readonly
    */
-  maximumTileCount: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  maximumTileCount;
 
   /**
    * The number of levels of detail containing available tiles in the tileset.
    *
-   * @memberof VoxelProvider.prototype
    * @type {number|undefined}
    * @readonly
    */
-  availableLevels: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  availableLevels;
 
   /**
    * Gets the number of keyframes in the dataset.
    *
-   * @memberof VoxelProvider.prototype
    * @type {number|undefined}
    * @readonly
    * @private
    */
-  keyframeCount: {
-    get: DeveloperError.throwInstantiationError,
-  },
+  keyframeCount;
 
   /**
    * Gets the {@link TimeIntervalCollection} for the dataset,
    * or undefined if it doesn't have timestamps.
    *
-   * @memberof VoxelProvider.prototype
    * @type {TimeIntervalCollection|undefined}
    * @readonly
    * @private
    */
-  timeIntervalCollection: {
-    get: DeveloperError.throwInstantiationError,
-  },
-});
-
-/**
- * Requests the data for a given tile.
- *
- * @param {object} [options] Object with the following properties:
- * @param {number} [options.tileLevel=0] The tile's level.
- * @param {number} [options.tileX=0] The tile's X coordinate.
- * @param {number} [options.tileY=0] The tile's Y coordinate.
- * @param {number} [options.tileZ=0] The tile's Z coordinate.
- * @privateparam {number} [options.keyframe=0] The requested keyframe.
- * @returns {Promise<VoxelContent>|undefined} A promise resolving to a VoxelContent containing the data for the tile, or undefined if the request could not be scheduled this frame.
- */
-VoxelProvider.prototype.requestData = function (options) {
-  DeveloperError.throwInstantiationError();
-};
+  timeIntervalCollection;
+}
 
 export default VoxelProvider;

--- a/packages/engine/Source/Scene/buildVoxelCustomShader.js
+++ b/packages/engine/Source/Scene/buildVoxelCustomShader.js
@@ -1,10 +1,15 @@
+// @ts-check
+
 import Color from "../Core/Color.js";
+import createColorRamp from "../Core/createColorRamp.js";
 import CustomShader from "./Model/CustomShader.js";
 import defined from "../Core/defined.js";
 import MetadataComponentType from "./MetadataComponentType.js";
 import MetadataType from "./MetadataType.js";
 import TextureUniform from "./Model/TextureUniform.js";
 import UniformType from "./Model/UniformType.js";
+
+/** @import VoxelProvider from "./VoxelProvider.js"; */
 
 /**
  * Builds a custom shader for a voxel primitive based on information
@@ -26,17 +31,38 @@ function buildVoxelCustomShader(provider) {
   // Loop over metadata properties and build a shader for the first property
   // that has a supported type and component type.
   for (let i = 0; i < names.length; i++) {
+    if (!rangeIsValid(minimumValues?.[i], maximumValues?.[i])) {
+      continue;
+    }
     const shader = constructMetadataShader(
       names[i],
       types[i],
       componentTypes[i],
-      minimumValues?.[i],
-      maximumValues?.[i],
+      minimumValues[i],
+      maximumValues[i],
     );
     if (defined(shader)) {
       return shader;
     }
   }
+}
+
+/**
+ * Check if a range of values is valid for constructing a meaningful shader.
+ *
+ * @param {number[]} minimumValue The minimum value of the range.
+ * @param {number[]} maximumValue The maximum value of the range.
+ * @returns {boolean} True if the range is valid, false otherwise.
+ *
+ * @private
+ */
+function rangeIsValid(minimumValue, maximumValue) {
+  if (!Array.isArray(minimumValue) || !Array.isArray(maximumValue)) {
+    return false;
+  }
+  const minimumComponent = Math.min(...minimumValue);
+  const maximumComponent = Math.max(...maximumValue);
+  return minimumComponent < maximumComponent;
 }
 
 /**
@@ -58,10 +84,6 @@ function constructMetadataShader(
   minimumValue,
   maximumValue,
 ) {
-  if (!defined(minimumValue) || !defined(maximumValue)) {
-    // We need minimum and maximum values to construct a shader.
-    return;
-  }
   if (
     type === MetadataType.VEC4 &&
     componentType === MetadataComponentType.FLOAT32
@@ -93,10 +115,6 @@ function buildColorShader(name, minimumValue, maximumValue) {
     // The data is out of the range expected for colors, so a color shader will be meaningless.
     return;
   }
-  if (maxComponent - minComponent === 0) {
-    // The data is constant, so a color shader will be meaningless.
-    return;
-  }
 
   return new CustomShader({
     fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
@@ -113,16 +131,11 @@ function buildColorShader(name, minimumValue, maximumValue) {
  * @param {string} name The name of the metadata property.
  * @param {number[]} minimumValue The minimum value of the metadata property.
  * @param {number[]} maximumValue The maximum value of the metadata property.
- * @returns {CustomShader|undefined} A custom shader for the metadata property, or undefined if a shader could not be constructed.
+ * @returns {CustomShader} A custom shader for the metadata property.
  *
  * @private
  */
 function buildColorMapShader(name, minimumValue, maximumValue) {
-  if (maximumValue - minimumValue === 0) {
-    // The data is constant, so a color map shader will be meaningless.
-    return;
-  }
-
   // Perceptually uniform color map similar to the "viridis" color map used in scientific visualization.
   const colorMapWidth = 128;
   const colorMap = createColorRamp(
@@ -170,51 +183,17 @@ function buildColorMapShader(name, minimumValue, maximumValue) {
     fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
   {
       float value = fsInput.metadata.${name};
-      float valMin = fsInput.metadataStatistics.${name}.min;
-      float valMax = fsInput.metadataStatistics.${name}.max;
       vec3 voxelNormal = fsInput.attributes.normalEC;
       float diffuse = max(0.0, dot(voxelNormal, czm_lightDirectionEC));
       float lighting = 0.5 + 0.5 * diffuse;
 
       if (value >= u_minimumValue && value <= u_maximumValue) {
-        float lerp = (value - valMin) / (valMax - valMin);
+        float lerp = (value - u_minimumValue) / (u_maximumValue - u_minimumValue);
         material.diffuse = texture(u_colorMap, vec2(lerp, 0.5)).rgb * lighting;
         material.alpha = 1.0;
       }
   }`,
   });
-}
-
-/**
- * Create a color ramp that linearly interpolates between the given colors.
- *
- * @param {Color[]} colors The array of colors to use for the color ramp.
- * @param {number} rampWidth The width of the color ramp texture to create.
- * @returns {Uint8Array} A typed array representing the color ramp.
- *
- * @private
- */
-function createColorRamp(colors, rampWidth) {
-  const ramp = document.createElement("canvas");
-  ramp.width = rampWidth;
-  ramp.height = 1;
-  const ctx = ramp.getContext("2d");
-  const grd = ctx.createLinearGradient(0, 0, ramp.width, 0);
-
-  const stepSize = 1 / (colors.length - 1);
-  for (let i = 0; i < colors.length; i++) {
-    const color = colors[i];
-    const stop = i * stepSize;
-    const cssColor = color.toCssColorString();
-    grd.addColorStop(stop, cssColor);
-  }
-
-  ctx.fillStyle = grd;
-  ctx.fillRect(0, 0, ramp.width, ramp.height);
-
-  const imageData = ctx.getImageData(0, 0, ramp.width, ramp.height);
-  const array = new Uint8Array(imageData.data.buffer);
-  return array;
 }
 
 export default buildVoxelCustomShader;

--- a/packages/engine/Source/Scene/buildVoxelCustomShader.js
+++ b/packages/engine/Source/Scene/buildVoxelCustomShader.js
@@ -37,18 +37,6 @@ function buildVoxelCustomShader(provider) {
       return shader;
     }
   }
-
-  // No supported properties were found. Use a default shader that renders a constant color.
-  return new CustomShader({
-    fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
-{
-    vec3 voxelNormal = fsInput.attributes.normalEC;
-    float diffuse = max(0.0, dot(voxelNormal, czm_lightDirectionEC));
-    float lighting = 0.5 + 0.5 * diffuse;
-    material.diffuse = vec3(lighting);
-    material.alpha = 1.0;
-}`,
-  });
 }
 
 /**

--- a/packages/engine/Source/Scene/buildVoxelCustomShader.js
+++ b/packages/engine/Source/Scene/buildVoxelCustomShader.js
@@ -10,7 +10,7 @@ import UniformType from "./Model/UniformType.js";
  * Builds a custom shader for a voxel primitive based on information
  * from the VoxelProvider about the metadata properties.
  *
- * Supports scalar float properties, or vec3 or vec4 properties of type uint8 or float32.
+ * Supports scalar float properties, or vec4 properties with float components.
  *
  * @function
  *

--- a/packages/engine/Source/Scene/buildVoxelCustomShader.js
+++ b/packages/engine/Source/Scene/buildVoxelCustomShader.js
@@ -1,0 +1,232 @@
+import Color from "../Core/Color.js";
+import CustomShader from "./Model/CustomShader.js";
+import defined from "../Core/defined.js";
+import MetadataComponentType from "./MetadataComponentType.js";
+import MetadataType from "./MetadataType.js";
+import TextureUniform from "./Model/TextureUniform.js";
+import UniformType from "./Model/UniformType.js";
+
+/**
+ * Builds a custom shader for a voxel primitive based on information
+ * from the VoxelProvider about the metadata properties.
+ *
+ * Supports scalar float properties, or vec3 or vec4 properties of type uint8 or float32.
+ *
+ * @function
+ *
+ * @param {VoxelProvider} provider The VoxelProvider for the primitive.
+ * @returns {CustomShader|undefined} A custom shader for the primitive, or undefined if a shader could not be constructed.
+ *
+ * @private
+ */
+function buildVoxelCustomShader(provider) {
+  const { names, types, componentTypes, minimumValues, maximumValues } =
+    provider;
+
+  // Loop over metadata properties and build a shader for the first property
+  // that has a supported type and component type.
+  for (let i = 0; i < names.length; i++) {
+    const shader = constructMetadataShader(
+      names[i],
+      types[i],
+      componentTypes[i],
+      minimumValues?.[i],
+      maximumValues?.[i],
+    );
+    if (defined(shader)) {
+      return shader;
+    }
+  }
+
+  // No supported properties were found. Use a default shader that renders a constant color.
+  return new CustomShader({
+    fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+{
+    vec3 voxelNormal = fsInput.attributes.normalEC;
+    float diffuse = max(0.0, dot(voxelNormal, czm_lightDirectionEC));
+    float lighting = 0.5 + 0.5 * diffuse;
+    material.diffuse = vec3(lighting);
+    material.alpha = 1.0;
+}`,
+  });
+}
+
+/**
+ * Construct a metadata shader for a single metadata property.
+ *
+ * @param {string} name The name of the metadata property.
+ * @param {MetadataType} type The type of the metadata property.
+ * @param {MetadataComponentType} componentType The component type of the metadata property.
+ * @param {number[]} minimumValue The minimum value of the metadata property.
+ * @param {number[]} maximumValue The maximum value of the metadata property.
+ * @returns {CustomShader|undefined} A custom shader for the metadata property, or undefined if a shader could not be constructed.
+ *
+ * @private
+ */
+function constructMetadataShader(
+  name,
+  type,
+  componentType,
+  minimumValue,
+  maximumValue,
+) {
+  if (!defined(minimumValue) || !defined(maximumValue)) {
+    // We need minimum and maximum values to construct a shader.
+    return;
+  }
+  if (
+    type === MetadataType.VEC4 &&
+    componentType === MetadataComponentType.FLOAT32
+  ) {
+    return buildColorShader(name, minimumValue, maximumValue);
+  } else if (
+    type === MetadataType.SCALAR &&
+    componentType === MetadataComponentType.FLOAT32
+  ) {
+    return buildColorMapShader(name, minimumValue, maximumValue);
+  }
+}
+
+/**
+ * Build a color shader for a metadata property of type VEC4 and component type FLOAT32.
+ *
+ * @param {string} name The name of the metadata property.
+ * @param {number[]} minimumValue The minimum value of the metadata property.
+ * @param {number[]} maximumValue The maximum value of the metadata property.
+ * @returns {CustomShader|undefined} A custom shader for the metadata property, or undefined if a shader could not be constructed.
+ *
+ * @private
+ */
+function buildColorShader(name, minimumValue, maximumValue) {
+  // Check if the values are in a range that would be meaningful to interpret as colors.
+  const minComponent = Math.min(...minimumValue);
+  const maxComponent = Math.max(...maximumValue);
+  if (minComponent < 0 || maxComponent > 1) {
+    // The data is out of the range expected for colors, so a color shader will be meaningless.
+    return;
+  }
+  if (maxComponent - minComponent === 0) {
+    // The data is constant, so a color shader will be meaningless.
+    return;
+  }
+
+  return new CustomShader({
+    fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+{
+    material.diffuse = fsInput.metadata.${name}.rgb;
+    material.alpha = fsInput.metadata.${name}.a;
+}`,
+  });
+}
+
+/**
+ * Build a color map shader for a metadata property of type SCALAR and component type FLOAT32.
+ *
+ * @param {string} name The name of the metadata property.
+ * @param {number[]} minimumValue The minimum value of the metadata property.
+ * @param {number[]} maximumValue The maximum value of the metadata property.
+ * @returns {CustomShader|undefined} A custom shader for the metadata property, or undefined if a shader could not be constructed.
+ *
+ * @private
+ */
+function buildColorMapShader(name, minimumValue, maximumValue) {
+  if (maximumValue - minimumValue === 0) {
+    // The data is constant, so a color map shader will be meaningless.
+    return;
+  }
+
+  // Perceptually uniform color map similar to the "viridis" color map used in scientific visualization.
+  const colorMapWidth = 128;
+  const colorMap = createColorRamp(
+    [
+      new Color(0.267, 0.004, 0.329),
+      new Color(0.282, 0.14, 0.457),
+      new Color(0.254, 0.265, 0.53),
+      new Color(0.207, 0.372, 0.553),
+      new Color(0.164, 0.471, 0.558),
+      new Color(0.128, 0.567, 0.551),
+      new Color(0.135, 0.659, 0.518),
+      new Color(0.194, 0.741, 0.443),
+      new Color(0.282, 0.819, 0.369),
+      new Color(0.396, 0.898, 0.301),
+      new Color(0.538, 0.965, 0.236),
+      new Color(0.741, 0.998, 0.149),
+      new Color(0.993, 1.0, 0.144),
+    ],
+    colorMapWidth,
+  );
+
+  const textureUniform = new TextureUniform({
+    typedArray: colorMap,
+    width: colorMapWidth,
+    height: 1,
+  });
+
+  return new CustomShader({
+    uniforms: {
+      u_colorMap: {
+        type: UniformType.SAMPLER_2D,
+        value: textureUniform,
+      },
+      // The starting values are also available in the shader from the metadata statistics.
+      // But by using uniforms, we enable later dynamic changes to the range.
+      u_minimumValue: {
+        type: UniformType.FLOAT,
+        value: minimumValue[0],
+      },
+      u_maximumValue: {
+        type: UniformType.FLOAT,
+        value: maximumValue[0],
+      },
+    },
+    fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+  {
+      float value = fsInput.metadata.${name};
+      float valMin = fsInput.metadataStatistics.${name}.min;
+      float valMax = fsInput.metadataStatistics.${name}.max;
+      vec3 voxelNormal = fsInput.attributes.normalEC;
+      float diffuse = max(0.0, dot(voxelNormal, czm_lightDirectionEC));
+      float lighting = 0.5 + 0.5 * diffuse;
+
+      if (value >= u_minimumValue && value <= u_maximumValue) {
+        float lerp = (value - valMin) / (valMax - valMin);
+        material.diffuse = texture(u_colorMap, vec2(lerp, 0.5)).rgb * lighting;
+        material.alpha = 1.0;
+      }
+  }`,
+  });
+}
+
+/**
+ * Create a color ramp that linearly interpolates between the given colors.
+ *
+ * @param {Color[]} colors The array of colors to use for the color ramp.
+ * @param {number} rampWidth The width of the color ramp texture to create.
+ * @returns {Uint8Array} A typed array representing the color ramp.
+ *
+ * @private
+ */
+function createColorRamp(colors, rampWidth) {
+  const ramp = document.createElement("canvas");
+  ramp.width = rampWidth;
+  ramp.height = 1;
+  const ctx = ramp.getContext("2d");
+  const grd = ctx.createLinearGradient(0, 0, ramp.width, 0);
+
+  const stepSize = 1 / (colors.length - 1);
+  for (let i = 0; i < colors.length; i++) {
+    const color = colors[i];
+    const stop = i * stepSize;
+    const cssColor = color.toCssColorString();
+    grd.addColorStop(stop, cssColor);
+  }
+
+  ctx.fillStyle = grd;
+  ctx.fillRect(0, 0, ramp.width, ramp.height);
+
+  const imageData = ctx.getImageData(0, 0, ramp.width, ramp.height);
+  const array = new Uint8Array(imageData.data.buffer);
+  return array;
+}
+
+export default buildVoxelCustomShader;

--- a/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/VoxelPrimitiveSpec.js
@@ -1,6 +1,7 @@
 import {
   Cartesian3,
   Cesium3DTilesVoxelProvider,
+  clone,
   CustomShader,
   Matrix4,
   VoxelBoxShape,
@@ -383,14 +384,6 @@ describe(
       scene.renderForSpecs();
     });
 
-    it("uses default style", function () {
-      const primitive = new VoxelPrimitive({ provider });
-      scene.primitives.add(primitive);
-      scene.renderForSpecs();
-      primitive.style = undefined;
-      expect(primitive.style).toBe(VoxelPrimitive.DefaultStyle);
-    });
-
     it("accepts a new Custom Shader", async function () {
       const primitive = new VoxelPrimitive({ provider });
       scene.primitives.add(primitive);
@@ -401,13 +394,14 @@ describe(
         return primitive.ready;
       });
 
-      expect(primitive.customShader).toBe(VoxelPrimitive.DefaultCustomShader);
+      const defaultShader = clone(primitive.customShader);
 
-      // If new shader is undefined, we should get DefaultCustomShader again
+      // If new shader is undefined, we should get the default shader again
       primitive.customShader = undefined;
       scene.renderForSpecs();
-      expect(primitive.customShader).toBe(VoxelPrimitive.DefaultCustomShader);
-
+      expect(primitive.customShader.fragmentShaderText).toBe(
+        defaultShader.fragmentShaderText,
+      );
       const modifiedShader = new CustomShader({
         fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
 {

--- a/packages/sandcastle/gallery/voxels-in-3d-tiles/main.js
+++ b/packages/sandcastle/gallery/voxels-in-3d-tiles/main.js
@@ -16,22 +16,11 @@ const viewer = new Cesium.Viewer("cesiumContainer", {
 viewer.extend(Cesium.viewerVoxelInspectorMixin);
 viewer.scene.debugShowFramesPerSecond = true;
 
-const customShaderColor = new Cesium.CustomShader({
-  fragmentShaderText: `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
-  {
-      material.diffuse = fsInput.metadata.a.rgb;
-      material.alpha = fsInput.metadata.a.a;
-  }`,
-});
-
 function createPrimitive(provider) {
   viewer.scene.primitives.removeAll();
 
   const voxelPrimitive = viewer.scene.primitives.add(
-    new Cesium.VoxelPrimitive({
-      provider: provider,
-      customShader: customShaderColor,
-    }),
+    new Cesium.VoxelPrimitive({ provider }),
   );
 
   voxelPrimitive.nearestSampling = true;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This PR is a first step towards making it easier for users to visualize voxel data, without having to write shader code.

### Scope of application

It currently supports only two cases, but these are the most common use cases we have seen so far:
1. Color mapped rendering of FLOAT metadata (common in scientific visualizations)
2. Direct rendering of colors supplied as VEC4 data (common for testing data)

In both cases, the new shader is only constructed if `minimumValues` and `maximumValues` properties are available from the `VoxelProvider`. Again, this is the most common case, since a `Cesium3DTilesVoxelProvider` reading tilesets from Cesium tilers will have these properties.

All other inputs will revert to a constant white shading as before, with one change: the default white shader now includes a basic cosine term to account for the angle between the surface and the scene light source.

Any existing apps and Sandcastles that explicitly supply a `CustomShader` will be unaffected. The new default shader only applies when a `CustomShader` is not supplied.

### Other changes

The first commit was a cleanup/refactor of `VoxelPrimitive`. This class was still structured around an earlier (obsolete) version of `VoxelProvider` that constructed immediately and eventually set a `ready` flag. Since we now `await` the `VoxelProvider` setup before constructing the `VoxelPrimitive`, much of the `VoxelPrimitive` setup can be moved into the constructor, simplifying the later `update` loop.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Run voxel-related specs locally, confirm no failures.
- Load the ["Voxels in 3D Tiles" Sandcastle](http://localhost:8080/Apps/Sandcastle2/index.html?id=voxels-in-3d-tiles) (locally from this branch), and verify that individual voxel cells are colored as before. This Sandcastle now does not specify a shader, and uses the default shader for color data specified as vec4.
- Load this [modified version of the Voxel Rendering Sandcastle with no specified shader](http://localhost:8080/Apps/Sandcastle2/index.html#c=5Vprc9u4Ff0rGE8/UDZD+ZGd7thOpo5s73oqx57ITRM/Zg2RkIQuSKgAqIjK+L/3AuADfEh2290ms/V4TBE494GLi4sDyDSec6HQNsISDYikaYwmgsfofis0b/dbR/cJtaARTqIQS8VIgalaDO4+CXkiFVpQ8oUI9AYl5EuuNfho2rxC74AnCtOEiPstH329TxAaY0mGOCPisBC5iPGUiMw0BtriteALGhFxIrMk9LQQKrA3lJFLPB8RsaAhySULvBH+m2C5SCk0TimLLnmUMmJ6t06kJEr2b8hSpYLI/nsMT8zOsFCzi4v7rZ5vNdin/Vv6fU3DX7X3E8wkMV1TwkMe1dswRBMryhO3UdGYMIiG2zYX/B8k1MhCsRKp7ZIhSQj4TZomn3pmFmz8AxgFSSIvH6xt/MiXhF0kcg6qubikS5pomVzCKA4iMk6noxn/ci5wTOQ1ESMCExvBhGoXnImeMj7G7EbgRE64iAGQG7vEStDlaxP4UYgZMaHPOwcQTviEkwPTf8ZITBIl6xN6xhidS06j4O8/jX58HcR4SeM0/oAjmkr/94PqSbVRnKSJCT+CNApJpBNhRJMpIzrXTByL/PLkDM9Jz+axmlEZmAYIh3kelc0xTd7xNIlkFSmjaKRhN9mcBFOiLgtQrjYIGU+I13PU4OUL1BSgtWoiyLpEwghlfalW8+P96CP96wglOiUAfwcrmTMO6/eh6lRg23QWaUAUjrDCxqePZ4PXDjbkUFUSmPibNUIDFxCcD69Obg72HQXt5Gu0VFC8wJThMSNDsiBMG9uDzqcqkWUosApnAz2iRjB0k2cz4tlECGDRKq6jEAjyz5RIdQoDAYVlLnl8rp8yTxY6KVsCRXP/0FvwLwcgJAjUIJOEMZVar64K3uN7jrSAROXY0JhkepUyo2P30U6aGSRCdpi1GW/kwFEFW+gxDSB5FMAqRLCEfcJ5zeqvK0eDDkFhwiTF3e6D0x3OcJJUJrqyBTK4TACD87SenqPE5kg1YeeMY3WwfyIEzjxnCNs1c3YmCx2QKhFUKEKi+kgbQ1uindrrkVPNoNTNAtg2PhhV79N4rOslibxKt+v1LCW1MjkLEqjTrrBXuAg5jDxGFFqBxO4RPI7r8UarnZ0yT0p0ZtFZHZ1Bi4Mu3KFJRJa3n0FktXFydQSaTUeFqtL00ppe1k0voaVmujDOiJgT8QmElqiPvJq5V7AEjroFtLdZQyDbJHBrhlcXWBUCTZEZgPUk7ZTubaPd4AeAF9b1+0HZf2ve91umTZUJdhtybdxCxwz076B9QG/rQFq1r3Rzb41UmCe+W6XMbvqzZN7MR9JHC1/b92u1rWvAJgVAlVfkwg5a9hqrxrFfLrs7K7iDdh9A2jgE1SnaCN2roFNBSLIRvF+BxywlG7EHDyaMf/6hRD3ZD0+tIgh/gRepxt45sK0mhkUhsqXkrrT2YBOsVZElZwvi5Xo15mkdgbhMmaL/R/zhtY/0ryM0x1EEm+c7AkWDrJXbg9z1iwXtyp1MVPNksVHsD0JX9gu68lwq/dsMxK6Jr6hkH775+Mk+PtvHLXoCFblgXkI0dalRli7Xn2ExxVp9ls386WtnYKCEPz0WZ7I23flfsJCvzk7no1p2l682aZ9yVxxh3U+iU3cdveiM1NiYa1bdFmM4WPotqawllTWlsrbUqiW1akqt7CHqqMY5T5RNEshjtL1dpZqDyg9iP5klMeBcRGsXeUcItl0rkBRdA34es+rGNDmnXnNdlNPqa06p8a7VmHU1rhqbbsv6hAqpRjieM2JCRBOsyEtzxqzqJql71cwdvwJ/bhLCJjhzwLeNs0AL3E6MUA9hyEPM1k61hWtmacA2O55Bd7Hmdqjr3NnlwjkVftmUFRy4i3y3NTxHwXMHLNNea6ubb3fA17BuYyVPYofy1SimG+x2doUMctCr8F03O+BODYG6s9evY57J5KWPMh+tfCd3eg0Nju+1njqubef27MNVDdKuSLXubjvtE0jBrquob2TWGtEk1qWhQB+T2n4Fy01K9ppKsm4l2SYl+00lq24lq01KnuXo/xVD16b+U4IeCgK5eC1oTBUF5DxnU5BoqVRwiJ9heMvXUu2udF7ISDAT8wU5Ycyr3zEsLD/LcTCodQqqJePem9ekvXI1Fy4elp/KNOz3Xa8Pa2PIQU+9shw7Q1rULofNjbG+ZWZBewi1hiNHRwiEW+BgwrIbbs4PsAWM5jMiiFcXCsa1Xr8oVJrc2vvxXTi9mswo3MzntWXcuchzx9p1m+d021hOBJ7q4mLb9M3/IXpccBqVPZeYJt55/nKRzFPYiKV5+rCqObyGq/iXWAfqErJIUKiacf6hp02Uc1a0wslpMkmlDmSuKYjzhA7yc/R0XFV7TTKQ0seEORYkCbPyZmGNNHZO+f0+uuEohmCFiNHpTN91YqX9SKY+0k6QpeW32u+IhDhrGJ7R8NeESOl4a2YgAJeAJ51SqXASEigIe7vmJ9g9ao0Ys/kMl37P+RfPHZBfWclp/GP1bUb1JZNeITecszEWlyRJvTsnusrM3P1WecMPZqrDEtLV4X4rz37IFMIgxw+dU1FrWy6WVZ5Az38JUFW+7jP12XB4cT26ujgtF2q1WxTGqhN+YOiLE8oKUhzMDaQd85cVs/I6yJQDu878jngOMqbrt/juwjn4PLx4f3r2oSOav20E3vHldzf4d1efvs24JVG/0dDXXIV9DyPfUEO++fj/aFXkmwf096ojDz3ni3Ig/BFrXlyOQn0FPprjkJwtYAP+2YK8Gj8McbLAZlfMdejvmswufGIi5FWh0vRTc5TazZ7R0iCd7r0LBwpwzSU1Kt6gQkcwz9vc2yr93waRSwNzCgvtXk1RdcznsGszPvUasoaD++sCYeZleHZ+88tgeDH4qwZv+VvHUmWMvNWa/5L/R0oqmBcEfUXgUAkzJfvjFMyoILQ84rhfiBxHdIFo9Kbj308QnGalhJ5JyqAer6C0vz3uA74mBlRIc9WrBREMGBJAZntvh7YxCILjPry2pZQlK47GfwE) and verify that the default constant shader now shades based on lighting angle.
- Load this [local Sandcastle demonstrating the default color-mapped shader for scalar data](http://localhost:8080/Apps/Sandcastle2/index.html#c=zVdtb9s2EP4rhLEPSuPKTtNhQ5Jmc920COC8IPa6trGB0tI55kaJGkm5Vgr/9x1JUS+O0xYrBjQILPv43B3vuRdSLMmE1OQJoYoMQbE8IQspEjLtRPbXtHM8TZkDjWkaR1RpDh5TSyxumkYiVZqsGHwCSV6QFD6VVsO3VhZ4u0ORaspSkNNOl3yepoTMqYIRLUAeeZXzhN6BLKwwNB6vpVixGORAFWkUGCXisRPG4YJmY5ArFkGp6fFW+Q/JS5VKaZ4zHl+IOOdgVzsDpUCr3gTWOpegepcUn5SfUamX5+fTzl7XWXBP91nt+5pFf5vdLyhXYJfuQEQibss0S4Bj4E0ZRYapZiKthZu9Bp+fiYoghS6JaAKSkg1S6zi2ILsYxjDP78ZL8em1RJS6BjkGVI8Rq2UODXN3XMwpn0iaqoWQCQJKPi6olmz93NI1jigHS1i5OEQS8BtND+36GYcEUq3aaTjjnGVKsDj888341+dhQtcsyZMbGrNcdf8/qEmFY2yRp5GhkmDyI4hN+i5yrpkpkLdiDdwXRaCWNIM9V3x6yVRoBciGfR5X4hgzlio0qdoVXRMSPO8S879XKyUsfSnyNFY1u9b72NieFBmEd6AvPKjcSxhxkULQNEPX32DGgx41k5qKQBO32H6CC2y6Wb2o0Yxd9FUAmsZUU2t+PByMBjcNdCRwGKSY+ckjasMmIHw9uhpMDp/NWsyY5L2lPHf6t/2wP5u1Yt4CHLQBdEUZp3MOI1gBN5DDevFhcW9JELoxhfK1+ggzKbQw5IQS/sGt6FcYHdqrKiwQmXmqsoZ8r2pW7qxrv75zj/fu8cE2b6loC5YQtiBBpUROX+yMsnRCiAScSba8E6bM3v6CSFeT7eOlsH4UqfTJHAozB7g1/9PnnRw+JQebj366WTY3bnMuqlYPbHXFcQ0zbHmALavb/qyxjCmIcbIA4FByrhwlTxr2w6L9c032HX+7xe8a5m3Rogx3YAUyj/SNdWmkJntBbaFrN9tt7GnvuBkxfmos4q2+GzqpnYC+4AdS0iK49d5njr4HaVKCryAozRrMpj2v/tOWXVHU43sZ4gHmDFzmydycARAH7Rh9hCsXUG6DbFH7pXzcbxE+NPOkHIyvuaD68JkjpDbvicXuIwEHTe4R3z/Gx0nbMrnf36/q3LlgaQzrD4i//3KVHDulykXhXBRtFwVKGi7aTt6jSulunzxiv+Fh7Tys2x7WKGl5qNg246x11C7DFO8ZzWQFnqmmokves29RbStSni2pw6Cy1VpwIWTgLe6TfvjzLpeWBdQJPDH7ZN20X+X91gJmCG06OyV98lsZ8BF5itO70t24L5vGgCkbpbLp53PdGBKohmvJEqYZtlBWDuiSZHcRCt0lKPMohR2XiBUMOA/ajb1yQ77EbV1SW2tBmUTv8Kj6Vg7KXi/KlcbOWlK73PxlIRvHWtsl5o7iONBjmmR4E7yrL2gPkEpDNmb3Zpf98JcyjMcCpnEctPXLbreXRsx9MRH2noA+x9kSJGzBw3lrteuL2ByS7naKJ3UdVyN5bTs+g/XbgdnbRAg+p/IC0jy4NbqldY2VfITvEi/FGk+h+lQmZgLiNMMXBAfE7AHHs+6ocQI/aGWfoTKvX70E1kW9+3r18upd12PqFni0JEvExrHU3RFmdZf9AYM9G43Or8dX5692hOx91Tfb0I7xRnPXEH8htZCDvv1rAL+DvmHBzcyRPyB7w/ej88tXZzffVS/29tDpdk6ULjicGvHv5et3jq+oYdjTgGMDranePMcXTh1GSrl2POl5pZOYrQiLX+x42yYRp0rhyiLn3MyWaef0pIf4lhoe5GYQXK1AcloYyPLgdOSEYRie9PDnQy3tWrxh8V8).

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->
GitHub Copilot, inline autocomplete only

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
N/A (which model does autocomplete use??)