### PR TITLE
Smaller image for panorama sandcastle demo

### DIFF
--- a/packages/sandcastle/gallery/panorama/main.js
+++ b/packages/sandcastle/gallery/panorama/main.js
@@ -21,7 +21,7 @@ const equirectangularFromFile = () => {
   const transform = Cesium.Transforms.eastNorthUpToFixedFrame(position);
 
   const image =
-    "https://upload.wikimedia.org/wikipedia/commons/0/08/Laon_Cathedral_Interior_360x180%2C_Picardy%2C_France_-_Diliff.jpg";
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Laon_Cathedral_Interior_360x180%2C_Picardy%2C_France_-_Diliff.jpg/3840px-Laon_Cathedral_Interior_360x180%2C_Picardy%2C_France_-_Diliff.jpg";
 
   const credit = new Cesium.Credit(
     "Photo by DAVID ILIFF. " +


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

We were using the full size version of an image for the panorama example that was 22.9MB. Switch to a version which is 2.3MB and still plenty detailed.

## Issue number and link

https://github.com/CesiumGS/cesium/issues/13492

## Testing plan

The image is small enough that the sandcastle should work across most browsers, test on Firefox specifically.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [NA] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
