### PR TITLE
Use larger epsilon for S2Cell center checks

### DIFF
--- a/packages/engine/Specs/Core/S2CellSpec.js
+++ b/packages/engine/Specs/Core/S2CellSpec.js
@@ -269,35 +269,35 @@ describe("Core/S2Cell", function () {
   it("gets correct center of cell", function () {
     expect(S2Cell.fromToken("1").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(0.0, 0.0),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
     expect(S2Cell.fromToken("3").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(90.0, 0.0),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
     expect(S2Cell.fromToken("5").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(-180.0, 90.0),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
     expect(S2Cell.fromToken("7").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(-180.0, 0.0),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
     expect(S2Cell.fromToken("9").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(-90.0, 0.0),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
     expect(S2Cell.fromToken("b").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(0.0, -90.0),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
     expect(S2Cell.fromToken("2ef59bd352b93ac3").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(105.64131803774308, -10.490091033598308),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
     expect(S2Cell.fromToken("1234567").getCenter()).toEqualEpsilon(
       Cartesian3.fromDegrees(9.868307318504081, 27.468392925827605),
-      CesiumMath.EPSILON15,
+      CesiumMath.EPSILON10,
     );
   });
 


### PR DESCRIPTION

# Description

Changed the epsilon in the `Core/S2Cell` `"gets correct center of cell"` tests from `EPSILON15` to `EPSILON10`. The reasons why I think that this is appropriate:

- From a quick glance, specs that involve results from `Cartographic.fromCartesian` usually use `EPSILON7` or `EPSILON8`
- The error is from some nearly-ULP-difference in `Math.atan2`, as described in https://github.com/CesiumGS/cesium/issues/13619#issuecomment-4939240107

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/13619

## Testing plan

Wait for CI to pass, and/or run that specific test **in the latest version of Chrome**. (It worked all the time in FireFox)

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] **n/a** I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage. In fact, I **only** did that 😁 
- [ ] **n/a** I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code. Diligently.

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

