### PR TITLE
Fix PolylineGlowMaterial rendering issue on Ubuntu (#13632)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Fixed incorrect JSDoc description for `offCenterFrustum` in `OrthographicFrustum` and `PerspectiveFrustum`, which was copied from `projectionMatrix` and incorrectly described the property as returning a projection matrix. [#13570](https://github.com/CesiumGS/cesium/pull/13570)
 - Auto-normalize non-unit `alignedAxis` in `BillboardCollection` instead of silently ignoring it. [#6596](https://github.com/CesiumGS/cesium/issues/6596)
 - Fixed SPZ-compressed Gaussian splat loading to read the compressed payload from the buffer view declared by `KHR_gaussian_splatting_compression_spz_2`, preventing incorrect cache reuse for assets with SPZ payloads in different buffer views. [#12847](https://github.com/CesiumGS/cesium/issues/12847)
+- Fixed incorrect parameter order when calling `clamp` in `PolylineGlowMaterial` shader, which caused the alpha value to always be 1.0 regardless of the glow intensity.
 
 ## 1.143 - 2026-07-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -462,3 +462,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Mustafa Senoğu](https://github.com/mmustafasenoglu)
 - [Stephan Cho](https://github.com/stephan271c)
 - [Sam Pomeroy](https://github.com/SamPomeroy)
+- [zhaochen](https://github.com/cyzhao-dad)

--- a/packages/engine/Source/Shaders/Materials/PolylineGlowMaterial.glsl
+++ b/packages/engine/Source/Shaders/Materials/PolylineGlowMaterial.glsl
@@ -15,7 +15,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
 
     vec4 fragColor;
     fragColor.rgb = max(vec3(glow - 1.0 + color.rgb), color.rgb);
-    fragColor.a = clamp(0.0, 1.0, glow) * color.a;
+    fragColor.a = clamp(glow, 0.0, 1.0) * color.a;
     fragColor = czm_gammaCorrect(fragColor);
 
     material.emission = fragColor.rgb;


### PR DESCRIPTION
Fixes #13632

### Description

Fixed an error in the usage of the `clamp` function in `PolylineGlowMaterial` shader: the parameter order was incorrect (`clamp(0.0, 1.0, glow)` instead of `clamp(glow, 0.0, 1.0)`), which caused the alpha value to always be `1.0` regardless of the glow intensity. This fixes the rendering issue where `PolylineGlowMaterial` did not display correctly on Ubuntu systems.

Issue link: https://github.com/CesiumGS/cesium/issues/13632

### Testing Done

#### Sandcastle example
The existing Sandcastle example `polyline` can be used to verify the fix:
- File: `packages/sandcastle/gallery/polyline/main.js`
- The `glowingLine` entity uses `PolylineGlowMaterialProperty` with `glowPower: 0.2`, `taperPower: 0.5`, `color: Cesium.Color.CORNFLOWERBLUE`.

#### Steps to reproduce and verify
1. Run the Sandcastle `polyline` example on Ubuntu before the fix → the glowing blue line renders incorrectly (alpha is always 1.0, glow effect is lost).
2. Apply the fix → the glowing blue line renders correctly with proper glow intensity and transparency.

#### ESLint & unit tests
- Ran full ESLint, no warnings/errors
- All existing unit tests pass

### AI Compliance

- [x] This contribution was developed by the contributor. AI tools were used only for code review and documentation assistance, not for generating the core fix.
- [x] The contributor has reviewed and takes full responsibility for all changes.

Signed-off-by: zhaochen <453157936@qq.com>