### PR TITLE
Fix: Clamped billboards did not render in 2D/CV scene modes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Fixed incorrect JSDoc description for `offCenterFrustum` in `OrthographicFrustum` and `PerspectiveFrustum`, which was copied from `projectionMatrix` and incorrectly described the property as returning a projection matrix. [#13570](https://github.com/CesiumGS/cesium/pull/13570)
 - Auto-normalize non-unit `alignedAxis` in `BillboardCollection` instead of silently ignoring it. [#6596](https://github.com/CesiumGS/cesium/issues/6596)
 - Fixed SPZ-compressed Gaussian splat loading to read the compressed payload from the buffer view declared by `KHR_gaussian_splatting_compression_spz_2`, preventing incorrect cache reuse for assets with SPZ payloads in different buffer views. [#12847](https://github.com/CesiumGS/cesium/issues/12847)
+- Fixed terrain-clamped billboards, labels, and points being mispositioned and not properly rendering in 2D/Columbus view. [#5042](https://github.com/CesiumGS/cesium/issues/5042) [#12531](https://github.com/CesiumGS/cesium/issues/12531)
 
 ## 1.143 - 2026-07-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Changed the typing of `PrimitiveCollection.add` to return the added primitive as the same type instead of `any`. [#13742](https://github.com/CesiumGS/cesium/issues/13742)
 - Fixed draped polylines rendering at the wrong width at large widths, in both `"pixels"` and `"meters"` width units. [#13737](https://github.com/CesiumGS/cesium/pull/13737)
 - Fixed geometry clipped by a `ClippingPolygonCollection` still casting shadows. The clipping uv origin is now read from the eye of the pass being rendered, so it matches the delta computed in the vertex shader during shadow casts. [#13768](https://github.com/CesiumGS/cesium/issues/13768)
+- Fixed terrain-clamped billboards, labels, and points being mispositioned and not properly rendering in 2D/Columbus view. [#5042](https://github.com/CesiumGS/cesium/issues/5042) [#12531](https://github.com/CesiumGS/cesium/issues/12531)
 
 ## 1.145 - 2026-09-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 - Changed the typing of `PrimitiveCollection.add` to return the added primitive as the same type instead of `any`. [#13742](https://github.com/CesiumGS/cesium/issues/13742)
 - Fixed draped polylines rendering at the wrong width at large widths, in both `"pixels"` and `"meters"` width units. [#13737](https://github.com/CesiumGS/cesium/pull/13737)
 - Fixed geometry clipped by a `ClippingPolygonCollection` still casting shadows. The clipping uv origin is now read from the eye of the pass being rendered, so it matches the delta computed in the vertex shader during shadow casts. [#13768](https://github.com/CesiumGS/cesium/issues/13768)
-- Fixed terrain-clamped billboards, labels, and points being mispositioned and not properly rendering in 2D/Columbus view. [#5042](https://github.com/CesiumGS/cesium/issues/5042) [#12531](https://github.com/CesiumGS/cesium/issues/12531)
+- Fixed terrain-clamped billboards and labels being mispositioned and not properly rendering in 2D/Columbus view. [#5042](https://github.com/CesiumGS/cesium/issues/5042) [#12531](https://github.com/CesiumGS/cesium/issues/12531)
 
 ## 1.145 - 2026-09-02
 

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -1163,30 +1163,22 @@ Billboard._updateClamping = function (collection, owner) {
     return;
   }
 
-  function updateFunction(clampedPosition) {
-    const updatedClampedPosition = ellipsoid.cartographicToCartesian(
-      clampedPosition,
-      owner._clampedPosition,
-    );
-
+  function handleSceneUpdateHeight(clampedPositionCartographic) {
+    // Apply the height offset in cartographic space
     if (isHeightReferenceRelative(owner._heightReference)) {
-      if (owner._mode === SceneMode.SCENE3D) {
-        clampedPosition.height += position.height;
-        ellipsoid.cartographicToCartesian(
-          clampedPosition,
-          updatedClampedPosition,
-        );
-      } else {
-        updatedClampedPosition.x += position.height;
-      }
+      clampedPositionCartographic.height += position.height;
     }
 
-    owner._clampedPosition = updatedClampedPosition;
+    // Assign via the setter, as the setter marks the position as dirty.
+    owner._clampedPosition = ellipsoid.cartographicToCartesian(
+      clampedPositionCartographic,
+      owner._clampedPosition,
+    );
   }
 
   owner._removeCallbackFunc = scene.updateHeight(
     position,
-    updateFunction,
+    handleSceneUpdateHeight,
     owner._heightReference,
   );
 
@@ -1196,7 +1188,7 @@ Billboard._updateClamping = function (collection, owner) {
     scratchCartographic.height = height;
   }
 
-  updateFunction(scratchCartographic);
+  handleSceneUpdateHeight(scratchCartographic);
 };
 
 /**
@@ -1351,14 +1343,28 @@ Billboard.prototype._setTranslate = function (value) {
   }
 };
 
+// `_getActualPosition` is distinct in meaning from `this._actualPosition`
+// _getActualPosition is expected to return the _exact_ position in the current render state's projection
+// _actualPosition holds the position in the current render frame; its *projected* form is only meaningful in 2D/Columbus View (in 3D it is just a copy of _position)
 Billboard.prototype._getActualPosition = function () {
-  return defined(this._clampedPosition)
-    ? this._clampedPosition
-    : this._actualPosition;
+  if (defined(this._clampedPosition)) {
+    return this._mode === SceneMode.SCENE3D
+      ? this._clampedPosition
+      : this._actualPosition;
+  }
+  return this._actualPosition;
 };
 
 Billboard.prototype._setActualPosition = function (value) {
-  if (!defined(this._clampedPosition)) {
+  // Store the render-frame position. For clamped billboards in 3D the ECEF
+  // _clampedPosition is used directly by _getActualPosition, so _actualPosition
+  // is only needed (and only updated) outside 3D — but it MUST be updated there
+  // so 2D/Columbus View get the projected position instead of a stale ECEF one.
+
+  // We only update the actual position when one of:
+  // - Scene mode is not 3D (to capture mode changes)
+  // - We don't have a clamped position
+  if (!defined(this._clampedPosition) || this._mode !== SceneMode.SCENE3D) {
     Cartesian3.clone(value, this._actualPosition);
   }
   makeDirty(this, POSITION_INDEX);
@@ -1375,7 +1381,17 @@ Billboard._computeActualPosition = function (
     if (frameState.mode !== billboard._mode) {
       billboard._updateClamping();
     }
-    return billboard._clampedPosition;
+
+    // clampedPosition is always ECEF, so safe to return direct in 3D.
+    if (frameState.mode === SceneMode.SCENE3D) {
+      return billboard._clampedPosition;
+    }
+
+    // in 2D and Columbus View project the coordinate into the current map frame.
+    return SceneTransforms.computeActualEllipsoidPosition(
+      frameState,
+      billboard._clampedPosition,
+    );
   } else if (frameState.mode === SceneMode.SCENE3D) {
     return position;
   }
@@ -1462,20 +1478,17 @@ Billboard.prototype.computeScreenSpacePosition = function (scene, result) {
   Cartesian2.clone(this._pixelOffset, scratchPixelOffset);
   Cartesian2.add(scratchPixelOffset, this._translate, scratchPixelOffset);
 
+  // If _clampedPosition is set, that is what we favour.
+  const position = this._clampedPosition ?? this._position;
+
   let modelMatrix = billboardCollection.modelMatrix;
-  let position = this._position;
-  if (defined(this._clampedPosition)) {
-    position = this._clampedPosition;
-    if (scene.mode !== SceneMode.SCENE3D) {
-      // position needs to be in world coordinates
-      const projection = scene.mapProjection;
-      const ellipsoid = projection.ellipsoid;
-      const cart = projection.unproject(position, scratchCartographic);
-      position = ellipsoid.cartographicToCartesian(cart, scratchCartesian3);
-      modelMatrix = Matrix4.IDENTITY;
-    }
+
+  if (this._clampedPosition && scene.mode !== SceneMode.SCENE3D) {
+    // The model matrix isn't applied when rendering clamped in 2D/CV.
+    modelMatrix = Matrix4.IDENTITY;
   }
 
+  // _computeScreenSpacePosition always expects ECEF position, so no unprojection required.
   const windowCoordinates = Billboard._computeScreenSpacePosition(
     modelMatrix,
     position,

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -1349,7 +1349,9 @@ Billboard.prototype._setTranslate = function (value) {
 
 // `_actualPosition` is the billboard's position in the current render frame:
 // ECEF in 3D, and the projected map coordinate in 2D/Columbus View.
-// It is kept current by `recomputeActualPositions`
+// It is kept current by `recomputeActualPositions` in 2D/Columbus View, and —
+// for clamped billboards in 3D — by the `_clampedPosition` setter (3D has no
+// per-frame actual-position recompute).
 Billboard.prototype._getActualPosition = function () {
   return this._actualPosition;
 };

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -1017,6 +1017,10 @@ Object.defineProperties(Billboard.prototype, {
         value,
         this._actualClampedPosition,
       );
+      if (this._mode === SceneMode.SCENE3D) {
+        // In 3D mode the actual (rendered) position is the same as clamped position (ECEF).
+        Cartesian3.clone(value, this._actualPosition);
+      }
       makeDirty(this, POSITION_INDEX);
     },
   },
@@ -1343,30 +1347,15 @@ Billboard.prototype._setTranslate = function (value) {
   }
 };
 
-// `_getActualPosition` is distinct in meaning from `this._actualPosition`
-// _getActualPosition is expected to return the _exact_ position in the current render state's projection
-// _actualPosition holds the position in the current render frame; its *projected* form is only meaningful in 2D/Columbus View (in 3D it is just a copy of _position)
+// `_actualPosition` is the billboard's position in the current render frame:
+// ECEF in 3D, and the projected map coordinate in 2D/Columbus View.
+// It is kept current by `recomputeActualPositions`
 Billboard.prototype._getActualPosition = function () {
-  if (defined(this._clampedPosition)) {
-    return this._mode === SceneMode.SCENE3D
-      ? this._clampedPosition
-      : this._actualPosition;
-  }
   return this._actualPosition;
 };
 
 Billboard.prototype._setActualPosition = function (value) {
-  // Store the render-frame position. For clamped billboards in 3D the ECEF
-  // _clampedPosition is used directly by _getActualPosition, so _actualPosition
-  // is only needed (and only updated) outside 3D — but it MUST be updated there
-  // so 2D/Columbus View get the projected position instead of a stale ECEF one.
-
-  // We only update the actual position when one of:
-  // - Scene mode is not 3D (to capture mode changes)
-  // - We don't have a clamped position
-  if (!defined(this._clampedPosition) || this._mode !== SceneMode.SCENE3D) {
-    Cartesian3.clone(value, this._actualPosition);
-  }
+  Cartesian3.clone(value, this._actualPosition);
   makeDirty(this, POSITION_INDEX);
 };
 
@@ -1382,12 +1371,12 @@ Billboard._computeActualPosition = function (
       billboard._updateClamping();
     }
 
-    // clampedPosition is always ECEF, so safe to return direct in 3D.
+    // Clamped position is already our rendering position when in 3D
     if (frameState.mode === SceneMode.SCENE3D) {
       return billboard._clampedPosition;
     }
 
-    // in 2D and Columbus View project the coordinate into the current map frame.
+    // in 2D and Columbus View we instead project the ECEF coordinate into the current map frame.
     return SceneTransforms.computeActualEllipsoidPosition(
       frameState,
       billboard._clampedPosition,
@@ -1478,13 +1467,12 @@ Billboard.prototype.computeScreenSpacePosition = function (scene, result) {
   Cartesian2.clone(this._pixelOffset, scratchPixelOffset);
   Cartesian2.add(scratchPixelOffset, this._translate, scratchPixelOffset);
 
-  // If _clampedPosition is set, that is what we favour.
   const position = this._clampedPosition ?? this._position;
 
   let modelMatrix = billboardCollection.modelMatrix;
 
   if (this._clampedPosition && scene.mode !== SceneMode.SCENE3D) {
-    // The model matrix isn't applied when rendering clamped in 2D/CV.
+    // The model matrix isn't applied when rendering clamped in 2D/CV (see BillboardCollection#update)
     modelMatrix = Matrix4.IDENTITY;
   }
 

--- a/packages/engine/Source/Scene/Billboard.js
+++ b/packages/engine/Source/Scene/Billboard.js
@@ -1362,6 +1362,7 @@ Billboard.prototype._setActualPosition = function (value) {
 };
 
 const tempCartesian3 = new Cartesian4();
+const scratchActualPosition = new Cartesian3();
 Billboard._computeActualPosition = function (
   billboard,
   position,
@@ -1382,6 +1383,7 @@ Billboard._computeActualPosition = function (
     return SceneTransforms.computeActualEllipsoidPosition(
       frameState,
       billboard._clampedPosition,
+      scratchActualPosition,
     );
   } else if (frameState.mode === SceneMode.SCENE3D) {
     return position;
@@ -1391,6 +1393,7 @@ Billboard._computeActualPosition = function (
   return SceneTransforms.computeActualEllipsoidPosition(
     frameState,
     tempCartesian3,
+    scratchActualPosition,
   );
 };
 

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -1448,7 +1448,7 @@ function recomputeActualPositions(
       billboard._setActualPosition(actualPosition);
 
       if (recomputeBoundingVolume) {
-        positions.push(actualPosition);
+        positions.push(billboard._getActualPosition());
       } else {
         BoundingSphere.expand(boundingVolume, actualPosition, boundingVolume);
       }

--- a/packages/engine/Source/Scene/QuadtreePrimitive.js
+++ b/packages/engine/Source/Scene/QuadtreePrimitive.js
@@ -1444,15 +1444,18 @@ function updateHeights(primitive, frameState) {
         defined(terrainData) && terrainData.wasCreatedByUpsampling();
 
       if (tile.level > data.level && !upsampledGeometryFromParent) {
-        let position;
-        // find cached entry
+        let positionCarto;
+        // Cached as a cartographic (converted below). A cartographic is
+        // inherently mode-independent, so a single entry is valid in every
+        // scene mode (the raw pick is ECEF in 3D but projected in 2D/CV).
         const cachedData = tile.getPositionCacheEntry(
           data.positionCartographic,
           primitive.maximumScreenSpaceError,
         );
         if (defined(cachedData)) {
-          // cache hit
-          position = cachedData;
+          // cache hit; clone into a scratch so the callback can never mutate
+          // the cached entry (which would corrupt it for every other tile).
+          positionCarto = Cartographic.clone(cachedData, scratchCartographic);
         } else {
           if (!defined(data.positionOnEllipsoidSurface)) {
             // cartesian has to be on the ellipsoid surface for `ellipsoid.geodeticSurfaceNormal`
@@ -1518,7 +1521,7 @@ function updateHeights(primitive, frameState) {
             Cartesian3.clone(Cartesian3.UNIT_X, scratchRay.direction);
           }
 
-          position = tile.data.pick(
+          const position = tile.data.pick(
             scratchRay,
             mode,
             projection,
@@ -1527,21 +1530,41 @@ function updateHeights(primitive, frameState) {
           );
 
           if (defined(position)) {
-            // `pick` wrote into the module-level `scratchPosition`, so `position`
-            // aliases it — clone before caching or the next pick mutates every entry.
-            tile.setPositionCacheEntry(
-              data.positionCartographic,
-              primitive.maximumScreenSpaceError,
-              Cartesian3.clone(position),
-            );
+            // Convert the mode-frame pick result to a mode-independent
+            // cartographic before caching, so a cached entry is valid in every
+            // scene mode.
+            if (mode === SceneMode.SCENE3D) {
+              // In 3D the pick result is already ECEF.
+              positionCarto = ellipsoid.cartesianToCartographic(
+                position,
+                scratchCartographic,
+              );
+            } else {
+              // In 2D and Columbus View the pick result is in the projected map frame, laid out as
+              // (height, easting, northing). Un-swizzle it back to the projection's native
+              // (easting, northing, height) layout and unproject to recover the true cartographic.
+              const projected = Cartesian3.fromElements(
+                position.y,
+                position.z,
+                position.x,
+                scratchPosition,
+              );
+              positionCarto = projection.unproject(
+                projected,
+                scratchCartographic,
+              );
+            }
+            if (defined(positionCarto)) {
+              tile.setPositionCacheEntry(
+                data.positionCartographic,
+                primitive.maximumScreenSpaceError,
+                Cartographic.clone(positionCarto),
+              );
+            }
           }
         }
-        if (defined(position)) {
+        if (defined(positionCarto)) {
           if (defined(data.callback)) {
-            const positionCarto = ellipsoid.cartesianToCartographic(
-              position,
-              scratchCartographic,
-            );
             data.callback(positionCarto);
           }
           data.level = tile.level;

--- a/packages/engine/Source/Scene/QuadtreePrimitive.js
+++ b/packages/engine/Source/Scene/QuadtreePrimitive.js
@@ -15,6 +15,7 @@ import QuadtreeOccluders from "./QuadtreeOccluders.js";
 import QuadtreeTile from "./QuadtreeTile.js";
 import QuadtreeTileLoadState from "./QuadtreeTileLoadState.js";
 import SceneMode from "./SceneMode.js";
+import SceneTransforms from "./SceneTransforms.js";
 import TileReplacementQueue from "./TileReplacementQueue.js";
 import TileSelectionResult from "./TileSelectionResult.js";
 
@@ -1533,27 +1534,12 @@ function updateHeights(primitive, frameState) {
             // Convert the mode-frame pick result to a mode-independent
             // cartographic before caching, so a cached entry is valid in every
             // scene mode.
-            if (mode === SceneMode.SCENE3D) {
-              // In 3D the pick result is already ECEF.
-              positionCarto = ellipsoid.cartesianToCartographic(
+            positionCarto =
+              SceneTransforms.actualEllipsoidPositionToCartographic(
+                frameState,
                 position,
                 scratchCartographic,
               );
-            } else {
-              // In 2D and Columbus View the pick result is in the projected map frame, laid out as
-              // (height, easting, northing). Un-swizzle it back to the projection's native
-              // (easting, northing, height) layout and unproject to recover the true cartographic.
-              const projected = Cartesian3.fromElements(
-                position.y,
-                position.z,
-                position.x,
-                scratchPosition,
-              );
-              positionCarto = projection.unproject(
-                projected,
-                scratchCartographic,
-              );
-            }
             if (defined(positionCarto)) {
               tile.setPositionCacheEntry(
                 data.positionCartographic,

--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -296,6 +296,16 @@ const projectedPosition = new Cartesian3();
 const positionInCartographic = new Cartographic();
 
 /**
+ * Transforms a position in world coordinates to the coordinate frame used to render the current scene mode.
+ *
+ * In 3D this is the same as the input ECEF coordinate.
+ * In 2D and Columbus View this is the projected map frame laid out as (height, easting, northing).
+ * In 2D the height is flattened to 0.
+ *
+ * @param {FrameState} frameState
+ * @param {Cartesian3} position The world-space (ECEF) position.
+ * @param {Cartesian3} [result]
+ * @returns {Cartesian3|undefined}
  * @private
  */
 SceneTransforms.computeActualEllipsoidPosition = function (

--- a/packages/engine/Source/Scene/SceneTransforms.js
+++ b/packages/engine/Source/Scene/SceneTransforms.js
@@ -470,4 +470,53 @@ SceneTransforms.drawingBufferToWorldCoordinates = function (
   }
   return Cartesian3.fromCartesian4(worldCoords, result);
 };
+
+const scratchActualPosition = new Cartesian3();
+
+/**
+ * Converts a position sampled from the actual ellipsoid/terrain surface in the
+ * current scene mode's coordinate frame into a mode-independent {@link Cartographic}.
+ *
+ * In 3D the position is already in ECEF (world) coordinates and is converted directly.
+ * In 2D and Columbus View the position is in the projected map frame, laid out as
+ * (height, easting, northing); it is un-swizzled back to the projection's native
+ * (easting, northing, height) layout and unprojected to recover the true cartographic.
+ *
+ * @param {FrameState} frameState The frame state.
+ * @param {Cartesian3} position The position in the current scene mode's coordinate frame.
+ * @param {Cartographic} [result] An optional object to store the result.
+ * @returns {Cartographic|undefined} The modified result parameter or a new Cartographic instance if one was not provided. This may be <code>undefined</code> if the cartographic could not be computed.
+ *
+ * @private
+ */
+SceneTransforms.actualEllipsoidPositionToCartographic = function (
+  frameState,
+  position,
+  result,
+) {
+  //>>includeStart('debug', pragmas.debug);
+  if (!defined(frameState)) {
+    throw new DeveloperError("frameState is required.");
+  }
+  if (!defined(position)) {
+    throw new DeveloperError("position is required.");
+  }
+  //>>includeEnd('debug');
+
+  if (frameState.mode === SceneMode.SCENE3D) {
+    return frameState.mapProjection.ellipsoid.cartesianToCartographic(
+      position,
+      result,
+    );
+  }
+
+  const projected = Cartesian3.fromElements(
+    position.y,
+    position.z,
+    position.x,
+    scratchActualPosition,
+  );
+  return frameState.mapProjection.unproject(projected, result);
+};
+
 export default SceneTransforms;

--- a/packages/engine/Source/Shaders/BillboardCollectionVS.glsl
+++ b/packages/engine/Source/Shaders/BillboardCollectionVS.glsl
@@ -292,7 +292,9 @@ void main()
     v_compressed.y = enableDepthCheck;
 
 #ifdef VS_THREE_POINT_DEPTH_CHECK
-if (lengthSq < (u_threePointDepthTestDistance * u_threePointDepthTestDistance) && (enableDepthCheck == 1.0)) {
+// In 2D, the globe and billboards are coplanar, but the depth reconstruction from getGlobeDepth is imprecise
+// It suffered error greater than the depthsilon of 10.0, causing the verts to be discarded for clamped billboards.
+if (czm_sceneMode != czm_sceneMode2D && lengthSq < (u_threePointDepthTestDistance * u_threePointDepthTestDistance) && (enableDepthCheck == 1.0)) {
     float depthsilon = 10.0;
     vec2 depthOrigin;
     // Horizontal origin for labels comes from a special attribute. If that value is 0, this is a billboard - use the regular origin.

--- a/packages/engine/Source/Shaders/BillboardCollectionVS.glsl
+++ b/packages/engine/Source/Shaders/BillboardCollectionVS.glsl
@@ -101,7 +101,17 @@ float getGlobeDepth(vec4 positionEC)
     vec4 eyeCoordinate = czm_windowToEyeCoordinates(posWC.xy, globeDepth);
     return eyeCoordinate.z / eyeCoordinate.w;
 }
+
+// In 2D, the globe and billboards are coplanar, but the depth reconstruction from getGlobeDepth is imprecise:
+// it suffered error greater than the depthsilon of 10.0, causing the verts to be discarded for clamped billboards.
+bool shouldRunThreePointDepthCheck(float lengthSq, float enableDepthCheck)
+{
+    return czm_sceneMode != czm_sceneMode2D &&
+        lengthSq < (u_threePointDepthTestDistance * u_threePointDepthTestDistance) &&
+        enableDepthCheck == 1.0;
+}
 #endif
+
 void main()
 {
     // Modifying this shader may also require modifications to Billboard._computeScreenSpacePosition
@@ -292,9 +302,7 @@ void main()
     v_compressed.y = enableDepthCheck;
 
 #ifdef VS_THREE_POINT_DEPTH_CHECK
-// In 2D, the globe and billboards are coplanar, but the depth reconstruction from getGlobeDepth is imprecise
-// It suffered error greater than the depthsilon of 10.0, causing the verts to be discarded for clamped billboards.
-if (czm_sceneMode != czm_sceneMode2D && lengthSq < (u_threePointDepthTestDistance * u_threePointDepthTestDistance) && (enableDepthCheck == 1.0)) {
+if (shouldRunThreePointDepthCheck(lengthSq, enableDepthCheck)) {
     float depthsilon = 10.0;
     vec2 depthOrigin;
     // Horizontal origin for labels comes from a special attribute. If that value is 0, this is a billboard - use the regular origin.

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -20,6 +20,7 @@ import {
   BlendOption,
   HeightReference,
   HorizontalOrigin,
+  SceneMode,
   TextureAtlas,
   VerticalOrigin,
   SplitDirection,
@@ -2703,6 +2704,49 @@ describe("Scene/BillboardCollection", function () {
           //Setting position to zero should clear the clamped position.
           b.position = Cartesian3.ZERO;
           expect(b._clampedPosition).toBeUndefined();
+        });
+
+        it("uses a projected position (not the ECEF clamped position) in 2D", function () {
+          // Regression: in 2D a clamped billboard kept its Earth-centered
+          // _clampedPosition as the render-frame position and was drawn off the
+          // map. In 2D/CV the render frame is the projected map position.
+          spyOn(scene, "updateHeight");
+
+          const position = Cartesian3.fromDegrees(-72.0, 40.0);
+          const b = billboardsWithHeight.add({
+            heightReference: HeightReference.CLAMP_TO_GROUND,
+            position: position,
+          });
+
+          // In 3D the render-frame position is the ECEF clamped position itself.
+          scene.renderForSpecs();
+          expect(b._clampedPosition).toBeDefined();
+          expect(b._getActualPosition()).toEqual(b._clampedPosition);
+
+          scene.morphTo2D(0.0);
+          return pollToPromise(function () {
+            scene.renderForSpecs();
+            return scene.mode === SceneMode.SCENE2D;
+          }).then(function () {
+            const projection = scene.mapProjection;
+            const carto = projection.ellipsoid.cartesianToCartographic(
+              b._clampedPosition,
+            );
+            const projected = projection.project(carto);
+            // 2D flattens the height to the map datum: (0, easting, northing).
+            const expected = new Cartesian3(0.0, projected.x, projected.y);
+
+            const actual = b._getActualPosition();
+            expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON6);
+            // And crucially NOT the raw ECEF clamped position.
+            expect(
+              Cartesian3.equalsEpsilon(
+                actual,
+                b._clampedPosition,
+                CesiumMath.EPSILON3,
+              ),
+            ).toBe(false);
+          });
         });
 
         it("removes callback after disableDepthTest", function () {

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -2750,6 +2750,55 @@ describe("Scene/BillboardCollection", function () {
           });
         });
 
+        it("uses a projected position (not the ECEF clamped position) in Columbus View", function () {
+          // Columbus View keeps the real height, unlike 2D which flattens it,
+          // so the render-frame position is (height, easting, northing). It must
+          // still be the projected map position, not the raw ECEF clamped one.
+          spyOn(scene, "updateHeight");
+          spyOn(scene, "getHeight").and.returnValue(500.0);
+
+          const position = Cartesian3.fromDegrees(-72.0, 40.0);
+          const b = billboardsWithHeight.add({
+            heightReference: HeightReference.CLAMP_TO_GROUND,
+            position: position,
+          });
+
+          scene.renderForSpecs();
+          expect(b._clampedPosition).toBeDefined();
+
+          scene.morphToColumbusView(0.0);
+          scene.camera.setView({ destination: Rectangle.MAX_VALUE });
+          return pollToPromise(function () {
+            scene.renderForSpecs();
+            return scene.mode === SceneMode.COLUMBUS_VIEW;
+          }).then(function () {
+            const projection = scene.mapProjection;
+            const carto = projection.ellipsoid.cartesianToCartographic(
+              b._clampedPosition,
+            );
+            const projected = projection.project(carto);
+            // Columbus View preserves the height: (height, easting, northing).
+            const expected = new Cartesian3(
+              projected.z,
+              projected.x,
+              projected.y,
+            );
+
+            const actual = b._getActualPosition();
+            expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON6);
+            // The height must be preserved (not flattened to 0 like 2D).
+            expect(actual.x).toBeGreaterThan(0.0);
+            // And crucially NOT the raw ECEF clamped position.
+            expect(
+              Cartesian3.equalsEpsilon(
+                actual,
+                b._clampedPosition,
+                CesiumMath.EPSILON3,
+              ),
+            ).toBe(false);
+          });
+        });
+
         it("removes callback after disableDepthTest", function () {
           const removeCallback = jasmine.createSpy();
           spyOn(scene, "updateHeight").and.returnValue(removeCallback);

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -2724,6 +2724,7 @@ describe("Scene/BillboardCollection", function () {
           expect(b._getActualPosition()).toEqual(b._clampedPosition);
 
           scene.morphTo2D(0.0);
+          scene.camera.setView({ destination: Rectangle.MAX_VALUE });
           return pollToPromise(function () {
             scene.renderForSpecs();
             return scene.mode === SceneMode.SCENE2D;

--- a/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -1086,18 +1086,18 @@ describe("Scene/QuadtreePrimitive", function () {
         expect(position1).toEqual(position2);
       });
 
-      it("position cache stores a new Cartesian3 per entry to prevent unintended mutation", function () {
+      it("position cache stores a distinct cartographic per entry to prevent unintended mutation", function () {
         // Previously, every pick() inside `updateHeights` passed the same module-level `scratchPosition`,
-        // so every cached entry ended up aliasing a single shared Cartesian3.
+        // so every cached entry ended up aliasing a single shared object.
         // The next pick() mutated every prior entry across every tile.
         // Observable symptom is clamped billboards jumping to heights from neighbouring tiles
         // (CesiumGS/cesium#12602).
 
-        // To test, we drive two `updateHeight` registrations whose picks return different cartesians,
-        // then assert that every cached cartesian is a distinct object
-        // AND that none of them were mutated to match the last pick's cartesian after the fact.
-        // Prior to fix, all cache entries would reference the same object
-        // with value {x:4000, y:5000, z:6000}, i.e. the final pick.
+        // The pick result is converted to a mode-independent cartographic before caching.
+        // We drive two `updateHeight` registrations whose picks return different positions,
+        // then assert that every cached cartographic is a distinct object
+        // AND that none of them were mutated to match the last pick after the fact.
+        // Prior to fix, all cache entries would reference the same object, i.e. the final pick.
 
         const tileProvider = createSpyTileProvider();
         tileProvider.getReady.and.returnValue(true);
@@ -1110,8 +1110,12 @@ describe("Scene/QuadtreePrimitive", function () {
           },
         };
 
-        const positionA = new Cartesian3(1000, 2000, 3000);
-        const positionB = new Cartesian3(4000, 5000, 6000);
+        // Realistic surface ECEF positions so `cartesianToCartographic` succeeds.
+        const positionA = Cartesian3.fromDegrees(-72.0, 40.0, 100.0);
+        const positionB = Cartesian3.fromDegrees(10.0, -20.0, 250.0);
+        const ellipsoid = Ellipsoid.WGS84;
+        const cartoA = ellipsoid.cartesianToCartographic(positionA);
+        const cartoB = ellipsoid.cartesianToCartographic(positionB);
         let pickCount = 0;
 
         tileProvider.loadTile.and.callFake(function (frameState, tile) {
@@ -1170,18 +1174,18 @@ describe("Scene/QuadtreePrimitive", function () {
         expect(pickCount).toBeGreaterThanOrEqual(2);
         expect(storedValues.length).toBeGreaterThanOrEqual(2);
 
-        // Every stored value must be a distinct Cartesian3 instance.
-        // With the alias bug, two stored entries would reference the same `scratchPosition`.
+        // Every stored value must be a distinct object instance.
+        // With the alias bug, two stored entries would reference the same scratch.
         const uniqueRefs = new Set(storedValues);
         expect(uniqueRefs.size).toBe(storedValues.length);
 
-        // The stored positions must equal the values pick() produced at the time they were cached.
-        // With the bug, every entry would now equal whichever position was cached last.
+        // The stored cartographics must equal the values pick() produced at the time they
+        // were cached. With the bug, every entry would now equal whichever was cached last.
         const hasPositionA = storedValues.some((v) =>
-          Cartesian3.equalsEpsilon(v, positionA, CesiumMath.EPSILON10),
+          Cartographic.equalsEpsilon(v, cartoA, CesiumMath.EPSILON10),
         );
         const hasPositionB = storedValues.some((v) =>
-          Cartesian3.equalsEpsilon(v, positionB, CesiumMath.EPSILON10),
+          Cartographic.equalsEpsilon(v, cartoB, CesiumMath.EPSILON10),
         );
         expect(hasPositionA).toBe(true);
         expect(hasPositionB).toBe(true);

--- a/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/packages/engine/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -1191,6 +1191,90 @@ describe("Scene/QuadtreePrimitive", function () {
         expect(hasPositionB).toBe(true);
       });
 
+      it("unprojects the pick result to a cartographic in 2D and Columbus View", function () {
+        // In 2D and Columbus View, GlobeSurfaceTile.pick returns the hit in the
+        // projected map frame (swizzled to (height, easting, northing)), not
+        // ECEF. updateHeights must un-swizzle and unproject that back into a
+        // cartographic for the callback; running cartesianToCartographic on the
+        // projected point (as the code once did) would yield a garbage position.
+        const projection = scene.mapProjection;
+        const originalMode = scene.frameState.mode;
+
+        [SceneMode.SCENE2D, SceneMode.COLUMBUS_VIEW].forEach(function (mode) {
+          const tileProvider = createSpyTileProvider();
+          tileProvider.getReady.and.returnValue(true);
+          tileProvider.computeTileVisibility.and.returnValue(Visibility.FULL);
+          tileProvider.computeDistanceToTile.and.returnValue(1e-15);
+          tileProvider.terrainProvider = {
+            getTileDataAvailable: function () {
+              return true;
+            },
+          };
+
+          // The terrain point the pick "finds" at the registered location.
+          const expected = Cartographic.fromDegrees(-72.0, 40.0, 123.0);
+
+          // Reproduce a GlobeSurfaceTile.pick result in the current mode's frame:
+          // project to (easting, northing, height), then swizzle to (height, easting, northing).
+          const projected = projection.project(expected);
+          const pickInModeFrame = new Cartesian3(
+            projected.z,
+            projected.x,
+            projected.y,
+          );
+
+          tileProvider.loadTile.and.callFake(function (frameState, tile) {
+            tile.state = QuadtreeTileLoadState.DONE;
+            tile.renderable = true;
+            tile.data = {
+              pick: function (
+                ray,
+                pickMode,
+                pickProjection,
+                cullBackFaces,
+                result,
+              ) {
+                return Cartesian3.clone(pickInModeFrame, result);
+              },
+              mesh: {},
+            };
+          });
+
+          const quadtree = new QuadtreePrimitive({
+            tileProvider: tileProvider,
+          });
+
+          let received;
+          quadtree.updateHeight(
+            Cartographic.fromDegrees(-72.0, 40.0),
+            function (carto) {
+              received = Cartographic.clone(carto, received);
+            },
+          );
+
+          scene.frameState.mode = mode;
+          try {
+            for (let i = 0; i < 3; ++i) {
+              // Advance the frame so tile selection reruns each cycle.
+              ++scene.frameState.frameNumber;
+              quadtree.update(scene.frameState);
+              quadtree.beginFrame(scene.frameState);
+              quadtree.render(scene.frameState);
+              quadtree.endFrame(scene.frameState);
+            }
+          } finally {
+            scene.frameState.mode = originalMode;
+          }
+
+          // The callback must receive the true cartographic (mode-independent),
+          // not cartesianToCartographic of the projected point.
+          expect(received).toBeDefined();
+          expect(
+            Cartographic.equalsEpsilon(received, expected, CesiumMath.EPSILON7),
+          ).toBe(true);
+        });
+      });
+
       it("gives correct priority to tile loads", function () {
         const tileProvider = createSpyTileProvider();
         tileProvider.getReady.and.returnValue(true);

--- a/packages/engine/Specs/Scene/SceneTransformsSpec.js
+++ b/packages/engine/Specs/Scene/SceneTransformsSpec.js
@@ -1,6 +1,7 @@
 import {
   Cartesian2,
   Cartesian3,
+  Cartographic,
   Ellipsoid,
   Math as CesiumMath,
   OrthographicFrustum,
@@ -302,6 +303,59 @@ describe(
       );
       expect(windowCoordinates).toBeDefined();
       scene.destroyForSpecs();
+    });
+
+    it("actualEllipsoidPositionToCartographic converts an ECEF position in 3D", function () {
+      const cartographic = Cartographic.fromDegrees(-75.0, 40.0, 100.0);
+      const position = Ellipsoid.WGS84.cartographicToCartesian(cartographic);
+
+      scene.renderForSpecs();
+
+      const result = SceneTransforms.actualEllipsoidPositionToCartographic(
+        scene.frameState,
+        position,
+      );
+      expect(result.longitude).toEqualEpsilon(
+        cartographic.longitude,
+        CesiumMath.EPSILON8,
+      );
+      expect(result.latitude).toEqualEpsilon(
+        cartographic.latitude,
+        CesiumMath.EPSILON8,
+      );
+      expect(result.height).toEqualEpsilon(
+        cartographic.height,
+        CesiumMath.EPSILON4,
+      );
+    });
+
+    it("actualEllipsoidPositionToCartographic unprojects a swizzled map position in Columbus View", function () {
+      scene.morphToColumbusView(0);
+      scene.renderForSpecs();
+
+      const projection = scene.frameState.mapProjection;
+      const cartographic = Cartographic.fromDegrees(-75.0, 40.0, 100.0);
+      const projected = projection.project(cartographic);
+
+      // The pick result in 2D/CV is laid out as (height, easting, northing).
+      const position = new Cartesian3(projected.z, projected.x, projected.y);
+
+      const result = SceneTransforms.actualEllipsoidPositionToCartographic(
+        scene.frameState,
+        position,
+      );
+      expect(result.longitude).toEqualEpsilon(
+        cartographic.longitude,
+        CesiumMath.EPSILON8,
+      );
+      expect(result.latitude).toEqualEpsilon(
+        cartographic.latitude,
+        CesiumMath.EPSILON8,
+      );
+      expect(result.height).toEqualEpsilon(
+        cartographic.height,
+        CesiumMath.EPSILON4,
+      );
     });
   },
   "WebGL",


### PR DESCRIPTION
# Description

Terrain-clamped billboards were invisible in 2D and Columbus View (or, more accurately, drawn in the wrong place and failing depth test). Un-clamped billboards had peculiar rendering issues in 2D.

<img width="1102" height="609" alt="image" src="https://github.com/user-attachments/assets/40d7fbb9-a3b0-4628-bfb7-595f3999345d" />


_Broken 2D left,  3D right_


And, lastly, the bounding sphere of clamped billboards in 2D/CV mode often covered the majority of the globe.
<img width="705" height="672" alt="image" src="https://github.com/user-attachments/assets/f4fbf5b2-1e65-4855-8809-4eadba61ebdd" />


A few separate issues contributed to the problem




## Position / coordinate frame confusion

Initial debugging with spector.js revealed that no draw commands were submitted after the globe pass, which led me to suspect frustum culling as the culprit.

Logging the 'actualPosition` revealed that the position was outside of the expected range

| Cartographic | 3D | 2D |
| :--- | :--- | :--- |
| `(-2.1250727546554997, 0.8177268971321392, 4500)` | `(-2301506.550232819, -3718076.377732224, 4633834.269943927)` | `(-5232539.533463152, -8453150.669048188, 10574895.589471862)` |

In 2D and columbus, the coordinate is meant to be in the projected-map frame (swizzled so X=height), but what we got was _dramatically_ out of range height values.

There are two positions attached to billboards when clamped: 

The **clamped position** is the position on the terrain that the billboard should clamp to, and it is updated by `scene.updateHeight` callbacks.

The **actual position**, conversely, is meant to reflect the position that the billboard should actually render in the current rendering frame, as it is the vertex loaded onto the GPU and used for frustum culling.


The breakdown comes from the ambiguity of the coordinate frame - it seems like a lot of code was written assuming only ECEF exists in a bunch of places, which is not true and which I've now learnt debugging this issue 😁 


### Billboard Clamped Position
The space this is intended to be in is not clear as the `updateFunction` converted it to ECEF, but then acted upon it as if it were in the projected map frame as it incremented the X to apply a vertical offset.

`computeScreenSpacePosition` assumed that the coordinate was in the current mode frame, and did an unproject step to convert back to ECEF if not 3D. This was _not_ the case and the coordinate was already in ECEF, so did not require any transformation at all. This caused the screen position calculated to be very much incorrect too.

Fixes:
- The clamped position was changed to always be in ECEF, and the extra conversions removed.
- Actual position is kept as an accurate "rendered position". The naming was not changed to prevent any breakages, but could be improved to reduce ambiguity.

### Tile pick positions in update height callbacks
`QuadTreePrimitive.updateHeights` assumed coordinates coming back from `GlobeSurfaceTile.pick` were in ECEF. However they also reflect the current projected map frame. They were always passed into `cartesianToCartographic` to get a cartographic out, which converted assuming ECEF and gave the wrong cartographic back.

Fixes:
- Unproject/swizzle the position to get the cartographic instead of `cartesianToCartographic`.
- Update cache to store Cartographic to prevent caching of a different frame returning inappropriate positions.



## Three point check at smaller distances

When the camera was close to the billboard, it would not render, but draw commands were submitted. This meant it was likely getting discarded in the shader.

In 2D mode, the globe and billboard are (theoretically) coplanar. But in reality, `getGlobeDepth` is relatively imprecise when we are in 2D. The error it produced was _greater_ than the built in "depthsilon" of 10 units used in the three point check,  which caused the verts to be erroneously discarded.

This was confirmed with a debug shader colouring the billboards by this distance.

<img width="347" height="319" alt="image" src="https://github.com/user-attachments/assets/5dd04d30-ad63-4dbd-8379-284ec392c9f6" />

_3D, green in range, yellow within depthsilon_

<img width="713" height="524" alt="image" src="https://github.com/user-attachments/assets/33f4c504-360c-4a35-80af-814a4ca47119" />

_2D, all red = discarded_


`BillboardCollectionVS.glsl` has a max distance check when determining whether to use the three point check or not, which meant that this symptom did not show at moderate to far distances as the check wasn't run.

The proposed fix is to skip the three-point check when in 2D mode, as we are expecting all billboards to pass the depth check against the globe. (This may be a faulty assumption!)



## Issue number and link

Fixes #5042
Fixes #12531
Fixes #5041 (I believe, sandcastle and forum link are both dead)
Fixes #8307 


## Testing plan

Unit tests:
- `BillboardCollection` spec: a `CLAMP_TO_GROUND` billboard reports the **projected** map position (not the raw ECEF clamped position) in 2D.
- `QuadtreePrimitive` spec: the height cache stores a distinct **cartographic** per entry and is not mutated by callbacks.

Manually verified with [this sandcastle](https://sandcastle.cesium.com/#c=1VmNTxs7Ev9XprmTbvMubIBC2wPSHoTQhy4QBGmrU7fiObuTxMJr77O9gVzF/e0nf+xmNywfrd6ddEh8xJ4Zz/zm5/HYdLswRikJ5RsxI2mGCSwUcLH6OKGMTQSRiQISS6EUqBg5QioSVGHEu13zDX1G4xsgfHk7R4kgOOg5woyJCYIWkDESI+hbASmRNyjVntUC2ID+8PDsYnAMgcSkDeZrD+ZIZ3N9iVOUyGN0Mtfj0fXHy9Gn82Mg2pqPzaKYABO8y4gOS5vno/ON0m68JLz90Ob56HzQATGdKtTw761NSAGJ0h0vCIqkGcPE22z+mkqRgnYAghJANSiqVRm+FDlPQAsRRjziNM2E1PALEAV9VDRPnYGoFdtPUWvfiMWCKw0LircooQccb710+NmOBYV8X3BNKEcZtTrwPeJQuLJXKPjchmaZL0KyxA8E7U7E79v7xWIupT2/aGg/7kfc/g5tEsMEMz0fo9KHM0K50t4S9EDLHEtLGeVHOWXJuusX5XjQtlF2uwXod5lEpTABykGShBKuQExNUmdU5wlCIEU+m7Nlp8i749BfFDCirUg7LNYfnZxcDcbXZ4Px4PIKerC1GW5WUPWsPk3JzMS78tZC1BdMyMB7bD+El4PjDuy8a4daHBNNPl0OgxVsU3r3I7b6/zw8bzIWcYYa1FzcHhm+UD67yuwu6sGUMLUCt7IXey5nYSZpSjVdoApJkgSGBBXUjwqFvmAMY00FD777bN8bDqxiYWSC7FG7FZtDI9hoz8UyzbmdAJJlbHmMk3z2WbA8xaDtSLqKIkzM7FUlcCdpvHiAxn7E72v2JU4M3meuoAQ+tRdCdVxiLoTyK3a7cIkpuUFXNUrfldmzeo5UwsSvBQvnAVUgMRZplmtMQJuKwJbhmvsSU7HAQ8ZsGsFjuDa8pmPQtE4BZEJR48YeVHx3U9SQaq9GVz+zQKlpTNhI0lllp3+uDYdHo/F4dOZV1ipfqfNrfTxcq7JW+74W2cuc13in9yBq+Qoctfz4VHA7vrWT3YEiXG0olHRazmf0DtnIFuS9Kov7RGpUlPDtYLMDW9vtwh5lzO6sMqLVnnUSSi/ZKl7L3CszFJ6cDofXh+fH16NP4+Hp+cDLi1wzyvELTfR8D17/Ufi9hAIFZesEWFWY/3767YH4wpyveVtkvHLu/s+zbqvrH5f2MnEPy5hFx5VJib/nqPQl8uJku/eH28bGhutPVu3Pxk9+RZyoJY+hrHzW3KEOYiK1mEmSzWnsS50v5sIczNXpsDxO9ytiRD8Q8yeqD952dq4RdIfuI60XBL5rojMupGkbl+tNWztcLbwqGdB7kO/X9vy8dJ1AwATvGEc7sBlutldunVd6VO/as71crV+ruJOiRqkuULpFhxYW79aAMZopQZPwy8erdzthSu5omlv3clXB0i0+tMAb+P+61op0IWhY5hc4I3oexkIFjOh2+4HBehfVr6QqKFes41Pof/VBf4MekFtCdWHEjfv+7UwofYyaUIaue4CiCfQwXUixoAlKv1W+ulW/2Y/V5YqK8GxC/RZ1zq1o2Vkb9zxcG/b5/PDBRFv6YH6/pBsotqfzeE54wtb71KtYIvKrjMQ4WCDXvzqhwG33mPAFsXa8cqhQn/Is14euGQrsvmhD7311O0qyXDXXMUlRknCG+oLGN5dk6XTCorhWQY0LCMu+zDXjGY1vAkmWHTfqVOgUglc+jASnlGMSlAbavj4YoHQuudW4Nz+KYtJAMdfIFiaqxgySnccwGy8zDIeDk/F1f3ja/0fZ75uSmOCU5MxEZlCwmMBPlcQ6mgq1uRy5gypBpSkn7qRqJuMxziSiCja2trfCt7tvdzuw8yZ8t7u93YGdv73ZDN+WN6TSdcqppoStF0Lk2tYe+8l4ZS95T7m+Xsc/e6W+NRXUKrljXJl+97HKELd875GT06XcaYUxo8i1PeWgC9udhknXE5SzVS4+R2LryP8NeX1ev5i6mHNNWXmN15Shgtwc6NUEz8kCgQmSYOJvDeWp4oqStUcVpEg45bNpzjpGikMiRWbl6wRS5Z3V3Rdc9odUaeQ2o1XMjFNDQZILKWbmtmz3mWnN7B+Fkk138HuOuXlKKWqQA9eNQq/Xg80STmhc23c4tjlrZqiftym499fIcp9oIdiEyJ9ud8p9Ym7FhbEeJCLOUxP1DPWAofnzaHmaBFHLy0Qt44Ylkh/xcTbYiCUSjd5MELUSunDqpXRIE+hBxXht0naYZcm2gmSiBMs1NkpqkVmh3eyucZ7hVD8pMCHxjX9OMmJyNiHBjilW/nszfLfbbnaSJPZia9TePGZdyMS1JbmygjulYLHhi7emkGQZ8qQ/pywJCpzrB6t9GoQefDX63909wtwAXptLAaRCZvM9CCxBHcft0Fi8Pg5MD2MZVVPsm8Z7kiswPHzaRiFqT4Nma9vPuLFdcePbfj2sj1Lk2YuIVEqHMSNKnRP7rFE83W1Mcq0F3zApzSzSRUKq8JY22mtuHFltg7F7hk1JFljp9c5j8pSvzoeC95OnHPVkmITmpmfeHZFrv3pogfXTgrs7T291WQnKamOlLchlBakEE06FHJB4HgRCz1GaSIoqZAece6ZG+QeWYB1MEpsHq6hV3BSLRSYVVftI9pieO1fsz1X6qgmZOBF3CsFk37cIlSi+bn77gdUqbVHz66oWsxl7+c2x4EiiiXYOvTT/K41naVARddUjJXJG+diXuKLGlATIs4RoPNZE25t4wYeKmTqpfnsEjD348/eXvEh/gKg1Oo9aYDb76OQkat3/tr+24ipFDmHfKD2Wq+IW8vzqZdt0XwPqiX3xskf2Vy8Qs0E+QPvp14r9iDdpNFWjVTg16q6/nHrK+pbs41XXQfqn3c2d7TY8S92J+jHiFvLP0rYU/AHSHqkaZUsTa4Q9qkNgifrwNf9RXtZDqLHyMT42vI970pXGnqJc078aXjU+uT/6/rUG0AtZVpVv4ljhvZlvdVoHNlf2HPi7/+9ZLlkQhl2NacaIRtWd5PEN6jBW9l5+0C1UDhK6AJr0Gv5bBhboXtSa5oxd0X9h1Hp/0E3ooqZmmn3KZ6MFSkaWRmS+9X7oBsMwPOjOtxq0yn6xnPsP), which was AI generated.


Video Before and After

Shows the scenes working in 3D, then 2D, then the red wireframe shows the bounding sphere.

https://github.com/user-attachments/assets/552efcf3-85c0-4a4f-9721-9f6f2d5eb360



## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

Crush was used to generate the sandcastle and unit tests.

If yes, I used the following Model(s):

Claude Opus 4.8