### PR TITLE
BufferPolygonCollection: Support polygon outline/stroke

### DIFF
--- a/packages/engine/Source/Scene/BufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/BufferPolygonCollection.js
@@ -7,6 +7,7 @@ import Frozen from "../Core/Frozen.js";
 import assert from "../Core/assert.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
 import renderPolygons from "./renderBufferPolygonCollection.js";
+import renderPolylines from "./renderBufferPolylineCollection.js";
 import BufferPolygonMaterial from "./BufferPolygonMaterial.js";
 
 /** @import BlendOption from "./BlendOption.js"; */
@@ -311,6 +312,12 @@ class BufferPolygonCollection extends BufferPrimitiveCollection {
         this,
         frameState,
         this._renderContext,
+      );
+      // TODO(donmccurdy): Why no TSC error? Store and dispose contexts properly.
+      this._strokeRenderContext = renderPolylines(
+        this,
+        frameState,
+        this._strokeRenderContext,
       );
     }
   }

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -175,7 +175,8 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
         vOffset++;
       }
 
-      polygon._dirty = false;
+      // TODO(donmccurdy): Move dirty flag reset to the collection.
+      // polygon._dirty = false;
     }
   }
 
@@ -332,8 +333,9 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
 
   frameState.commandList.push(command);
 
-  collection._dirtyCount = 0;
-  collection._dirtyOffset = 0;
+  // TODO(donmccurdy): Move dirty flag reset to the collection.
+  // collection._dirtyCount = 0;
+  // collection._dirtyOffset = 0;
 
   return renderContext;
 }

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -23,6 +23,9 @@ import IndexDatatype from "../Core/IndexDatatype.js";
 import PolylineCommon from "../Shaders/PolylineCommon.js";
 import BufferPolylineMaterial from "./BufferPolylineMaterial.js";
 import BlendOption from "./BlendOption.js";
+import BufferPolygonCollection from "./BufferPolygonCollection.js";
+import BufferPolygon from "./BufferPolygon.js";
+import BufferPolygonMaterial from "./BufferPolygonMaterial.js";
 
 /** @import FrameState from "./FrameState.js"; */
 /** @import BufferPolylineCollection from "./BufferPolylineCollection.js"; */
@@ -78,8 +81,13 @@ const BufferPolylineAttributeLocations = {
  */
 
 // Scratch variables.
+
 const polyline = new BufferPolyline();
-const material = new BufferPolylineMaterial();
+const polylineMaterial = new BufferPolylineMaterial();
+
+const polygon = new BufferPolygon();
+const polygonMaterial = new BufferPolygonMaterial();
+
 const pickColor = new Color();
 const cartesian = new Cartesian3();
 const prevCartesian = new Cartesian3();
@@ -102,7 +110,7 @@ const encodedN = new EncodedCartesian3();
  * | \ | \ | \ | \ | ...
  * 1 - 3 - 5 - 7 - 9
  *
- * @param {BufferPolylineCollection} collection
+ * @param {BufferPolylineCollection|BufferPolygonCollection} collection
  * @param {FrameState} frameState
  * @param {BufferPolylineRenderContext} [renderContext]
  * @returns {BufferPolylineRenderContext}
@@ -111,7 +119,10 @@ const encodedN = new EncodedCartesian3();
 function renderBufferPolylineCollection(collection, frameState, renderContext) {
   const context = frameState.context;
   renderContext = renderContext || { destroy: destroyRenderContext };
+
   const useFloat64 = collection._positionDatatype === ComponentDatatype.DOUBLE;
+  const isPolygonStroke = collection instanceof BufferPolygonCollection;
+
   const attributeLocations = useFloat64
     ? BufferPolylineAttributeLocationsFloat64
     : BufferPolylineAttributeLocations;
@@ -191,25 +202,38 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
     } = renderContext.attributeArrays;
 
     for (let i = _dirtyOffset, il = _dirtyOffset + _dirtyCount; i < il; i++) {
-      collection.get(i, polyline);
+      const primitive = /** @type {BufferPolyline|BufferPolygon} */ (
+        collection.get(i, isPolygonStroke ? polygon : polyline)
+      );
 
-      if (!polyline._dirty) {
+      if (!primitive._dirty) {
         continue;
       }
 
-      polyline.getMaterial(material);
-      const encodedColor = AttributeCompression.encodeRGB8(material.color);
-      const colorAlpha = material.color.alpha;
-      Color.fromRgba(polyline._pickId, pickColor);
-      const show = polyline.show;
+      primitive.getMaterial(
+        isPolygonStroke ? polygonMaterial : polylineMaterial,
+      );
 
-      let vOffset = polyline.vertexOffset * 2; // vertex offset
-      let iOffset = (polyline.vertexOffset - i) * 6; // index offset
+      const encodedColor = AttributeCompression.encodeRGB8(
+        isPolygonStroke ? polygonMaterial.outlineColor : polylineMaterial.color,
+      );
+
+      const colorAlpha = isPolygonStroke
+        ? polygonMaterial.outlineColor.alpha
+        : polylineMaterial.color.alpha;
+
+      Color.fromRgba(primitive._pickId, pickColor);
+      const show = primitive.show;
+
+      let vOffset = primitive.vertexOffset * 2; // vertex offset
+      let iOffset = (primitive.vertexOffset - i) * 6; // index offset
 
       const posView = collection._positionView;
-      const posStart = polyline.vertexOffset * 3;
+      const posStart = primitive.vertexOffset * 3;
 
-      for (let j = 0, jl = polyline.vertexCount; j < jl; j++) {
+      // TODO(donmccurdy): For polygons, need to repeat 1st vertex.
+      // TODO(donmccurdy): For polygons, need to break on holes.
+      for (let j = 0, jl = primitive.vertexCount; j < jl; j++) {
         const isFirstSegment = j === 0;
         const isLastSegment = j === jl - 1;
 
@@ -306,7 +330,9 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
 
           showColorWidthAndTexCoordArray[vOffset * 4] = show ? 1 : 0;
           showColorWidthAndTexCoordArray[vOffset * 4 + 1] = encodedColor;
-          showColorWidthAndTexCoordArray[vOffset * 4 + 2] = material.width;
+          showColorWidthAndTexCoordArray[vOffset * 4 + 2] = isPolygonStroke
+            ? polygonMaterial.outlineWidth
+            : polylineMaterial.width;
           showColorWidthAndTexCoordArray[vOffset * 4 + 3] = j / (jl - 1);
 
           alphaArray[vOffset] = colorAlpha * 255.0;
@@ -315,7 +341,7 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
         }
       }
 
-      polyline._dirty = false;
+      primitive._dirty = false;
     }
   }
 
@@ -466,7 +492,9 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
     });
   } else if (collection._dirtyCount > 0) {
     const { indexOffset, indexCount, vertexOffset, vertexCount } =
-      getPolylineDirtyRanges(collection);
+      isPolygonStroke
+        ? getPolygonDirtyRanges(collection)
+        : getPolylineDirtyRanges(collection);
 
     renderContext.vertexArray.copyIndexFromRange(
       renderContext.indexArray,
@@ -511,7 +539,9 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
     });
   }
 
-  const drawCount = getDrawIndexCount(collection);
+  const drawCount = isPolygonStroke
+    ? getPolygonDrawIndexCount(collection)
+    : getPolylineDrawIndexCount(collection);
 
   if (!defined(renderContext.command)) {
     renderContext.command = new DrawCommand({
@@ -555,8 +585,18 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
  * @param {BufferPolylineCollection} collection
  * @ignore
  */
-function getDrawIndexCount(collection) {
+function getPolylineDrawIndexCount(collection) {
   return (collection.vertexCount - collection.primitiveCount) * 6;
+}
+
+/**
+ * Returns number of drawn (not allocated) indices for given collection.
+ * @param {BufferPolygonCollection} collection
+ * @ignore
+ */
+function getPolygonDrawIndexCount(collection) {
+  const loopCount = collection.primitiveCount - collection.holeCount;
+  return (collection.vertexCount - loopCount) * 6;
 }
 
 /**
@@ -579,6 +619,16 @@ function getPolylineDirtyRanges(collection) {
   const indexCount = segmentCount * 6;
 
   return { indexOffset, indexCount, vertexOffset, vertexCount };
+}
+
+/**
+ * Computes dirty ranges for attribute and index buffers in a collection.
+ * @param {BufferPolygonCollection} collection
+ * @ignore
+ */
+function getPolygonDirtyRanges(collection) {
+  // TODO(donmccurdy): Must account for repeating 1st vertex, and for holes.
+  return getPolylineDirtyRanges(/** @type {*} */ (collection));
 }
 
 /**

--- a/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolylineMaterialVS.glsl
@@ -42,7 +42,6 @@ void main()
     vec4 positionEC = czm_modelView * vec4(position, 1.0);
     vec4 prevPositionEC = czm_modelView * vec4(prevPosition, 1.0);
     vec4 nextPositionEC = czm_modelView * vec4(nextPosition, 1.0);
-    // Positions are already in eye space; use the EC variant to skip the redundant transform.
     vec4 positionWC = getPolylineWindowCoordinatesEC(positionEC, prevPositionEC, nextPositionEC, expandDir, width, usePrevious, polylineAngle);
 #endif
 


### PR DESCRIPTION
# Description

Work in progress support for polygon outline/stroke.

My intention is to reuse the existing polyline renderer when drawing polygons, such that stroked polygon collections render in two draw calls. Because polyline rendering is non-trivial I expect this will be easier to maintain that adding more code in the polygon rendering path.

Current results, for a hand-drawn polygon around Portugal, with a hole:

<img width="706" height="542" alt="Screenshot 2026-06-05 at 4 43 21 PM" src="https://github.com/user-attachments/assets/2060d521-3bb2-4eac-a74f-e0b90474119a" />

Currently missing from the PR, we'll need adjustments to polyline geometry to break the line when changing from the outer ring to inner rings (holes), and to connect the last vertex of each ring smoothly to the first. Because this isn't done yet, you'll see a line crossing from the exterior to the interior ring at the top of the polygon.

Adding this feature also makes it obvious that we'll want the option to draw wide polylines oriented to match the polygon normals, rather than in screen space. We'll want to keep screen space as an option, e.g. for 3D polylines not associated with any polygon surface. Probably this can be a separate PR.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<details>
<summary>Script</summary>

```javascript
import * as Cesium from "cesium";

const viewer = new Cesium.Viewer("cesiumContainer");

const collectionF32 = new Cesium.BufferPolygonCollection({
  positionDatatype: Cesium.ComponentDatatype.FLOAT,
  //blendOption: Cesium.BlendOption.OPAQUE,
});

const outerArray = [
-9.1060068,
41.932511,
-8.7687165,
41.5393067,
-8.7906097,
41.0726782,
-8.7657704,
40.7027307,
-8.8715181,
40.2118752,
-9.0368531,
39.7357774,
-9.3208907,
39.2868535,
-9.404848,
39.013347,
-9.6162232,
38.5011473,
-9.3217704,
38.5219586,
-9.2577431,
38.3671817,
-8.8107884,
38.4465488,
-8.8131368,
37.9453081,
-8.8218309,
37.5593435,
-8.8539515,
37.2309873,
-9.0030784,
36.9254703,
-8.6544963,
37.1000105,
-7.9098278,
37.0087116,
-7.3981352,
37.2076215,
-7.5322703,
37.5998871,
-7.1434638,
38.0625821,
-6.9886751,
38.1515095,
-7.13748,
38.2966062,
-7.1963535,
38.4520593,
-7.1445031,
38.7072537,
-6.9673008,
38.9911168,
-7.1803312,
39.2277717,
-7.5418465,
39.6636791,
-6.9243217,
39.6671497,
-6.9155804,
39.8597622,
-6.9151682,
40.1461557,
-7.0014708,
40.1904277,
-6.9641543,
40.2731745,
-6.8785718,
40.3030045,
-6.7822412,
40.5583549,
-6.8768352,
40.8035172,
-6.9733244,
41.1237843,
-6.7904103,
41.1964822,
-6.4567974,
41.3554278,
-6.2799618,
41.4474522,
-6.2745001,
41.620046,
-6.4943108,
41.7870376,
-6.568064,
41.8678021,
-6.6009106,
41.9899708,
-6.92661,
42.0913581,
-7.1374613,
42.0447298,
-7.234827,
42.001446,
-7.5341158,
41.8912083,
-7.9618347,
41.9896937,
-8.2900047,
41.9147361,
-8.3261168,
42.1024208,
-8.3124149,
42.1382753,
-8.6583144,
42.1351053,
-8.7024129,
42.1030458,
-9.1060068,
41.932511
];

const innerArray = [-8.288739,41.2567498,-8.3554652,40.3320923,-8.6860413,39.6456403,-9.0736472,38.8819228,-8.4293344,38.6304499,-7.5041296,38.8015568,-7.3320294,39.0022361,-7.9342183,39.7504666,-7.7749506,39.9584831,-7.1443824,39.9496422,-7.200264,40.1377107,-7.3964314,40.3505942,-7.1848431,40.5237281,-7.0376082,40.6463876,-7.2908755,41.2798265,-7.441394,41.6905707,-7.8612644,41.7019289,-8.0294237,41.7581464,-8.2535049,41.6719541,-8.3298846,41.5530753,-8.288739,41.2567498];
const positionsArray = [...outerArray, ...innerArray];

const positions2D = Cesium.Cartesian2.unpackArray(positionsArray);
const positions = degreesArrayToTypedArray(positionsArray, Float32Array);
const triangles = Cesium.PolygonPipeline.triangulate(positions2D, [outerArray.length / 2]);
const holes = new Uint32Array([outerArray.length / 2]);

const material = new Cesium.BufferPolygonMaterial({
  color: Cesium.Color.WHITE,
  outlineColor: Cesium.Color.PURPLE,
  outlineWidth: 12,
});
material.color.alpha = 0.75;
material.outlineColor.alpha = 0.75;

collectionF32.add({
  material,
  positions,
  triangles,
  holes,
});

viewer.scene.primitives.add(collectionF32);
viewer.zoomTo(collectionF32);

function degreesArrayToTypedArray (degreesArray, TypedArray) {
  const cartesianArray = Cesium.Cartesian3.fromDegreesArray(
    degreesArray
  );

  return Cesium.Cartesian3.packArray(
    cartesianArray,
    new TypedArray(cartesianArray.length * 3)
  );
}
```

</details>

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->






#### PR Dependency Tree


* **PR #13551**
  * **PR #13552** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)