### PR TITLE
Sandcastle Copilot: Tool registry handling fix

### DIFF
--- a/packages/sandcastle/src/copilot/hooks/useToolChainExecution.ts
+++ b/packages/sandcastle/src/copilot/hooks/useToolChainExecution.ts
@@ -12,7 +12,7 @@ import type {
 import {
   initializeToolRegistry,
   setToolRegistry,
-  toolRegistry,
+  ToolRegistry,
 } from "../ai/tools/toolRegistry";
 import { AIClientFactory } from "../ai/clients/AIClientFactory";
 import { buildGeminiFunctionCallPart } from "../ai/clients/geminiShared";
@@ -66,20 +66,25 @@ export function useToolChainExecution({
     workingCodeRef.current = codeContext;
   }, [codeContext]);
 
-  const registryInitializedRef = useRef(false);
+  // One registry per hook instance: its getSourceCode closure must read THIS
+  // instance's workingCodeRef. Reusing a registry created by a previous mount
+  // (the old module-singleton guard) left apply_diff matching against the
+  // unmounted instance's frozen code snapshot after the panel was closed,
+  // edited, and reopened - so no search block the model wrote could ever match.
+  const registryRef = useRef<ToolRegistry | null>(null);
   useEffect(() => {
-    if (!registryInitializedRef.current && !toolRegistry) {
-      registryInitializedRef.current = true;
-      const registry = initializeToolRegistry((file: "javascript" | "html") => {
-        const ctx = workingCodeRef.current;
-        return file === "javascript" ? ctx.javascript : ctx.html;
-      });
-      setToolRegistry(registry);
-    }
+    const registry = initializeToolRegistry((file: "javascript" | "html") => {
+      const ctx = workingCodeRef.current;
+      return file === "javascript" ? ctx.javascript : ctx.html;
+    });
+    registryRef.current = registry;
+    // Keep the module-level binding pointed at the live registry for any
+    // external consumers.
+    setToolRegistry(registry);
   }, []);
 
   const getTools = useCallback((): ToolDefinition[] | undefined => {
-    return toolRegistry ? toolRegistry.getAllTools() : undefined;
+    return registryRef.current ? registryRef.current.getAllTools() : undefined;
   }, []);
 
   const getWorkingCode = useCallback((): CodeContext => {
@@ -88,7 +93,8 @@ export function useToolChainExecution({
 
   const executeToolCall = useCallback(
     async (toolCall: ToolCall): Promise<ToolResult> => {
-      if (toolCall.name !== "apply_diff" || !toolRegistry) {
+      const registry = registryRef.current;
+      if (toolCall.name !== "apply_diff" || !registry) {
         return {
           tool_call_id: toolCall.id,
           status: "error",
@@ -96,7 +102,7 @@ export function useToolChainExecution({
         };
       }
 
-      const result = await toolRegistry.executeTool(toolCall);
+      const result = await registry.executeTool(toolCall);
 
       // Update workingCodeRef so subsequent chained calls see the modified code.
       if (result.status === "success" && result.output) {


### PR DESCRIPTION
https://github.com/CesiumGS/cesium/issues/13614

## Testing plan

Open Copilot → close it → edit the JS → reopen → ask for an edit. Before the fix every apply_diff fails with the nonsense closest-match hints; after it they apply normally.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
