### PR TITLE
TerrainPicker: ES6 + type checking

### DIFF
--- a/packages/engine/Source/Core/TerrainEncoding.js
+++ b/packages/engine/Source/Core/TerrainEncoding.js
@@ -422,7 +422,7 @@ TerrainEncoding.prototype.decodePosition = function (buffer, index, result) {
 /**
  * Decode a position from the vertex buffer and apply vertical exaggeration.
  *
- * @param {Float32Array} buffer
+ * @param {Float32Array|Float64Array} buffer
  * @param {number} index
  * @param {Cartesian3} [result]
  * @returns {Cartesian3} The exaggerated position.

--- a/packages/engine/Source/Core/TerrainPicker.js
+++ b/packages/engine/Source/Core/TerrainPicker.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import AxisAlignedBoundingBox from "./AxisAlignedBoundingBox.js";
 import Cartesian3 from "./Cartesian3.js";
 import defined from "./defined.js";
@@ -12,147 +14,195 @@ import Check from "./Check.js";
 import DeveloperError from "./DeveloperError.js";
 import CesiumMath from "./Math.js";
 
+/** @import TerrainEncoding from "./TerrainEncoding.js"; */
+/** @import MapProjection from "./MapProjection.js"; */
+
 // Terrain picker can be 4 levels deep (0-3)
 const MAXIMUM_TERRAIN_PICKER_LEVEL = 3;
 
 /**
  * Creates an object that handles arbitrary ray intersections with a terrain mesh using a spatial acceleration structure.
  *
- * @alias TerrainPicker
- * @constructor
- *
- * @param {Float64Array} vertices The terrain mesh's vertex buffer.
- * @param {Uint8Array|Uint16Array|Uint32Array} indices The terrain mesh's index buffer.
- * @param {TerrainEncoding} encoding The terrain mesh's vertex encoding.
- *
  * @private
  */
-function TerrainPicker(vertices, indices, encoding) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("vertices", vertices);
-  Check.defined("indices", indices);
-  Check.defined("encoding", encoding);
-  //>>includeEnd('debug');
+class TerrainPicker {
+  /**
+   * @param {Float64Array} vertices The terrain mesh's vertex buffer.
+   * @param {Uint8Array|Uint16Array|Uint32Array} indices The terrain mesh's index buffer.
+   * @param {TerrainEncoding} encoding The terrain mesh's vertex encoding.
+   */
+  constructor(vertices, indices, encoding) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.defined("vertices", vertices);
+    Check.defined("indices", indices);
+    Check.defined("encoding", encoding);
+    //>>includeEnd('debug');
+
+    /**
+     * The terrain mesh's vertex buffer.
+     * @type {Float64Array}
+     */
+    this._vertices = vertices;
+    /**
+     * The terrain mesh's index buffer.
+     * @type {Uint8Array|Uint16Array|Uint32Array}
+     */
+    this._indices = indices;
+    /**
+     * The terrain mesh's vertex encoding.
+     * @type {TerrainEncoding}
+     */
+    this._encoding = encoding;
+    /**
+     * The inverse of the terrain mesh tile's transform from world space to local space.
+     * @type {Matrix4}
+     */
+    this._inverseTransform = new Matrix4(); // Compute as-needed on rebuild
+    /**
+     * Whether or not to reset this terrain mesh's picker on the next ray intersection.
+     * @type {Boolean}
+     */
+    this._needsRebuild = true;
+    /**
+     * The root node of the terrain picker's quadtree.
+     * @type {TerrainPickerNode}
+     */
+    this._rootNode = new TerrainPickerNode();
+  }
 
   /**
-   * The terrain mesh's vertex buffer.
-   * @type {Float64Array}
+   * Indicates whether the terrain picker needs to be rebuilt due to changes in the underlying terrain mesh's vertices or indices.
+   * @type {boolean}
    */
-  this._vertices = vertices;
+  get needsRebuild() {
+    return this._needsRebuild;
+  }
+
+  set needsRebuild(value) {
+    this._needsRebuild = value;
+  }
+
   /**
-   * The terrain mesh's index buffer.
-   * @type {Uint32Array}
+   * Determines the point on the mesh where the given ray intersects.
+   * @param {Ray} ray The ray to test.
+   * @param {Matrix4} tileTransform The terrain mesh tile's transform from local space to world space.
+   * @param {Boolean} cullBackFaces Whether to consider back-facing triangles as intersections.
+   * @param {SceneMode} mode The scene mode (2D/3D/Columbus View).
+   * @param {MapProjection} projection The map projection.
+   * @returns {Cartesian3 | undefined} result The intersection point, or undefined if there is no intersection.
+   * @private
    */
-  this._indices = indices;
-  /**
-   * The terrain mesh's vertex encoding.
-   * @type {TerrainEncoding}
-   */
-  this._encoding = encoding;
-  /**
-   * The inverse of the terrain mesh tile's transform from world space to local space.
-   * @type {Matrix4}
-   */
-  this._inverseTransform = new Matrix4(); // Compute as-needed on rebuild
-  /**
-   * Whether or not to reset this terrain mesh's picker on the next ray intersection.
-   * @type {Boolean}
-   */
-  this._needsRebuild = true;
-  /**
-   * The root node of the terrain picker's quadtree.
-   * @type {TerrainPickerNode}
-   */
-  this._rootNode = new TerrainPickerNode();
+  rayIntersect(ray, tileTransform, cullBackFaces, mode, projection) {
+    // Lazily (re)create the terrain picker
+    if (this._needsRebuild) {
+      reset(this, tileTransform);
+    }
+
+    const invTransform = this._inverseTransform;
+
+    const transformedRay = scratchTransformedRay;
+
+    transformedRay.origin = Matrix4.multiplyByPoint(
+      invTransform,
+      ray.origin,
+      transformedRay.origin,
+    );
+    transformedRay.direction = Matrix4.multiplyByPointAsVector(
+      invTransform,
+      ray.direction,
+      transformedRay.direction,
+    );
+
+    /** @type {IntersectingNode[]} */
+    const intersections = [];
+    getNodesIntersectingRay(this._rootNode, transformedRay, intersections);
+
+    return findClosestPointInClosestNode(
+      this,
+      intersections,
+      ray,
+      cullBackFaces,
+      mode,
+      projection,
+    );
+  }
 }
 
 const incrementallyBuildTerrainPickerTaskProcessor = new TaskProcessor(
   "incrementallyBuildTerrainPicker",
 );
 
-Object.defineProperties(TerrainPicker.prototype, {
-  /**
-   * Indicates whether the terrain picker needs to be rebuilt due to changes in the underlying terrain mesh's vertices or indices.
-   * @memberof TerrainPicker.prototype
-   * @type {boolean}
-   */
-  needsRebuild: {
-    get: function () {
-      return this._needsRebuild;
-    },
-    set: function (value) {
-      this._needsRebuild = value;
-    },
-  },
-});
-
 /**
  * A node in the terrain picker quadtree.
- * @constructor
  * @private
  */
-function TerrainPickerNode() {
-  /**
-   * The tree-space x-coordinate of this node.
-   * @type {Number}
-   */
-  this.x = 0;
-  /**
-   * The tree-space y-coordinate of this node.
-   * @type {Number}
-   */
-  this.y = 0;
-  /**
-   * The level of this node in the quadtree.
-   * @type {Number}
-   */
-  this.level = 0;
-  /**
-   * The axis-aligned bounding box of this node (in the tree's local space).
-   * @type {AxisAlignedBoundingBox}
-   */
-  this.aabb = createAABBForNode(this.x, this.y, this.level);
-  /**
-   * The indices of the triangles that intersect this node.
-   * @type {Uint32Array}
-   */
-  this.intersectingTriangles = new Uint32Array(0);
-  /**
-   * The child terrain picker nodes of this node.
-   * @type {TerrainPickerNode[]}
-   */
-  this.children = [];
-  /**
-   * Whether or not this node is currently building its children on a worker.
-   * @type {Boolean}
-   */
-  this.buildingChildren = false;
-}
-
-/**
- * Adds a child node to this node.
- *
- * @param {number} childIdx The index of the child to add (0-3).
- * @memberof TerrainPickerNode
- */
-TerrainPickerNode.prototype.addChild = function (childIdx) {
-  //>>includeStart('debug', pragmas.debug);
-  if (childIdx < 0 || childIdx > 3) {
-    throw new DeveloperError(
-      "TerrainPickerNode child index must be between 0 and 3, inclusive.",
-    );
+class TerrainPickerNode {
+  constructor() {
+    /**
+     * The tree-space x-coordinate of this node.
+     * @type {number}
+     */
+    this.x = 0;
+    /**
+     * The tree-space y-coordinate of this node.
+     * @type {number}
+     */
+    this.y = 0;
+    /**
+     * The level of this node in the quadtree.
+     * @type {number}
+     */
+    this.level = 0;
+    /**
+     * The axis-aligned bounding box of this node (in the tree's local space).
+     * @type {AxisAlignedBoundingBox}
+     */
+    this.aabb = createAABBForNode(this.x, this.y, this.level);
+    /**
+     * The indices of the triangles that intersect this node.
+     * @type {Uint32Array}
+     */
+    this.intersectingTriangles = new Uint32Array(0);
+    /**
+     * The child terrain picker nodes of this node.
+     * @type {TerrainPickerNode[]}
+     */
+    this.children = [];
+    /**
+     * Whether or not this node is currently building its children on a worker.
+     * @type {Boolean}
+     */
+    this.buildingChildren = false;
   }
-  //>>includeEnd('debug');
 
-  const childNode = new TerrainPickerNode();
-  // Use bitwise operations to get child x,y from child index and parent x,y
-  childNode.x = this.x * 2 + (childIdx & 1);
-  childNode.y = this.y * 2 + ((childIdx >> 1) & 1);
-  childNode.level = this.level + 1;
-  childNode.aabb = createAABBForNode(childNode.x, childNode.y, childNode.level);
+  /**
+   * Adds a child node to this node.
+   *
+   * @param {number} childIdx The index of the child to add (0-3).
+   */
+  addChild(childIdx) {
+    //>>includeStart('debug', pragmas.debug);
+    if (childIdx < 0 || childIdx > 3) {
+      throw new DeveloperError(
+        "TerrainPickerNode child index must be between 0 and 3, inclusive.",
+      );
+    }
+    //>>includeEnd('debug');
 
-  this.children[childIdx] = childNode;
-};
+    const childNode = new TerrainPickerNode();
+    // Use bitwise operations to get child x,y from child index and parent x,y
+    childNode.x = this.x * 2 + (childIdx & 1);
+    childNode.y = this.y * 2 + ((childIdx >> 1) & 1);
+    childNode.level = this.level + 1;
+    childNode.aabb = createAABBForNode(
+      childNode.x,
+      childNode.y,
+      childNode.level,
+    );
+
+    this.children[childIdx] = childNode;
+  }
+}
 
 const scratchTransformedRay = new Ray();
 const scratchTrianglePoints = [
@@ -162,59 +212,9 @@ const scratchTrianglePoints = [
 ];
 
 /**
- * Determines the point on the mesh where the given ray intersects.
- * @param {Ray} ray The ray to test.
- * @param {Matrix4} tileTransform The terrain mesh tile's transform from local space to world space.
- * @param {Boolean} cullBackFaces Whether to consider back-facing triangles as intersections.
- * @param {SceneMode} mode The scene mode (2D/3D/Columbus View).
- * @param {MapProjection} projection The map projection.
- * @returns {Cartesian3 | undefined} result The intersection point, or undefined if there is no intersection.
- * @memberof TerrainPicker
- * @private
- */
-TerrainPicker.prototype.rayIntersect = function (
-  ray,
-  tileTransform,
-  cullBackFaces,
-  mode,
-  projection,
-) {
-  // Lazily (re)create the terrain picker
-  if (this._needsRebuild) {
-    reset(this, tileTransform);
-  }
-
-  const invTransform = this._inverseTransform;
-
-  const transformedRay = scratchTransformedRay;
-
-  transformedRay.origin = Matrix4.multiplyByPoint(
-    invTransform,
-    ray.origin,
-    transformedRay.origin,
-  );
-  transformedRay.direction = Matrix4.multiplyByPointAsVector(
-    invTransform,
-    ray.direction,
-    transformedRay.direction,
-  );
-
-  const intersections = [];
-  getNodesIntersectingRay(this._rootNode, transformedRay, intersections);
-
-  return findClosestPointInClosestNode(
-    this,
-    intersections,
-    ray,
-    cullBackFaces,
-    mode,
-    projection,
-  );
-};
-
-/**
  * Resets the terrain picker's quadtree structure to just the root node. Done whenever the underlying terrain mesh changes.
- * @param terrainPicker The terrain picker to reset.
+ * @param {TerrainPicker} terrainPicker The terrain picker to reset.
+ * @param {Matrix4} tileTransform
  * @private
  */
 function reset(terrainPicker, tileTransform) {
@@ -287,16 +287,19 @@ function packTriangleBuffers(
 ) {
   Cartesian3.pack(
     trianglePositions[0],
+    // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
     trianglePositionsBuffer,
     9 * bufferIndex,
   );
   Cartesian3.pack(
     trianglePositions[1],
+    // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
     trianglePositionsBuffer,
     9 * bufferIndex + 3,
   );
   Cartesian3.pack(
     trianglePositions[2],
+    // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
     trianglePositionsBuffer,
     9 * bufferIndex + 6,
   );
@@ -558,7 +561,7 @@ function getVertexPosition(
  * Adds triangles to the child nodes of the given node by launching a worker process to do AABB-triangle testing.
  *
  * @param {Matrix4} inverseTransform
- * @param {TerrainNode} node
+ * @param {TerrainPickerNode} node
  * @param {Uint32Array} triangleIndices
  * @param {Float64Array} trianglePositions
  * @returns {Promise<void>} A promise that resolves when the triangles have been added to the child nodes.
@@ -574,11 +577,14 @@ async function addTrianglesToChildrenNodes(
 
   // Prepare data to be sent to a worker
   const inverseTransformPacked = new Float64Array(16);
+  // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
   Matrix4.pack(inverseTransform, inverseTransformPacked, 0);
 
   const aabbArray = new Float64Array(6 * 4); // 6 elements per AABB, 4 children
   for (let i = 0; i < 4; i++) {
+    // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
     Cartesian3.pack(node.children[i].aabb.minimum, aabbArray, i * 6);
+    // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
     Cartesian3.pack(node.children[i].aabb.maximum, aabbArray, i * 6 + 3);
   }
 
@@ -610,7 +616,9 @@ async function addTrianglesToChildrenNodes(
 
   // After worker completes, it transfers back a buffer of intersecting triangles for each child node
   // Assign these to the child nodes
-  const result = await incrementallyBuildTerrainPickerPromise;
+  const result = /** @type {{intersectingTrianglesArrays: ArrayBuffer[]}} */ (
+    await incrementallyBuildTerrainPickerPromise
+  );
   result.intersectingTrianglesArrays.forEach((buffer, index) => {
     // Guard against case where tree is reset while waiting for worker
     if (defined(node.children[index])) {

--- a/packages/engine/Source/Core/TerrainPicker.js
+++ b/packages/engine/Source/Core/TerrainPicker.js
@@ -17,7 +17,10 @@ import CesiumMath from "./Math.js";
 /** @import TerrainEncoding from "./TerrainEncoding.js"; */
 /** @import MapProjection from "./MapProjection.js"; */
 
-// Terrain picker can be 4 levels deep (0-3)
+/**
+ * Terrain picker can be 4 levels deep (0-3)
+ * @ignore
+ */
 const MAXIMUM_TERRAIN_PICKER_LEVEL = 3;
 
 /**


### PR DESCRIPTION
# Description

Updates TerrainPicker.js to ES6, and enables type checking. No functional changes, but catches a few minor typos in JSDoc.

## Issue number and link

- #4434 
- #8359 

## Testing plan

Diff on `Cesium.d.ts` (`./scripts/diff-types.sh`) is empty. Unit tests should pass.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] ~~I have updated `CHANGES.md` with a short summary of my change~~
- [ ] ~~I have added or updated unit tests to ensure consistent code coverage~~
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
