### PR TITLE
Reduce threshold for discarding small splats

### DIFF
--- a/packages/engine/Source/Shaders/PrimitiveGaussianSplatVS.glsl
+++ b/packages/engine/Source/Shaders/PrimitiveGaussianSplatVS.glsl
@@ -5,8 +5,16 @@
 
 // Passes local quad coordinates and color to the fragment shader for Gaussian evaluation. 
 //
+
 // Discards splats outside the view frustum or with negligible screen size.
 //
+// The minimum size of a splat in pixels, squared. When the
+// squared size of the pixel (in x- AND y direction) is 
+// smaller than this threshold, then it is discarded.
+// See https://github.com/CesiumGS/cesium/issues/13304
+const float DISCARD_PIXEL_SIZE_SQUARED = 0.5;
+
+
 #if defined(HAS_SPHERICAL_HARMONICS)
 const uint coefficientCount[3] = uint[3](3u,8u,15u);
 const float SH_C1 = 0.48860251;
@@ -174,7 +182,8 @@ void main() {
 
     vec4 covVectors = calcCovVectors(splatViewPos.xyz, Vrk);
 
-    if (dot(covVectors.xy, covVectors.xy) < 4.0 && dot(covVectors.zw, covVectors.zw) < 4.0) {
+    if (dot(covVectors.xy, covVectors.xy) < DISCARD_PIXEL_SIZE_SQUARED && 
+        dot(covVectors.zw, covVectors.zw) < DISCARD_PIXEL_SIZE_SQUARED) {
         gl_Position = discardVec;
         return;
     }


### PR DESCRIPTION
# Description

Reduces the threshold for a `discard` in the splat renderer from 2x2 pixels to ~0.7x0.7 pixels.

## Issue number and link

https://github.com/CesiumGS/cesium/issues/13304

## Testing plan

A test data set with a sandcastle:

[splatsDiscard.zip](https://github.com/user-attachments/files/30238452/splatsDiscard.zip)

Here is a comparison of rendering that splat data set with JSplat and with CesiumJS:

<img width="458" height="393" alt="Cesium Splat Discard" src="https://github.com/user-attachments/assets/64106bf3-96a7-42ae-9611-713747ab1394" />

That moiré effect for CesiumJS is certainly not desired. It's not clear whether this is "related" to this change, because with that early `discard`, the splats simply disappeared before it could happen. But maybe that can be tracked in a dedicated issue.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] **n/a?** I have updated `CHANGES.md` with a short summary of my change
- [ ] **n/a** I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting
