### PR TITLE
Move #13388 CHANGES entry to 1.144 section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,5 @@
 # Change Log
 
-- Fixed a bug in `GeocoderViewModel` where a duplicate `destroy` method silently overwrote the first, preventing `_suggestionSubscription` from being disposed on destroy. [#13580](https://github.com/CesiumGS/cesium/pull/13580)
-
 ## 1.144 - 2026-08-01
 
 ### @cesium/engine

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 #### Fixes :wrench:
 
 - Fixed a bug in `GeocoderViewModel` where a duplicate `destroy` method silently overwrote the first, preventing `_suggestionSubscription` from being disposed on destroy. [#13580](https://github.com/CesiumGS/cesium/pull/13580)
+- Fixed geometry clipped by `ClippingPlaneCollection` or `ClippingPolygonCollection` still casting shadows. [#6261](https://github.com/CesiumGS/cesium/issues/6261)
 
 ## 1.143 - 2026-07-01
 
@@ -27,7 +28,6 @@
 - Fixed a bug where callbacks registered with `Scene.updateHeight` would sometimes receive positions computed for other tiles, causing clamped entities to show incorrect heights. [#12602](https://github.com/CesiumGS/cesium/issues/12602)
 - Invalid glTF sampler wrap modes now fall back to `TextureWrap.REPEAT` instead of thowing a `DeveloperError` in development builds. [#13562](https://github.com/CesiumGS/cesium/pull/13562)
 - Fixed a bug in `BufferPointCollection` where `outlineColor` was bleeding into the visible area when set to `0px`. [#13543](https://github.com/CesiumGS/cesium/pull/13543)
-- Fixed geometry clipped by `ClippingPlaneCollection` or `ClippingPolygonCollection` still casting shadows. [#6261](https://github.com/CesiumGS/cesium/issues/6261)
 
 ## 1.142 - 2026-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Fixed a bug in `GeocoderViewModel` where a duplicate `destroy` method silently overwrote the first, preventing `_suggestionSubscription` from being disposed on destroy. [#13580](https://github.com/CesiumGS/cesium/pull/13580)
 - Fixed geometry clipped by `ClippingPlaneCollection` or `ClippingPolygonCollection` still casting shadows. [#6261](https://github.com/CesiumGS/cesium/issues/6261)
+- Fixed a bug in `Transforms.computeMoonFixedToIcrfMatrix` which caused the `result` parameter to not be used. [#13463](https://github.com/CesiumGS/cesium/pull/13463)
 
 ## 1.143 - 2026-07-01
 


### PR DESCRIPTION
# Description

The changelog entry for the clipped-geometry shadow fix (#13388) was
placed under the `1.143` section. Since `1.143` was already released on
2026-07-01, this follow-up moves the entry to the unreleased `1.144`
section, as noted by @javagl in the review.

This is a documentation-only change: it moves a single line in
`CHANGES.md` and touches no source code.

## Issue number and link

Follow-up to #13388.
Review note: https://github.com/CesiumGS/cesium/pull/13388

## Testing plan

No code changes — `CHANGES.md` only. Verified the entry now appears under
`## 1.144 - 2026-08-01` and is no longer present under `## 1.143`, and
that no other changelog lines were added, removed, or duplicated
(`git diff`: 1 insertion, 1 deletion).

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting
