### PR TITLE
Subdivide polygon rings in PolygonPipeline for curved MVT outlines

### DIFF
--- a/packages/engine/Source/Core/PolygonPipeline.js
+++ b/packages/engine/Source/Core/PolygonPipeline.js
@@ -86,19 +86,20 @@ const subdivisionT2Scratch = new Cartesian2();
 const subdivisionTexcoordMidScratch = new Cartesian2();
 
 /**
- * Subdivides positions and raises points to the surface of the ellipsoid.
+ * Subdivides a triangulated polygon, splitting triangle edges longer than the
+ * granularity so the mesh follows the ellipsoid surface. New vertices are shared
+ * across triangles by tracking split edges. Returns plain arrays plus the
+ * edge-split map so callers can reconstruct other topology (e.g. ring loops).
  *
- * @param {Ellipsoid} ellipsoid The ellipsoid the polygon in on.
- * @param {Cartesian3[]} positions An array of {@link Cartesian3} positions of the polygon.
- * @param {number[]} indices An array of indices that determines the triangles in the polygon.
- * @param {Cartesian2[]} texcoords An optional array of {@link Cartesian2} texture coordinates of the polygon.
- * @param {number} [granularity=CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
- *
- * @exception {DeveloperError} At least three indices are required.
- * @exception {DeveloperError} The number of indices must be divisable by three.
- * @exception {DeveloperError} Granularity must be greater than zero.
+ * @param {Ellipsoid} ellipsoid The ellipsoid the polygon is on.
+ * @param {Cartesian3[]} positions The polygon positions.
+ * @param {number[]} indices The triangle indices.
+ * @param {Cartesian2[]} [texcoords] Optional texture coordinates.
+ * @param {number} [granularity=CesiumMath.RADIANS_PER_DEGREE] The granularity in radians.
+ * @returns {{subdividedPositions: number[], subdividedIndices: number[], subdividedTexcoords: number[], edges: object, hasTexcoords: boolean}}
+ * @private
  */
-PolygonPipeline.computeSubdivision = function (
+function subdivideTriangles(
   ellipsoid,
   positions,
   indices,
@@ -144,6 +145,7 @@ PolygonPipeline.computeSubdivision = function (
   const subdividedIndices = [];
 
   // Used to make sure shared edges are not split more than once.
+  // Maps "<minIndex> <maxIndex>" to the inserted midpoint vertex index.
   const edges = {};
 
   const radius = ellipsoid.maximumRadius;
@@ -292,6 +294,64 @@ PolygonPipeline.computeSubdivision = function (
     }
   }
 
+  return {
+    subdividedPositions: subdividedPositions,
+    subdividedIndices: subdividedIndices,
+    subdividedTexcoords: subdividedTexcoords,
+    edges: edges,
+    hasTexcoords: hasTexcoords,
+  };
+}
+
+/**
+ * Expands a polygon edge (a, b) in order, appending the indices of any vertices
+ * inserted along it by {@link subdivideTriangles} (recursively) to <code>out</code>.
+ * The endpoints themselves are not appended.
+ *
+ * @param {object} edges The edge-split map from {@link subdivideTriangles}.
+ * @param {number} a The start vertex index of the edge.
+ * @param {number} b The end vertex index of the edge.
+ * @param {number[]} out The array to append inserted vertex indices to.
+ * @private
+ */
+function expandSubdividedEdge(edges, a, b, out) {
+  const key = a < b ? `${a} ${b}` : `${b} ${a}`;
+  const mid = edges[key];
+  if (!defined(mid)) {
+    return;
+  }
+  expandSubdividedEdge(edges, a, mid, out);
+  out.push(mid);
+  expandSubdividedEdge(edges, mid, b, out);
+}
+
+/**
+ * Subdivides positions and raises points to the surface of the ellipsoid.
+ *
+ * @param {Ellipsoid} ellipsoid The ellipsoid the polygon in on.
+ * @param {Cartesian3[]} positions An array of {@link Cartesian3} positions of the polygon.
+ * @param {number[]} indices An array of indices that determines the triangles in the polygon.
+ * @param {Cartesian2[]} texcoords An optional array of {@link Cartesian2} texture coordinates of the polygon.
+ * @param {number} [granularity=CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
+ *
+ * @exception {DeveloperError} At least three indices are required.
+ * @exception {DeveloperError} The number of indices must be divisable by three.
+ * @exception {DeveloperError} Granularity must be greater than zero.
+ */
+PolygonPipeline.computeSubdivision = function (
+  ellipsoid,
+  positions,
+  indices,
+  texcoords,
+  granularity,
+) {
+  const {
+    subdividedPositions,
+    subdividedIndices,
+    subdividedTexcoords,
+    hasTexcoords,
+  } = subdivideTriangles(ellipsoid, positions, indices, texcoords, granularity);
+
   const geometryOptions = {
     attributes: {
       position: new GeometryAttribute({
@@ -313,6 +373,81 @@ PolygonPipeline.computeSubdivision = function (
   }
 
   return new Geometry(geometryOptions);
+};
+
+/**
+ * Subdivides a triangulated polygon so that both its fill triangles and its
+ * exterior and interior rings follow the ellipsoid surface. Vertices inserted
+ * while splitting long edges are shared between the fill and the rings, so the
+ * outline and fill stay watertight (no T-junctions).
+ * <p>
+ * Unlike {@link PolygonPipeline.computeSubdivision}, this returns plain arrays
+ * and updated ring (loop) topology rather than a {@link Geometry}, since the
+ * ring topology cannot be recovered from a triangle mesh alone.
+ * </p>
+ *
+ * @param {Ellipsoid} ellipsoid The ellipsoid the polygon is on.
+ * @param {Cartesian3[]} positions The polygon vertices, with the exterior ring
+ *        first followed by each interior ring (hole) contiguously.
+ * @param {number[]} indices Triangle indices from {@link PolygonPipeline.triangulate}.
+ * @param {number[]} [holeOffsets] The index in <code>positions</code> where each
+ *        interior ring (hole) begins. Omit when the polygon has no holes.
+ * @param {number} [granularity=CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between subdivision points.
+ * @returns {{positions: number[], indices: number[], loops: number[][]}} The
+ *        subdivided positions (flattened <code>[x, y, z, ...]</code>), triangle
+ *        indices, and rings. <code>loops[0]</code> is the exterior ring and
+ *        <code>loops[1..]</code> are the holes; each loop is a list of vertex
+ *        indices into the returned positions.
+ *
+ * @exception {DeveloperError} At least three indices are required.
+ * @exception {DeveloperError} The number of indices must be divisable by three.
+ * @exception {DeveloperError} Granularity must be greater than zero.
+ */
+PolygonPipeline.computeSubdivisionWithRings = function (
+  ellipsoid,
+  positions,
+  indices,
+  holeOffsets,
+  granularity,
+) {
+  const { subdividedPositions, subdividedIndices, edges } = subdivideTriangles(
+    ellipsoid,
+    positions,
+    indices,
+    undefined,
+    granularity,
+  );
+
+  // Determine the [start, end) vertex range of each ring in the input
+  // positions: the exterior ring first, then each hole.
+  const ringStarts = [0];
+  if (defined(holeOffsets)) {
+    for (let h = 0; h < holeOffsets.length; h++) {
+      ringStarts.push(holeOffsets[h]);
+    }
+  }
+
+  // Rebuild each closed ring, walking original edges and inserting the shared
+  // midpoints that subdivision added along them.
+  const loops = [];
+  for (let r = 0; r < ringStarts.length; r++) {
+    const start = ringStarts[r];
+    const end =
+      r + 1 < ringStarts.length ? ringStarts[r + 1] : positions.length;
+    const loop = [];
+    for (let v = start; v < end; v++) {
+      const next = v + 1 < end ? v + 1 : start;
+      loop.push(v);
+      expandSubdividedEdge(edges, v, next, loop);
+    }
+    loops.push(loop);
+  }
+
+  return {
+    positions: subdividedPositions,
+    indices: subdividedIndices,
+    loops: loops,
+  };
 };
 
 const subdivisionC0Scratch = new Cartographic();

--- a/packages/engine/Source/Core/PolygonPipeline.js
+++ b/packages/engine/Source/Core/PolygonPipeline.js
@@ -60,7 +60,10 @@ PolygonPipeline.computeWindingOrder2D = function (positions) {
 /**
  * Triangulate a polygon.
  *
- * @param {Cartesian2[]} positions Cartesian2 array containing the vertices of the polygon
+ * @param {Cartesian2[]|number[]|Float64Array} positions A {@link Cartesian2} array, or a flat
+ *        numeric array (or typed array) of <code>[x, y, x, y, ...]</code>,
+ *        containing the vertices of the polygon. Passing the flat form lets
+ *        callers with typed-array data avoid boxing each vertex.
  * @param {number[]} [holes] An array of the staring indices of the holes.
  * @returns {number[]} Index array representing triangles that fill the polygon
  */
@@ -69,7 +72,12 @@ PolygonPipeline.triangulate = function (positions, holes) {
   Check.defined("positions", positions);
   //>>includeEnd('debug');
 
-  const flattenedPositions = Cartesian2.packArray(positions);
+  // earcut consumes a flat [x, y, ...] array. Accept that form directly so
+  // callers do not have to box each vertex into a Cartesian2 first.
+  const flattenedPositions =
+    positions.length === 0 || typeof positions[0] === "number"
+      ? positions
+      : Cartesian2.packArray(positions);
   return earcut(flattenedPositions, holes, 2);
 };
 
@@ -92,9 +100,11 @@ const subdivisionTexcoordMidScratch = new Cartesian2();
  * edge-split map so callers can reconstruct other topology (e.g. ring loops).
  *
  * @param {Ellipsoid} ellipsoid The ellipsoid the polygon is on.
- * @param {Cartesian3[]} positions The polygon positions.
+ * @param {Cartesian3[]|number[]|Float64Array} positions The polygon positions, either as a
+ *        {@link Cartesian3} array or a flat <code>[x, y, z, ...]</code> array.
  * @param {number[]} indices The triangle indices.
- * @param {Cartesian2[]} [texcoords] Optional texture coordinates.
+ * @param {Cartesian2[]|number[]|Float64Array} [texcoords] Optional texture coordinates, either
+ *        as a {@link Cartesian2} array or a flat <code>[x, y, ...]</code> array.
  * @param {number} [granularity=CesiumMath.RADIANS_PER_DEGREE] The granularity in radians.
  * @returns {{subdividedPositions: number[], subdividedIndices: number[], subdividedTexcoords: number[], edges: object, hasTexcoords: boolean}}
  * @private
@@ -122,23 +132,42 @@ function subdivideTriangles(
   // triangles that need (or might need) to be subdivided.
   const triangles = indices.slice(0);
 
+  // Positions and texcoords may be supplied either as Cartesian arrays or as
+  // flat numeric/typed arrays. Detect once so the copy below reads either form.
+  const positionsAreFlat =
+    positions.length === 0 || typeof positions[0] === "number";
+  const texcoordsAreFlat =
+    hasTexcoords &&
+    (texcoords.length === 0 || typeof texcoords[0] === "number");
+
   // New positions due to edge splits are appended to the positions list.
   let i;
-  const length = positions.length;
+  const length = positionsAreFlat ? positions.length / 3 : positions.length;
   const subdividedPositions = new Array(length * 3);
   const subdividedTexcoords = new Array(length * 2);
   let q = 0;
   let p = 0;
   for (i = 0; i < length; i++) {
-    const item = positions[i];
-    subdividedPositions[q++] = item.x;
-    subdividedPositions[q++] = item.y;
-    subdividedPositions[q++] = item.z;
+    if (positionsAreFlat) {
+      subdividedPositions[q++] = positions[i * 3];
+      subdividedPositions[q++] = positions[i * 3 + 1];
+      subdividedPositions[q++] = positions[i * 3 + 2];
+    } else {
+      const item = positions[i];
+      subdividedPositions[q++] = item.x;
+      subdividedPositions[q++] = item.y;
+      subdividedPositions[q++] = item.z;
+    }
 
     if (hasTexcoords) {
-      const texcoordItem = texcoords[i];
-      subdividedTexcoords[p++] = texcoordItem.x;
-      subdividedTexcoords[p++] = texcoordItem.y;
+      if (texcoordsAreFlat) {
+        subdividedTexcoords[p++] = texcoords[i * 2];
+        subdividedTexcoords[p++] = texcoords[i * 2 + 1];
+      } else {
+        const texcoordItem = texcoords[i];
+        subdividedTexcoords[p++] = texcoordItem.x;
+        subdividedTexcoords[p++] = texcoordItem.y;
+      }
     }
   }
 
@@ -387,8 +416,9 @@ PolygonPipeline.computeSubdivision = function (
  * </p>
  *
  * @param {Ellipsoid} ellipsoid The ellipsoid the polygon is on.
- * @param {Cartesian3[]} positions The polygon vertices, with the exterior ring
- *        first followed by each interior ring (hole) contiguously.
+ * @param {Cartesian3[]|number[]|Float64Array} positions The polygon vertices, with the
+ *        exterior ring first followed by each interior ring (hole) contiguously.
+ *        Either a {@link Cartesian3} array or a flat <code>[x, y, z, ...]</code> array.
  * @param {number[]} indices Triangle indices from {@link PolygonPipeline.triangulate}.
  * @param {number[]} [holeOffsets] The index in <code>positions</code> where each
  *        interior ring (hole) begins. Omit when the polygon has no holes.
@@ -418,6 +448,13 @@ PolygonPipeline.computeSubdivisionWithRings = function (
     granularity,
   );
 
+  // positions may be a Cartesian3 array or a flat [x, y, z, ...] array; the
+  // number of input vertices differs accordingly.
+  const vertexCount =
+    positions.length === 0 || typeof positions[0] === "number"
+      ? positions.length / 3
+      : positions.length;
+
   // Determine the [start, end) vertex range of each ring in the input
   // positions: the exterior ring first, then each hole.
   const ringStarts = [0];
@@ -432,8 +469,7 @@ PolygonPipeline.computeSubdivisionWithRings = function (
   const loops = [];
   for (let r = 0; r < ringStarts.length; r++) {
     const start = ringStarts[r];
-    const end =
-      r + 1 < ringStarts.length ? ringStarts[r + 1] : positions.length;
+    const end = r + 1 < ringStarts.length ? ringStarts[r + 1] : vertexCount;
     const loop = [];
     for (let v = start; v < end; v++) {
       const next = v + 1 < end ? v + 1 : start;

--- a/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
+++ b/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import Cartesian2 from "../Core/Cartesian2.js";
 import Cartesian3 from "../Core/Cartesian3.js";
 import ComponentDatatype from "../Core/ComponentDatatype.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
@@ -580,10 +579,22 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
 
         for (const group of groups) {
           const rings = [group.outerRing, ...group.holes];
-          /** @type {Cartesian2[]} */
-          const positions2D = [];
-          /** @type {Cartesian3[]} */
-          const worldPositions = [];
+
+          // Count vertices up front so the pipeline inputs can be packed into
+          // flat typed arrays instead of boxing each vertex into Cartesian2/3.
+          let totalVertexCount = 0;
+          for (let ringIndex = 0; ringIndex < rings.length; ringIndex++) {
+            totalVertexCount += rings[ringIndex].length;
+          }
+
+          if (totalVertexCount < 3) {
+            continue;
+          }
+
+          // Flat [x, y, ...] tile coordinates for triangulation and flat
+          // [x, y, z, ...] world positions for subdivision.
+          const positions2D = new Float64Array(totalVertexCount * 2);
+          const worldPositions = new Float64Array(totalVertexCount * 3);
           /** @type {number[]} */
           const holeOffsets = [];
           let vertexOffset = 0;
@@ -595,23 +606,22 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
             }
 
             for (const point of ring) {
-              positions2D.push(new Cartesian2(point.x, point.y));
-              worldPositions.push(
-                tilePointToWorld(
-                  point,
-                  tileX,
-                  tileY,
-                  tileZ,
-                  extent,
-                  DEFAULT_HEIGHT,
-                ),
+              positions2D[vertexOffset * 2] = point.x;
+              positions2D[vertexOffset * 2 + 1] = point.y;
+              tilePointToWorld(
+                point,
+                tileX,
+                tileY,
+                tileZ,
+                extent,
+                DEFAULT_HEIGHT,
+                scratchWorld,
               );
+              worldPositions[vertexOffset * 3] = scratchWorld.x;
+              worldPositions[vertexOffset * 3 + 1] = scratchWorld.y;
+              worldPositions[vertexOffset * 3 + 2] = scratchWorld.z;
               vertexOffset++;
             }
-          }
-
-          if (positions2D.length < 3) {
-            continue;
           }
 
           const triangles = PolygonPipeline.triangulate(
@@ -1038,16 +1048,17 @@ function appendTilePointAsLocalPosition(
  * @param {number} tileZ
  * @param {number} extent
  * @param {number} height
+ * @param {Cartesian3} [result] An optional position to store the result.
  * @returns {Cartesian3} A new world-space position.
  * @ignore
  */
-function tilePointToWorld(point, tileX, tileY, tileZ, extent, height) {
+function tilePointToWorld(point, tileX, tileY, tileZ, extent, height, result) {
   const n = 1 << tileZ;
   const u = (tileX + point.x / extent) / n;
   const v = (tileY + point.y / extent) / n;
   const lon = u * 2 * Math.PI - Math.PI;
   const lat = Math.atan(Math.sinh(Math.PI * (1 - 2 * v)));
-  return Cartesian3.fromRadians(lon, lat, height);
+  return Cartesian3.fromRadians(lon, lat, height, undefined, result);
 }
 
 /**

--- a/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
+++ b/packages/engine/Source/Scene/buildVectorGltfFromMVT.js
@@ -627,19 +627,21 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
             continue;
           }
 
-          // Subdivide the triangulated fill so large triangles follow the
-          // ellipsoid's curvature. The original ring vertices keep their
-          // indices (subdivision appends new midpoints), preserving the hole
-          // offsets used to reconstruct polygon outlines.
-          const subdivided = PolygonPipeline.computeSubdivision(
+          // Subdivide the triangulated fill AND the exterior/interior rings so
+          // both follow the ellipsoid's curvature, sharing the same boundary
+          // vertices (no T-junctions between fill and outline). The returned
+          // loops reference subdivided vertices, so ring topology is updated to
+          // include the midpoints inserted along long ring edges.
+          const subdivided = PolygonPipeline.computeSubdivisionWithRings(
             subdivisionEllipsoid,
             worldPositions,
             triangles,
-            undefined,
+            holeOffsets.length > 0 ? holeOffsets : undefined,
             granularity,
           );
-          const subdividedValues = subdivided.attributes.position.values;
+          const subdividedValues = subdivided.positions;
           const subdividedIndices = subdivided.indices;
+          const subdividedLoops = subdivided.loops;
           const subdividedVertexCount = subdividedValues.length / 3;
 
           if (subdividedVertexCount < 3 || subdividedIndices.length < 3) {
@@ -648,31 +650,21 @@ function buildVectorGltfFromMVT(decoded, tileCoordinates, options) {
 
           const globalVertexStart = polygonPositions.length / 3;
           const globalIndexStart = polygonIndices.length;
-          // Number of ring vertices before subdivision. computeSubdivision keeps
-          // these as the first vertices (original indices) and appends interior
-          // midpoints afterwards, so the ring vertices remain addressable here.
-          const originalRingVertexCount = worldPositions.length;
 
           polygonIndicesOffsets.push(globalIndexStart);
 
-          // Build EXT_mesh_polygon loop (ring) indices for this polygon: the
-          // exterior ring first, then each hole ring, separated by the primitive
-          // restart index. Indices reference the shared POSITION buffer.
+          // Build EXT_mesh_polygon loop (ring) indices for this polygon from the
+          // subdivided rings: the exterior ring first, then each hole ring,
+          // separated by the primitive restart index. Indices reference the
+          // shared POSITION buffer.
           polygonLoopIndicesOffsets.push(polygonLoopIndices.length);
-          const exteriorEnd =
-            holeOffsets.length > 0 ? holeOffsets[0] : originalRingVertexCount;
-          for (let v = 0; v < exteriorEnd; v++) {
-            polygonLoopIndices.push(globalVertexStart + v);
-          }
-          for (let h = 0; h < holeOffsets.length; h++) {
-            const holeStart = holeOffsets[h];
-            const holeEnd =
-              h + 1 < holeOffsets.length
-                ? holeOffsets[h + 1]
-                : originalRingVertexCount;
-            polygonLoopIndices.push(primitiveRestartIndex);
-            for (let v = holeStart; v < holeEnd; v++) {
-              polygonLoopIndices.push(globalVertexStart + v);
+          for (let r = 0; r < subdividedLoops.length; r++) {
+            if (r > 0) {
+              polygonLoopIndices.push(primitiveRestartIndex);
+            }
+            const loop = subdividedLoops[r];
+            for (let v = 0; v < loop.length; v++) {
+              polygonLoopIndices.push(globalVertexStart + loop[v]);
             }
           }
 

--- a/packages/engine/Specs/Core/PolygonPipelineSpec.js
+++ b/packages/engine/Specs/Core/PolygonPipelineSpec.js
@@ -421,6 +421,118 @@ describe("Core/PolygonPipeline", function () {
   });
   ///////////////////////////////////////////////////////////////////////
 
+  it("computeSubdivisionWithRings returns the exterior ring with no holes", function () {
+    // A small quad on the surface that should not be subdivided.
+    const positions = [
+      new Cartesian3(6378137, 0, 0),
+      new Cartesian3(6377802.759444977, 58441.30561735455, 0),
+      new Cartesian3(6377802.759444977, 58441.30561735455, 29025.647900582237),
+      new Cartesian3(6378137, 0, 29025.647900582237),
+    ];
+    const indices = PolygonPipeline.triangulate(
+      [
+        new Cartesian2(0, 0),
+        new Cartesian2(1, 0),
+        new Cartesian2(1, 1),
+        new Cartesian2(0, 1),
+      ],
+      undefined,
+    );
+
+    const result = PolygonPipeline.computeSubdivisionWithRings(
+      Ellipsoid.WGS84,
+      positions,
+      indices,
+    );
+
+    expect(result.positions.length).toEqual(positions.length * 3);
+    expect(result.indices.length).toEqual(indices.length);
+    // One exterior ring, no holes.
+    expect(result.loops.length).toEqual(1);
+    expect(result.loops[0]).toEqual([0, 1, 2, 3]);
+  });
+
+  it("computeSubdivisionWithRings subdivides long ring edges and shares vertices with the fill", function () {
+    // A large triangle spanning a wide arc so its edges exceed the granularity
+    // and must be subdivided.
+    const positions = [
+      new Cartesian3(6378137, 0, 0),
+      new Cartesian3(0, 6378137, 0),
+      new Cartesian3(0, 0, 6356752.314245179),
+    ];
+    const indices = [0, 1, 2];
+
+    const result = PolygonPipeline.computeSubdivisionWithRings(
+      Ellipsoid.WGS84,
+      positions,
+      indices,
+      undefined,
+      CesiumMath.toRadians(5.0),
+    );
+
+    expect(result.loops.length).toEqual(1);
+    const loop = result.loops[0];
+    // Ring topology now includes vertices inserted along the long edges.
+    expect(loop.length).toBeGreaterThan(positions.length);
+
+    const vertexCount = result.positions.length / 3;
+    // Every loop index references a valid vertex in the subdivided positions.
+    for (let i = 0; i < loop.length; i++) {
+      expect(loop[i]).toBeGreaterThanOrEqual(0);
+      expect(loop[i]).toBeLessThan(vertexCount);
+    }
+    // The original corners are preserved, in order, as a subsequence of the loop.
+    expect(loop.indexOf(0)).toBeLessThan(loop.indexOf(1));
+    expect(loop.indexOf(1)).toBeLessThan(loop.indexOf(2));
+
+    // Inserted ring vertices are shared with the triangle fill (no T-junctions):
+    // every loop vertex is referenced by at least one triangle index.
+    const usedByFill = new Set(result.indices);
+    for (let i = 0; i < loop.length; i++) {
+      expect(usedByFill.has(loop[i])).toBe(true);
+    }
+  });
+
+  it("computeSubdivisionWithRings returns one loop per ring with holes", function () {
+    // Outer square (0..3) with an inner square hole (4..7).
+    const positions = [
+      new Cartesian3(6378137, 0, 0),
+      new Cartesian3(6377802.759444977, 58441.30561735455, 0),
+      new Cartesian3(6377802.759444977, 58441.30561735455, 29025.647900582237),
+      new Cartesian3(6378137, 0, 29025.647900582237),
+      new Cartesian3(6378100, 14610, 7256),
+      new Cartesian3(6378100, 43830, 7256),
+      new Cartesian3(6378100, 43830, 21769),
+      new Cartesian3(6378100, 14610, 21769),
+    ];
+    const contour = [
+      new Cartesian2(0, 0),
+      new Cartesian2(4, 0),
+      new Cartesian2(4, 4),
+      new Cartesian2(0, 4),
+      new Cartesian2(1, 1),
+      new Cartesian2(3, 1),
+      new Cartesian2(3, 3),
+      new Cartesian2(1, 3),
+    ];
+    const holeOffsets = [4];
+    const indices = PolygonPipeline.triangulate(contour, holeOffsets);
+
+    const result = PolygonPipeline.computeSubdivisionWithRings(
+      Ellipsoid.WGS84,
+      positions,
+      indices,
+      holeOffsets,
+    );
+
+    // One exterior ring plus one hole.
+    expect(result.loops.length).toEqual(2);
+    expect(result.loops[0]).toEqual([0, 1, 2, 3]);
+    expect(result.loops[1]).toEqual([4, 5, 6, 7]);
+  });
+
+  ///////////////////////////////////////////////////////////////////////
+
   it("computeRhumbLineSubdivision throws without ellipsoid", function () {
     expect(function () {
       PolygonPipeline.computeRhumbLineSubdivision();

--- a/packages/engine/Specs/Core/PolygonPipelineSpec.js
+++ b/packages/engine/Specs/Core/PolygonPipelineSpec.js
@@ -531,6 +531,56 @@ describe("Core/PolygonPipeline", function () {
     expect(result.loops[1]).toEqual([4, 5, 6, 7]);
   });
 
+  it("triangulate accepts a flat typed array of positions", function () {
+    const contour = [
+      new Cartesian2(0, 0),
+      new Cartesian2(1, 0),
+      new Cartesian2(1, 1),
+      new Cartesian2(0, 1),
+    ];
+    const flat = new Float64Array([0, 0, 1, 0, 1, 1, 0, 1]);
+
+    const fromCartesians = PolygonPipeline.triangulate(contour);
+    const fromFlat = PolygonPipeline.triangulate(flat);
+
+    expect(fromFlat).toEqual(fromCartesians);
+  });
+
+  it("computeSubdivisionWithRings accepts a flat typed array of positions", function () {
+    const cartesianPositions = [
+      new Cartesian3(6378137, 0, 0),
+      new Cartesian3(0, 6378137, 0),
+      new Cartesian3(0, 0, 6356752.314245179),
+    ];
+    const flatPositions = new Float64Array([
+      6378137, 0, 0, 0, 6378137, 0, 0, 0, 6356752.314245179,
+    ]);
+    const indices = [0, 1, 2];
+    const granularity = CesiumMath.toRadians(5.0);
+
+    const fromCartesians = PolygonPipeline.computeSubdivisionWithRings(
+      Ellipsoid.WGS84,
+      cartesianPositions,
+      indices,
+      undefined,
+      granularity,
+    );
+    const fromFlat = PolygonPipeline.computeSubdivisionWithRings(
+      Ellipsoid.WGS84,
+      flatPositions,
+      indices,
+      undefined,
+      granularity,
+    );
+
+    // The typed-array path must produce identical results to the Cartesian path.
+    expect(fromFlat.positions).toEqual(fromCartesians.positions);
+    expect(fromFlat.indices).toEqual(fromCartesians.indices);
+    expect(fromFlat.loops).toEqual(fromCartesians.loops);
+    // Sanity check: long ring edges were still subdivided.
+    expect(fromFlat.loops[0].length).toBeGreaterThan(3);
+  });
+
   ///////////////////////////////////////////////////////////////////////
 
   it("computeRhumbLineSubdivision throws without ellipsoid", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Refactors `PolygonPipeline.computeSubdivision` into a shared internal subdivider and adds `computeSubdivisionWithRings`, which updates exterior/interior ring topology and returns plain arrays ({positions, indices, loops}) instead of a Geometry. The MVT producer now emits `EXT_mesh_polygon` `loopIndices` that include the subdivided midpoints, so polygon outlines follow the ellipsoid curvature and share vertices with the fill triangles (no T-junctions).
Additionally, triangulate, subdivideTriangles, and computeSubdivisionWithRings now accept flat typed arrays ([x, y, (z), ...]) in addition to Cartesian2[]/Cartesian3[]. The MVT producer packs positions directly into Float64Arrays instead of allocating a Cartesian per vertex, avoiding per-vertex boxing and GC pressure. This is fully backward compatible — the Cartesian input path is unchanged, with only a single typeof format check added per call.
<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
