### PR TITLE
Support `destroyObject(o)` on ES6 class instances

### DIFF
--- a/packages/engine/Source/Core/destroyObject.js
+++ b/packages/engine/Source/Core/destroyObject.js
@@ -5,6 +5,27 @@ function returnTrue() {
 }
 
 /**
+ * Returns the prototype chain of a given object. Object may be an instance
+ * of an ES6 class, or of a class defined by prototype-based inheritance.
+ *
+ * @param {object} object
+ * @returns {Array<object>}
+ */
+function getPrototypeChain(object) {
+  const prototypes = [];
+
+  let value = object;
+  while ((value = Object.getPrototypeOf(value))) {
+    if (value === Object.prototype) {
+      break;
+    }
+    prototypes.push(value);
+  }
+
+  return prototypes;
+}
+
+/**
  * Destroys an object.  Each of the object's functions, including functions in its prototype,
  * is replaced with a function that throws a {@link DeveloperError}, except for the object's
  * <code>isDestroyed</code> function, which is set to a function that returns <code>true</code>.
@@ -40,9 +61,11 @@ function destroyObject(object, message) {
     //>>includeEnd('debug');
   }
 
-  for (const key in object) {
-    if (typeof object[key] === "function") {
-      object[key] = throwOnDestroyed;
+  for (const prototype of getPrototypeChain(object)) {
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      if (typeof object[key] === "function") {
+        object[key] = throwOnDestroyed;
+      }
     }
   }
 

--- a/packages/engine/Source/Core/destroyObject.js
+++ b/packages/engine/Source/Core/destroyObject.js
@@ -62,8 +62,9 @@ function destroyObject(object, message) {
   }
 
   for (const prototype of getPrototypeChain(object)) {
-    for (const key of Object.getOwnPropertyNames(prototype)) {
-      if (typeof object[key] === "function") {
+    const descriptors = Object.getOwnPropertyDescriptors(prototype);
+    for (const key in descriptors) {
+      if (descriptors[key].writable && typeof object[key] === "function") {
         object[key] = throwOnDestroyed;
       }
     }

--- a/packages/engine/Specs/Core/destroyObjectSpec.js
+++ b/packages/engine/Specs/Core/destroyObjectSpec.js
@@ -1,0 +1,62 @@
+import { destroyObject } from "../../index.js";
+
+describe("Core/destroyObject", function () {
+  it("destroys prototype-based class", function () {
+    function Parent() {}
+    Parent.prototype.isDestroyed = () => false;
+    Parent.prototype.inheritedFn = () => true;
+
+    function Child() {}
+    Child.prototype = new Parent();
+    Child.prototype.instanceFn = () => true;
+    Child.staticFn = () => true;
+
+    const object = new Child();
+
+    expect(object.isDestroyed()).toBe(false);
+    expect(() => object.inheritedFn()).not.toThrowDeveloperError();
+    expect(() => object.instanceFn()).not.toThrowDeveloperError();
+    expect(() => Child.staticFn()).not.toThrowDeveloperError();
+
+    destroyObject(object);
+
+    expect(object.isDestroyed()).toBe(true);
+    expect(() => object.inheritedFn()).toThrowDeveloperError();
+    expect(() => object.instanceFn()).toThrowDeveloperError();
+    expect(() => Child.staticFn()).not.toThrowDeveloperError();
+  });
+
+  it("destroys ES6 class", function () {
+    class Parent {
+      isDestroyed() {
+        return false;
+      }
+      inheritedFn() {
+        return true;
+      }
+    }
+
+    class Child extends Parent {
+      instanceFn() {
+        return true;
+      }
+      staticFn() {
+        return true;
+      }
+    }
+
+    const object = new Child();
+
+    expect(object.isDestroyed()).toBe(false);
+    expect(() => object.inheritedFn()).not.toThrowDeveloperError();
+    expect(() => object.instanceFn()).not.toThrowDeveloperError();
+    expect(() => Child.staticFn()).not.toThrowDeveloperError();
+
+    destroyObject(object);
+
+    expect(object.isDestroyed()).toBe(true);
+    expect(() => object.inheritedFn()).toThrowDeveloperError();
+    expect(() => object.instanceFn()).toThrowDeveloperError();
+    expect(() => Child.staticFn()).not.toThrowDeveloperError();
+  });
+});

--- a/packages/engine/Specs/Core/destroyObjectSpec.js
+++ b/packages/engine/Specs/Core/destroyObjectSpec.js
@@ -11,6 +11,15 @@ describe("Core/destroyObject", function () {
     Child.prototype.instanceFn = () => true;
     Child.staticFn = () => true;
 
+    Object.defineProperty(Child.prototype, "getterFn", {
+      get: () => {
+        // destroyObject must not execute getters on the target object;
+        // doing so may throw errors if the getter accesses properties
+        // that have already been removed.
+        throw new Error("Getter must not be called.");
+      },
+    });
+
     const object = new Child();
 
     expect(object.isDestroyed()).toBe(false);
@@ -42,6 +51,12 @@ describe("Core/destroyObject", function () {
       }
       staticFn() {
         return true;
+      }
+      get getterFn() {
+        // destroyObject must not execute getters on the target object;
+        // doing so may throw errors if the getter accesses properties
+        // that have already been removed.
+        throw new Error("Getter must not be called.");
       }
     }
 


### PR DESCRIPTION
# Description

Currently `destroyObject(object)` cannot see methods of ES6 class instances, and fails to replace them when the object is destroyed. As discussed in #12266, the behavior of destroyObject could perhaps be reconsidered. However, I think adoption of ES6 class syntax (and type checking, which ES6 classes are a prerequisite for) will be smoother if we can avoid unnecessary functional changes within the migration, so... I'd like to try making destroyObject compatible with ES6 classes.

This PR extends destroyObject to support ES6 class instances as input, and adds unit tests for both ES6 classes and prototype-based inheritance to verify that both continue to work as expected.

## Issue number and link

- Related #12266

## Testing plan

See unit tests added.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13560** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)