### PR TITLE
Handle invalid glTF sampler wrap modes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 #### Fixes :wrench:
 
+- Fixed invalid glTF sampler wrap modes causing a `DeveloperError` to be thrown instead of falling back to `TextureWrap.REPEAT`. [#13562](https://github.com/CesiumGS/cesium/pull/13562)
 - Fixed `EdgeVisibilityRendering` release test failures. [#13545](https://github.com/CesiumGS/cesium/pull/13545)
 - Fix for `BufferPointCollection` preventing outlineColor from bleeding slightly into the visible area when outlineWidth=0px. [#13543](https://github.com/CesiumGS/cesium/pull/13543)
 - Fixed a bug where callbacks registered with `Scene.updateHeight` could receive positions computed for other tiles, causing clamped entities to show incorrect heights. [#12602](https://github.com/CesiumGS/cesium/issues/12602)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -452,3 +452,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jonathan Sullivan](https://github.com/jplusequalt)
 - [Chalabi](https://github.com/chalabi2)
 - [Michal Mitter](https://github.com/mittermichal)
+- [Andrea Churchwell](https://github.com/Andreachurchwell)

--- a/packages/engine/Source/Scene/GltfLoaderUtil.js
+++ b/packages/engine/Source/Scene/GltfLoaderUtil.js
@@ -119,6 +119,14 @@ GltfLoaderUtil.createSampler = function (options) {
     wrapT = TextureWrap.REPEAT;
   }
 
+  if (!TextureMinificationFilter.validate(minFilter)) {
+    minFilter = TextureMinificationFilter.LINEAR;
+  }
+
+  if (!TextureMagnificationFilter.validate(magFilter)) {
+    magFilter = TextureMagnificationFilter.LINEAR;
+  }
+
   return new Sampler({
     wrapS: wrapS,
     wrapT: wrapT,

--- a/packages/engine/Source/Scene/GltfLoaderUtil.js
+++ b/packages/engine/Source/Scene/GltfLoaderUtil.js
@@ -111,6 +111,14 @@ GltfLoaderUtil.createSampler = function (options) {
     }
   }
 
+  if (!TextureWrap.validate(wrapS)) {
+    wrapS = TextureWrap.REPEAT;
+  }
+
+  if (!TextureWrap.validate(wrapT)) {
+    wrapT = TextureWrap.REPEAT;
+  }
+
   return new Sampler({
     wrapS: wrapS,
     wrapT: wrapT,
@@ -164,10 +172,10 @@ GltfLoaderUtil.createModelTextureReader = function (options) {
 
     // prettier-ignore
     transform = new Matrix3(
-        Math.cos(rotation) * scale.x, -Math.sin(rotation) * scale.y, offset.x,
-        Math.sin(rotation) * scale.x, Math.cos(rotation) * scale.y, offset.y,
-        0.0, 0.0, 1.0
-      );
+      Math.cos(rotation) * scale.x, -Math.sin(rotation) * scale.y, offset.x,
+      Math.sin(rotation) * scale.x, Math.cos(rotation) * scale.y, offset.y,
+      0.0, 0.0, 1.0
+    );
   }
 
   const modelTextureReader = new ModelComponents.TextureReader();

--- a/packages/engine/Specs/Scene/GltfLoaderUtilSpec.js
+++ b/packages/engine/Specs/Scene/GltfLoaderUtilSpec.js
@@ -288,6 +288,16 @@ describe(
       );
     });
 
+    it("createSampler falls back to REPEAT for invalid wrap modes", function () {
+      const sampler = createSampler({
+        wrapS: -1,
+        wrapT: -1,
+      });
+
+      expect(sampler.wrapS).toBe(TextureWrap.REPEAT);
+      expect(sampler.wrapT).toBe(TextureWrap.REPEAT);
+    });
+
     it("createModelTextureReader creates texture with default values", function () {
       const textureInfo = {
         index: 0,

--- a/packages/engine/Specs/Scene/GltfLoaderUtilSpec.js
+++ b/packages/engine/Specs/Scene/GltfLoaderUtilSpec.js
@@ -298,6 +298,24 @@ describe(
       expect(sampler.wrapT).toBe(TextureWrap.REPEAT);
     });
 
+    it("createSampler falls back to LINEAR for invalid minFilter", function () {
+      const sampler = createSampler({
+        minFilter: -1,
+      });
+
+      expect(sampler.minificationFilter).toBe(TextureMinificationFilter.LINEAR);
+    });
+
+    it("createSampler falls back to LINEAR for invalid magFilter", function () {
+      const sampler = createSampler({
+        magFilter: -1,
+      });
+
+      expect(sampler.magnificationFilter).toBe(
+        TextureMagnificationFilter.LINEAR,
+      );
+    });
+
     it("createModelTextureReader creates texture with default values", function () {
       const textureInfo = {
         index: 0,
@@ -328,10 +346,10 @@ describe(
 
       // prettier-ignore
       const expectedTransform = new Matrix3(
-      0.1, 0.0, 0.5,
-      0.0, 0.2, 0.5,
-      0.0, 0.0, 1.0
-    );
+        0.1, 0.0, 0.5,
+        0.0, 0.2, 0.5,
+        0.0, 0.0, 1.0
+      );
 
       const modelTexture = GltfLoaderUtil.createModelTextureReader({
         textureInfo: textureInfo,
@@ -359,10 +377,10 @@ describe(
       // must be reversed.
       // prettier-ignore
       const expectedTransform = new Matrix3(
-      Math.cos(-angle), -Math.sin(-angle), 0.0,
-      Math.sin(-angle), Math.cos(-angle), 0.0,
-      0.0, 0.0, 1.0
-    );
+        Math.cos(-angle), -Math.sin(-angle), 0.0,
+        Math.sin(-angle), Math.cos(-angle), 0.0,
+        0.0, 0.0, 1.0
+      );
 
       const modelTexture = GltfLoaderUtil.createModelTextureReader({
         textureInfo: textureInfo,


### PR DESCRIPTION

# Description

This PR fixes issue #12781 by handling invalid glTF sampler wrap modes in `GltfLoaderUtil.createSampler`.

Previously, invalid `wrapS` or `wrapT` values would reach `Sampler` and throw a `DeveloperError`. This change validates the wrap modes in the glTF loading path and falls back to `TextureWrap.REPEAT` when invalid values are encountered.

## Issue number and link

Fixes #12781

## Testing plan

Added a new unit test:

* `createSampler falls back to REPEAT for invalid wrap modes`

Verified that:

* The new test fails before the fix with `DeveloperError: Invalid sampler.wrapS`
* The new test passes after the fix
* The full test suite returns to the previous failure count after the fix

## Author checklist

* [x] I have submitted a Contributor License Agreement
* [x] I have added my name to `CONTRIBUTORS.md`
* [x] I have updated `CHANGES.md` with a short summary of my change
* [x] I have added or updated unit tests to ensure consistent code coverage
* [ ] I have updated the inline documentation, and included code examples where relevant
* [x] I have performed a self-review of my code

## AI acknowledgment

* [x] I used AI to generate content in this PR
* [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tool(s) and/or Service(s):

* ChatGPT

If yes, I used the following Model(s):

* GPT-5.5

