### PR TITLE
GeoJsonPrimitive: Add simplestyle-spec 1.1 support

### DIFF
--- a/packages/engine/Source/Scene/GeoJsonPrimitive.js
+++ b/packages/engine/Source/Scene/GeoJsonPrimitive.js
@@ -1,11 +1,9 @@
 // @ts-check
 
-/** @import {GeoJson, GeoJsonFeature, GeoJsonGeometry, GeoJsonPosition} from "../Core/globalTypes.js"; */
-/** @import FrameState from "./FrameState.js"; */
-
 import Cartesian2 from "../Core/Cartesian2.js";
 import Cartesian3 from "../Core/Cartesian3.js";
 import Check from "../Core/Check.js";
+import Color from "../Core/Color.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
@@ -16,10 +14,17 @@ import Resource from "../Core/Resource.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import BufferPoint from "./BufferPoint.js";
 import BufferPointCollection from "./BufferPointCollection.js";
+import BufferPointMaterial from "./BufferPointMaterial.js";
 import BufferPolygon from "./BufferPolygon.js";
 import BufferPolygonCollection from "./BufferPolygonCollection.js";
+import BufferPolygonMaterial from "./BufferPolygonMaterial.js";
 import BufferPolyline from "./BufferPolyline.js";
 import BufferPolylineCollection from "./BufferPolylineCollection.js";
+import BufferPolylineMaterial from "./BufferPolylineMaterial.js";
+
+/** @import {GeoJson, GeoJsonFeature, GeoJsonGeometry, GeoJsonPosition} from "../Core/globalTypes.js"; */
+/** @import BufferPrimitiveMaterial from "./BufferPrimitiveMaterial.js"; */
+/** @import FrameState from "./FrameState.js"; */
 
 /**
  * @typedef {object} GeoJsonPrimitiveConstructorOptions
@@ -30,6 +35,18 @@ import BufferPolylineCollection from "./BufferPolylineCollection.js";
  * @property {boolean} [show=true]
  * @property {function(number, object, Record<string, unknown>):object} [pickObjectFactory]
  */
+
+const scratchPoint = new BufferPoint();
+const scratchPolyline = new BufferPolyline();
+const scratchPolygon = new BufferPolygon();
+
+const scratchPointMaterial = new BufferPointMaterial();
+const scratchPolylineMaterial = new BufferPolylineMaterial();
+const scratchPolygonMaterial = new BufferPolygonMaterial();
+
+const defaultPointMaterial = new BufferPointMaterial();
+const defaultPolylineMaterial = new BufferPolylineMaterial();
+const defaultPolygonMaterial = new BufferPolygonMaterial();
 
 /**
  * Lightweight GeoJSON loader that converts features directly into
@@ -125,68 +142,104 @@ class GeoJsonPrimitive {
     for (let i = 0; i < parseResult.features.length; i++) {
       const feature = parseResult.features[i];
       const featureId = feature.featureId;
-      const sourceProperties = this._properties[featureId];
+      const properties = this._properties[featureId];
+
+      let pointMaterial = defaultPointMaterial;
+      if (properties !== Frozen.EMPTY_OBJECT && feature.points.length > 0) {
+        pointMaterial = parseSimpleStylePointProps(
+          properties,
+          scratchPointMaterial,
+        );
+      }
 
       for (let j = 0; j < feature.points.length; j++) {
         const idx = pointIndex++;
-        this._points.add({
-          featureId: featureId,
-          position: toCartesian(feature.points[j], ellipsoid, scratch),
-          pickObject: allowPicking
-            ? createPickObject(
-                this,
-                idx,
-                this._points,
-                BufferPoint,
-                sourceProperties,
-              )
-            : undefined,
-        });
+        this._points.add(
+          {
+            featureId: featureId,
+            position: toCartesian(feature.points[j], ellipsoid, scratch),
+            material: pointMaterial,
+            pickObject: allowPicking
+              ? createPickObject(
+                  this,
+                  idx,
+                  this._points,
+                  BufferPoint,
+                  properties,
+                )
+              : undefined,
+          },
+          scratchPoint,
+        );
+      }
+
+      let polylineMaterial = defaultPolylineMaterial;
+      if (properties !== Frozen.EMPTY_OBJECT && feature.polylines.length > 0) {
+        polylineMaterial = parseSimpleStylePolylineProps(
+          properties,
+          scratchPolylineMaterial,
+        );
       }
 
       for (let j = 0; j < feature.polylines.length; j++) {
         const idx = polylineIndex++;
-        this._polylines.add({
-          featureId: featureId,
-          positions: packPositionsToScratch(
-            feature.polylines[j],
-            ellipsoid,
-            getPackedPositionScratch,
-          ),
-          pickObject: allowPicking
-            ? createPickObject(
-                this,
-                idx,
-                this._polylines,
-                BufferPolyline,
-                sourceProperties,
-              )
-            : undefined,
-        });
+        this._polylines.add(
+          {
+            featureId: featureId,
+            positions: packPositionsToScratch(
+              feature.polylines[j],
+              ellipsoid,
+              getPackedPositionScratch,
+            ),
+            material: polylineMaterial,
+            pickObject: allowPicking
+              ? createPickObject(
+                  this,
+                  idx,
+                  this._polylines,
+                  BufferPolyline,
+                  properties,
+                )
+              : undefined,
+          },
+          scratchPolyline,
+        );
+      }
+
+      let polygonMaterial = defaultPolygonMaterial;
+      if (properties !== Frozen.EMPTY_OBJECT && feature.polygons.length > 0) {
+        polygonMaterial = parseSimpleStylePolygonProps(
+          properties,
+          scratchPolygonMaterial,
+        );
       }
 
       for (let j = 0; j < feature.polygons.length; j++) {
         const polygon = feature.polygons[j];
         const idx = polygonIndex++;
-        this._polygons.add({
-          featureId: featureId,
-          positions: packPositionsToScratch(
-            polygon.positions,
-            ellipsoid,
-            getPackedPositionScratch,
-          ),
-          holes: polygon.holes,
-          triangles: polygon.triangles,
-          pickObject: allowPicking
-            ? createPickObject(
-                this,
-                idx,
-                this._polygons,
-                BufferPolygon,
-                sourceProperties,
-              )
-            : undefined,
-        });
+        this._polygons.add(
+          {
+            featureId: featureId,
+            positions: packPositionsToScratch(
+              polygon.positions,
+              ellipsoid,
+              getPackedPositionScratch,
+            ),
+            holes: polygon.holes,
+            triangles: polygon.triangles,
+            material: polygonMaterial,
+            pickObject: allowPicking
+              ? createPickObject(
+                  this,
+                  idx,
+                  this._polygons,
+                  BufferPolygon,
+                  properties,
+                )
+              : undefined,
+          },
+          scratchPolygon,
+        );
       }
     }
   }
@@ -869,6 +922,98 @@ function packPositionsToScratch(positions, ellipsoid, getScratch) {
  */
 function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reference: https://github.com/mapbox/simplestyle-spec
+ *
+ * @typedef {object} GeoJsonSimpleStyleProperties
+ * @property {string} [title] Title to show when this item is clicked or hovered over.
+ * @property {string} [description] Description to show when this item is clicked or hovered over.
+ * @property {'small'|'medium'|'large'} [marker-size] Size of the marker.
+ * @property {string} [marker-symbol] Symbol to position in center of this icon. Allowed values include Icon ID, integer 0–9, lowerchase character "a" to "z".
+ * @property {string} [marker-color] Marker color. Value must follow COLOR RULES.
+ * @property {string} [stroke] Color of a line as part of a polygon, polyline, or multigeometry. Value must follow COLOR RULES.
+ * @property {number} [stroke-opacity] Opacity of the line component of a polygon, polyline, or multigeometry, [0, 1].
+ * @property {number} [stroke-width] Width of the line component of a polygon, polyline, or multigeometry, >= 0.
+ * @property {string} [fill] Color of the interior of a polygon. Value must follow COLOR RULES.
+ * @property {number} [fill-opacity] Opacity of the interior of a polygon, [0, 1].
+ * @ignore
+ */
+
+/**
+ * @param {GeoJsonSimpleStyleProperties} props
+ * @param {BufferPointMaterial} result
+ * @returns {BufferPointMaterial}
+ * @ignore
+ */
+function parseSimpleStylePointProps(props, result) {
+  if (defined(props["fill"])) {
+    Color.fromCssColorString(props["fill"], result.color);
+  } else {
+    Color.clone(Color.WHITE, result.color);
+  }
+
+  result.color.alpha = props["fill-opacity"] ?? 1.0;
+
+  if (defined(props["stroke"])) {
+    Color.fromCssColorString(props["stroke"], result.outlineColor);
+  } else {
+    Color.clone(Color.WHITE, result.outlineColor);
+  }
+
+  result.outlineColor.alpha = props["stroke-opacity"] ?? 1.0;
+  result.outlineWidth = props["stroke-width"] ?? 1.0;
+
+  return result;
+}
+
+/**
+ * @param {GeoJsonSimpleStyleProperties} props
+ * @param {BufferPolylineMaterial} result
+ * @returns {BufferPolylineMaterial}
+ * @ignore
+ */
+function parseSimpleStylePolylineProps(props, result) {
+  // simplestyle-spec defines 'stroke' for polylines, but BufferPolylineMaterial
+  // uses 'color', not 'outline-color'.
+  if (defined(props["stroke"])) {
+    Color.fromCssColorString(props["stroke"], result.color);
+  } else {
+    Color.clone(Color.WHITE, result.color);
+  }
+
+  result.color.alpha = props["stroke-opacity"] ?? 1.0;
+  result.width = props["stroke-width"] ?? 1.0;
+
+  return result;
+}
+
+/**
+ * @param {GeoJsonSimpleStyleProperties} props
+ * @param {BufferPolygonMaterial} result
+ * @returns {BufferPolygonMaterial}
+ * @ignore
+ */
+function parseSimpleStylePolygonProps(props, result) {
+  if (defined(props["fill"])) {
+    Color.fromCssColorString(props["fill"], result.color);
+  } else {
+    Color.clone(Color.WHITE, result.color);
+  }
+
+  result.color.alpha = props["fill-opacity"] ?? 1.0;
+
+  if (defined(props["stroke"])) {
+    Color.fromCssColorString(props["stroke"], result.outlineColor);
+  } else {
+    Color.clone(Color.WHITE, result.outlineColor);
+  }
+
+  result.outlineColor.alpha = props["stroke-opacity"] ?? 1.0;
+  result.outlineWidth = props["stroke-width"] ?? 1.0;
+
+  return result;
 }
 
 export default GeoJsonPrimitive;

--- a/packages/engine/Specs/Scene/GeoJsonPrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/GeoJsonPrimitiveSpec.js
@@ -1,7 +1,10 @@
 import {
   BufferPoint,
+  BufferPointMaterial,
   BufferPolygon,
+  BufferPolygonMaterial,
   BufferPolyline,
+  BufferPolylineMaterial,
   GeoJsonPrimitive,
   RuntimeError,
 } from "../../index.js";
@@ -148,6 +151,107 @@ describe("Scene/GeoJsonPrimitive", function () {
     expect(loader.points.primitiveCount).toBe(2);
     expect(loader.polylines).toBeUndefined();
     expect(loader.polygons).toBeUndefined();
+  });
+
+  it("accepts simplestyle 1.1 - polygons", () => {
+    const geoJson = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {
+            fill: "#FF0000",
+            "fill-opacity": 0.5,
+            stroke: "#00FF00",
+            "stroke-opacity": 0.75,
+            "stroke-width": 4,
+          },
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [-21.0205342, 33.4930122],
+                [-2.452129, 28.8391351],
+                [-1.0079093, 37.5961399],
+                [-15.872334, 43.690817],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+
+    const primitive = new GeoJsonPrimitive({ geoJson });
+    const polygon = primitive.polygons.get(0, new BufferPolygon());
+    const material = polygon.getMaterial(new BufferPolygonMaterial());
+
+    expect(material.color.toCssHexString()).toBe("#ff000080");
+    expect(material.outlineColor.toCssHexString()).toBe("#00ff00c0");
+    expect(material.outlineWidth).toBe(4);
+  });
+
+  it("accepts simplestyle 1.1 - polylines", () => {
+    const geoJson = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {
+            fill: "#FF0000", // ignored
+            "fill-opacity": 0.5, // ignored
+            stroke: "#00FF00",
+            "stroke-opacity": 0.75,
+            "stroke-width": 4,
+          },
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [-21.0205342, 33.4930122],
+              [-2.452129, 28.8391351],
+              [-1.0079093, 37.5961399],
+              [-15.872334, 43.690817],
+            ],
+          },
+        },
+      ],
+    };
+
+    const primitive = new GeoJsonPrimitive({ geoJson });
+    const polyline = primitive.polylines.get(0, new BufferPolyline());
+    const material = polyline.getMaterial(new BufferPolylineMaterial());
+
+    expect(material.color.toCssHexString()).toBe("#00ff00c0");
+    expect(material.width).toBe(4);
+  });
+
+  it("accepts simplestyle 1.1 - points", () => {
+    const geoJson = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {
+            fill: "#FF0000",
+            "fill-opacity": 0.5,
+            stroke: "#00FF00",
+            "stroke-opacity": 0.75,
+            "stroke-width": 4,
+          },
+          geometry: {
+            type: "Point",
+            coordinates: [-21.0205342, 33.4930122],
+          },
+        },
+      ],
+    };
+
+    const primitive = new GeoJsonPrimitive({ geoJson });
+    const point = primitive.points.get(0, new BufferPoint());
+    const material = point.getMaterial(new BufferPointMaterial());
+
+    expect(material.color.toCssHexString()).toBe("#ff000080");
+    expect(material.outlineColor.toCssHexString()).toBe("#00ff00c0");
+    expect(material.outlineWidth).toBe(4);
   });
 
   it("throws for unsupported top-level types", function () {


### PR DESCRIPTION

# Description

Small PR for simplestyle-spec 1.1 support, matching GeoJsonDataSource.

Note that I've implemented parsing for polygon strokes/outlines, but we don't yet support rendering those with BufferPolygonCollection. That's tracked in #13444 and likely coming soon.

## Issue number and link

n/a

## Testing plan

Added unit tests.

Example:

```javascript
import * as Cesium from "cesium";

const viewer = new Cesium.Viewer("cesiumContainer");

const prim = new Cesium.GeoJsonPrimitive({geoJson:{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "fill": "rgba(255, 0, 0, 1)",
        "fill-opacity": 0.5,
        "stroke": "rgba(0, 255, 42, 1)",
        "stroke-opacity": 1,
        "stroke-width": 4
      },
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              -21.0205342,
              33.4930122
            ],
            [
              -2.452129,
              28.8391351
            ],
            [
              -1.0079093,
              37.5961399
            ],
            [
              -15.872334,
              43.690817
            ],
            [
              -28.0149113,
              41.298494
            ],
            [
              -21.0205342,
              33.4930122
            ]
          ]
        ]
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              5.3598656,
              40.6971887
            ],
            [
              5.3598656,
              40.6971887
            ],
            [
              5.3598656,
              40.6971887
            ],
            [
              5.3598656,
              40.6971887
            ]
          ]
        ]
      }
    },
    {
      "type": "Feature",
      "properties": {
        "fill": "rgba(255, 251, 0, 1)",
        "fill-opacity": 0.5,
        "stroke-opacity": 0
      },
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              7.0446799311852715,
              38.543931943776784
            ],
            [
              22.660401203559474,
              37.37844114327537
            ],
            [
              19.905181227216417,
              26.68449771610058
            ],
            [
              6.262298933950717,
              27.891271337207428
            ],
            [
              7.0446799311852715,
              38.543931943776784
            ]
          ]
        ]
      }
    },
    {
      "type": "Feature",
      "properties": {
        "stroke": "rgba(9, 1, 255, 1)",
        "stroke-opacity": 0.5,
        "stroke-width": 8
      },
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            -6.1582405,
            45.4765483
          ],
          [
            3.3412389,
            50.0247762
          ],
          [
            3.4903598,
            43.1650568
          ],
          [
            9.1983068,
            46.6367064
          ],
          [
            10.786459,
            41.6176047
          ],
          [
            23.3025144,
            44.7244527
          ],
          [
            23.0069026,
            40.4267745
          ]
        ]
      }
    }
  ]
}});


viewer.scene.primitives.add(prim);
```

Result:
<img width="946" height="453" alt="Screenshot 2026-06-04 at 6 01 49 PM" src="https://github.com/user-attachments/assets/d9a3d75b-2c40-4075-aa14-3c02e73f6e25" />



## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->






#### PR Dependency Tree


* **PR #13549** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)