### PR TITLE
Shader rework for terrain polygon clipping

### DIFF
--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -1173,7 +1173,7 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
   Check.typeOf.object("context", context);
   //>>includeEnd('debug');
 
-  const vectorTileData = {};
+  const vectorTileData = { polygonRings: [] };
 
   if (this.length === 0) {
     return vectorTileData;

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -1181,7 +1181,7 @@ ClippingPolygonCollection.prototype.requestRectangleData = function (
   Check.typeOf.object("context", context);
   //>>includeEnd('debug');
 
-  const vectorTileData = {};
+  const vectorTileData = { polygonRings: [] };
 
   if (this.length === 0) {
     return vectorTileData;

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -1105,7 +1105,7 @@ ClippingPolygonCollection.prototype.computeIntersectionWithBoundingVolume =
         scratchRectanglePolygon,
       );
 
-      const result = Rectangle.simpleIntersection(
+      const result = Rectangle.intersection(
         tileBoundingRectangle,
         polygonBoundingRectangle,
         scratchRectangleIntersection,

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -1113,7 +1113,7 @@ ClippingPolygonCollection.prototype.computeIntersectionWithBoundingVolume =
         scratchRectanglePolygon,
       );
 
-      const result = Rectangle.simpleIntersection(
+      const result = Rectangle.intersection(
         tileBoundingRectangle,
         polygonBoundingRectangle,
         scratchRectangleIntersection,

--- a/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
@@ -399,7 +399,11 @@ class GlobeSurfaceShaderSet {
       if (hasVectorLayer) {
         vs.defines.push("HAS_VECTOR_LAYER");
         fs.defines.push("HAS_VECTOR_LAYER");
-        fs.sources.unshift(VectorCommon); // before GlobeFS.
+      }
+
+      // Polygon clipping builds on top of the same machinery vector rendering uses
+      if (hasVectorLayer || enableClippingPolygons) {
+        fs.sources.unshift(VectorCommon);
       }
 
       let computeDayColor =

--- a/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
@@ -408,8 +408,8 @@ class GlobeSurfaceShaderSet {
         vs.defines.push("EXAGGERATION");
       }
 
-      if (hasVectorLayer) {
-        vs.defines.push("HAS_VECTOR_LAYER");
+      // Polygon clipping builds on top of the same machinery vector rendering uses
+      if (hasVectorLayer || enableClippingPolygons) {
         fs.defines.push("HAS_VECTOR_LAYER");
         if (hasVectorPolylines) {
           fs.defines.push("HAS_VECTOR_POLYLINES");

--- a/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
@@ -408,8 +408,7 @@ class GlobeSurfaceShaderSet {
         vs.defines.push("EXAGGERATION");
       }
 
-      // Polygon clipping builds on top of the same machinery vector rendering uses
-      if (hasVectorLayer || enableClippingPolygons) {
+      if (hasVectorLayer) {
         fs.defines.push("HAS_VECTOR_LAYER");
         if (hasVectorPolylines) {
           fs.defines.push("HAS_VECTOR_POLYLINES");
@@ -426,7 +425,11 @@ class GlobeSurfaceShaderSet {
         if (vectorMixedWidthUnits) {
           fs.defines.push("VECTOR_WIDTH_MIXED_UNITS");
         }
-        fs.sources.unshift(VectorCommon); // before GlobeFS.
+      }
+
+      // Polygon clipping builds on top of the same machinery vector rendering uses
+      if (hasVectorLayer || enableClippingPolygons) {
+        fs.sources.unshift(VectorCommon);
       }
 
       let computeDayColor =

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1436,6 +1436,26 @@ function updateTileClippingPolygonData(
 }
 
 /**
+ * Determines whether a tile is wholly clipped away by inverse clipping. In
+ * inverse mode a clipped tile with no polygon geometry lies entirely outside
+ * every polygon, so all of it is clipped and it should not be drawn.
+ * @param {GlobeSurfaceTileProvider} tileProvider
+ * @param {GlobeSurfaceTile} surfaceTile
+ * @returns {boolean}
+ * @ignore
+ */
+function isTileClippedAwayByInversePolygons(tileProvider, surfaceTile) {
+  const clippingPolygons = tileProvider._clippingPolygons;
+  return (
+    defined(clippingPolygons) &&
+    clippingPolygons.enabled &&
+    clippingPolygons.length > 0 &&
+    clippingPolygons.inverse &&
+    (surfaceTile.clippingPolygonData?.polygonRings.length ?? 0) === 0
+  );
+}
+
+/**
  * @param {GlobeSurfaceTileProvider} surface
  * @param {FrameState} frameState
  * @ignore
@@ -2442,6 +2462,10 @@ const defaultUndergroundColorAlphaByDistance = new NearFarScalar();
  */
 function addDrawCommandsForTile(tileProvider, tile, frameState) {
   const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+
+  if (isTileClippedAwayByInversePolygons(tileProvider, surfaceTile)) {
+    return;
+  }
 
   if (!defined(surfaceTile.vertexArray)) {
     if (surfaceTile.fill === undefined) {

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -2098,6 +2098,23 @@ function createTileUniformMap(frameState, globeSurfaceTileProvider) {
         frameState.context.defaultTexture
       );
     },
+    u_clippingEdgeTexture: function () {
+      return (
+        this.properties.clippingEdgeTexture ?? frameState.context.defaultTexture
+      );
+    },
+    u_clippingEdgePrimitiveIndicesTexture: function () {
+      return (
+        this.properties.clippingEdgePrimitiveIndicesTexture ??
+        frameState.context.defaultTexture
+      );
+    },
+    u_clippingGridCellIndicesTexture: function () {
+      return (
+        this.properties.clippingGridCellIndicesTexture ??
+        frameState.context.defaultTexture
+      );
+    },
 
     // make a separate object so that changes to the properties are seen on
     // derived commands that combine another uniform map with this one.
@@ -2169,6 +2186,10 @@ function createTileUniformMap(frameState, globeSurfaceTileProvider) {
       vectorPolygonEdgeTexture: undefined,
       vectorPolygonEdgePrimitiveIndicesTexture: undefined,
       vectorPolygonGridCellIndicesTexture: undefined,
+
+      clippingEdgeTexture: undefined,
+      clippingEdgePrimitiveIndicesTexture: undefined,
+      clippingGridCellIndicesTexture: undefined,
     },
   };
 
@@ -2541,8 +2562,10 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
     defined(tileProvider.clippingPolygons) &&
     tileProvider.clippingPolygons.enabled
   ) {
-    --maxTextures;
-    --maxTextures;
+    // Vector polygon clipping samples three textures: edges, per-edge
+    // primitive indices, and the grid cell index header.
+    // TODO: remove the two decrements above when removing old clipping implementation.
+    maxTextures -= 3;
   }
 
   maxTextures -= globeTranslucencyState.numberOfTextureUniforms;
@@ -3125,6 +3148,16 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
         vectorData.polygonEdgePrimitiveIndicesTexture;
       uniformMapProperties.vectorPolygonGridCellIndicesTexture =
         vectorData.polygonGridCellIndicesTexture;
+    }
+
+    const clippingPolygonData = surfaceTile.clippingPolygonData;
+    if (defined(clippingPolygonData)) {
+      uniformMapProperties.clippingEdgeTexture =
+        clippingPolygonData.polygonEdgeTexture;
+      uniformMapProperties.clippingEdgePrimitiveIndicesTexture =
+        clippingPolygonData.polygonEdgePrimitiveIndicesTexture;
+      uniformMapProperties.clippingGridCellIndicesTexture =
+        clippingPolygonData.polygonGridCellIndicesTexture;
     }
 
     // update clipping polygons

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1475,6 +1475,26 @@ function updateTileClippingPolygonData(
 }
 
 /**
+ * Determines whether a tile is wholly clipped away by inverse clipping. In
+ * inverse mode a clipped tile with no polygon geometry lies entirely outside
+ * every polygon, so all of it is clipped and it should not be drawn.
+ * @param {GlobeSurfaceTileProvider} tileProvider
+ * @param {GlobeSurfaceTile} surfaceTile
+ * @returns {boolean}
+ * @ignore
+ */
+function isTileClippedAwayByInversePolygons(tileProvider, surfaceTile) {
+  const clippingPolygons = tileProvider._clippingPolygons;
+  return (
+    defined(clippingPolygons) &&
+    clippingPolygons.enabled &&
+    clippingPolygons.length > 0 &&
+    clippingPolygons.inverse &&
+    (surfaceTile.clippingPolygonData?.polygonRings.length ?? 0) === 0
+  );
+}
+
+/**
  * @param {GlobeSurfaceTileProvider} surface
  * @param {FrameState} frameState
  * @ignore
@@ -2486,6 +2506,10 @@ const defaultUndergroundColorAlphaByDistance = new NearFarScalar();
  */
 function addDrawCommandsForTile(tileProvider, tile, frameState) {
   const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+
+  if (isTileClippedAwayByInversePolygons(tileProvider, surfaceTile)) {
+    return;
+  }
 
   if (!defined(surfaceTile.vertexArray)) {
     if (surfaceTile.fill === undefined) {

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -3162,11 +3162,14 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
 
     // update clipping polygons
     const clippingPolygons = tileProvider._clippingPolygons;
+    const hasClippingPolygonGeometry =
+      (clippingPolygonData?.polygonRings.length ?? 0) > 0;
     const clippingPolygonsEnabled =
       defined(clippingPolygons) &&
       clippingPolygons.enabled &&
       clippingPolygons.length > 0 &&
-      tile.isClipped;
+      tile.isClipped &&
+      hasClippingPolygonGeometry;
 
     surfaceShaderSetOptions.numberOfDayTextures = numberOfDayTextures;
     surfaceShaderSetOptions.applyBrightness = applyBrightness;

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -2140,6 +2140,23 @@ function createTileUniformMap(frameState, globeSurfaceTileProvider) {
     u_vectorMetersPerUv: function () {
       return this.properties.vectorMetersPerUv;
     },
+    u_clippingEdgeTexture: function () {
+      return (
+        this.properties.clippingEdgeTexture ?? frameState.context.defaultTexture
+      );
+    },
+    u_clippingEdgePrimitiveIndicesTexture: function () {
+      return (
+        this.properties.clippingEdgePrimitiveIndicesTexture ??
+        frameState.context.defaultTexture
+      );
+    },
+    u_clippingGridCellIndicesTexture: function () {
+      return (
+        this.properties.clippingGridCellIndicesTexture ??
+        frameState.context.defaultTexture
+      );
+    },
 
     // make a separate object so that changes to the properties are seen on
     // derived commands that combine another uniform map with this one.
@@ -2212,6 +2229,10 @@ function createTileUniformMap(frameState, globeSurfaceTileProvider) {
       vectorPolygonEdgePrimitiveIndicesTexture: undefined,
       vectorPolygonGridCellIndicesTexture: undefined,
       vectorMetersPerUv: new Cartesian2(),
+
+      clippingEdgeTexture: undefined,
+      clippingEdgePrimitiveIndicesTexture: undefined,
+      clippingGridCellIndicesTexture: undefined,
     },
   };
 
@@ -2585,8 +2606,10 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
     defined(tileProvider.clippingPolygons) &&
     tileProvider.clippingPolygons.enabled
   ) {
-    --maxTextures;
-    --maxTextures;
+    // Vector polygon clipping samples three textures: edges, per-edge
+    // primitive indices, and the grid cell index header.
+    // TODO: remove the two decrements above when removing old clipping implementation.
+    maxTextures -= 3;
   }
 
   maxTextures -= globeTranslucencyState.numberOfTextureUniforms;
@@ -3175,6 +3198,16 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
         vectorData.metersPerUv,
         uniformMapProperties.vectorMetersPerUv,
       );
+    }
+
+    const clippingPolygonData = surfaceTile.clippingPolygonData;
+    if (defined(clippingPolygonData)) {
+      uniformMapProperties.clippingEdgeTexture =
+        clippingPolygonData.polygonEdgeTexture;
+      uniformMapProperties.clippingEdgePrimitiveIndicesTexture =
+        clippingPolygonData.polygonEdgePrimitiveIndicesTexture;
+      uniformMapProperties.clippingGridCellIndicesTexture =
+        clippingPolygonData.polygonGridCellIndicesTexture;
     }
 
     // update clipping polygons

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -3212,11 +3212,14 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
 
     // update clipping polygons
     const clippingPolygons = tileProvider._clippingPolygons;
+    const hasClippingPolygonGeometry =
+      (clippingPolygonData?.polygonRings.length ?? 0) > 0;
     const clippingPolygonsEnabled =
       defined(clippingPolygons) &&
       clippingPolygons.enabled &&
       clippingPolygons.length > 0 &&
-      tile.isClipped;
+      tile.isClipped &&
+      hasClippingPolygonGeometry;
 
     surfaceShaderSetOptions.numberOfDayTextures = numberOfDayTextures;
     surfaceShaderSetOptions.applyBrightness = applyBrightness;

--- a/packages/engine/Source/Shaders/GlobeFS.glsl
+++ b/packages/engine/Source/Shaders/GlobeFS.glsl
@@ -457,9 +457,16 @@ void main()
 #endif
 
 #ifdef ENABLE_CLIPPING_POLYGONS
-    vec2 clippingPosition = v_clippingPosition;
-    int regionIndex = v_regionIndex;
-    clipPolygons(u_clippingDistance, CLIPPING_POLYGON_REGIONS_LENGTH, clippingPosition, regionIndex);
+    bool insideAny = vectorClip(v_textureCoordinates.xy);
+    #ifdef CLIPPING_INVERSE
+        if (!insideAny) {
+            discard;
+        }
+    #else
+        if (insideAny) {
+            discard;
+        }
+    #endif
 #endif
 
 #ifdef HIGHLIGHT_FILL_TILE

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -7,6 +7,10 @@ uniform highp sampler2D u_vectorPolygonEdgeTexture;
 uniform highp sampler2D u_vectorPolygonEdgePrimitiveIndicesTexture;
 uniform highp sampler2D u_vectorPolygonGridCellIndicesTexture;
 
+uniform highp sampler2D u_clippingEdgeTexture;
+uniform highp sampler2D u_clippingEdgePrimitiveIndicesTexture;
+uniform highp sampler2D u_clippingGridCellIndicesTexture;
+
 // UV-space offset from the closest point on the segment to p.
 vec2 vectorOffsetToLine(vec2 p, vec4 line)
 {
@@ -29,41 +33,41 @@ ivec2 vectorIndexToUv(int index, ivec2 size)
     return ivec2(u, v);
 }
 
-// Drape clamped vector polylines onto the terrain surface. The fragment's
-// tile UV picks a grid cell, then only that cell's line segments (packed in
-// tile-local UV space) are tested for proximity. Within the line width, the
-// vector color is alpha-composited over the terrain (no discard).
-vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
+// Returns [start, end) index range for the grid cell containing uv. An empty
+// range (start == end == 0) means a placeholder grid, so callers loop zero times.
+ivec2 vectorCellRange(vec2 uv, highp sampler2D gridCellIndicesTexture)
 {
-    // A tile without polylines binds a 1x1 placeholder; a real grid header
-    // [gridWidth, gridHeight, ...] is at least 3 texels.
-    ivec2 headerSize = textureSize(u_vectorGridCellIndicesTexture, 0);
+    ivec2 headerSize = textureSize(gridCellIndicesTexture, 0);
     if (headerSize.x * headerSize.y < 3)
     {
-        return baseColor;
+        return ivec2(0);
     }
 
-    // Inverse UV-per-pixel Jacobian: measures line distance in screen pixels so
-    // width stays constant under anisotropic (oblique) foreshortening.
-    mat2 screenFromUv = inverse(mat2(dFdx(vectorUv), dFdy(vectorUv)));
-    int gridWidth = int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(0, headerSize), 0).r);
-    int gridHeight = int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(1, headerSize), 0).r);
-    int cellX = clamp(int(vectorUv.x * float(gridWidth)), 0, gridWidth - 1);
-    int cellY = clamp(int(vectorUv.y * float(gridHeight)), 0, gridHeight - 1);
+    int gridWidth  = int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(0, headerSize), 0).r);
+    int gridHeight = int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(1, headerSize), 0).r);
+    int cellX = clamp(int(uv.x * float(gridWidth)),  0, gridWidth  - 1);
+    int cellY = clamp(int(uv.y * float(gridHeight)), 0, gridHeight - 1);
     int cellIndex = cellX + cellY * gridWidth;
 
-    // Cell end offsets follow the two gridWidth/gridHeight texels, so cell
-    // N's end is at texel N + 2. A cell's start is the previous cell's end
-    // (texel N + 1); cell 0's start is implicitly 0.
-    int indexEnd = int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(cellIndex + 2, headerSize), 0).r);
+    int indexEnd = int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(cellIndex + 2, headerSize), 0).r);
     int indexStart = cellIndex == 0
         ? 0
-        : int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(cellIndex + 1, headerSize), 0).r);
+        : int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(cellIndex + 1, headerSize), 0).r);
 
+    return ivec2(indexStart, indexEnd);
+}
+
+vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
+{
+    // Computed unconditionally (whether or not cell contains polylines)
+    // so the derivatives stay in uniform control flow.
+    mat2 screenFromUv = inverse(mat2(dFdx(vectorUv), dFdy(vectorUv)));
+
+    ivec2 range = vectorCellRange(vectorUv, u_vectorGridCellIndicesTexture);
     ivec2 segmentTextureSize = textureSize(u_vectorSegmentTexture, 0);
     ivec2 primitiveTextureSize = textureSize(u_vectorWidthTexture, 0);
 
-    for (int i = indexStart; i < indexEnd; i++)
+    for (int i = range.x; i < range.y; i++)
     {
         ivec2 segmentUv = vectorIndexToUv(i, segmentTextureSize);
         vec4 segment = texelFetch(u_vectorSegmentTexture, segmentUv, 0);
@@ -76,7 +80,6 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         vec2 offsetUv = vectorOffsetToLine(vectorUv, segment);
         if (length(screenFromUv * offsetUv) < lineWidth)
         {
-            // Alpha-composite vector over terrain.
             vec4 vectorColor = texelFetch(u_vectorColorTexture, primitiveUv, 0);
             baseColor = vectorColor * vec4(vectorColor.aaa, 1.0) + baseColor * (1.0 - vectorColor.a);
             break;
@@ -122,35 +125,14 @@ bool vectorEdgeCrossesRay(vec4 edge, vec2 p)
 // primitive's fill color is alpha-composited in primitive order (no discard).
 vec4 vectorPolygonRender(vec2 vectorUv, vec4 baseColor)
 {
-    // A tile without polygons binds a 1x1 placeholder; a real grid header
-    // [gridWidth, gridHeight, ...] is at least 3 texels.
-    ivec2 headerSize = textureSize(u_vectorPolygonGridCellIndicesTexture, 0);
-    if (headerSize.x * headerSize.y < 3)
-    {
-        return baseColor;
-    }
-
-    int gridWidth = int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(0, headerSize), 0).r);
-    int gridHeight = int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(1, headerSize), 0).r);
-    int cellX = clamp(int(vectorUv.x * float(gridWidth)), 0, gridWidth - 1);
-    int cellY = clamp(int(vectorUv.y * float(gridHeight)), 0, gridHeight - 1);
-    int cellIndex = cellX + cellY * gridWidth;
-
-    // Cell end offsets follow the two gridWidth/gridHeight texels, so cell
-    // N's end is at texel N + 2. A cell's start is the previous cell's end
-    // (texel N + 1); cell 0's start is implicitly 0.
-    int indexEnd = int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(cellIndex + 2, headerSize), 0).r);
-    int indexStart = cellIndex == 0
-        ? 0
-        : int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(cellIndex + 1, headerSize), 0).r);
-
+    ivec2 range = vectorCellRange(vectorUv, u_vectorPolygonGridCellIndicesTexture);
     ivec2 edgeTextureSize = textureSize(u_vectorPolygonEdgeTexture, 0);
     ivec2 primitiveTextureSize = textureSize(u_vectorColorTexture, 0);
 
     int currentPrimitive = -1;
     bool inside = false;
 
-    for (int i = indexStart; i < indexEnd; i++)
+    for (int i = range.x; i < range.y; i++)
     {
         ivec2 edgeUv = vectorIndexToUv(i, edgeTextureSize);
         vec4 edge = texelFetch(u_vectorPolygonEdgeTexture, edgeUv, 0);
@@ -175,4 +157,41 @@ vec4 vectorPolygonRender(vec2 vectorUv, vec4 baseColor)
     baseColor = vectorCompositePolygonFill(baseColor, currentPrimitive, inside, primitiveTextureSize);
 
     return baseColor;
+}
+
+// Returns true if uv is inside any polygon in its grid cell
+// If performing inverse-clipping, it is up to the caller to negate the result.
+bool vectorClip(vec2 uv)
+{
+    uv = clamp(uv, vec2(0.0), vec2(1.0));
+    ivec2 range = vectorCellRange(uv, u_clippingGridCellIndicesTexture);
+    ivec2 edgeTextureSize = textureSize(u_clippingEdgeTexture, 0);
+
+    int currentPrimitive = -1;
+    bool inside = false;
+
+    for (int i = range.x; i < range.y; i++)
+    {
+        ivec2 edgeUv = vectorIndexToUv(i, edgeTextureSize);
+        int primitiveIndex = int(texelFetch(u_clippingEdgePrimitiveIndicesTexture, edgeUv, 0).r);
+
+        // New primitive: the previous group is complete, check if it was inside and return early if so.
+        if (primitiveIndex != currentPrimitive)
+        {
+            if (inside)
+            {
+                return true;
+            }
+            currentPrimitive = primitiveIndex;
+            inside = false;
+        }
+
+        vec4 edge = texelFetch(u_clippingEdgeTexture, edgeUv, 0);
+        if (vectorEdgeCrossesRay(edge, uv))
+        {
+            inside = !inside;
+        }
+    }
+
+    return inside; // last group
 }

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -250,6 +250,7 @@ vec4 vectorPolygonRender(vec2 vectorUv, vec4 baseColor)
 // If performing inverse-clipping, it is up to the caller to negate the result.
 bool vectorClip(vec2 uv)
 {
+    // Clamp to [0, 1] to address small interpolation precision error that can occur at the boundaries of tiles
     uv = clamp(uv, vec2(0.0), vec2(1.0));
     ivec2 range = vectorCellRange(uv, u_clippingGridCellIndicesTexture);
     ivec2 edgeTextureSize = textureSize(u_clippingEdgeTexture, 0);

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -17,6 +17,10 @@ uniform highp sampler2D u_vectorPolygonEdgePrimitiveIndicesTexture;
 uniform highp sampler2D u_vectorPolygonGridCellIndicesTexture;
 #endif
 
+uniform highp sampler2D u_clippingEdgeTexture;
+uniform highp sampler2D u_clippingEdgePrimitiveIndicesTexture;
+uniform highp sampler2D u_clippingGridCellIndicesTexture;
+
 // UV-space offset from the closest point on the segment to p.
 vec2 vectorOffsetToLine(vec2 p, vec4 line)
 {
@@ -39,6 +43,30 @@ ivec2 vectorIndexToUv(int index, ivec2 size)
     return ivec2(u, v);
 }
 
+// Returns [start, end) index range for the grid cell containing uv. An empty
+// range (start == end == 0) means a placeholder grid, so callers loop zero times.
+ivec2 vectorCellRange(vec2 uv, highp sampler2D gridCellIndicesTexture)
+{
+    ivec2 headerSize = textureSize(gridCellIndicesTexture, 0);
+    if (headerSize.x * headerSize.y < 3)
+    {
+        return ivec2(0);
+    }
+
+    int gridWidth  = int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(0, headerSize), 0).r);
+    int gridHeight = int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(1, headerSize), 0).r);
+    int cellX = clamp(int(uv.x * float(gridWidth)),  0, gridWidth  - 1);
+    int cellY = clamp(int(uv.y * float(gridHeight)), 0, gridHeight - 1);
+    int cellIndex = cellX + cellY * gridWidth;
+
+    int indexEnd = int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(cellIndex + 2, headerSize), 0).r);
+    int indexStart = cellIndex == 0
+        ? 0
+        : int(texelFetch(gridCellIndicesTexture, vectorIndexToUv(cellIndex + 1, headerSize), 0).r);
+
+    return ivec2(indexStart, indexEnd);
+}
+
 #ifdef VECTOR_ANTIALIAS
 // Half-pixel band across a line's edge over which coverage fades.
 const float vectorCoverageRadius = 0.5;
@@ -53,6 +81,21 @@ const float vectorCoverageRadius = 0.0;
 vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
 {
 #ifdef HAS_VECTOR_POLYLINES
+    // Inverse UV-per-pixel Jacobian: measures line distance in screen pixels so
+    // width stays constant under anisotropic (oblique) foreshortening.
+    // Computed unconditionally so the derivatives stay in uniform control flow.
+    mat2 screenFromUv = inverse(mat2(dFdx(vectorUv), dFdy(vectorUv)));
+
+#ifdef VECTOR_WIDTH_IN_METERS
+    mat2 metersFromUv = mat2(u_vectorMetersPerUv.x, 0.0, 0.0, u_vectorMetersPerUv.y);
+    // Edge distances are always compared in pixels, whatever unit a width was authored in,
+    // so ground meters are converted using the coarser of the two screen axes.
+    // Computed unconditionally so the derivatives stay in uniform control flow.
+    float pixelsPerMeter = 1.0 / max(
+        length(metersFromUv * dFdx(vectorUv)),
+        length(metersFromUv * dFdy(vectorUv)));
+#endif
+
     // A tile without polylines binds a 1x1 placeholder; a real grid header
     // [gridWidth, gridHeight, ...] is at least 3 texels.
     ivec2 headerSize = textureSize(u_vectorGridCellIndicesTexture, 0);
@@ -61,40 +104,7 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         return baseColor;
     }
 
-    // Screen-space metric. The inverse UV-per-pixel Jacobian holds a line's screen width
-    // constant under anisotropic (oblique) foreshortening.
-    mat2 pixelsFromUv = inverse(mat2(dFdx(vectorUv), dFdy(vectorUv)));
-
-#ifdef VECTOR_WIDTH_IN_METERS
-    mat2 metersFromUv = mat2(u_vectorMetersPerUv.x, 0.0, 0.0, u_vectorMetersPerUv.y);
-    // Edge distances are always compared in pixels, whatever unit a width was authored in,
-    // so ground meters are converted using the coarser of the two screen axes.
-    float pixelsPerMeter = 1.0 / max(
-        length(metersFromUv * dFdx(vectorUv)),
-        length(metersFromUv * dFdy(vectorUv)));
-#endif
-
-    // Half-pixel band across a line's edge over which coverage fades.
-#ifdef VECTOR_ANTIALIAS
-    float vectorCoverageRadius = 0.5;
-#else
-    float vectorCoverageRadius = 0.0;
-#endif
-
-    int gridWidth = int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(0, headerSize), 0).r);
-    int gridHeight = int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(1, headerSize), 0).r);
-    int cellX = clamp(int(vectorUv.x * float(gridWidth)), 0, gridWidth - 1);
-    int cellY = clamp(int(vectorUv.y * float(gridHeight)), 0, gridHeight - 1);
-    int cellIndex = cellX + cellY * gridWidth;
-
-    // Cell end offsets follow the two gridWidth/gridHeight texels, so cell
-    // N's end is at texel N + 2. A cell's start is the previous cell's end
-    // (texel N + 1); cell 0's start is implicitly 0.
-    int indexEnd = int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(cellIndex + 2, headerSize), 0).r);
-    int indexStart = cellIndex == 0
-        ? 0
-        : int(texelFetch(u_vectorGridCellIndicesTexture, vectorIndexToUv(cellIndex + 1, headerSize), 0).r);
-
+    ivec2 range = vectorCellRange(vectorUv, u_vectorGridCellIndicesTexture);
     ivec2 segmentTextureSize = textureSize(u_vectorSegmentTexture, 0);
     ivec2 primitiveTextureSize = textureSize(u_vectorWidthTexture, 0);
 
@@ -104,7 +114,7 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
     float nearestEdgeDistance = 1.0e30;
     int nearestPrimitiveIndex = -1;
 
-    for (int i = indexStart; i < indexEnd; i++)
+    for (int i = range.x; i < range.y; i++)
     {
         ivec2 segmentUv = vectorIndexToUv(i, segmentTextureSize);
         vec4 segment = texelFetch(u_vectorSegmentTexture, segmentUv, 0);
@@ -120,11 +130,11 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         // A negative width marks a width in meters; see VectorPipeline.
         float edgeDistance = width < 0.0
             ? (length(metersFromUv * offsetToLine) - halfWidth) * pixelsPerMeter
-            : length(pixelsFromUv * offsetToLine) - halfWidth;
+            : length(screenFromUv * offsetToLine) - halfWidth;
 #elif defined(VECTOR_WIDTH_IN_METERS)
         float edgeDistance = (length(metersFromUv * offsetToLine) - halfWidth) * pixelsPerMeter;
 #else
-        float edgeDistance = length(pixelsFromUv * offsetToLine) - halfWidth;
+        float edgeDistance = length(screenFromUv * offsetToLine) - halfWidth;
 #endif
 
         if (edgeDistance < nearestEdgeDistance)
@@ -137,6 +147,8 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         // segment supplies the color, so overlapping translucent lines do not blend.
         if (nearestEdgeDistance <= -vectorCoverageRadius)
         {
+            vec4 vectorColor = texelFetch(u_vectorColorTexture, primitiveUv, 0);
+            baseColor = vectorColor * vec4(vectorColor.aaa, 1.0) + baseColor * (1.0 - vectorColor.a);
             break;
         }
     }
@@ -199,35 +211,14 @@ bool vectorEdgeCrossesRay(vec4 edge, vec2 p)
 vec4 vectorPolygonRender(vec2 vectorUv, vec4 baseColor)
 {
 #ifdef HAS_VECTOR_POLYGONS
-    // A tile without polygons binds a 1x1 placeholder; a real grid header
-    // [gridWidth, gridHeight, ...] is at least 3 texels.
-    ivec2 headerSize = textureSize(u_vectorPolygonGridCellIndicesTexture, 0);
-    if (headerSize.x * headerSize.y < 3)
-    {
-        return baseColor;
-    }
-
-    int gridWidth = int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(0, headerSize), 0).r);
-    int gridHeight = int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(1, headerSize), 0).r);
-    int cellX = clamp(int(vectorUv.x * float(gridWidth)), 0, gridWidth - 1);
-    int cellY = clamp(int(vectorUv.y * float(gridHeight)), 0, gridHeight - 1);
-    int cellIndex = cellX + cellY * gridWidth;
-
-    // Cell end offsets follow the two gridWidth/gridHeight texels, so cell
-    // N's end is at texel N + 2. A cell's start is the previous cell's end
-    // (texel N + 1); cell 0's start is implicitly 0.
-    int indexEnd = int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(cellIndex + 2, headerSize), 0).r);
-    int indexStart = cellIndex == 0
-        ? 0
-        : int(texelFetch(u_vectorPolygonGridCellIndicesTexture, vectorIndexToUv(cellIndex + 1, headerSize), 0).r);
-
+    ivec2 range = vectorCellRange(vectorUv, u_vectorPolygonGridCellIndicesTexture);
     ivec2 edgeTextureSize = textureSize(u_vectorPolygonEdgeTexture, 0);
     ivec2 primitiveTextureSize = textureSize(u_vectorColorTexture, 0);
 
     int currentPrimitive = -1;
     bool inside = false;
 
-    for (int i = indexStart; i < indexEnd; i++)
+    for (int i = range.x; i < range.y; i++)
     {
         ivec2 edgeUv = vectorIndexToUv(i, edgeTextureSize);
         vec4 edge = texelFetch(u_vectorPolygonEdgeTexture, edgeUv, 0);
@@ -255,4 +246,41 @@ vec4 vectorPolygonRender(vec2 vectorUv, vec4 baseColor)
 #else
     return baseColor;
 #endif
+}
+
+// Returns true if uv is inside any polygon in its grid cell
+// If performing inverse-clipping, it is up to the caller to negate the result.
+bool vectorClip(vec2 uv)
+{
+    uv = clamp(uv, vec2(0.0), vec2(1.0));
+    ivec2 range = vectorCellRange(uv, u_clippingGridCellIndicesTexture);
+    ivec2 edgeTextureSize = textureSize(u_clippingEdgeTexture, 0);
+
+    int currentPrimitive = -1;
+    bool inside = false;
+
+    for (int i = range.x; i < range.y; i++)
+    {
+        ivec2 edgeUv = vectorIndexToUv(i, edgeTextureSize);
+        int primitiveIndex = int(texelFetch(u_clippingEdgePrimitiveIndicesTexture, edgeUv, 0).r);
+
+        // New primitive: the previous group is complete, check if it was inside and return early if so.
+        if (primitiveIndex != currentPrimitive)
+        {
+            if (inside)
+            {
+                return true;
+            }
+            currentPrimitive = primitiveIndex;
+            inside = false;
+        }
+
+        vec4 edge = texelFetch(u_clippingEdgeTexture, edgeUv, 0);
+        if (vectorEdgeCrossesRay(edge, uv))
+        {
+            inside = !inside;
+        }
+    }
+
+    return inside; // last group
 }

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -147,8 +147,6 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         // segment supplies the color, so overlapping translucent lines do not blend.
         if (nearestEdgeDistance <= -vectorCoverageRadius)
         {
-            vec4 vectorColor = texelFetch(u_vectorColorTexture, primitiveUv, 0);
-            baseColor = vectorColor * vec4(vectorColor.aaa, 1.0) + baseColor * (1.0 - vectorColor.a);
             break;
         }
     }


### PR DESCRIPTION
# Description

This PR is the 4th installment in the effort to reimplement Clipping Polygons on top of the vector data pipeline -- specifically, for terrain (3d tiles and models to come). 

In this PR, I wire up the vector-clipping texture uniforms and make the shader changes to actually use them. Thus, as of this PR, terrain clipping actually operates via the vector shaders!

And just look at the difference in quality:

Vector-based clipping: 

<img width="800" height="749" alt="image" src="https://github.com/user-attachments/assets/6a75112c-5d12-465f-a087-5d5c3756e3c7" />

SDF-based clipping:

<img width="2722" height="2548" alt="image" src="https://github.com/user-attachments/assets/b4c0de3b-bb6a-4fc1-a66a-e1c890cfb75e" />

## Issue number and link

https://github.com/iTwin/cesiumjs-web3d-internal/issues/34

## Testing plan

[A sandcastle that uses a star shaped polygon to clip the globe ](https://ci-builds.cesium.com/cesium/clipping-globe-shader-rework/Apps/Sandcastle2/index.html#c=nVhtb+M2Ev4rA+MOkFOHVrxJ9xBHe7ebdA8Bur3g4rYfqgVCS2OLdzQpkJQdd+H/fhiSkmXnrb18iC1qXp55H1qsam0cnAC3cI1WNCtYGL2CfFD4p3wwzZUIRPdclQW3TmJLsz/xdLkaj+FaK2e0tOAqBCt+R9CL8N1xA4UUdS3UEmott0utIBEKVujQ2CHz/B/L/zTW8blE4A5Mo5xYIawFD0KkKNHAHKXesFxJdF7ufcElQgZnKUs9kEIr62AtcIMGMlC4ieaxX/xZ0hpIcLlQaPLBcNry2QIViQv8zD9Oc+U/mS0MorqveYHXfIWGR4slGoaKgF9rKYUVWt2gw8IJrSCDBZcWPTYCvdFGljM0hgs1zZUzW/iWKzg4hwz4hgvXIi8Mcoe/9ig+2q0qEsINATNz4cWd0WvvqOxY0w4K7ooKEjRGm2HUKlSpN4xLNC55mFVoEDbcAlfgycCrprB5aRC1MPjLN/9+90AYdjEDPpYl/FPrpUS4q7TTBrkU1okC3t3ATEgkwaVPhX1i6MZRoggXo+qIDl3fN/Ho2C3h493NLLxmlJu3Wn20Ft1tmUwm7y8m6fu+k2ojVsKJNVrGyzKJcocveYdyQktkUi+Th89cSCzBaZCaly2my+c9MasQeEGawDZmwQsEvVGhNI4rwU79sXYVGhAWConcYBndEaTcRyEZ5IMYg17hoXJoXq021iZ4EWizzofcOLSCq3fefTe4NIg2OX1/ztKz778fwXnK3qcXkxGkLB22Gj81QpbA4eK01kKFSqRGwoHCpBdQayso/S1woxtVBsO9bparRaNCcYTEvnfc3LUMSaAaUV6g+TcvRWNHIJTaP3idthcjB6iaL9wZ8bi3bGa4sgttVpYht+4nbVz1cz3Tn8Ujlp8NX2FUFRIkyNnjzuC3r70X1mENGXzhrmJ3tzCOIDzFeAxkgqO2RXY6Xfs859KhUdxhsGXsjYA1GicKtIxYF9pAQmEWkEE6BQFXUTKcwGQK4rvvop0tEOOdABkI+CtMIMsySOHvfW/BZd9d0z4zV0vfLQWcBItOexZNpmSJ0Y4QWw08IAFKPAtN3RckdcHlYXvdZ1ISKCHILrRNvN4hnET0o5bg1FNYoV6kSFkavw+jJV2IWN3YKonaQ/TP2aqRTtRy+2l7R+CTLjFGAfPoBcjDYZC/o38GXWPUXlOvsNvMXxi0FVzHMrsLVTY+eqZxEMcABdrXQGMMUsXQ3Ipzz0Mq9rTUA3xhlIC8qMDPwTkWvLEIL6sQFpR2XqTR88Y66lVCndaSOkdrDBQVV0u0I5+iwkHBFWgltzD3PQpLmG9Bq65xPa3XIwg2OShF269myJ6t8ZhKodLDQzfMj5/hBFJ2Hk8v/GcIVYxSP54v+Sb51uZOQHwJv7UJ9jJ7y3SQdJeH9nV5uhvGr1/95+5gLDpHYex6stM+FY7mQ5iMyA0Fxa9ZRCRUJNPqIBK8ruW2BdwGQCwgOZoX2cHE6HpJGIdLqefIbKU3kIEzDcYSIzntbITOC/GkpW/XmsOXxVFuQAaNKnEhFJaRePcUwjNcL6VaFBKC35bsfsIfmLSH+IayQ4jPmX9kfM9Zr1j+qg27Jwny3HLwfLKwXB0lgJ/McWst/HLKFnI70yGJS7ROKE6Zc/nnJv8kHcHfUpr9Pq+1EahcFBRdUyEvhVp2gn1Pd5rGD1c26XgBauGK6iW60/OLPSVt1Zdd89+NcrXrlo+ZXtIUm6PbICrwQW0XU19F5K93N21gRkBRIAf72uv52Evr+XlTiaLCNZquJn1L3UTns1ztrz20P860lnNuvqBqEt9P2lzBR3cJ+WDWll00SiuL1JAuIRlC9mFfWa/veJHmSbx9LXX+eaK9Xbn/L/WB8Q8r/9oF5z5c036+JYdyf6Pbb6V+6PUud91WKvkcaZ0oddGsUDm2RPeDRPr6aXtbJvnAs/5IZAfXNRnvOm8wBlR9TqHqxr3NeEtkfb6mLrkLQCDrO9KbwMj5dCukEZ/Bw31nNd0TupHGXNhCk7PhDlYPNCp6d1fv7PZem6y5bHCvpn/n/alZzdFEitDmvJ3Mn5D+ns7dQ+htZNBrBD0DY6CfBj+gfUvZG6oiu1ZtKIIz99YnfQXDTuArDD2NISGPjRmMBlfWbSV+IMP+EX/eaIxMGBs7XNWSO7TjeVP8lzq6tcR0NW5ZrkqxBlFmz/yEAIXk1mb5YNFIeS9+x3zw4WpcivUBG90chVr+a41G8i2RVGcffgyHjLGrcXX2DJcLfSYfeNT7835NdGwAV94NsRlsa8zygaGVLx+Es5VQWT5I2UV3wB+zfHCW+r/2kK4Hh2Ter56QTvYI2uLKlfdTlg82onTVJUzStH6k8zGZE1FFRMrnLr08gPMEyiGMlyDEMn2C4OwAQfTQ/wA) (feel free to add terrain and test that too). Use the slider or input field to change the scale of the star and ensure it's crisp at all scales.

[Dynamic clipping collection](https://ci-builds.cesium.com/cesium/clipping-globe-shader-rework/Apps/Sandcastle2/index.html#c=pVjrbhu5FX6VAyFAxxt5pKw3wa5spc1t3QDJxkic5kdVNPTwSEMsRU5JjmRtIKAPsU/YJykOL3OTHKfbP7aGl3M+nst3DinWlTYOvgNm4QVaUa9hafQaFqPCfy1G5wslwqIPTPGCWScxrWlH/LqFKrSyDjYCt2hgDgq3UWr+Nz+WJbkvtHJMKDSL0Ri+LBTAZALXJcKl1iuJsEJdaI4GhAWD/6qFQQ5OQ22bJVeldtogk8I6UcDZS7gWEm1OwtL2WVL/WqvLMHZl9EZwNNe7CvPLd+8u37waL9T+5DyhtwUqhHk8Re4//eEmk3tUjwkeJ1MyBUw6NIo5BFubJSuQ4BdSVPlCSXSw1UZyvw3d+UI5swt26I7DHNiWCZdOURhkDgOIPoazl3FL5oUAaCV3H61Qq0/ClWHHZWMUZ2oc0zp/7L7O3JZ6C3NYMmnRz3oL5JURa+HEBm3OOM+6W0jIHgrmihIyNEabk3AWMqiWmEu9yj6/ogmQmnGhVneZEFxEAQ++eEn7z156tP97XAmtQG/QwLYURektWpHASsvdSisLzCAYprheyx3YgjmHBnme3GuCiHm0Nlo3g9NH02k+9RZB5gd+TN9W166cwdlZ/Fba0PcPj/33PgXGe8ZFbUEvAVlRQom3bKUVky2+Ukscg1CwRofGNngi7ihgDj9OpwQmCf6ga1MgCXamdiUstQFXIhS1MaicF2tnQSv6KBIWtMIE4U8WKm2FE1qRzskEnsGLiOkqqH6hpcSCVkDBlI8cuEHQW4UcbnZeWozhMVgNditcUQq18uLiDKXpTS0kt8BgadCWULRyPV+4Ei320AQLMM6RX6VhmMPf/5FO//E1WOdzqGTEAKww2iZVrqPBxqxiBYXoh5hxc1iMVlLfBHqi+eSOV4rdSOQw97kQJ4XaoLHYCX4PgmgpyO0ozOE9MmvFioy0LVEhxaT3DKlA3qR9UTK1wgSw6NveJiVvSLxBxnXtvLfLrjaw4jcEprgfX2sfxwX5n3E+MbjWGwTcoHKNVcluPqC4Luo1zazQvZJIP5/vXvNsMQpLFqOTeH7JrHtFQrzhlFbBbstaBRB1xZnDD35X1klxckTtd0We4rgUCnk2POwJ/PnAALlEtXIlzGAa2MaLzx3eOioSAc3n6NEZPPjSc/Ee/vPv35vcp2kPJQzTeYJVaKI53f5zh1GeU8wCI1qoJTMpbYAZXSuakFpNJHNQE5n674JJTxOnngtO6wqWhq0x71gqEPVfg6xMarUSruY4Bsmc/9W3Hirn62U03wtmHFrB1FlOifMSVwbRHhMzhmk+DRweRKGq3zJnxG0r7dowZZfarG1OqH8h0B+ra/2zuEX+MyHPAoCunGqYjuCZJ/NpAnOYnoOAC3hyDuLhw3iYtJcpqpFzyARM4MkJfJeQvGWuzK8/vfvn1evz7oZg0l670JogCysB/O5C28zLJ7E96hz31lmh7luXGB7gJKJpqamqbdkobtEbcftDvq6lE5XcPd9daaFc1ph8HA4yvuMcJyc9dXv6Y9DVRrWKO4H5SRj02T7McKJ3YD1y0H5hYg+DS5qxYGrlxBq9uHXtWDibl8yBLSnmhBJOMAmVrmrJkjRfAmqL5pQbsUGVOAyoN+jG+VYY9DllsxZPE9sNV0YHPCOip+7Bb3kjrEOFJsviNFVHjrcnMH+aAqrLSJ99nQDmwjJ48MX/99lMa/vsdN5pbw6RvPf2/D+wBIf8ATRD3jkoldETyJui2dT6Nj7hmQ+ydpuX2e2Vb7Bg1CxTFTe2FBXVdqUdVXbnGQFNWOe2iKop413v+nredgdDym8g9zP3ruYidaYYSu9sWItjdsQiPEs/un2qp6AhQenloIPo0FHjd2pZ7waZfenI2590EvR4gJ93crcd7vWp3nbDKp6at9hNpA6B6nohkRkQrvW6diWarjtYVcldQt44Y1BOYX7oNg9XLCEbdEfzTn/UGC10+340XQViizScPaL6SHfjfbqEbNAa9O4PjfL7riIHK45gqFXUEXd4P+4BpcWvnLGr455DDhUcg9wx2X14j9rMgz7gkBRezzj3Xfnw8kN0xOLlxxejSNKuFCqWCLr89IKK85QEvfRumg2Yp110V4KHob4GHRlV1yxOU3MBp93F3YYidSytOH+z+oo83121Av3yu1qU+/stv7HPE6HKN2Ki7GF7+j8zR8sBvmYPGna5CyiSy7q+CEXlDbNu4BKfu33ssWumHJ426RMoqQ2g4Xl1ld1xyqD6oGGnO0N2V8d+Co/aAw/IyV9r4gtKwdZoWL6Uu2sdigBH64Ty0Tm7p+k9/Yn6NDj7if4+mU7D7fgkPdmEOzJSJaZLSCX9Vbl5C4idES6XWDiqjxthxQ0tUv4lIl+obgKcH3wepGBzvQok+q5qumQ6WPQDXV5msBhdBm4dpycZi8TJM8i6fQV89dIaVxxY1zNbqI3jhaIO/RtJtg885MAQ9ldfuf7IeVzY+G3niTHVPi5SDl5rLW+YeYuqzvpHCF45uvp57ZxW2WJEhBmDgh4cWyfT5vu3fv+4CSna3jnusUvR94/7t6JBSPnc3N+vOPIHtZ2k9IAcvlkCk3KA+o70fyZldpQoE9n4K/r+uMFXK4mN5tDSNXpI/bDbg6wosfgV+SGs9nEmLjnOWXhk2VG79qC9jo88XWyp1TyCqX0T+iqWY8s8ltF4dGHdTuJT2veX+JReG5nl+cThuqJe305u6uJXag+sD+eLSdpywcUGBJ8feTeHQjJr54vRspbyg/gNF6OnFxMuNr1t8b313QaNZDtaUj56+iYM5nl+MSkfHdnlQiQtRh51O55ejNot8f9/AQ) -- this one tests adding and removing clipping polygons from a collection. On this PR branch, the 3D tiles option still uses the SDF approach and will not render crisply.

[Standard clipping regions sandcastle](https://ci-builds.cesium.com/cesium/clipping-globe-shader-rework/Apps/Sandcastle2/index.html?id=clipping-regions) -- basic functionality check

[The clipping performance dev sandcastle](https://ci-builds.cesium.com/cesium/clipping-globe-shader-rework/Apps/Sandcastle2/index.html?id=clipping-performance-dev) is another good one for testing various numbers (of polygons, points per polygon, spacing, etc.). NOTE: in this PR, I have not yet removed the SDF code paths. So the performance of clipping will appear the same or worse, as the SDF textures are still being generated.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->


#### PR Dependency Tree


* **PR #13623**
  * **PR #13635**
    * **PR #13636**
      * **PR #13637** 👈
        * **PR #13638**
          * **PR #13641**
            * **PR #13647**
              * **PR #13654**
                * **PR #13660**
                  * **PR #13665**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)