### PR TITLE
Vector Textures for Polygon Clipping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,0 @@
-# Project Instructions
-
-1. When authoring new code, comments should explain the _why_, not the _what_. Most comments should be brief, reserving longer comments for exceptional cases. Comments should not be so specific that they need to change frequently when the surrounding code changes.
-2. Prefer the if-guard pattern / early-return from functions rather and avoid nested or complex conditionals when possible.
-3. Prefer new-lines between blocks for readability.
-4. After authoring new code, as a final step ask yourself: is this code as simple and readable as it can be without hurting performance? Pretend someone else wrote the code and you're the reviewer. If you can simplify it, do so.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Project Instructions
+
+1. When authoring new code, comments should explain the _why_, not the _what_. Most comments should be brief, reserving longer comments for exceptional cases. Comments should not be so specific that they need to change frequently when the surrounding code changes.
+2. Prefer the if-guard pattern / early-return from functions rather and avoid nested or complex conditionals when possible.
+3. Prefer new-lines between blocks for readability.
+4. After authoring new code, as a final step ask yourself: is this code as simple and readable as it can be without hurting performance? Pretend someone else wrote the code and you're the reviewer. If you can simplify it, do so.

--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -107,11 +107,11 @@ const scratchSegmentEnd = new Cartesian2();
 class VectorPipeline {
   /**
    * @param {BufferPolylineCollection} collection
-   * @param {TilingScheme} tilingScheme
+   * @param {Ellipsoid} ellipsoid
    * @param {VectorCollectionData} [result]
    * @returns {VectorCollectionData}
    */
-  static packPolylineCollectionData(collection, tilingScheme, result) {
+  static packPolylineCollectionData(collection, ellipsoid, result) {
     if (
       defined(result) &&
       collection._dirtyCount === 0 &&
@@ -122,7 +122,6 @@ class VectorPipeline {
 
     const primitiveCount = collection.primitiveCount;
     const boundingVolume = collection.boundingVolume;
-    const ellipsoid = tilingScheme.ellipsoid;
 
     const rectangle = Rectangle.fromBoundingSphere(boundingVolume, ellipsoid);
     const positions = _getProjectedPositions(collection, ellipsoid);
@@ -329,11 +328,11 @@ class VectorPipeline {
 
   /**
    * @param {BufferPolygonCollection} collection
-   * @param {TilingScheme} tilingScheme
+   * @param {Ellipsoid} ellipsoid
    * @param {VectorCollectionData} [result]
    * @returns {VectorCollectionData}
    */
-  static packPolygonCollectionData(collection, tilingScheme, result) {
+  static packPolygonCollectionData(collection, ellipsoid, result) {
     if (
       defined(result) &&
       collection._dirtyCount === 0 &&
@@ -344,7 +343,6 @@ class VectorPipeline {
 
     const primitiveCount = collection.primitiveCount;
     const boundingVolume = collection.boundingVolume;
-    const ellipsoid = tilingScheme.ellipsoid;
 
     const rectangle = Rectangle.fromBoundingSphere(boundingVolume, ellipsoid);
     const positions = _getProjectedPositions(collection, ellipsoid);

--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -122,11 +122,11 @@ const scratchSegmentEnd = new Cartesian2();
 class VectorPipeline {
   /**
    * @param {BufferPolylineCollection} collection
-   * @param {TilingScheme} tilingScheme
+   * @param {Ellipsoid} ellipsoid
    * @param {VectorCollectionData} [result]
    * @returns {VectorCollectionData}
    */
-  static packPolylineCollectionData(collection, tilingScheme, result) {
+  static packPolylineCollectionData(collection, ellipsoid, result) {
     if (
       defined(result) &&
       collection._dirtyCount === 0 &&
@@ -137,7 +137,6 @@ class VectorPipeline {
 
     const primitiveCount = collection.primitiveCount;
     const boundingVolume = collection.boundingVolume;
-    const ellipsoid = tilingScheme.ellipsoid;
 
     const rectangle = Rectangle.fromBoundingSphere(boundingVolume, ellipsoid);
     const positions = _getProjectedPositions(collection, ellipsoid);
@@ -349,11 +348,11 @@ class VectorPipeline {
 
   /**
    * @param {BufferPolygonCollection} collection
-   * @param {TilingScheme} tilingScheme
+   * @param {Ellipsoid} ellipsoid
    * @param {VectorCollectionData} [result]
    * @returns {VectorCollectionData}
    */
-  static packPolygonCollectionData(collection, tilingScheme, result) {
+  static packPolygonCollectionData(collection, ellipsoid, result) {
     if (
       defined(result) &&
       collection._dirtyCount === 0 &&
@@ -364,7 +363,6 @@ class VectorPipeline {
 
     const primitiveCount = collection.primitiveCount;
     const boundingVolume = collection.boundingVolume;
-    const ellipsoid = tilingScheme.ellipsoid;
 
     const rectangle = Rectangle.fromBoundingSphere(boundingVolume, ellipsoid);
     const positions = _getProjectedPositions(collection, ellipsoid);

--- a/packages/engine/Source/Core/VectorProvider.js
+++ b/packages/engine/Source/Core/VectorProvider.js
@@ -24,7 +24,7 @@ const scratchIntersectRectangle = new Rectangle();
  *
  * @callback PackCollectionData
  * @param {*} collection
- * @param {TilingScheme} tilingScheme
+ * @param {Ellipsoid} ellipsoid
  * @param {VectorCollectionData} [result]
  * @returns {VectorCollectionData}
  * @private
@@ -371,13 +371,14 @@ class VectorProvider {
       return cache;
     }
 
-    const data = packCollectionData(collection, this._tilingScheme, cache);
+    const ellipsoid = this.ellipsoid;
+    const data = packCollectionData(collection, ellipsoid, cache);
 
     // If dirty, the version increments +1 when marked clean below.
     data.version = collection._version + (dirty ? 1 : 0);
     data.rectangle = Rectangle.fromBoundingSphere(
       collection.boundingVolume,
-      this.ellipsoid,
+      ellipsoid,
       data.rectangle,
     );
     this._collectionDataCache.set(collection, data);

--- a/packages/engine/Source/Core/VectorProvider.js
+++ b/packages/engine/Source/Core/VectorProvider.js
@@ -29,7 +29,7 @@ const scratchIntersectRectangle = new Rectangle();
  *
  * @callback PackCollectionData
  * @param {*} collection
- * @param {TilingScheme} tilingScheme
+ * @param {Ellipsoid} ellipsoid
  * @param {VectorCollectionData} [result]
  * @returns {VectorCollectionData}
  * @private
@@ -579,13 +579,14 @@ class VectorProvider {
       return cache;
     }
 
-    const data = packCollectionData(collection, this._tilingScheme, cache);
+    const ellipsoid = this.ellipsoid;
+    const data = packCollectionData(collection, ellipsoid, cache);
 
     // If dirty, the version increments +1 when marked clean below.
     data.version = collection._version + (dirty ? 1 : 0);
     data.rectangle = Rectangle.fromBoundingSphere(
       collection.boundingVolume,
-      this.ellipsoid,
+      ellipsoid,
       data.rectangle,
     );
     this._collectionDataCache.set(collection, data);

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -1212,7 +1212,7 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
  * @param {VectorTileData} rectangleData The data (including textures) for the clipping polygons in the specified rectangle.
  * @ignore
  */
-ClippingPolygonCollection.prototype.releaseRectangleData = function (data) {
+ClippingPolygonCollection.releaseRectangleData = function (data) {
   VectorPipeline.freeResources(data);
 };
 

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -1205,7 +1205,7 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
  * @param {VectorTileData} rectangleData The data (including textures) for the clipping polygons in the specified rectangle.
  * @ignore
  */
-ClippingPolygonCollection.prototype.releaseRectangleData = function (data) {
+ClippingPolygonCollection.releaseRectangleData = function (data) {
   VectorPipeline.freeResources(data);
 };
 

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -28,7 +28,7 @@ import BufferPolygon from "./BufferPolygon.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import VectorPipeline from "../Core/VectorPipeline.js";
 
-/** @import VectorCollectionData from "../Core/VectorPipeline.js" */
+/** @import { VectorCollectionData } from "../Core/VectorPipeline.js" */
 
 // Reused flyweight for reading/writing individual BufferPolygons.
 const bufferPolygonScratch = new BufferPolygon();
@@ -212,6 +212,7 @@ function ClippingPolygonCollection(options) {
 
   /**
    * @type {VectorCollectionData}
+   * @private
    */
   this._vectorCollectionData = VectorPipeline.packPolygonCollectionData(
     this._bufferPolygonCollection,

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -32,8 +32,6 @@ import VectorPipeline from "../Core/VectorPipeline.js";
 // Reused flyweight for reading/writing individual BufferPolygons.
 const bufferPolygonScratch = new BufferPolygon();
 
-const scratchRectangle = new Rectangle();
-
 /**
  * A ClippingPolygon paired with the index of its mirrored primitive in a collection's BufferPolygonCollection.
  *
@@ -1184,12 +1182,7 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
 
   const vectorTileData = {};
 
-  // Early out if there are no polygons or the rectangle does not intersect the collection's bounding rectangle
-  const collectionRectangle = this._vectorCollectionData.rectangle;
-  if (
-    this.length === 0 ||
-    !Rectangle.intersection(rectangle, collectionRectangle, scratchRectangle)
-  ) {
+  if (this.length === 0) {
     return vectorTileData;
   }
 
@@ -1199,6 +1192,11 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
     rectangle,
     vectorTileData,
   );
+
+  // No overlapping polygons means no textures to pack (and the caller can skip the clipping rendering step)
+  if (vectorTileData.polygonRings.length === 0) {
+    return vectorTileData;
+  }
 
   VectorPipeline.packPolygonGrid(vectorTileData);
 

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -33,8 +33,6 @@ import VectorPipeline from "../Core/VectorPipeline.js";
 // Reused flyweight for reading/writing individual BufferPolygons.
 const bufferPolygonScratch = new BufferPolygon();
 
-const scratchRectangle = new Rectangle();
-
 /**
  * A ClippingPolygon paired with the index of its mirrored primitive in a collection's BufferPolygonCollection.
  *
@@ -1177,12 +1175,7 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
 
   const vectorTileData = {};
 
-  // Early out if there are no polygons or the rectangle does not intersect the collection's bounding rectangle
-  const collectionRectangle = this._vectorCollectionData.rectangle;
-  if (
-    this.length === 0 ||
-    !Rectangle.intersection(rectangle, collectionRectangle, scratchRectangle)
-  ) {
+  if (this.length === 0) {
     return vectorTileData;
   }
 
@@ -1192,6 +1185,11 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
     rectangle,
     vectorTileData,
   );
+
+  // No overlapping polygons means no textures to pack (and the caller can skip the clipping rendering step)
+  if (vectorTileData.polygonRings.length === 0) {
+    return vectorTileData;
+  }
 
   VectorPipeline.packPolygonGrid(vectorTileData);
 

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -807,8 +807,9 @@ function packPolygonsAsFloats(clippingPolygonCollection) {
 
 const textureResolutionScratch = new Cartesian2();
 /**
- * Called when {@link Viewer} or {@link CesiumWidget} render the scene to
- * build the resources for clipping polygons.
+ * Called by the collection's owner (a {@link Cesium3DTileset}, {@link Model}, or
+ * the globe surface tile provider) during the scene update to build the
+ * resources for clipping polygons.
  * <p>
  * Do not call this function directly.
  * </p>
@@ -1161,8 +1162,8 @@ ClippingPolygonCollection.setOwner = function (
 
 /**
  * Compute data and pack into textures used for vector-style clipping.
- * Consumers must listen to {@link ClippingPolygonCollection#polygonAdded} and {@link ClippingPolygonCollection#polygonRemoved}
- * to know when to release stale data and request new data for a given rectangle.
+ * Consumers should listen to {@link ClippingPolygonCollection#polygonAdded} and {@link ClippingPolygonCollection#polygonRemoved}
+ * to know when this data becomes stale. It will be refreshed on the next update call (note: update is invoked by the collection's owner).
  *
  * @param {Rectangle} rectangle The region of space to to consider for clipping. Polygons outside of this rectangle
  *                              will not be included in the returned data.

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -1165,7 +1165,7 @@ ClippingPolygonCollection.setOwner = function (
  * Consumers should listen to {@link ClippingPolygonCollection#polygonAdded} and {@link ClippingPolygonCollection#polygonRemoved}
  * to know when this data becomes stale. It will be refreshed on the next update call (note: update is invoked by the collection's owner).
  *
- * @param {Rectangle} rectangle The region of space to to consider for clipping. Polygons outside of this rectangle
+ * @param {Rectangle} rectangle The region of space to consider for clipping. Polygons outside of this rectangle
  *                              will not be included in the returned data.
  * @param {Context} context The context to use for creating textures.
  * @returns {VectorTileData} The data (including textures) for the clipping polygons in the specified rectangle.
@@ -1209,7 +1209,7 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
 /**
  * Destroy resources associated with the given rectangle data.
  *
- * @param {VectorTileData} rectangleData The data (including textures) for the clipping polygons in the specified rectangle.
+ * @param {VectorTileData} data The data (including textures) for the clipping polygons in the specified rectangle.
  * @ignore
  */
 ClippingPolygonCollection.releaseRectangleData = function (data) {

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -27,7 +27,7 @@ import BufferPolygon from "./BufferPolygon.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import VectorPipeline from "../Core/VectorPipeline.js";
 
-/** @import VectorCollectionData from "../Core/VectorPipeline.js" */
+/** @import { VectorCollectionData } from "../Core/VectorPipeline.js" */
 
 // Reused flyweight for reading/writing individual BufferPolygons.
 const bufferPolygonScratch = new BufferPolygon();
@@ -206,6 +206,7 @@ function ClippingPolygonCollection(options) {
 
   /**
    * @type {VectorCollectionData}
+   * @private
    */
   this._vectorCollectionData = VectorPipeline.packPolygonCollectionData(
     this._bufferPolygonCollection,

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -25,9 +25,15 @@ import Pass from "../Renderer/Pass.js";
 import BufferPolygonCollection from "./BufferPolygonCollection.js";
 import BufferPrimitiveCollection from "./BufferPrimitiveCollection.js";
 import BufferPolygon from "./BufferPolygon.js";
+import Ellipsoid from "../Core/Ellipsoid.js";
+import VectorPipeline from "../Core/VectorPipeline.js";
+
+/** @import VectorCollectionData from "../Core/VectorPipeline.js" */
 
 // Reused flyweight for reading/writing individual BufferPolygons.
 const bufferPolygonScratch = new BufferPolygon();
+
+const scratchRectangle = new Rectangle();
 
 /**
  * A ClippingPolygon paired with the index of its mirrored primitive in a collection's BufferPolygonCollection.
@@ -52,6 +58,7 @@ const bufferPolygonScratch = new BufferPolygon();
  * @param {boolean} [options.enabled=true] Determines whether the clipping polygons are active.
  * @param {boolean} [options.inverse=false] If true, a region will be clipped if it is outside of every polygon in the collection. Otherwise, a region will only be clipped if it is on the inside of any polygon.
  * @param {number} [options.quality=1.0] A scalar that controls the resolution of the signed distance texture used for clipping. Values greater than 1.0 increase quality, values less than 1.0 decrease it. Must be greater than 0.0.
+ * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.default] The ellipsoid to use to project the clipping polygons onto the globe.
  *
  * @example
  * const positions = Cesium.Cartesian3.fromRadiansArray([
@@ -182,6 +189,13 @@ function ClippingPolygonCollection(options) {
    */
   this.polygonRemoved = new Event();
 
+  /**
+   * The ellipsoid to use to project the clipping polygons onto the globe.
+   * @type {Ellipsoid}
+   * @default Ellipsoid.default
+   */
+  this.ellipsoid = options.ellipsoid ?? Ellipsoid.default;
+
   // If this ClippingPolygonCollection has an owner, only its owner should update or destroy it.
   // This is because in a Cesium3DTileset multiple models may reference the tileset's ClippingPolygonCollection.
   this._owner = undefined;
@@ -195,6 +209,14 @@ function ClippingPolygonCollection(options) {
   this._signedDistanceTexture = undefined;
 
   this._signedDistanceComputeCommand = undefined;
+
+  /**
+   * @type {VectorCollectionData}
+   */
+  this._vectorCollectionData = VectorPipeline.packPolygonCollectionData(
+    this._bufferPolygonCollection,
+    this.ellipsoid,
+  );
 }
 
 Object.defineProperties(ClippingPolygonCollection.prototype, {
@@ -953,6 +975,12 @@ ClippingPolygonCollection.prototype.update = function (frameState) {
   }
 
   this._signedDistanceComputeCommand = createSignedDistanceTextureCommand(this);
+
+  // Update the vector polygon data
+  this._vectorCollectionData = VectorPipeline.packPolygonCollectionData(
+    this._bufferPolygonCollection,
+    this.ellipsoid,
+  );
 };
 
 function createDebugCommand(texture, context) {
@@ -1123,6 +1151,62 @@ ClippingPolygonCollection.setOwner = function (
     clippingPolygonsCollection._owner = owner;
     owner[key] = clippingPolygonsCollection;
   }
+};
+
+/**
+ * Compute data and pack into textures used for vector-style clipping.
+ * Consumers must listen to {@link ClippingPolygonCollection#polygonAdded} and {@link ClippingPolygonCollection#polygonRemoved}
+ * to know when to release stale data and request new data for a given rectangle.
+ *
+ * @param {Rectangle} rectangle The region of space to to consider for clipping. Polygons outside of this rectangle
+ *                              will not be included in the returned data.
+ * @param {Context} context The context to use for creating textures.
+ * @returns {VectorTileData} The data (including textures) for the clipping polygons in the specified rectangle.
+ *
+ * @ignore
+ */
+ClippingPolygonCollection.prototype.requestRectangleData = function (
+  rectangle,
+  context,
+) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("rectangle", rectangle);
+  Check.typeOf.object("context", context);
+  //>>includeEnd('debug');
+
+  const vectorTileData = {};
+
+  // Early out if there are no polygons or the rectangle does not intersect the collection's bounding rectangle
+  const collectionRectangle = this._vectorCollectionData.rectangle;
+  if (
+    this.length === 0 ||
+    !Rectangle.intersection(rectangle, collectionRectangle, scratchRectangle)
+  ) {
+    return vectorTileData;
+  }
+
+  VectorPipeline.packPolygonRings(
+    this._bufferPolygonCollection,
+    this._vectorCollectionData,
+    rectangle,
+    vectorTileData,
+  );
+
+  VectorPipeline.packPolygonGrid(vectorTileData);
+
+  VectorPipeline.packPolygonTextures(context, vectorTileData);
+
+  return vectorTileData;
+};
+
+/**
+ * Destroy resources associated with the given rectangle data.
+ *
+ * @param {VectorTileData} rectangleData The data (including textures) for the clipping polygons in the specified rectangle.
+ * @ignore
+ */
+ClippingPolygonCollection.prototype.releaseRectangleData = function (data) {
+  VectorPipeline.freeResources(data);
 };
 
 /**

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -24,9 +24,15 @@ import PolygonSignedDistanceFS from "../Shaders/PolygonSignedDistanceFS.js";
 import Pass from "../Renderer/Pass.js";
 import BufferPolygonCollection from "./BufferPolygonCollection.js";
 import BufferPolygon from "./BufferPolygon.js";
+import Ellipsoid from "../Core/Ellipsoid.js";
+import VectorPipeline from "../Core/VectorPipeline.js";
+
+/** @import VectorCollectionData from "../Core/VectorPipeline.js" */
 
 // Reused flyweight for reading/writing individual BufferPolygons.
 const bufferPolygonScratch = new BufferPolygon();
+
+const scratchRectangle = new Rectangle();
 
 /**
  * A ClippingPolygon paired with the index of its mirrored primitive in a collection's BufferPolygonCollection.
@@ -51,6 +57,7 @@ const bufferPolygonScratch = new BufferPolygon();
  * @param {boolean} [options.enabled=true] Determines whether the clipping polygons are active.
  * @param {boolean} [options.inverse=false] If true, a region will be clipped if it is outside of every polygon in the collection. Otherwise, a region will only be clipped if it is on the inside of any polygon.
  * @param {number} [options.quality=1.0] A scalar that controls the resolution of the signed distance texture used for clipping. Values greater than 1.0 increase quality, values less than 1.0 decrease it. Must be greater than 0.0.
+ * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.default] The ellipsoid to use to project the clipping polygons onto the globe.
  *
  * @example
  * const positions = Cesium.Cartesian3.fromRadiansArray([
@@ -176,6 +183,13 @@ function ClippingPolygonCollection(options) {
    */
   this.polygonRemoved = new Event();
 
+  /**
+   * The ellipsoid to use to project the clipping polygons onto the globe.
+   * @type {Ellipsoid}
+   * @default Ellipsoid.default
+   */
+  this.ellipsoid = options.ellipsoid ?? Ellipsoid.default;
+
   // If this ClippingPolygonCollection has an owner, only its owner should update or destroy it.
   // This is because in a Cesium3DTileset multiple models may reference the tileset's ClippingPolygonCollection.
   this._owner = undefined;
@@ -189,6 +203,14 @@ function ClippingPolygonCollection(options) {
   this._signedDistanceTexture = undefined;
 
   this._signedDistanceComputeCommand = undefined;
+
+  /**
+   * @type {VectorCollectionData}
+   */
+  this._vectorCollectionData = VectorPipeline.packPolygonCollectionData(
+    this._bufferPolygonCollection,
+    this.ellipsoid,
+  );
 }
 
 Object.defineProperties(ClippingPolygonCollection.prototype, {
@@ -960,6 +982,12 @@ ClippingPolygonCollection.prototype.update = function (frameState) {
   }
 
   this._signedDistanceComputeCommand = createSignedDistanceTextureCommand(this);
+
+  // Update the vector polygon data
+  this._vectorCollectionData = VectorPipeline.packPolygonCollectionData(
+    this._bufferPolygonCollection,
+    this.ellipsoid,
+  );
 };
 
 function createDebugCommand(texture, context) {
@@ -1130,6 +1158,62 @@ ClippingPolygonCollection.setOwner = function (
     clippingPolygonsCollection._owner = owner;
     owner[key] = clippingPolygonsCollection;
   }
+};
+
+/**
+ * Compute data and pack into textures used for vector-style clipping.
+ * Consumers must listen to {@link ClippingPolygonCollection#polygonAdded} and {@link ClippingPolygonCollection#polygonRemoved}
+ * to know when to release stale data and request new data for a given rectangle.
+ *
+ * @param {Rectangle} rectangle The region of space to to consider for clipping. Polygons outside of this rectangle
+ *                              will not be included in the returned data.
+ * @param {Context} context The context to use for creating textures.
+ * @returns {VectorTileData} The data (including textures) for the clipping polygons in the specified rectangle.
+ *
+ * @ignore
+ */
+ClippingPolygonCollection.prototype.requestRectangleData = function (
+  rectangle,
+  context,
+) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("rectangle", rectangle);
+  Check.typeOf.object("context", context);
+  //>>includeEnd('debug');
+
+  const vectorTileData = {};
+
+  // Early out if there are no polygons or the rectangle does not intersect the collection's bounding rectangle
+  const collectionRectangle = this._vectorCollectionData.rectangle;
+  if (
+    this.length === 0 ||
+    !Rectangle.intersection(rectangle, collectionRectangle, scratchRectangle)
+  ) {
+    return vectorTileData;
+  }
+
+  VectorPipeline.packPolygonRings(
+    this._bufferPolygonCollection,
+    this._vectorCollectionData,
+    rectangle,
+    vectorTileData,
+  );
+
+  VectorPipeline.packPolygonGrid(vectorTileData);
+
+  VectorPipeline.packPolygonTextures(context, vectorTileData);
+
+  return vectorTileData;
+};
+
+/**
+ * Destroy resources associated with the given rectangle data.
+ *
+ * @param {VectorTileData} rectangleData The data (including textures) for the clipping polygons in the specified rectangle.
+ * @ignore
+ */
+ClippingPolygonCollection.prototype.releaseRectangleData = function (data) {
+  VectorPipeline.freeResources(data);
 };
 
 /**

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -902,4 +902,118 @@ describe("Scene/ClippingPolygonCollection", function () {
     expect(result.x).toBe(128);
     expect(result.y).toBe(128);
   });
+
+  it("requestRectangleData throws without a rectangle", function () {
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions })],
+    });
+    const scene = createScene();
+
+    expect(() => {
+      polygons.requestRectangleData(undefined, scene.context);
+    }).toThrowDeveloperError();
+
+    scene.destroyForSpecs();
+  });
+
+  it("requestRectangleData throws without a context", function () {
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions })],
+    });
+
+    expect(() => {
+      polygons.requestRectangleData(Rectangle.MAX_VALUE, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("requestRectangleData packs textures for an overlapping rectangle", function () {
+    const scene = createScene();
+    if (!scene.context.webgl2) {
+      scene.destroyForSpecs();
+      return;
+    }
+
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions })],
+    });
+
+    const data = polygons.requestRectangleData(
+      Rectangle.MAX_VALUE,
+      scene.context,
+    );
+
+    expect(data.polygonEdgeTexture).toBeDefined();
+    expect(data.polygonEdgeTexture.width).toBeGreaterThan(0);
+    expect(data.polygonEdgeTexture.height).toBeGreaterThan(0);
+    expect(data.polygonEdgePrimitiveIndicesTexture).toBeDefined();
+    expect(data.polygonGridCellIndicesTexture).toBeDefined();
+
+    ClippingPolygonCollection.releaseRectangleData(data);
+    scene.destroyForSpecs();
+  });
+
+  it("requestRectangleData returns empty data for a non-overlapping rectangle", function () {
+    const scene = createScene();
+    if (!scene.context.webgl2) {
+      scene.destroyForSpecs();
+      return;
+    }
+
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions })],
+    });
+
+    // A rectangle (radians) on the far side of the globe from `positions`.
+    const farRectangle = new Rectangle(2.0, -1.0, 2.5, -0.5);
+    const data = polygons.requestRectangleData(farRectangle, scene.context);
+
+    expect(data.polygonEdgeTexture).toBeUndefined();
+
+    scene.destroyForSpecs();
+  });
+
+  it("requestRectangleData returns empty data when there are no polygons", function () {
+    const scene = createScene();
+    if (!scene.context.webgl2) {
+      scene.destroyForSpecs();
+      return;
+    }
+
+    const polygons = new ClippingPolygonCollection();
+
+    const data = polygons.requestRectangleData(
+      Rectangle.MAX_VALUE,
+      scene.context,
+    );
+
+    expect(data.polygonEdgeTexture).toBeUndefined();
+
+    scene.destroyForSpecs();
+  });
+
+  it("releaseRectangleData destroys the packed textures", function () {
+    const scene = createScene();
+    if (!scene.context.webgl2) {
+      scene.destroyForSpecs();
+      return;
+    }
+
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions })],
+    });
+
+    const data = polygons.requestRectangleData(
+      Rectangle.MAX_VALUE,
+      scene.context,
+    );
+    const edgeTexture = data.polygonEdgeTexture;
+    const gridCellIndicesTexture = data.polygonGridCellIndicesTexture;
+
+    ClippingPolygonCollection.releaseRectangleData(data);
+
+    expect(edgeTexture.isDestroyed()).toBe(true);
+    expect(gridCellIndicesTexture.isDestroyed()).toBe(true);
+
+    scene.destroyForSpecs();
+  });
 });


### PR DESCRIPTION
# Description

This is the second step in reimplementing Clipping Polygons on top of the vector data pipeline. In step one, I created a `BufferPolygonCollection` as a mirrored backing data structure for the `ClippingPolygonCollection` class. In this PR, I expose a new (internal) API on `ClippingPolygonCollection` -- `requestRectangleData` -- analogous to the similarly named versions provided by `VectorProvider`. This API accepts a rectangular region of an ellipsoid, and processes the clipping polygons within that rectangle to create textures used for vector-style clipping (by calling the `VectorPipeline` APIs).

There is also a parallel `releaseRectangleData` API. The intention is for various consumers (terrain, 3d tiles, standalone models) to call these APIs with their respective footprint rectangles.

## Issue number and link

https://github.com/iTwin/cesiumjs-web3d-internal/issues/32

## Testing plan

Again, there are no outward facing changes in this PR. At this point, clipping still relies on the SDF path. The machinery is just being put into place for vector clipping. As such, more regression testing suffices ([sandcastle](https://sandcastle.cesium.com/?id=clipping-regions))

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->


#### PR Dependency Tree


* **PR #13623**
  * **PR #13635** 👈
    * **PR #13636**
      * **PR #13637**
        * **PR #13638**
          * **PR #13641**
            * **PR #13647**
              * **PR #13654**
                * **PR #13660**
                  * **PR #13665**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)