### PR TITLE
Remove SDF polygon clipping from Globe

### DIFF
--- a/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
@@ -263,12 +263,6 @@ class GlobeSurfaceShaderSet {
         );
       }
 
-      // Need to go before GlobeFS
-      if (currentClippingPolygonsShaderState !== 0) {
-        fs.sources.unshift(getPolygonClippingFunction(frameState.context));
-        vs.sources.unshift(getUnpackClippingFunction(frameState.context));
-      }
-
       vs.defines.push(quantizationDefine);
       fs.defines.push(
         `TEXTURE_UNITS ${numberOfDayTextures}`,
@@ -364,20 +358,10 @@ class GlobeSurfaceShaderSet {
 
       if (enableClippingPolygons) {
         fs.defines.push("ENABLE_CLIPPING_POLYGONS");
-        vs.defines.push("ENABLE_CLIPPING_POLYGONS");
 
         if (clippingPolygons.inverse) {
           fs.defines.push("CLIPPING_INVERSE");
         }
-
-        fs.defines.push(
-          // @ts-expect-error Missing types.
-          `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`,
-        );
-        vs.defines.push(
-          // @ts-expect-error Missing types.
-          `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`,
-        );
       }
 
       if (colorCorrect) {
@@ -540,41 +524,6 @@ function getPositionMode(sceneMode) {
   }
 
   return positionMode;
-}
-
-/**
- * @param {Context} context
- * @ignore
- */
-function getPolygonClippingFunction(context) {
-  // return a noop for webgl1
-  // @ts-expect-error Missing types.
-  if (!context.webgl2) {
-    return `void clipPolygons(highp sampler2D clippingDistance, int regionsLength, vec2 clippingPosition, int regionIndex) {
-    }`;
-  }
-
-  return `void clipPolygons(highp sampler2D clippingDistance, int regionsLength, vec2 clippingPosition, int regionIndex) {
-    czm_clipPolygons(clippingDistance, regionsLength, clippingPosition, regionIndex);
-  }`;
-}
-
-/**
- * @param {Context} context
- * @ignore
- */
-function getUnpackClippingFunction(context) {
-  // return a noop for webgl1
-  // @ts-expect-error Missing types.
-  if (!context.webgl2) {
-    return `vec4 unpackClippingExtents(highp sampler2D extentsTexture, int index) {
-      return vec4();
-    }`;
-  }
-
-  return `vec4 unpackClippingExtents(highp sampler2D extentsTexture, int index) {
-    return czm_unpackClippingExtents(extentsTexture, index);
-  }`;
 }
 
 /**

--- a/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
@@ -275,12 +275,6 @@ class GlobeSurfaceShaderSet {
         );
       }
 
-      // Need to go before GlobeFS
-      if (currentClippingPolygonsShaderState !== 0) {
-        fs.sources.unshift(getPolygonClippingFunction(frameState.context));
-        vs.sources.unshift(getUnpackClippingFunction(frameState.context));
-      }
-
       vs.defines.push(quantizationDefine);
       fs.defines.push(
         `TEXTURE_UNITS ${numberOfDayTextures}`,
@@ -376,20 +370,10 @@ class GlobeSurfaceShaderSet {
 
       if (enableClippingPolygons) {
         fs.defines.push("ENABLE_CLIPPING_POLYGONS");
-        vs.defines.push("ENABLE_CLIPPING_POLYGONS");
 
         if (clippingPolygons.inverse) {
           fs.defines.push("CLIPPING_INVERSE");
         }
-
-        fs.defines.push(
-          // @ts-expect-error Missing types.
-          `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`,
-        );
-        vs.defines.push(
-          // @ts-expect-error Missing types.
-          `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`,
-        );
       }
 
       if (colorCorrect) {
@@ -566,41 +550,6 @@ function getPositionMode(sceneMode) {
   }
 
   return positionMode;
-}
-
-/**
- * @param {Context} context
- * @ignore
- */
-function getPolygonClippingFunction(context) {
-  // return a noop for webgl1
-  // @ts-expect-error Missing types.
-  if (!context.webgl2) {
-    return `void clipPolygons(highp sampler2D clippingDistance, int regionsLength, vec2 clippingPosition, int regionIndex) {
-    }`;
-  }
-
-  return `void clipPolygons(highp sampler2D clippingDistance, int regionsLength, vec2 clippingPosition, int regionIndex) {
-    czm_clipPolygons(clippingDistance, regionsLength, clippingPosition, regionIndex);
-  }`;
-}
-
-/**
- * @param {Context} context
- * @ignore
- */
-function getUnpackClippingFunction(context) {
-  // return a noop for webgl1
-  // @ts-expect-error Missing types.
-  if (!context.webgl2) {
-    return `vec4 unpackClippingExtents(highp sampler2D extentsTexture, int index) {
-      return vec4();
-    }`;
-  }
-
-  return `vec4 unpackClippingExtents(highp sampler2D extentsTexture, int index) {
-    return czm_unpackClippingExtents(extentsTexture, index);
-  }`;
 }
 
 /**

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -479,8 +479,6 @@ class GlobeSurfaceTileProvider {
     if (defined(clippingPolygons) && clippingPolygons.enabled) {
       // @ts-expect-error Missing types.
       clippingPolygons.update(frameState);
-      // @ts-expect-error Missing types.
-      clippingPolygons.queueCommands(frameState);
     }
 
     this._usedDrawCommands = 0;
@@ -2026,22 +2024,6 @@ function createTileUniformMap(frameState, globeSurfaceTileProvider) {
       style.alpha = this.properties.clippingPlanesEdgeWidth;
       return style;
     },
-    u_clippingDistance: function () {
-      const texture =
-        globeSurfaceTileProvider._clippingPolygons.clippingTexture;
-      if (defined(texture)) {
-        return texture;
-      }
-      return frameState.context.defaultTexture;
-    },
-    u_clippingExtents: function () {
-      // @ts-expect-error Missing types.
-      const texture = globeSurfaceTileProvider._clippingPolygons.extentsTexture;
-      if (defined(texture)) {
-        return texture;
-      }
-      return frameState.context.defaultTexture;
-    },
     u_minimumBrightness: function () {
       return frameState.fog.minimumBrightness;
     },
@@ -2588,7 +2570,6 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
   ) {
     // Vector polygon clipping samples three textures: edges, per-edge
     // primitive indices, and the grid cell index header.
-    // TODO: remove the two decrements above when removing old clipping implementation.
     maxTextures -= 3;
   }
 

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -483,8 +483,6 @@ class GlobeSurfaceTileProvider {
     if (defined(clippingPolygons) && clippingPolygons.enabled) {
       // @ts-expect-error Missing types.
       clippingPolygons.update(frameState);
-      // @ts-expect-error Missing types.
-      clippingPolygons.queueCommands(frameState);
     }
 
     this._usedDrawCommands = 0;
@@ -2065,22 +2063,6 @@ function createTileUniformMap(frameState, globeSurfaceTileProvider) {
       style.alpha = this.properties.clippingPlanesEdgeWidth;
       return style;
     },
-    u_clippingDistance: function () {
-      const texture =
-        globeSurfaceTileProvider._clippingPolygons.clippingTexture;
-      if (defined(texture)) {
-        return texture;
-      }
-      return frameState.context.defaultTexture;
-    },
-    u_clippingExtents: function () {
-      // @ts-expect-error Missing types.
-      const texture = globeSurfaceTileProvider._clippingPolygons.extentsTexture;
-      if (defined(texture)) {
-        return texture;
-      }
-      return frameState.context.defaultTexture;
-    },
     u_minimumBrightness: function () {
       return frameState.fog.minimumBrightness;
     },
@@ -2632,7 +2614,6 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
   ) {
     // Vector polygon clipping samples three textures: edges, per-edge
     // primitive indices, and the grid cell index header.
-    // TODO: remove the two decrements above when removing old clipping implementation.
     maxTextures -= 3;
   }
 

--- a/packages/engine/Source/Shaders/GlobeFS.glsl
+++ b/packages/engine/Source/Shaders/GlobeFS.glsl
@@ -77,12 +77,6 @@ uniform mat4 u_clippingPlanesMatrix;
 uniform vec4 u_clippingPlanesEdgeStyle;
 #endif
 
-#ifdef ENABLE_CLIPPING_POLYGONS
-uniform highp sampler2D u_clippingDistance;
-in vec2 v_clippingPosition;
-flat in int v_regionIndex;
-#endif
-
 #if defined(GROUND_ATMOSPHERE) || defined(FOG) && defined(DYNAMIC_ATMOSPHERE_LIGHTING) && (defined(ENABLE_VERTEX_LIGHTING) || defined(ENABLE_DAYNIGHT_SHADING))
 uniform float u_minimumBrightness;
 #endif

--- a/packages/engine/Source/Shaders/GlobeVS.glsl
+++ b/packages/engine/Source/Shaders/GlobeVS.glsl
@@ -46,12 +46,6 @@ out vec3 v_atmosphereMieColor;
 out float v_atmosphereOpacity;
 #endif
 
-#ifdef ENABLE_CLIPPING_POLYGONS
-uniform highp sampler2D u_clippingExtents;
-out vec2 v_clippingPosition;
-flat out int v_regionIndex;
-#endif
-
 // These functions are generated at runtime.
 vec4 getPosition(vec3 position, float height, vec2 textureCoordinates);
 float get2DYPositionFraction(vec2 textureCoordinates);
@@ -212,32 +206,6 @@ void main()
 
     v_normalMC = normalMC;
     v_normalEC = czm_normal3D * v_normalMC;
-#endif
-
-#ifdef ENABLE_CLIPPING_POLYGONS
-    vec2 sphericalLatLong = czm_approximateSphericalCoordinates(position3DWC);
-    sphericalLatLong.y = czm_branchFreeTernary(sphericalLatLong.y < czm_pi, sphericalLatLong.y, sphericalLatLong.y - czm_twoPi);
-    
-    vec2 minDistance = vec2(czm_infinity);
-    v_clippingPosition = vec2(czm_infinity);
-    v_regionIndex = -1;
-
-    for (int regionIndex = 0; regionIndex < CLIPPING_POLYGON_REGIONS_LENGTH; regionIndex++) {
-        vec4 extents = unpackClippingExtents(u_clippingExtents, regionIndex);
-        vec2 rectUv = (sphericalLatLong.yx - extents.yx) * extents.wz;
-
-        vec2 clamped = clamp(rectUv, vec2(0.0), vec2(1.0));
-        vec2 distance = abs(rectUv - clamped) * extents.wz;
-
-        float threshold = 0.01;
-        if (minDistance.x > distance.x || minDistance.y > distance.y) {
-            minDistance = distance;
-            v_clippingPosition = rectUv;
-            if (rectUv.x > threshold && rectUv.y > threshold && rectUv.x < 1.0 - threshold && rectUv.y < 1.0 - threshold) {
-                v_regionIndex = regionIndex;
-            }
-        }
-    }
 #endif
 
 #if defined(FOG) || (defined(GROUND_ATMOSPHERE) && !defined(PER_FRAGMENT_GROUND_ATMOSPHERE))


### PR DESCRIPTION
# Description

This PR simply removes now-unused code from the Globe classes / shaders related to SDF-based polygon clipping (since down-stack PRs have reimplemented Globe polygon clipping on the vector pipeline).

## Issue number and link

None

## Testing plan

Regression testing -- follow same testing plan as in #13637

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->


#### PR Dependency Tree


* **PR #13623**
  * **PR #13635**
    * **PR #13636**
      * **PR #13637**
        * **PR #13638** 👈
          * **PR #13641**
            * **PR #13647**
              * **PR #13654**
                * **PR #13660**
                  * **PR #13665**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)