### PR TITLE
Added requesttype request statistics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 1.143 - 2026-07-01
 
+- Added per-request-type request statistics to `RequestScheduler` debug reporting, including terrain, imagery, 3D Tiles, and other request categories.
+
 ### @cesium/engine
 
 #### Fixes :wrench:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -455,3 +455,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Andrea Churchwell](https://github.com/Andreachurchwell)
 - [John Eismeier](https://github.com/jeis4wpi)
 - [Shriyam Shrivastava](https://github.com/shrivs4)
+- [Raymond Lin](https://github.com/rlin1214)

--- a/packages/engine/Source/Core/RequestScheduler.js
+++ b/packages/engine/Source/Core/RequestScheduler.js
@@ -8,6 +8,7 @@ import isBlobUri from "./isBlobUri.js";
 import isDataUri from "./isDataUri.js";
 import RequestState from "./RequestState.js";
 import RuntimeError from "./RuntimeError.js";
+import RequestType from "./RequestType.js";
 
 function sortRequests(a, b) {
   return a.priority - b.priority;
@@ -15,6 +16,10 @@ function sortRequests(a, b) {
 
 const statistics = {
   numberOfAttemptedRequests: 0,
+  numberOfTerrainRequests: 0,
+  numberOfImageryRequests: 0,
+  numberOfTiles3DRequests: 0,
+  numberOfOtherRequests: 0,
   numberOfActiveRequests: 0,
   numberOfCancelledRequests: 0,
   numberOfCancelledActiveRequests: 0,
@@ -399,6 +404,23 @@ RequestScheduler.request = function (request) {
 
   ++statistics.numberOfAttemptedRequests;
 
+  // Track request counts by RequestType for debugging and fine-grained
+  // request statistics. This allows monitoring the distribution of
+  // terrain, imagery, and 3D Tiles requests handled by the scheduler.
+  switch (request.type) {
+    case RequestType.TERRAIN:
+      ++statistics.numberOfTerrainRequests;
+      break;
+    case RequestType.IMAGERY:
+      ++statistics.numberOfImageryRequests;
+      break;
+    case RequestType.TILES3D:
+      ++statistics.numberOfTiles3DRequests;
+      break;
+    default:
+      ++statistics.numberOfOtherRequests;
+  }
+
   if (!defined(request.serverKey)) {
     request.serverKey = RequestScheduler.getServerKey(request.url);
   }
@@ -453,7 +475,33 @@ function updateStatistics() {
       );
       statistics.numberOfAttemptedRequests = 0;
     }
+    if (statistics.numberOfTerrainRequests > 0) {
+      console.log(
+        `Number of terrain requests: ${statistics.numberOfTerrainRequests}`,
+      );
+      statistics.numberOfTerrainRequests = 0;
+    }
 
+    if (statistics.numberOfImageryRequests > 0) {
+      console.log(
+        `Number of imagery requests: ${statistics.numberOfImageryRequests}`,
+      );
+      statistics.numberOfImageryRequests = 0;
+    }
+
+    if (statistics.numberOfTiles3DRequests > 0) {
+      console.log(
+        `Number of 3D Tiles requests: ${statistics.numberOfTiles3DRequests}`,
+      );
+      statistics.numberOfTiles3DRequests = 0;
+    }
+
+    if (statistics.numberOfOtherRequests > 0) {
+      console.log(
+        `Number of other requests: ${statistics.numberOfOtherRequests}`,
+      );
+      statistics.numberOfOtherRequests = 0;
+    }
     if (statistics.numberOfCancelledRequests > 0) {
       console.log(
         `Number of cancelled requests: ${statistics.numberOfCancelledRequests}`,
@@ -498,6 +546,10 @@ RequestScheduler.clearForSpecs = function () {
 
   // Clear stats
   statistics.numberOfAttemptedRequests = 0;
+  statistics.numberOfTerrainRequests = 0;
+  statistics.numberOfImageryRequests = 0;
+  statistics.numberOfTiles3DRequests = 0;
+  statistics.numberOfOtherRequests = 0;
   statistics.numberOfActiveRequests = 0;
   statistics.numberOfCancelledRequests = 0;
   statistics.numberOfCancelledActiveRequests = 0;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

This change adds per-request-type statistics to RequestScheduler using the existing RequestType enum.

Previously, RequestType values were assigned to requests and propagated through the request pipeline, but they were not used for debugging, logging, or statistics collection. This change tracks the number of requests by type and reports them through the existing debugShowStatistics mechanism.

The following request categories are tracked:

-Terrain requests
-Imagery requests
-3D Tiles requests
-Other requests

These statistics can help developers better understand request distribution and provide more fine-grained debugging information when analyzing application behavior.

## Issue number and link

fixes issue #13048 

## Testing plan

-Added request-type counters to the RequestScheduler statistics object.
-Incremented counters when requests are processed by RequestScheduler.request.
-Added logging of request-type statistics when RequestScheduler.debugShowStatistics is enabled.
-Reset counters after logging to match the behavior of existing statistics.
-Started the Cesium development server and opened Sandcastle.
-Enabled statistics reporting and verified that imagery, terrain, 3D Tiles, and other request counts were logged correctly.
-Verified that counters reset after reporting and did not accumulate indefinitely.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [X] I have added my name to `CONTRIBUTORS.md`
- [X] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [X] I have performed a self-review of my code

## AI acknowledgment

- [X] I used AI to generate content in this PR
- [X] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

ChatGPT

If yes, I used the following Model(s):

GPT-5.5
