### PR TITLE
Add @interface items to docs sidebar and search

### DIFF
--- a/Tools/jsdoc/cesium_template/publish.js
+++ b/Tools/jsdoc/cesium_template/publish.js
@@ -204,6 +204,7 @@ function attachModuleSymbols(doclets, modules) {
  * @param {array<object>} members.mixins
  * @param {array<object>} members.modules
  * @param {array<object>} members.namespaces
+ * @param {array<object>} members.interfaces
  * @param {array<object>} members.tutorials
  * @param {array<object>} members.events
  * @return {string} The HTML for the navigation sidebar.
@@ -219,6 +220,7 @@ function buildNav(members) {
     .concat(members.classes)
     .concat(members.globals)
     .concat(members.namespaces)
+    .concat(members.interfaces)
     .sort(function (a, b) {
       return a.longname.toLowerCase().localeCompare(b.longname.toLowerCase());
     });


### PR DESCRIPTION
@donmccurdy 

PR Title:
Add @interface items to docs navigation sidebar and search

PR Body:

## Problem

Following up on #13555, interfaces (`@interface` tagged items) were still missing from the navigation sidebar and search in the generated documentation, even after their HTML pages were being generated correctly.

## Fix

Added `members.interfaces` to the `buildNav()` concat chain in `Tools/jsdoc/cesium_template/publish.js` so that `@interface` items are included in the sidebar and search alongside classes, namespaces, and modules.

Also updated the JSDoc comment for `buildNav()` to document `members.interfaces`.

## Result

`InterpolationAlgorithm`, `MapProjection`, and any future `@interface` tagged items now appear in the navigation sidebar and search.

Links to - https://github.com/CesiumGS/cesium/pull/13555

Test Images:
<img width="1500" height="464" alt="Screenshot 2026-06-13 at 12 49 13 PM" src="https://github.com/user-attachments/assets/7fd74c73-d3d5-4fe7-aff6-c1eb5c4deab4" />
<img width="1498" height="574" alt="Screenshot 2026-06-13 at 12 59 26 PM" src="https://github.com/user-attachments/assets/f93a52da-6efe-4271-87f6-df71b2b77c2c" />
