### PR TITLE
Fix EdgeVisibilityRendering spec failure in release tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.143 - 2026-07-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixed `EdgeVisibilityRendering` release test failures. [#13545](https://github.com/CesiumGS/cesium/pull/13545)
+
 ## 1.142 - 2026-06-01
 
 ### @cesium/engine

--- a/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
+++ b/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
@@ -53,7 +53,8 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
       pending("Skipping test in WebGL stub environment");
     }
 
-    await loadEdgeVisibilityModel();
+    const model = await loadEdgeVisibilityModel();
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
 
     scene._enableEdgeVisibility = true;
     scene.renderForSpecs();
@@ -66,13 +67,16 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
       const command = commands[i];
       if (command.pass === Pass.CESIUM_3D_TILE_EDGES) {
         edgeCommand = command;
-      } else if (command.pass === Pass.CESIUM_3D_TILE) {
+      } else if (
+        command.pass === Pass.OPAQUE ||
+        command.pass === Pass.CESIUM_3D_TILE
+      ) {
         regularCommand = command;
       }
     }
 
-    expect(edgeCommand).toBeDefined();
-    expect(regularCommand).toBeDefined();
+    expect(edgeCommand).not.toBeNull();
+    expect(regularCommand).not.toBeNull();
 
     if (
       edgeCommand &&
@@ -106,7 +110,8 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
       pending("Skipping test in WebGL stub environment");
     }
 
-    await loadEdgeVisibilityModel();
+    const model = await loadEdgeVisibilityModel();
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
 
     scene._enableEdgeVisibility = true;
     scene.renderForSpecs();
@@ -122,7 +127,7 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
       }
     }
 
-    expect(edgeCommand).toBeDefined();
+    expect(edgeCommand).not.toBeNull();
 
     const vertexShader = edgeCommand.shaderProgram._vertexShaderText;
     const fragmentShader = edgeCommand.shaderProgram._fragmentShaderText;

--- a/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
+++ b/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
@@ -60,8 +60,8 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
     scene.renderForSpecs();
 
     const commands = scene.frameState.commandList;
-    let edgeCommand = null;
-    let regularCommand = null;
+    let edgeCommand;
+    let regularCommand;
 
     for (let i = 0; i < commands.length; i++) {
       const command = commands[i];
@@ -75,8 +75,8 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
       }
     }
 
-    expect(edgeCommand).not.toBeNull();
-    expect(regularCommand).not.toBeNull();
+    expect(edgeCommand).toBeDefined();
+    expect(regularCommand).toBeDefined();
 
     if (
       edgeCommand &&
@@ -117,7 +117,7 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
     scene.renderForSpecs();
 
     const commands = scene.frameState.commandList;
-    let edgeCommand = null;
+    let edgeCommand;
 
     for (let i = 0; i < commands.length; i++) {
       const command = commands[i];
@@ -127,7 +127,7 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
       }
     }
 
-    expect(edgeCommand).not.toBeNull();
+    expect(edgeCommand).toBeDefined();
 
     const vertexShader = edgeCommand.shaderProgram._vertexShaderText;
     const fragmentShader = edgeCommand.shaderProgram._fragmentShaderText;


### PR DESCRIPTION
# Description

### What is Wrong
 
 `EdgeVisibilityRendering` failed in `--release` runs with `TypeError: Cannot read properties of null (reading 'shaderProgram')`.
 
 ### Cause

Two tests never set `edgeDisplayMode`, which now defaults to `SURFACES_ONLY` (suppresses edge commands). With no `CESIUM_3D_TILE_EDGES` command, the `null`-initialized variable passed into `toBeDefined()` and the test failed. We only see this problem in `--release` because normal CI's WebGL stub `pending()`s these tests.
 
 ### Fix
 - Set `edgeDisplayMode = SURFACES_AND_EDGES` so the edge pass is emitted.
 - Also match the surface command on `Pass.OPAQUE`.
 - Initialize command vars as `undefined` so `toBeDefined()` fails correctly now.  this was another latent problem.
 
 ### Verify
 ```bash
 npx gulp buildRelease
 npm run test -- --release --includeName EdgeVisibilityRendering
```

`main` will fail; this branch will succeed. (Don't pass --webglStub.)

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/13541

## Testing plan

1. Checked out `main`, did repro steps, saw error.
2. Checked out this branch, did repro steps, saw no error.
 
## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

GitHub Copilot

If yes, I used the following Model(s):

Claude Opus 4.8
