### PR TITLE
BufferPointCollection: Fix visible rings from 0px outlines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.143 - 2026-07-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fix for `BufferPointCollection` preventing outlineColor from bleeding slightly into the visible area when outlineWidth=0px. [#13543](https://github.com/CesiumGS/cesium/pull/13543)
+
 ## 1.142 - 2026-06-01
 
 ### @cesium/engine

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -150,9 +150,14 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
 
       outlineWidthColorAlphaArray[i * 3] = material.outlineWidth;
       outlineWidthColorAlphaArray[i * 3 + 1] = AttributeCompression.encodeRGB8(
-        material.outlineColor,
+        // When outlineWidth=0, overwrite outlineColor to prevent subpixel bleeding.
+        material.outlineWidth > 0 ? material.outlineColor : material.color,
       );
-      outlineWidthColorAlphaArray[i * 3 + 2] = material.outlineColor.alpha;
+      outlineWidthColorAlphaArray[i * 3 + 2] =
+        // When outlineWidth=0, overwrite outlineAlpha to prevent subpixel bleeding.
+        material.outlineWidth > 0
+          ? material.outlineColor.alpha
+          : material.color.alpha;
 
       point._dirty = false;
     }


### PR DESCRIPTION
# Description

Minor visual fix for BufferPointCollection. For points with `outlineWidth=0px`, especially with `blendOption=OPAQUE`, small hints of the outline color are currently visible at the edges of the point, likely related to smoothstep calls in the fragment shader. To fix this, we'll simply set the outline color and alpha to match the fill color and alpha, when outline width is zero.

The screenshots below show two overlapping points, intentionally in two shades of red. The outer points have hints of white ringing in "before", fixed in "after", which is the relevant change here.

| before | after |
|--|--|
| <img width="170" height="101" alt="before" src="https://github.com/user-attachments/assets/e6d635f4-1872-4178-87d4-6090b2b931cc" /> | <img width="170" height="101" alt="after" src="https://github.com/user-attachments/assets/8bc8995a-7f63-4901-b427-9399493fb817" /> |

## Issue number and link

n/a

## Testing plan

Unfortunately not sure how to test the rendered output with enough precision to detect this, and I'd prefer not to write unit tests against the vertex buffer content directly. This sandcastle is a simple reproduction:

```javascript
const viewer = new Cesium.Viewer("cesiumContainer");

const point = new Cesium.BufferPoint();

const collection = new Cesium.BufferPointCollection({
  blendOption: Cesium.BlendOption.OPAQUE
});

const material = new Cesium.BufferPointMaterial({
  color: Cesium.Color.CRIMSON,
  size: 48,
  outlineWidth: 0
});

collection.add({
  position: Cesium.Cartesian3.fromDegrees(-75.165222, 39.952583),
  material,
});

collection.add({
  position: Cesium.Cartesian3.fromDegrees(-73.935242, 40.730610),
  material,
});

viewer.scene.primitives.add(collection);
viewer.zoomTo(collection, new Cesium.HeadingPitchRange(undefined, -Math.PI / 4, 250_000));
```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13543** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)