### PR TITLE
Fix missing InterpolationAlgorithm documentation page (#13550)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 #### Fixes :wrench:
 
+- Fixed missing `InterpolationAlgorithm` documentation page that was returning a 404. [#13550](https://github.com/CesiumGS/cesium/issues/13550)
 - Fixed `EdgeVisibilityRendering` release test failures. [#13545](https://github.com/CesiumGS/cesium/pull/13545)
 - Fix for `BufferPointCollection` preventing outlineColor from bleeding slightly into the visible area when outlineWidth=0px. [#13543](https://github.com/CesiumGS/cesium/pull/13543)
 - Fixed a bug where callbacks registered with `Scene.updateHeight` could receive positions computed for other tiles, causing clamped entities to show incorrect heights. [#12602](https://github.com/CesiumGS/cesium/issues/12602)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -453,3 +453,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Chalabi](https://github.com/chalabi2)
 - [Michal Mitter](https://github.com/mittermichal)
 - [John Eismeier](https://github.com/jeis4wpi)
+- [Shriyam Shrivastava](https://github.com/shrivs4)

--- a/Tools/jsdoc/cesium_template/publish.js
+++ b/Tools/jsdoc/cesium_template/publish.js
@@ -458,6 +458,7 @@ exports.publish = function (taffyData, opts, tutorials) {
   var modules = taffy(members.modules);
   var namespaces = taffy(members.namespaces);
   var globals = taffy(members.globals);
+  var interfaces = taffy(members.interfaces);
 
   var typesJson = {};
 
@@ -474,6 +475,10 @@ exports.publish = function (taffyData, opts, tutorials) {
 
     if (!items.length) {
       items = helper.find(globals, { longname: longname });
+    }
+
+    if (!items.length) {
+      items = helper.find(interfaces, { longname: longname });
     }
 
     if (items.length) {

--- a/packages/engine/Source/Core/InterpolationAlgorithm.js
+++ b/packages/engine/Source/Core/InterpolationAlgorithm.js
@@ -1,65 +1,72 @@
+// @ts-check
+
 import DeveloperError from "./DeveloperError.js";
 
 /**
  * The interface for interpolation algorithms.
  *
- * @namespace InterpolationAlgorithm
+ * @interface
  *
  * @see LagrangePolynomialApproximation
  * @see LinearApproximation
  * @see HermitePolynomialApproximation
  */
-const InterpolationAlgorithm = {};
+class InterpolationAlgorithm {
+  /**
+   * Gets the name of this interpolation algorithm.
+   * @type {string}
+   */
+  type;
 
-/**
- * Gets the name of this interpolation algorithm.
- * @type {string}
- */
-InterpolationAlgorithm.type = undefined;
+  /**
+   * Given the desired degree, returns the number of data points required for interpolation.
+   *
+   * @function
+   * @param {number} degree The desired degree of interpolation.
+   * @returns {number} The number of required data points needed for the desired degree of interpolation.
+   */
+  getRequiredDataPoints(degree) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Given the desired degree, returns the number of data points required for interpolation.
- * @function
- *
- * @param {number} degree The desired degree of interpolation.
- * @returns {number} The number of required data points needed for the desired degree of interpolation.
- */
-InterpolationAlgorithm.getRequiredDataPoints =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Performs zero order interpolation.
+   *
+   * @function
+   * @param {number} x The independent variable for which the dependent variables will be interpolated.
+   * @param {number[]} xTable The array of independent variables to use to interpolate.  The values
+   * in this array must be in increasing order and the same value must not occur twice in the array.
+   * @param {number[]} yTable The array of dependent variables to use to interpolate.  For a set of three
+   * dependent values (p,q,w) at time 1 and time 2 this should be as follows: {p1, q1, w1, p2, q2, w2}.
+   * @param {number} yStride The number of dependent variable values in yTable corresponding to
+   * each independent variable value in xTable.
+   * @param {number[]} [result] An existing array into which to store the result.
+   * @returns {number[]} The array of interpolated values, or the result parameter if one was provided.
+   */
+  interpolateOrderZero(x, xTable, yTable, yStride, result) {
+    DeveloperError.throwInstantiationError();
+  }
 
-/**
- * Performs zero order interpolation.
- * @function
- *
- * @param {number} x The independent variable for which the dependent variables will be interpolated.
- * @param {number[]} xTable The array of independent variables to use to interpolate.  The values
- * in this array must be in increasing order and the same value must not occur twice in the array.
- * @param {number[]} yTable The array of dependent variables to use to interpolate.  For a set of three
- * dependent values (p,q,w) at time 1 and time 2 this should be as follows: {p1, q1, w1, p2, q2, w2}.
- * @param {number} yStride The number of dependent variable values in yTable corresponding to
- * each independent variable value in xTable.
- * @param {number[]} [result] An existing array into which to store the result.
- *
- * @returns {number[]} The array of interpolated values, or the result parameter if one was provided.
- */
-InterpolationAlgorithm.interpolateOrderZero =
-  DeveloperError.throwInstantiationError;
+  /**
+   * Performs higher order interpolation.  Not all interpolators need to support high-order interpolation,
+   * if this function remains undefined on implementing objects, interpolateOrderZero will be used instead.
+   *
+   * @function
+   * @param {number} x The independent variable for which the dependent variables will be interpolated.
+   * @param {number[]} xTable The array of independent variables to use to interpolate.  The values
+   * in this array must be in increasing order and the same value must not occur twice in the array.
+   * @param {number[]} yTable The array of dependent variables to use to interpolate.  For a set of three
+   * dependent values (p,q,w) at time 1 and time 2 this should be as follows: {p1, q1, w1, p2, q2, w2}.
+   * @param {number} yStride The number of dependent variable values in yTable corresponding to
+   * each independent variable value in xTable.
+   * @param {number} inputOrder The number of derivatives supplied for input.
+   * @param {number} outputOrder The number of derivatives desired for output.
+   * @param {number[]} [result] An existing array into which to store the result.
+   * @returns {number[]} The array of interpolated values, or the result parameter if one was provided.
+   */
+  interpolate(x, xTable, yTable, yStride, inputOrder, outputOrder, result) {
+    DeveloperError.throwInstantiationError();
+  }
+}
 
-/**
- * Performs higher order interpolation.  Not all interpolators need to support high-order interpolation,
- * if this function remains undefined on implementing objects, interpolateOrderZero will be used instead.
- * @function
- * @param {number} x The independent variable for which the dependent variables will be interpolated.
- * @param {number[]} xTable The array of independent variables to use to interpolate.  The values
- * in this array must be in increasing order and the same value must not occur twice in the array.
- * @param {number[]} yTable The array of dependent variables to use to interpolate.  For a set of three
- * dependent values (p,q,w) at time 1 and time 2 this should be as follows: {p1, q1, w1, p2, q2, w2}.
- * @param {number} yStride The number of dependent variable values in yTable corresponding to
- * each independent variable value in xTable.
- * @param {number} inputOrder The number of derivatives supplied for input.
- * @param {number} outputOrder The number of derivatives desired for output.
- * @param {number[]} [result] An existing array into which to store the result.
- * @returns {number[]} The array of interpolated values, or the result parameter if one was provided.
- */
-InterpolationAlgorithm.interpolate = DeveloperError.throwInstantiationError;
 export default InterpolationAlgorithm;

--- a/packages/engine/Source/Core/InterpolationAlgorithm.js
+++ b/packages/engine/Source/Core/InterpolationAlgorithm.js
@@ -3,7 +3,7 @@ import DeveloperError from "./DeveloperError.js";
 /**
  * The interface for interpolation algorithms.
  *
- * @interface InterpolationAlgorithm
+ * @namespace InterpolationAlgorithm
  *
  * @see LagrangePolynomialApproximation
  * @see LinearApproximation


### PR DESCRIPTION
## Problem

The `InterpolationAlgorithm` documentation page was returning a 404.

This happened because the JSDoc tag was `@interface`, which does not generate a standalone HTML page in Cesium's JSDoc setup.

## Fix

Changed `@interface` to `@namespace` in `InterpolationAlgorithm.js` to match the pattern used by the implementing algorithms:

- `LinearApproximation`
- `LagrangePolynomialApproximation`
- `HermitePolynomialApproximation`

This causes JSDoc to generate `InterpolationAlgorithm.html`, so the `{@link InterpolationAlgorithm}` references now resolve correctly.

## Testing

Ran `npm run build-docs` and confirmed that:

- `Build/Documentation/InterpolationAlgorithm.html` is generated
- The link from `LinearApproximation.html` navigates successfully to the generated page

Fixes #13550

## Visual:
<img width="1488" height="768" alt="Screenshot 2026-06-07 at 4 01 32 PM" src="https://github.com/user-attachments/assets/6983c016-ba6d-4755-9b45-73c4a8a1b774" />
