### PR TITLE
BufferPolylineCollection: Simplify float64/float32 branches

### DIFF
--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -109,6 +109,8 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
   if (collection._dirtyCount > 0) {
     const { attributeArrays } = renderContext;
 
+    const positionHighArray = attributeArrays.positionHigh;
+    const positionLowArray = attributeArrays.positionLow;
     const pickColorArray = attributeArrays.pickColor;
     const showSizeColorAlphaArray = attributeArrays.showSizeColorAlpha;
     const outlineWidthColorAlphaArray = attributeArrays.outlineWidthColorAlpha;
@@ -125,12 +127,10 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       if (useFloat64) {
         point.getPosition(cartesian);
         EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
-        attributeArrays.positionHigh[i * 3] = encodedCartesian.high.x;
-        attributeArrays.positionHigh[i * 3 + 1] = encodedCartesian.high.y;
-        attributeArrays.positionHigh[i * 3 + 2] = encodedCartesian.high.z;
-        attributeArrays.positionLow[i * 3] = encodedCartesian.low.x;
-        attributeArrays.positionLow[i * 3 + 1] = encodedCartesian.low.y;
-        attributeArrays.positionLow[i * 3 + 2] = encodedCartesian.low.z;
+        // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+        Cartesian3.pack(encodedCartesian.high, positionHighArray, i * 3);
+        // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+        Cartesian3.pack(encodedCartesian.low, positionLowArray, i * 3);
       }
 
       point.getMaterial(material);

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -73,7 +73,7 @@ const polygon = new BufferPolygon();
 const material = new BufferPolygonMaterial();
 const pickColor = new Color();
 const cartesian = new Cartesian3();
-const encodedCartesian = new EncodedCartesian3();
+const encodedC = new EncodedCartesian3();
 
 /**
  * @param {BufferPolygonCollection} collection
@@ -118,6 +118,8 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
     const { attributeArrays } = renderContext;
     const { _dirtyOffset, _dirtyCount } = collection;
 
+    const positionHighArray = attributeArrays.positionHigh;
+    const positionLowArray = attributeArrays.positionLow;
     const indexArray = renderContext.indexArray;
     const pickColorArray = attributeArrays.pickColor;
     const showColorAlphaArray = attributeArrays.showColorAlpha;
@@ -152,19 +154,13 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       // Update vertex arrays.
       for (let j = 0, jl = polygon.vertexCount; j < jl; j++) {
         if (useFloat64) {
-          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
+          // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
           Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
-          EncodedCartesian3.fromCartesian(cartesian, encodedCartesian);
-
-          attributeArrays.positionHigh[vOffset * 3] = encodedCartesian.high.x;
-          attributeArrays.positionHigh[vOffset * 3 + 1] =
-            encodedCartesian.high.y;
-          attributeArrays.positionHigh[vOffset * 3 + 2] =
-            encodedCartesian.high.z;
-
-          attributeArrays.positionLow[vOffset * 3] = encodedCartesian.low.x;
-          attributeArrays.positionLow[vOffset * 3 + 1] = encodedCartesian.low.y;
-          attributeArrays.positionLow[vOffset * 3 + 2] = encodedCartesian.low.z;
+          EncodedCartesian3.fromCartesian(cartesian, encodedC);
+          // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+          Cartesian3.pack(encodedC.high, positionHighArray, vOffset * 3);
+          // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+          Cartesian3.pack(encodedC.low, positionLowArray, vOffset * 3);
         }
 
         pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -84,9 +84,9 @@ const pickColor = new Color();
 const cartesian = new Cartesian3();
 const prevCartesian = new Cartesian3();
 const nextCartesian = new Cartesian3();
-const cartesianEnc = new EncodedCartesian3();
-const prevCartesianEnc = new EncodedCartesian3();
-const nextCartesianEnc = new EncodedCartesian3();
+const encodedC = new EncodedCartesian3();
+const encodedP = new EncodedCartesian3();
+const encodedN = new EncodedCartesian3();
 
 /**
  * Renders line segments as quads, each composed of two triangles. Writes each
@@ -167,13 +167,28 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
 
   if (collection._dirtyCount > 0) {
     const { _dirtyOffset, _dirtyCount } = collection;
-    const { attributeArrays } = renderContext;
 
     const indexArray = renderContext.indexArray;
-    const pickColorArray = attributeArrays.pickColor;
-    const showColorWidthAndTexCoordArray =
-      attributeArrays.showColorWidthAndTexCoord;
-    const alphaArray = attributeArrays.alpha;
+
+    const {
+      // Common.
+      pickColor: pickColorArray,
+      showColorWidthAndTexCoord: showColorWidthAndTexCoordArray,
+      alpha: alphaArray,
+
+      // 8-32 bit.
+      position,
+      prevPosition,
+      nextPosition,
+
+      // 64 bit.
+      positionHigh,
+      positionLow,
+      prevPositionHigh,
+      prevPositionLow,
+      nextPositionHigh,
+      nextPositionLow,
+    } = renderContext.attributeArrays;
 
     for (let i = _dirtyOffset, il = _dirtyOffset + _dirtyCount; i < il; i++) {
       collection.get(i, polyline);
@@ -191,199 +206,112 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       let vOffset = polyline.vertexOffset * 2; // vertex offset
       let iOffset = (polyline.vertexOffset - i) * 6; // index offset
 
-      const jl = polyline.vertexCount;
+      const posView = collection._positionView;
+      const posStart = polyline.vertexOffset * 3;
 
-      if (!useFloat64) {
-        const posView = collection._positionView;
-        const posStart = polyline.vertexOffset * 3;
-        const posArray = attributeArrays.position;
-        const prevPosArray = attributeArrays.prevPosition;
-        const nextPosArray = attributeArrays.nextPosition;
+      for (let j = 0, jl = polyline.vertexCount; j < jl; j++) {
+        const isFirstSegment = j === 0;
+        const isLastSegment = j === jl - 1;
 
-        for (let j = 0; j < jl; j++) {
-          const isFirstSegment = j === 0;
-          const isLastSegment = j === jl - 1;
+        // c=current, p=previous, n=next
 
-          const cx = posView[posStart + j * 3];
-          const cy = posView[posStart + j * 3 + 1];
-          const cz = posView[posStart + j * 3 + 2];
+        const cx = posView[posStart + j * 3];
+        const cy = posView[posStart + j * 3 + 1];
+        const cz = posView[posStart + j * 3 + 2];
 
-          let px, py, pz, nx, ny, nz;
+        let px, py, pz, nx, ny, nz;
 
-          if (isFirstSegment) {
-            nx = posView[posStart + 1 * 3];
-            ny = posView[posStart + 1 * 3 + 1];
-            nz = posView[posStart + 1 * 3 + 2];
-            // Mirror current over next to get synthetic prev.
-            px = 2 * cx - nx;
-            py = 2 * cy - ny;
-            pz = 2 * cz - nz;
-          } else if (isLastSegment) {
-            px = posView[posStart + (j - 1) * 3];
-            py = posView[posStart + (j - 1) * 3 + 1];
-            pz = posView[posStart + (j - 1) * 3 + 2];
-            // Mirror current over prev to get synthetic next.
-            nx = 2 * cx - px;
-            ny = 2 * cy - py;
-            nz = 2 * cz - pz;
-          } else {
-            px = posView[posStart + (j - 1) * 3];
-            py = posView[posStart + (j - 1) * 3 + 1];
-            pz = posView[posStart + (j - 1) * 3 + 2];
-            nx = posView[posStart + (j + 1) * 3];
-            ny = posView[posStart + (j + 1) * 3 + 1];
-            nz = posView[posStart + (j + 1) * 3 + 2];
-          }
-
-          if (!isLastSegment) {
-            indexArray[iOffset] = vOffset;
-            indexArray[iOffset + 1] = vOffset + 1;
-            indexArray[iOffset + 2] = vOffset + 2;
-            indexArray[iOffset + 3] = vOffset + 2;
-            indexArray[iOffset + 4] = vOffset + 1;
-            indexArray[iOffset + 5] = vOffset + 3;
-            iOffset += 6;
-          }
-
-          // Write each vertex twice for the quad.
-          for (let k = 0; k < 2; k++) {
-            posArray[vOffset * 3] = cx;
-            posArray[vOffset * 3 + 1] = cy;
-            posArray[vOffset * 3 + 2] = cz;
-
-            prevPosArray[vOffset * 3] = px;
-            prevPosArray[vOffset * 3 + 1] = py;
-            prevPosArray[vOffset * 3 + 2] = pz;
-
-            nextPosArray[vOffset * 3] = nx;
-            nextPosArray[vOffset * 3 + 1] = ny;
-            nextPosArray[vOffset * 3 + 2] = nz;
-
-            pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);
-            pickColorArray[vOffset * 4 + 1] = Color.floatToByte(
-              pickColor.green,
-            );
-            pickColorArray[vOffset * 4 + 2] = Color.floatToByte(pickColor.blue);
-            pickColorArray[vOffset * 4 + 3] = Color.floatToByte(
-              pickColor.alpha,
-            );
-
-            showColorWidthAndTexCoordArray[vOffset * 4] = show ? 1 : 0;
-            showColorWidthAndTexCoordArray[vOffset * 4 + 1] = encodedColor;
-            showColorWidthAndTexCoordArray[vOffset * 4 + 2] = material.width;
-            showColorWidthAndTexCoordArray[vOffset * 4 + 3] = j / (jl - 1);
-
-            alphaArray[vOffset] = colorAlpha * 255.0;
-
-            vOffset++;
-          }
+        if (isFirstSegment) {
+          nx = posView[posStart + 1 * 3];
+          ny = posView[posStart + 1 * 3 + 1];
+          nz = posView[posStart + 1 * 3 + 2];
+          // Mirror current over next to get synthetic prev.
+          px = 2 * cx - nx;
+          py = 2 * cy - ny;
+          pz = 2 * cz - nz;
+        } else if (isLastSegment) {
+          px = posView[posStart + (j - 1) * 3];
+          py = posView[posStart + (j - 1) * 3 + 1];
+          pz = posView[posStart + (j - 1) * 3 + 2];
+          // Mirror current over prev to get synthetic next.
+          nx = 2 * cx - px;
+          ny = 2 * cy - py;
+          nz = 2 * cz - pz;
+        } else {
+          px = posView[posStart + (j - 1) * 3];
+          py = posView[posStart + (j - 1) * 3 + 1];
+          pz = posView[posStart + (j - 1) * 3 + 2];
+          nx = posView[posStart + (j + 1) * 3];
+          ny = posView[posStart + (j + 1) * 3 + 1];
+          nz = posView[posStart + (j + 1) * 3 + 2];
         }
-      } else {
-        const cartesianArray = polyline.getPositions();
 
-        for (let j = 0; j < jl; j++) {
-          const isFirstSegment = j === 0;
-          const isLastSegment = j === jl - 1;
+        if (!isLastSegment) {
+          indexArray[iOffset] = vOffset;
+          indexArray[iOffset + 1] = vOffset + 1;
+          indexArray[iOffset + 2] = vOffset + 2;
+          indexArray[iOffset + 3] = vOffset + 2;
+          indexArray[iOffset + 4] = vOffset + 1;
+          indexArray[iOffset + 5] = vOffset + 3;
+          iOffset += 6;
+        }
 
-          // For first/last vertices, infer missing vertices by mirroring the segment.
-          // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-          Cartesian3.fromArray(cartesianArray, j * 3, cartesian);
-          if (isFirstSegment) {
-            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-            Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
-            Cartesian3.subtract(cartesian, nextCartesian, prevCartesian);
-            Cartesian3.add(cartesian, prevCartesian, prevCartesian);
-          } else if (isLastSegment) {
-            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-            Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
-            Cartesian3.subtract(cartesian, prevCartesian, nextCartesian);
-            Cartesian3.add(cartesian, nextCartesian, nextCartesian);
+        if (useFloat64) {
+          Cartesian3.fromElements(cx, cy, cz, cartesian);
+          Cartesian3.fromElements(px, py, pz, prevCartesian);
+          Cartesian3.fromElements(nx, ny, nz, nextCartesian);
+          EncodedCartesian3.fromCartesian(cartesian, encodedC);
+          EncodedCartesian3.fromCartesian(prevCartesian, encodedP);
+          EncodedCartesian3.fromCartesian(nextCartesian, encodedN);
+        }
+
+        // TODO(donmccurdy): Diverging from PolylineCollection.js, which writes
+        // internal vertices to buffer 4x, not 2x. Not sure that's needed?
+
+        // Write each vertex twice for the quad.
+        for (let k = 0; k < 2; k++) {
+          if (!useFloat64) {
+            position[vOffset * 3] = cx;
+            position[vOffset * 3 + 1] = cy;
+            position[vOffset * 3 + 2] = cz;
+
+            prevPosition[vOffset * 3] = px;
+            prevPosition[vOffset * 3 + 1] = py;
+            prevPosition[vOffset * 3 + 2] = pz;
+
+            nextPosition[vOffset * 3] = nx;
+            nextPosition[vOffset * 3 + 1] = ny;
+            nextPosition[vOffset * 3 + 2] = nz;
           } else {
-            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-            Cartesian3.fromArray(cartesianArray, (j - 1) * 3, prevCartesian);
-            // @ts-expect-error TODO(tsd-jsdoc): See https://github.com/CesiumGS/cesium/pull/13302.
-            Cartesian3.fromArray(cartesianArray, (j + 1) * 3, nextCartesian);
+            // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+            Cartesian3.pack(encodedC.high, positionHigh, vOffset * 3);
+            // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+            Cartesian3.pack(encodedC.low, positionLow, vOffset * 3);
+
+            // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+            Cartesian3.pack(encodedP.high, prevPositionHigh, vOffset * 3);
+            // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+            Cartesian3.pack(encodedP.low, prevPositionLow, vOffset * 3);
+
+            // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+            Cartesian3.pack(encodedN.high, nextPositionHigh, vOffset * 3);
+            // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
+            Cartesian3.pack(encodedN.low, nextPositionLow, vOffset * 3);
           }
 
-          // For each segment, draw two triangles.
-          if (!isLastSegment) {
-            indexArray[iOffset] = vOffset;
-            indexArray[iOffset + 1] = vOffset + 1;
-            indexArray[iOffset + 2] = vOffset + 2;
+          pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);
+          pickColorArray[vOffset * 4 + 1] = Color.floatToByte(pickColor.green);
+          pickColorArray[vOffset * 4 + 2] = Color.floatToByte(pickColor.blue);
+          pickColorArray[vOffset * 4 + 3] = Color.floatToByte(pickColor.alpha);
 
-            indexArray[iOffset + 3] = vOffset + 2;
-            indexArray[iOffset + 4] = vOffset + 1;
-            indexArray[iOffset + 5] = vOffset + 3;
+          showColorWidthAndTexCoordArray[vOffset * 4] = show ? 1 : 0;
+          showColorWidthAndTexCoordArray[vOffset * 4 + 1] = encodedColor;
+          showColorWidthAndTexCoordArray[vOffset * 4 + 2] = material.width;
+          showColorWidthAndTexCoordArray[vOffset * 4 + 3] = j / (jl - 1);
 
-            iOffset += 6;
-          }
+          alphaArray[vOffset] = colorAlpha * 255.0;
 
-          EncodedCartesian3.fromCartesian(cartesian, cartesianEnc);
-          EncodedCartesian3.fromCartesian(prevCartesian, prevCartesianEnc);
-          EncodedCartesian3.fromCartesian(nextCartesian, nextCartesianEnc);
-
-          // TODO(donmccurdy): Diverging from PolylineCollection.js, which writes
-          // internal vertices to buffer 4x, not 2x. Not sure that's needed?
-          for (let k = 0; k < 2; k++) {
-            // Position.
-            attributeArrays.positionHigh[vOffset * 3] = cartesianEnc.high.x;
-            attributeArrays.positionHigh[vOffset * 3 + 1] = cartesianEnc.high.y;
-            attributeArrays.positionHigh[vOffset * 3 + 2] = cartesianEnc.high.z;
-
-            attributeArrays.positionLow[vOffset * 3] = cartesianEnc.low.x;
-            attributeArrays.positionLow[vOffset * 3 + 1] = cartesianEnc.low.y;
-            attributeArrays.positionLow[vOffset * 3 + 2] = cartesianEnc.low.z;
-
-            // Previous position.
-            attributeArrays.prevPositionHigh[vOffset * 3] =
-              prevCartesianEnc.high.x;
-            attributeArrays.prevPositionHigh[vOffset * 3 + 1] =
-              prevCartesianEnc.high.y;
-            attributeArrays.prevPositionHigh[vOffset * 3 + 2] =
-              prevCartesianEnc.high.z;
-
-            attributeArrays.prevPositionLow[vOffset * 3] =
-              prevCartesianEnc.low.x;
-            attributeArrays.prevPositionLow[vOffset * 3 + 1] =
-              prevCartesianEnc.low.y;
-            attributeArrays.prevPositionLow[vOffset * 3 + 2] =
-              prevCartesianEnc.low.z;
-
-            // Next position.
-            attributeArrays.nextPositionHigh[vOffset * 3] =
-              nextCartesianEnc.high.x;
-            attributeArrays.nextPositionHigh[vOffset * 3 + 1] =
-              nextCartesianEnc.high.y;
-            attributeArrays.nextPositionHigh[vOffset * 3 + 2] =
-              nextCartesianEnc.high.z;
-
-            attributeArrays.nextPositionLow[vOffset * 3] =
-              nextCartesianEnc.low.x;
-            attributeArrays.nextPositionLow[vOffset * 3 + 1] =
-              nextCartesianEnc.low.y;
-            attributeArrays.nextPositionLow[vOffset * 3 + 2] =
-              nextCartesianEnc.low.z;
-
-            // Pick ID.
-            pickColorArray[vOffset * 4] = Color.floatToByte(pickColor.red);
-            pickColorArray[vOffset * 4 + 1] = Color.floatToByte(
-              pickColor.green,
-            );
-            pickColorArray[vOffset * 4 + 2] = Color.floatToByte(pickColor.blue);
-            pickColorArray[vOffset * 4 + 3] = Color.floatToByte(
-              pickColor.alpha,
-            );
-
-            // Properties.
-            showColorWidthAndTexCoordArray[vOffset * 4] = show ? 1 : 0;
-            showColorWidthAndTexCoordArray[vOffset * 4 + 1] = encodedColor;
-            showColorWidthAndTexCoordArray[vOffset * 4 + 2] = material.width;
-            showColorWidthAndTexCoordArray[vOffset * 4 + 3] = j / (jl - 1); // texcoord.s
-
-            alphaArray[vOffset] = colorAlpha * 255.0;
-
-            vOffset++;
-          }
+          vOffset++;
         }
       }
 


### PR DESCRIPTION
# Description

Minor simplification, particularly for BufferPolylineCollection. Previously there were two separate code paths for 64 bit and 8–32 bit vertex positions. We have two upcoming changes (#13516, and #13552) that I expect will need some debugging and/or feature additions in that code, so this PR is just attempting to simplify beforehand.

Unfortunately the types for `Cartesian3` APIs don't currently allow TypedArray, even though it is supported, so there's a lot of `@ts-expect-error` commenting.

## Issue number and link

n/a

## Testing plan

Simple example script rendering 32-bit and 64-bit polylines side by side:

```javascript
import * as Cesium from "cesium";

const viewer = new Cesium.Viewer("cesiumContainer");

const collectionF32 = new Cesium.BufferPolylineCollection({
  positionDatatype: Cesium.ComponentDatatype.FLOAT,
});

const collectionF64 = new Cesium.BufferPolylineCollection({
  positionDatatype: Cesium.ComponentDatatype.DOUBLE,
});

collectionF32.add({
  material: new Cesium.BufferPolylineMaterial({
    color: Cesium.Color.BLUE,
    width: 18,
  }),
  positions: degreesArrayToTypedArray([
    -122.41747314374474, 37.79101090764081,
    -122.41708061695125, 37.78914971567356,
    -122.41666355723294, 37.787249700518615,
    -122.41629556336358, 37.78538841381648,
    -122.41590303656972, 37.78360463673772,
    -122.4155350427007, 37.781588141242054,
    -122.41499531835925, 37.7790092735694,
  ], Float32Array),
});

collectionF64.add({
  material: new Cesium.BufferPolylineMaterial({
    color: Cesium.Color.PURPLE,
    width: 18,
  }),
  positions: degreesArrayToTypedArray([
    -122.41575583902211, 37.79124355334041,
    -122.4153878451531, 37.7893242044119,
    -122.41499531835925, 37.78742419374345,
    -122.4146763903392, 37.78564046580172,
    -122.41421026477155, 37.78379852763621,
    -122.41391586967634, 37.78191776445976,
    -122.41376867212873, 37.7809482802122,
  ], Float64Array),
});



viewer.scene.primitives.add(collectionF32);
viewer.scene.primitives.add(collectionF64);
viewer.zoomTo(collectionF32);

function degreesArrayToTypedArray (degreesArray, TypedArray) {
  const cartesianArray = Cesium.Cartesian3.fromDegreesArray(
    degreesArray
  );

  return Cesium.Cartesian3.packArray(
    cartesianArray,
    new TypedArray(cartesianArray.length * 3)
  );
}
```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->






#### PR Dependency Tree


* **PR #13551** 👈
  * **PR #13552**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)