### PR TITLE
Clipping texture plumbing

### DIFF
--- a/packages/engine/Source/Scene/GlobeSurfaceTile.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTile.js
@@ -37,7 +37,8 @@ import TerrainState from "./TerrainState.js";
 /** @import TerrainProvider from "../Core/TerrainProvider.js"; */
 /** @import TileBoundingRegion from "./TileBoundingRegion.js"; */
 /** @import TileImagery from "./TileImagery.js"; */
-/** @import VectorProvider, { VectorTileData } from "../Core/VectorProvider.js"; */
+/** @import VectorProvider from "../Core/VectorProvider.js"; */
+/** @import { VectorTileData } from "../Core/VectorPipeline.js"; */
 
 /**
  * Contains additional information about a {@link QuadtreeTile} of the globe's surface, and
@@ -66,6 +67,12 @@ class GlobeSurfaceTile {
 
     /** @type {VectorTileData} */
     this.vectorData = undefined;
+
+    /**
+     * Clipping polygons build on top of the vector tile data system (both rely on the same rendering technique).
+     * @type {VectorTileData}
+     */
+    this.clippingPolygonData = undefined;
 
     /** @type {VertexArray} */
     this.vertexArray = undefined;
@@ -167,6 +174,11 @@ class GlobeSurfaceTile {
     if (defined(this.vectorData)) {
       VectorPipeline.freeResources(this.vectorData);
       this.vectorData = undefined;
+    }
+
+    if (defined(this.clippingPolygonData)) {
+      VectorPipeline.freeResources(this.clippingPolygonData);
+      this.clippingPolygonData = undefined;
     }
 
     this.terrainData = undefined;

--- a/packages/engine/Source/Scene/GlobeSurfaceTile.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTile.js
@@ -19,6 +19,7 @@ import TextureMagnificationFilter from "../Renderer/TextureMagnificationFilter.j
 import TextureMinificationFilter from "../Renderer/TextureMinificationFilter.js";
 import TextureWrap from "../Renderer/TextureWrap.js";
 import VertexArray from "../Renderer/VertexArray.js";
+import ClippingPolygonCollection from "./ClippingPolygonCollection.js";
 import ImageryState from "./ImageryState.js";
 import QuadtreeTileLoadState from "./QuadtreeTileLoadState.js";
 import TerrainState from "./TerrainState.js";
@@ -177,7 +178,7 @@ class GlobeSurfaceTile {
     }
 
     if (defined(this.clippingPolygonData)) {
-      VectorPipeline.freeResources(this.clippingPolygonData);
+      ClippingPolygonCollection.releaseRectangleData(this.clippingPolygonData);
       this.clippingPolygonData = undefined;
     }
 

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -209,6 +209,12 @@ class GlobeSurfaceTileProvider {
      */
     this._clippingPolygons = undefined;
 
+    this._clippingPolygonsDirty = false;
+
+    this._removeClippingPolygonAdded = undefined;
+
+    this._removeClippingPolygonRemoved = undefined;
+
     /**
      * A property specifying a {@link Rectangle} used to selectively limit terrain and imagery rendering.
      * @type {Rectangle}
@@ -348,7 +354,33 @@ class GlobeSurfaceTileProvider {
   }
 
   set clippingPolygons(value) {
+    if (value === this._clippingPolygons) {
+      return;
+    }
+
     ClippingPolygonCollection.setOwner(value, this, "_clippingPolygons");
+
+    // First, remove the previous listeners if they exist
+    this._removeClippingPolygonAdded =
+      this._removeClippingPolygonAdded && this._removeClippingPolygonAdded();
+    this._removeClippingPolygonRemoved =
+      this._removeClippingPolygonRemoved &&
+      this._removeClippingPolygonRemoved();
+
+    this._clippingPolygonsDirty = true;
+
+    if (!defined(value)) {
+      return;
+    }
+
+    const markDirty = () => {
+      this._clippingPolygonsDirty = true;
+    };
+
+    this._removeClippingPolygonAdded =
+      value.polygonAdded.addEventListener(markDirty);
+    this._removeClippingPolygonRemoved =
+      value.polygonRemoved.addEventListener(markDirty);
   }
 
   /**
@@ -381,6 +413,21 @@ class GlobeSurfaceTileProvider {
       );
     }
 
+    const clippingPolygons = this._clippingPolygons;
+    if (defined(clippingPolygons) && this._clippingPolygonsDirty) {
+      this._quadtree.forEachLoadedTile((tile) => {
+        const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+        if (defined(surfaceTile?.clippingPolygonData)) {
+          ClippingPolygonCollection.releaseRectangleData(
+            surfaceTile.clippingPolygonData,
+          );
+          surfaceTile.clippingPolygonData = undefined;
+        }
+      });
+
+      this._clippingPolygonsDirty = false;
+    }
+
     // Record regions dirtied by changed collections, re-bake overlapping
     // tiles, and build vector data for new surface tiles.
     const vectorProvider = this._vectorProvider;
@@ -409,6 +456,30 @@ class GlobeSurfaceTileProvider {
       },
     );
     vectorProvider.makeClean();
+
+    // Similarly, for clipping polygons, re-request data as needed
+    if (defined(clippingPolygons)) {
+      this._quadtree.forEachRenderedTile(
+        /** @param {QuadtreeTile} tile */
+        (tile) => {
+          if (!tile.isClipped) {
+            return;
+          }
+
+          const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+          // The surface tile's clipping polygon data is cleared above whenever the clipping polygon collection changes.
+          if (defined(surfaceTile.clippingPolygonData)) {
+            return;
+          }
+
+          surfaceTile.clippingPolygonData =
+            clippingPolygons.requestRectangleData(
+              tile.rectangle,
+              frameState.context,
+            );
+        },
+      );
+    }
 
     // Add credits for terrain and imagery providers.
     updateCredits(this, frameState);
@@ -1171,6 +1242,11 @@ class GlobeSurfaceTileProvider {
       this._removeLayerMovedListener && this._removeLayerMovedListener();
     this._removeLayerShownListener =
       this._removeLayerShownListener && this._removeLayerShownListener();
+    this._removeClippingPolygonAdded =
+      this._removeClippingPolygonAdded && this._removeClippingPolygonAdded();
+    this._removeClippingPolygonRemoved =
+      this._removeClippingPolygonRemoved &&
+      this._removeClippingPolygonRemoved();
 
     return destroyObject(this);
   }

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -414,21 +414,6 @@ class GlobeSurfaceTileProvider {
       );
     }
 
-    const clippingPolygons = this._clippingPolygons;
-    if (defined(clippingPolygons) && this._clippingPolygonsDirty) {
-      this._quadtree.forEachLoadedTile((tile) => {
-        const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
-        if (defined(surfaceTile?.clippingPolygonData)) {
-          ClippingPolygonCollection.releaseRectangleData(
-            surfaceTile.clippingPolygonData,
-          );
-          surfaceTile.clippingPolygonData = undefined;
-        }
-      });
-
-      this._clippingPolygonsDirty = false;
-    }
-
     // Record regions dirtied by changed collections, re-bake overlapping
     // tiles, and build vector data for new surface tiles.
     const vectorProvider = this._vectorProvider;
@@ -460,30 +445,6 @@ class GlobeSurfaceTileProvider {
       },
     );
     vectorProvider.makeClean();
-
-    // Similarly, for clipping polygons, re-request data as needed
-    if (defined(clippingPolygons)) {
-      this._quadtree.forEachRenderedTile(
-        /** @param {QuadtreeTile} tile */
-        (tile) => {
-          if (!tile.isClipped) {
-            return;
-          }
-
-          const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
-          // The surface tile's clipping polygon data is cleared above whenever the clipping polygon collection changes.
-          if (defined(surfaceTile.clippingPolygonData)) {
-            return;
-          }
-
-          surfaceTile.clippingPolygonData =
-            clippingPolygons.requestRectangleData(
-              tile.rectangle,
-              frameState.context,
-            );
-        },
-      );
-    }
 
     // Add credits for terrain and imagery providers.
     updateCredits(this, frameState);
@@ -630,6 +591,10 @@ class GlobeSurfaceTileProvider {
       );
     }
 
+    if (this._clippingPolygonsDirty) {
+      releaseClippingPolygonData(this);
+    }
+
     // Add the tile render commands to the command list, sorted by texture count.
     const tilesToRenderByTextureCount = this._tilesToRenderByTextureCount;
     for (
@@ -650,6 +615,7 @@ class GlobeSurfaceTileProvider {
       ) {
         const tile = tilesToRender[tileIndex];
         const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+        updateTileClippingPolygonData(this, tile, surfaceTile, frameState);
         const tileBoundingRegion = surfaceTile.tileBoundingRegion;
         addDrawCommandsForTile(this, tile, frameState);
         frameState.minimumTerrainHeight = Math.min(
@@ -1451,6 +1417,60 @@ function sortTileImageryByLayerIndex(a, b) {
   }
 
   return aImagery.imageryLayer._layerIndex - bImagery.imageryLayer._layerIndex;
+}
+
+/**
+ * Releases cached clipping polygon data on all loaded tiles so it is rebuilt
+ * against the current collection, and clears the dirty flag.
+ * @param {GlobeSurfaceTileProvider} tileProvider
+ * @ignore
+ */
+function releaseClippingPolygonData(tileProvider) {
+  tileProvider._quadtree.forEachLoadedTile(
+    /** @param {QuadtreeTile} tile */
+    function (tile) {
+      const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+      if (!defined(surfaceTile?.clippingPolygonData)) {
+        return;
+      }
+
+      ClippingPolygonCollection.releaseRectangleData(
+        surfaceTile.clippingPolygonData,
+      );
+      surfaceTile.clippingPolygonData = undefined;
+    },
+  );
+  tileProvider._clippingPolygonsDirty = false;
+}
+
+/**
+ * Builds clipping polygon data for a tile about to be rendered, unless it is
+ * unclipped or its data was already built this frame.
+ * @param {GlobeSurfaceTileProvider} tileProvider
+ * @param {QuadtreeTile} tile
+ * @param {GlobeSurfaceTile} surfaceTile
+ * @param {FrameState} frameState
+ * @ignore
+ */
+function updateTileClippingPolygonData(
+  tileProvider,
+  tile,
+  surfaceTile,
+  frameState,
+) {
+  const clippingPolygons = tileProvider._clippingPolygons;
+  if (
+    !defined(clippingPolygons) ||
+    !tile.isClipped ||
+    defined(surfaceTile.clippingPolygonData)
+  ) {
+    return;
+  }
+
+  surfaceTile.clippingPolygonData = clippingPolygons.requestRectangleData(
+    tile.rectangle,
+    frameState.context,
+  );
 }
 
 /**

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -210,6 +210,12 @@ class GlobeSurfaceTileProvider {
      */
     this._clippingPolygons = undefined;
 
+    this._clippingPolygonsDirty = false;
+
+    this._removeClippingPolygonAdded = undefined;
+
+    this._removeClippingPolygonRemoved = undefined;
+
     /**
      * A property specifying a {@link Rectangle} used to selectively limit terrain and imagery rendering.
      * @type {Rectangle}
@@ -349,7 +355,33 @@ class GlobeSurfaceTileProvider {
   }
 
   set clippingPolygons(value) {
+    if (value === this._clippingPolygons) {
+      return;
+    }
+
     ClippingPolygonCollection.setOwner(value, this, "_clippingPolygons");
+
+    // First, remove the previous listeners if they exist
+    this._removeClippingPolygonAdded =
+      this._removeClippingPolygonAdded && this._removeClippingPolygonAdded();
+    this._removeClippingPolygonRemoved =
+      this._removeClippingPolygonRemoved &&
+      this._removeClippingPolygonRemoved();
+
+    this._clippingPolygonsDirty = true;
+
+    if (!defined(value)) {
+      return;
+    }
+
+    const markDirty = () => {
+      this._clippingPolygonsDirty = true;
+    };
+
+    this._removeClippingPolygonAdded =
+      value.polygonAdded.addEventListener(markDirty);
+    this._removeClippingPolygonRemoved =
+      value.polygonRemoved.addEventListener(markDirty);
   }
 
   /**
@@ -380,6 +412,21 @@ class GlobeSurfaceTileProvider {
           surfaceTile.imagery.sort(sortTileImageryByLayerIndex);
         },
       );
+    }
+
+    const clippingPolygons = this._clippingPolygons;
+    if (defined(clippingPolygons) && this._clippingPolygonsDirty) {
+      this._quadtree.forEachLoadedTile((tile) => {
+        const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+        if (defined(surfaceTile?.clippingPolygonData)) {
+          ClippingPolygonCollection.releaseRectangleData(
+            surfaceTile.clippingPolygonData,
+          );
+          surfaceTile.clippingPolygonData = undefined;
+        }
+      });
+
+      this._clippingPolygonsDirty = false;
     }
 
     // Record regions dirtied by changed collections, re-bake overlapping
@@ -413,6 +460,30 @@ class GlobeSurfaceTileProvider {
       },
     );
     vectorProvider.makeClean();
+
+    // Similarly, for clipping polygons, re-request data as needed
+    if (defined(clippingPolygons)) {
+      this._quadtree.forEachRenderedTile(
+        /** @param {QuadtreeTile} tile */
+        (tile) => {
+          if (!tile.isClipped) {
+            return;
+          }
+
+          const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+          // The surface tile's clipping polygon data is cleared above whenever the clipping polygon collection changes.
+          if (defined(surfaceTile.clippingPolygonData)) {
+            return;
+          }
+
+          surfaceTile.clippingPolygonData =
+            clippingPolygons.requestRectangleData(
+              tile.rectangle,
+              frameState.context,
+            );
+        },
+      );
+    }
 
     // Add credits for terrain and imagery providers.
     updateCredits(this, frameState);
@@ -1175,6 +1246,11 @@ class GlobeSurfaceTileProvider {
       this._removeLayerMovedListener && this._removeLayerMovedListener();
     this._removeLayerShownListener =
       this._removeLayerShownListener && this._removeLayerShownListener();
+    this._removeClippingPolygonAdded =
+      this._removeClippingPolygonAdded && this._removeClippingPolygonAdded();
+    this._removeClippingPolygonRemoved =
+      this._removeClippingPolygonRemoved &&
+      this._removeClippingPolygonRemoved();
 
     return destroyObject(this);
   }

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1461,6 +1461,7 @@ function updateTileClippingPolygonData(
   const clippingPolygons = tileProvider._clippingPolygons;
   if (
     !defined(clippingPolygons) ||
+    !clippingPolygons.enabled ||
     !tile.isClipped ||
     defined(surfaceTile.clippingPolygonData)
   ) {

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -413,21 +413,6 @@ class GlobeSurfaceTileProvider {
       );
     }
 
-    const clippingPolygons = this._clippingPolygons;
-    if (defined(clippingPolygons) && this._clippingPolygonsDirty) {
-      this._quadtree.forEachLoadedTile((tile) => {
-        const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
-        if (defined(surfaceTile?.clippingPolygonData)) {
-          ClippingPolygonCollection.releaseRectangleData(
-            surfaceTile.clippingPolygonData,
-          );
-          surfaceTile.clippingPolygonData = undefined;
-        }
-      });
-
-      this._clippingPolygonsDirty = false;
-    }
-
     // Record regions dirtied by changed collections, re-bake overlapping
     // tiles, and build vector data for new surface tiles.
     const vectorProvider = this._vectorProvider;
@@ -456,30 +441,6 @@ class GlobeSurfaceTileProvider {
       },
     );
     vectorProvider.makeClean();
-
-    // Similarly, for clipping polygons, re-request data as needed
-    if (defined(clippingPolygons)) {
-      this._quadtree.forEachRenderedTile(
-        /** @param {QuadtreeTile} tile */
-        (tile) => {
-          if (!tile.isClipped) {
-            return;
-          }
-
-          const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
-          // The surface tile's clipping polygon data is cleared above whenever the clipping polygon collection changes.
-          if (defined(surfaceTile.clippingPolygonData)) {
-            return;
-          }
-
-          surfaceTile.clippingPolygonData =
-            clippingPolygons.requestRectangleData(
-              tile.rectangle,
-              frameState.context,
-            );
-        },
-      );
-    }
 
     // Add credits for terrain and imagery providers.
     updateCredits(this, frameState);
@@ -626,6 +587,10 @@ class GlobeSurfaceTileProvider {
       );
     }
 
+    if (this._clippingPolygonsDirty) {
+      releaseClippingPolygonData(this);
+    }
+
     // Add the tile render commands to the command list, sorted by texture count.
     const tilesToRenderByTextureCount = this._tilesToRenderByTextureCount;
     for (
@@ -646,6 +611,7 @@ class GlobeSurfaceTileProvider {
       ) {
         const tile = tilesToRender[tileIndex];
         const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+        updateTileClippingPolygonData(this, tile, surfaceTile, frameState);
         const tileBoundingRegion = surfaceTile.tileBoundingRegion;
         addDrawCommandsForTile(this, tile, frameState);
         frameState.minimumTerrainHeight = Math.min(
@@ -1413,6 +1379,60 @@ function sortTileImageryByLayerIndex(a, b) {
   }
 
   return aImagery.imageryLayer._layerIndex - bImagery.imageryLayer._layerIndex;
+}
+
+/**
+ * Releases cached clipping polygon data on all loaded tiles so it is rebuilt
+ * against the current collection, and clears the dirty flag.
+ * @param {GlobeSurfaceTileProvider} tileProvider
+ * @ignore
+ */
+function releaseClippingPolygonData(tileProvider) {
+  tileProvider._quadtree.forEachLoadedTile(
+    /** @param {QuadtreeTile} tile */
+    function (tile) {
+      const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+      if (!defined(surfaceTile?.clippingPolygonData)) {
+        return;
+      }
+
+      ClippingPolygonCollection.releaseRectangleData(
+        surfaceTile.clippingPolygonData,
+      );
+      surfaceTile.clippingPolygonData = undefined;
+    },
+  );
+  tileProvider._clippingPolygonsDirty = false;
+}
+
+/**
+ * Builds clipping polygon data for a tile about to be rendered, unless it is
+ * unclipped or its data was already built this frame.
+ * @param {GlobeSurfaceTileProvider} tileProvider
+ * @param {QuadtreeTile} tile
+ * @param {GlobeSurfaceTile} surfaceTile
+ * @param {FrameState} frameState
+ * @ignore
+ */
+function updateTileClippingPolygonData(
+  tileProvider,
+  tile,
+  surfaceTile,
+  frameState,
+) {
+  const clippingPolygons = tileProvider._clippingPolygons;
+  if (
+    !defined(clippingPolygons) ||
+    !tile.isClipped ||
+    defined(surfaceTile.clippingPolygonData)
+  ) {
+    return;
+  }
+
+  surfaceTile.clippingPolygonData = clippingPolygons.requestRectangleData(
+    tile.rectangle,
+    frameState.context,
+  );
 }
 
 /**


### PR DESCRIPTION
# Description

This is the third step in reimplementing Clipping Polygons on top of the vector data pipeline -- specifically, for terrain. In steps one and two, I introduced the machinery for vector-clipping. Now that we have the necessary APIs to create vector-clipping textures, this PR calls them to create and update / manage the lifecycle of these textures (for terrain; models to follow).

## Issue number and link

https://github.com/iTwin/cesiumjs-web3d-internal/issues/33

## Testing plan

Once again, no external / behavioral changes here. Clipping is still using the SDF path at this point. Regression testing with [sandcastle](https://sandcastle.cesium.com/?id=clipping-regions) (plus, since changes to Globe classes were made, general regression testing on globe rendering isn't a bad idea).

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->


#### PR Dependency Tree


* **PR #13623**
  * **PR #13635**
    * **PR #13636** 👈
      * **PR #13637**
        * **PR #13638**
          * **PR #13641**
            * **PR #13647**
              * **PR #13654**
                * **PR #13660**
                  * **PR #13665**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)