### PR TITLE
Fix stale vector tile data for tiles that missed dirty regions while not rendered

### DIFF
--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -39,6 +39,8 @@ const scratchSegmentEnd = new Cartesian2();
  * @typedef {object} VectorTileData
  *
  * @property {boolean} show Whether this vector data should be rendered.
+ * @property {number} [changeCount] Provider change count this data was last
+ *   validated against, managed by VectorProvider.
  *
  * Stage 1: Collect vector segments intersecting tile.
  * @property {number[][]} [segments]

--- a/packages/engine/Source/Core/VectorProvider.js
+++ b/packages/engine/Source/Core/VectorProvider.js
@@ -71,6 +71,21 @@ class VectorProvider {
      * @private
      */
     this._dirtyRectangles = [];
+
+    /**
+     * Total number of dirty regions ever recorded. Tile data is stamped with
+     * this value when validated, so a tile that missed regions cleared while
+     * it was not rendered can be detected and re-baked.
+     * @private
+     */
+    this._changeCount = 0;
+
+    /**
+     * Value of {@link VectorProvider#_changeCount} at the last
+     * {@link VectorProvider#makeClean}.
+     * @private
+     */
+    this._changeCountAtClean = 0;
   }
 
   /** @type {TilingScheme} */
@@ -160,6 +175,7 @@ class VectorProvider {
       new Rectangle(),
     );
     this._dirtyRectangles.push(collectionRectangle);
+    this._changeCount++;
   }
 
   /**
@@ -175,7 +191,7 @@ class VectorProvider {
     const width = Rectangle.computeWidth(tileRectangle);
 
     /** @type {VectorTileData} */
-    const result = { show: true };
+    const result = { show: true, changeCount: this._changeCount };
 
     for (const collection of this._collections) {
       const collectionRectangle = Rectangle.fromBoundingSphere(
@@ -228,7 +244,9 @@ class VectorProvider {
    * Re-bakes a tile's vector data if the tile overlaps a region changed since
    * the last {@link VectorProvider#makeClean}, releasing the previous data.
    * Returns the current data unchanged when the tile is outside every changed
-   * region.
+   * region. A tile whose data predates regions already cleared — because the
+   * tile was not rendered while they were consumed — is re-baked
+   * conservatively.
    *
    * @param {number} x
    * @param {number} y
@@ -238,9 +256,22 @@ class VectorProvider {
    * @returns {VectorTileData|undefined}
    */
   updateTileData(x, y, level, context, currentData) {
-    const dirtyRectangles = this._dirtyRectangles;
-    const tilingScheme = this._tilingScheme;
-    if (!intersectRectangles(x, y, level, dirtyRectangles, tilingScheme)) {
+    const validated =
+      defined(currentData) &&
+      currentData.changeCount >= this._changeCountAtClean;
+
+    if (
+      validated &&
+      !intersectRectangles(
+        x,
+        y,
+        level,
+        this._dirtyRectangles,
+        this._tilingScheme,
+      )
+    ) {
+      // Now validated against every recorded change.
+      currentData.changeCount = this._changeCount;
       return currentData;
     }
 
@@ -257,6 +288,7 @@ class VectorProvider {
    */
   makeClean() {
     this._dirtyRectangles.length = 0;
+    this._changeCountAtClean = this._changeCount;
   }
 
   /**

--- a/packages/engine/Specs/Core/VectorProviderSpec.js
+++ b/packages/engine/Specs/Core/VectorProviderSpec.js
@@ -43,9 +43,9 @@ describe("Core/VectorProvider", function () {
   it("returns hidden vector data with no collections", function () {
     const provider = new VectorProvider({ tilingScheme });
     const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
-    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual({
-      show: false,
-    });
+    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual(
+      jasmine.objectContaining({ show: false }),
+    );
   });
 
   it("returns packed lookup data for a tile overlapping a polyline", function () {
@@ -103,9 +103,9 @@ describe("Core/VectorProvider", function () {
     provider.add(createPolylineCollection());
 
     const xy = tilingScheme.positionToTileXY(farPoint, level);
-    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual({
-      show: false,
-    });
+    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual(
+      jasmine.objectContaining({ show: false }),
+    );
   });
 
   it("stops returning data after a collection is removed", function () {
@@ -115,9 +115,9 @@ describe("Core/VectorProvider", function () {
     provider.remove(collection);
 
     const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
-    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual({
-      show: false,
-    });
+    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual(
+      jasmine.objectContaining({ show: false }),
+    );
   });
 
   it("keeps existing tile data when no dirty regions are recorded", function () {
@@ -154,6 +154,27 @@ describe("Core/VectorProvider", function () {
     const updated = provider.updateTileData(xy.x, xy.y, level, context, data);
     expect(updated).not.toBe(data);
     expect(updated.show).toBe(true);
+  });
+
+  it("re-bakes a tile that missed dirty regions consumed while it was not rendered", function () {
+    const provider = new VectorProvider({ tilingScheme });
+    const collection = createPolylineCollection();
+    provider.add(collection);
+
+    const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
+    const data = provider.requestTileData(xy.x, xy.y, level, context);
+    provider.makeClean();
+
+    // The collection is removed while the tile is outside the rendered set;
+    // another frame's pass consumes and clears the dirty region.
+    provider.remove(collection);
+    provider.update();
+    provider.makeClean();
+
+    // When the tile re-enters the rendered set it must not keep stale data.
+    const updated = provider.updateTileData(xy.x, xy.y, level, context, data);
+    expect(updated).not.toBe(data);
+    expect(updated.show).toBe(false);
   });
 
   it("records and clears a dirty rectangle for a collection with a local region", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Follow up to #13577.

I noticed that when I zoom the camera in and out, some tiles occasionally disappear and become invisible. However, it doesn't seem to be reproducible for everyone—for example, @donmccurdy couldn't reproduce it on macOS.

Below is a quick suggestion from GitHub Copilot that appears to fix the issue.

Dirty rectangles in `VectorProvider` are transient, they are recorded during the provider's `update()` pre-pass, tested against rendered tiles, and cleared by `makeClean()` at the end of the same frame. A tile that is **outside the rendered set** never gets a chance to test against them. When that tile later re-enters the rendered set, `updateTileData` finds no intersecting dirty rectangles and keeps its cached `VectorTileData`, even though the underlying collections have changed.


Added:
- `VectorProvider._changeCount`: incremented each time a dirty rectangle is recorded.
- `VectorProvider._changeCountAtClean`: snapshot taken in `makeClean()`.
- Every `VectorTileData` is stamped with the current `_changeCount` when baked, and re-stamped when it passes validation in `updateTileData`.
- In `updateTileData`, data stamped **before** the last clean may have missed dirty regions that were already consumed, so it is released and re-baked. Otherwise the existing dirty-rectangle intersection test applies as before.
<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
~~- [ ] I have added my name to `CONTRIBUTORS.md`~~
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):
GitHub Copilot
<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):
Fable 5.0
<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
