### PR TITLE
Clipping Polygon Holes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Added a `heightReference` option to `MVTDataProvider.fromUrl`, draping Mapbox Vector Tiles content onto terrain, 3D Tiles, or both. [#13727](https://github.com/CesiumGS/cesium/pull/13727)
 - Added `BufferPolylineCollection` option `widthUnits`, so a draped polyline's width can be measured in meters on the ground instead of screen pixels. [#13703](https://github.com/CesiumGS/cesium/pull/13703)
 - `ClippingPolygons` now use an algorithm, based on the techniques used for vector tiles, that vastly improves quality across distance scales. Warm-up cost is also modestly decreased. [#13654](https://github.com/CesiumGS/cesium/pull/13654)
+- `ClippingPolygons` now have support for specifying holes (aka islands) within each polygon. This works in inverse clipping workflows as well. [#13660](https://github.com/CesiumGS/cesium/pull/13660)
 
 #### Fixes :wrench:
 

--- a/packages/engine/Source/Scene/ClippingPolygon.js
+++ b/packages/engine/Source/Scene/ClippingPolygon.js
@@ -12,6 +12,7 @@ import Rectangle from "../Core/Rectangle.js";
  *
  * @param {object} options Object with the following properties:
  * @param {Cartesian3[]} options.positions A list of three or more Cartesian coordinates defining the outer ring of the clipping polygon.
+ * @param {Cartesian3[][]} [options.holes] An array of interior rings (holes), each a list of three or more Cartesian coordinates. Regions inside a hole are excluded from the polygon.
  * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.default]
  *
  * @example
@@ -45,6 +46,9 @@ function ClippingPolygon(options) {
 
   this._ellipsoid = options.ellipsoid ?? Ellipsoid.default;
   this._positions = copyArrayCartesian3(options.positions);
+  this._holes = defined(options.holes)
+    ? options.holes.map(copyArrayCartesian3)
+    : [];
 
   /**
    * A copy of the input positions.
@@ -132,6 +136,26 @@ function equalsArrayCartesian3(a, b) {
   return true;
 }
 
+/**
+ * Returns whether two arrays of rings are component-wise equal.
+ *
+ * @param {Cartesian3[][]} a The first array of rings
+ * @param {Cartesian3[][]} b The second array of rings
+ * @returns {boolean} Whether the ring arrays are equal
+ * @ignore
+ */
+function equalsHoles(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (!equalsArrayCartesian3(a[i], b[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 Object.defineProperties(ClippingPolygon.prototype, {
   /**
    * Returns the total number of positions in the polygon, include any holes.
@@ -142,7 +166,12 @@ Object.defineProperties(ClippingPolygon.prototype, {
    */
   length: {
     get: function () {
-      return this._positions.length;
+      let count = this._positions.length;
+      const holes = this._holes;
+      for (let i = 0; i < holes.length; i++) {
+        count += holes[i].length;
+      }
+      return count;
     },
   },
   /**
@@ -155,6 +184,18 @@ Object.defineProperties(ClippingPolygon.prototype, {
   positions: {
     get: function () {
       return this._positions;
+    },
+  },
+  /**
+   * Returns the interior rings (holes) of the polygon, each a list of positions.
+   *
+   * @memberof ClippingPolygon.prototype
+   * @type {Cartesian3[][]}
+   * @readonly
+   */
+  holes: {
+    get: function () {
+      return this._holes;
     },
   },
   /**
@@ -185,6 +226,7 @@ ClippingPolygon.clone = function (polygon, result) {
   if (!defined(result)) {
     return new ClippingPolygon({
       positions: polygon.positions,
+      holes: polygon.holes,
       ellipsoid: polygon.ellipsoid,
     });
   }
@@ -192,6 +234,7 @@ ClippingPolygon.clone = function (polygon, result) {
   result._ellipsoid = polygon.ellipsoid;
   result._positions.length = 0;
   result._positions.push(...polygon.positions);
+  result._holes = polygon.holes.map(copyArrayCartesian3);
   return result;
 };
 
@@ -210,7 +253,9 @@ ClippingPolygon.equals = function (left, right) {
   //>>includeEnd('debug');
 
   return (
-    left.ellipsoid.equals(right.ellipsoid) && left.positions === right.positions
+    left.ellipsoid.equals(right.ellipsoid) &&
+    left.positions === right.positions &&
+    equalsHoles(left.holes, right.holes)
   );
 };
 

--- a/packages/engine/Source/Scene/ClippingPolygon.js
+++ b/packages/engine/Source/Scene/ClippingPolygon.js
@@ -32,6 +32,34 @@ import Rectangle from "../Core/Rectangle.js";
  * const polygon = new Cesium.ClippingPolygon({
  *     positions: positions
  * });
+ *
+ * @example
+ * // A clipping polygon with two holes. Regions inside the holes are not clipped.
+ * const outerRing = Cesium.Cartesian3.fromDegreesArray([
+ *     -100.0, 40.0,
+ *     -90.0, 40.0,
+ *     -90.0, 50.0,
+ *     -100.0, 50.0,
+ * ]);
+ *
+ * const firstHole = Cesium.Cartesian3.fromDegreesArray([
+ *     -98.0, 42.0,
+ *     -96.0, 42.0,
+ *     -96.0, 44.0,
+ *     -98.0, 44.0,
+ * ]);
+ *
+ * const secondHole = Cesium.Cartesian3.fromDegreesArray([
+ *     -94.0, 46.0,
+ *     -92.0, 46.0,
+ *     -92.0, 48.0,
+ *     -94.0, 48.0,
+ * ]);
+ *
+ * const polygonWithHoles = new Cesium.ClippingPolygon({
+ *     positions: outerRing,
+ *     holes: [firstHole, secondHole],
+ * });
  */
 function ClippingPolygon(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -42,6 +70,15 @@ function ClippingPolygon(options) {
     options.positions.length,
     3,
   );
+  if (defined(options.holes)) {
+    for (let i = 0; i < options.holes.length; i++) {
+      Check.typeOf.number.greaterThanOrEquals(
+        `options.holes[${i}].length`,
+        options.holes[i].length,
+        3,
+      );
+    }
+  }
   //>>includeEnd('debug');
 
   this._ellipsoid = options.ellipsoid ?? Ellipsoid.default;
@@ -158,7 +195,7 @@ function equalsHoles(a, b) {
 
 Object.defineProperties(ClippingPolygon.prototype, {
   /**
-   * Returns the total number of positions in the polygon, include any holes.
+   * Returns the total number of positions in the polygon, including any holes.
    *
    * @memberof ClippingPolygon.prototype
    * @type {number}

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -86,15 +86,12 @@ function ClippingPolygonCollection(options) {
    */
   this._polygons = [];
 
-  const polygons = options.polygons;
+  const polygons = options.polygons ?? [];
   let numVertices = 0;
   let numHoles = 0;
-  if (defined(polygons)) {
-    const polygonsLength = polygons.length;
-    for (let i = 0; i < polygonsLength; ++i) {
-      numVertices += polygons[i].length;
-      numHoles += polygons[i].holes.length;
-    }
+  for (let i = 0; i < polygons.length; ++i) {
+    numVertices += polygons[i].length;
+    numHoles += polygons[i].holes.length;
   }
 
   // Note: update uses this as a sentinel for tracking changes to the collections. Leave it as 0 for now so that
@@ -108,25 +105,23 @@ function ClippingPolygonCollection(options) {
     // We just need it as a data structure, set show to false to prevent unnecessary render buffer allocations.
     show: false,
     // Preallocate double the initial data.
-    primitiveCountMax: polygons?.length > 0 ? 2 * polygons.length : 0,
+    primitiveCountMax: 2 * polygons.length,
     vertexCountMax: 2 * numVertices,
     holeCountMax: numHoles > 0 ? 2 * numHoles : 0,
     // This may be fine to stay as 0: we do not need the triangulation for Vector-based clipping.
     triangleCountMax: 0,
   });
 
-  if (defined(polygons)) {
-    for (let i = 0; i < polygons.length; ++i) {
-      const bufferIndex = this._bufferPolygonCollection.primitiveCount;
-      this._bufferPolygonCollection.add(
-        packClippingPolygon(polygons[i]),
-        bufferPolygonScratch,
-      );
-      this._polygons.push({
-        clippingPolygon: polygons[i],
-        bufferIndex: bufferIndex,
-      });
-    }
+  for (let i = 0; i < polygons.length; ++i) {
+    const bufferIndex = this._bufferPolygonCollection.primitiveCount;
+    this._bufferPolygonCollection.add(
+      packClippingPolygon(polygons[i]),
+      bufferPolygonScratch,
+    );
+    this._polygons.push({
+      clippingPolygon: polygons[i],
+      bufferIndex: bufferIndex,
+    });
   }
 
   if (defined(options.debugShowDistanceTexture)) {

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -88,10 +88,12 @@ function ClippingPolygonCollection(options) {
 
   const polygons = options.polygons;
   let numVertices = 0;
+  let numHoles = 0;
   if (defined(polygons)) {
     const polygonsLength = polygons.length;
     for (let i = 0; i < polygonsLength; ++i) {
       numVertices += polygons[i].length;
+      numHoles += polygons[i].holes.length;
     }
   }
 
@@ -106,25 +108,18 @@ function ClippingPolygonCollection(options) {
     // We just need it as a data structure, set show to false to prevent unnecessary render buffer allocations.
     show: false,
     // Preallocate double the initial data.
-    primitiveCountMax: 2 * (polygons?.length ?? 0),
+    primitiveCountMax: polygons?.length > 0 ? 2 * polygons.length : 0,
     vertexCountMax: 2 * numVertices,
-    // ClippingPolygonCollection does not support holes currently (when this changes, update accordingly)
-    holeCountMax: 0,
+    holeCountMax: numHoles > 0 ? 2 * numHoles : 0,
     // This may be fine to stay as 0: we do not need the triangulation for Vector-based clipping.
     triangleCountMax: 0,
   });
 
   if (defined(polygons)) {
     for (let i = 0; i < polygons.length; ++i) {
-      const positions = polygons[i].positions;
       const bufferIndex = this._bufferPolygonCollection.primitiveCount;
       this._bufferPolygonCollection.add(
-        {
-          positions: Cartesian3.packArray(
-            positions,
-            new Float64Array(positions.length * 3),
-          ),
-        },
+        packClippingPolygon(polygons[i]),
         bufferPolygonScratch,
       );
       this._polygons.push({
@@ -321,23 +316,62 @@ Object.defineProperties(ClippingPolygonCollection.prototype, {
 });
 
 /**
+ * Flattens a ClippingPolygon's outer ring and holes into the position and
+ * hole-offset arrays used by BufferPolygonCollection.add.
+ *
+ * @param {ClippingPolygon} polygon
+ * @returns {{positions: Float64Array, holes: (Uint32Array|undefined)}}
+ * @private
+ */
+function packClippingPolygon(polygon) {
+  const outer = polygon.positions;
+  const holeRings = polygon.holes;
+  const positions = new Float64Array(polygon.length * 3);
+
+  let vertexOffset = 0;
+  for (let i = 0; i < outer.length; i++) {
+    Cartesian3.pack(outer[i], positions, vertexOffset * 3);
+    vertexOffset++;
+  }
+
+  if (holeRings.length === 0) {
+    return { positions, holes: undefined };
+  }
+
+  // Each hole offset marks the vertex where that ring begins in positions.
+  const holes = new Uint32Array(holeRings.length);
+  for (let i = 0; i < holeRings.length; i++) {
+    const ring = holeRings[i];
+    holes[i] = vertexOffset;
+    for (let j = 0; j < ring.length; j++) {
+      Cartesian3.pack(ring[j], positions, vertexOffset * 3);
+      vertexOffset++;
+    }
+  }
+  return { positions, holes };
+}
+
+/**
  * Grows the backing BufferPolygonCollection if one more polygon of the given
- * vertex count would exceed capacity, returning the collection to add into.
+ * vertex and hole count would exceed capacity, returning the collection to add into.
  *
  * @param {ClippingPolygonCollection} collection
  * @param {number} addedVertexCount
+ * @param {number} addedHoleCount
  * @returns {BufferPolygonCollection}
  * @private
  */
-function reserveBufferCapacity(collection, addedVertexCount) {
+function reserveBufferCapacity(collection, addedVertexCount, addedHoleCount) {
   const buffer = collection._bufferPolygonCollection;
 
   const neededPrimitives = buffer.primitiveCount + 1;
   const neededVertices = buffer.vertexCount + addedVertexCount;
+  const neededHoles = buffer.holeCount + addedHoleCount;
 
   if (
     neededPrimitives <= buffer.primitiveCountMax &&
-    neededVertices <= buffer.vertexCountMax
+    neededVertices <= buffer.vertexCountMax &&
+    neededHoles <= buffer.holeCountMax
   ) {
     return buffer;
   }
@@ -350,6 +384,7 @@ function reserveBufferCapacity(collection, addedVertexCount) {
     {
       primitiveCountMax: CesiumMath.nextPowerOfTwo(neededPrimitives),
       vertexCountMax: CesiumMath.nextPowerOfTwo(neededVertices),
+      holeCountMax: CesiumMath.nextPowerOfTwo(neededHoles),
     },
     hasHiddenPolygons ? (polygon) => polygon.show : undefined,
   );
@@ -423,18 +458,17 @@ ClippingPolygonCollection.prototype.add = function (polygon) {
 
   const newPlaneIndex = this._polygons.length;
 
-  const bufferPolygonCollection = reserveBufferCapacity(this, polygon.length);
+  const bufferPolygonCollection = reserveBufferCapacity(
+    this,
+    polygon.length,
+    polygon.holes.length,
+  );
   this._polygons.push({
     clippingPolygon: polygon,
     bufferIndex: bufferPolygonCollection.primitiveCount,
   });
   bufferPolygonCollection.add(
-    {
-      positions: Cartesian3.packArray(
-        polygon.positions,
-        new Float64Array(polygon.positions.length * 3),
-      ),
-    },
+    packClippingPolygon(polygon),
     bufferPolygonScratch,
   );
 

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -89,11 +89,13 @@ function ClippingPolygonCollection(options) {
   // Add each ClippingPolygon object.
   const polygons = options.polygons;
   let numVertices = 0;
+  let numHoles = 0;
   if (defined(polygons)) {
     const polygonsLength = polygons.length;
     for (let i = 0; i < polygonsLength; ++i) {
       this._polygons.push({ clippingPolygon: polygons[i], bufferIndex: -1 });
       numVertices += polygons[i].length;
+      numHoles += polygons[i].holes.length;
     }
   }
 
@@ -116,24 +118,17 @@ function ClippingPolygonCollection(options) {
       numVertices > 0
         ? 2 * numVertices
         : BufferPrimitiveCollection.DEFAULT_CAPACITY,
-    // ClippingPolygonCollection does not support holes currently (when this changes, update accordingly)
-    holeCountMax: 0,
+    holeCountMax: numHoles > 0 ? 2 * numHoles : 0,
     // This may be fine to stay as 0: we do not need the triangulation for Vector-based clipping.
     triangleCountMax: 0,
   });
 
   if (defined(polygons)) {
     for (let i = 0; i < polygons.length; ++i) {
-      const positions = polygons[i].positions;
       this._polygons[i].bufferIndex =
         this._bufferPolygonCollection.primitiveCount;
       this._bufferPolygonCollection.add(
-        {
-          positions: Cartesian3.packArray(
-            positions,
-            new Float64Array(positions.length * 3),
-          ),
-        },
+        packClippingPolygon(polygons[i]),
         bufferPolygonScratch,
       );
     }
@@ -322,23 +317,62 @@ Object.defineProperties(ClippingPolygonCollection.prototype, {
 });
 
 /**
+ * Flattens a ClippingPolygon's outer ring and holes into the position and
+ * hole-offset arrays used by BufferPolygonCollection.add.
+ *
+ * @param {ClippingPolygon} polygon
+ * @returns {{positions: Float64Array, holes: (Uint32Array|undefined)}}
+ * @private
+ */
+function packClippingPolygon(polygon) {
+  const outer = polygon.positions;
+  const holeRings = polygon.holes;
+  const positions = new Float64Array(polygon.length * 3);
+
+  let vertexOffset = 0;
+  for (let i = 0; i < outer.length; i++) {
+    Cartesian3.pack(outer[i], positions, vertexOffset * 3);
+    vertexOffset++;
+  }
+
+  if (holeRings.length === 0) {
+    return { positions, holes: undefined };
+  }
+
+  // Each hole offset marks the vertex where that ring begins in positions.
+  const holes = new Uint32Array(holeRings.length);
+  for (let i = 0; i < holeRings.length; i++) {
+    const ring = holeRings[i];
+    holes[i] = vertexOffset;
+    for (let j = 0; j < ring.length; j++) {
+      Cartesian3.pack(ring[j], positions, vertexOffset * 3);
+      vertexOffset++;
+    }
+  }
+  return { positions, holes };
+}
+
+/**
  * Grows the backing BufferPolygonCollection if one more polygon of the given
- * vertex count would exceed capacity, returning the collection to add into.
+ * vertex and hole count would exceed capacity, returning the collection to add into.
  *
  * @param {ClippingPolygonCollection} collection
  * @param {number} addedVertexCount
+ * @param {number} addedHoleCount
  * @returns {BufferPolygonCollection}
  * @private
  */
-function reserveBufferCapacity(collection, addedVertexCount) {
+function reserveBufferCapacity(collection, addedVertexCount, addedHoleCount) {
   const buffer = collection._bufferPolygonCollection;
 
   const neededPrimitives = buffer.primitiveCount + 1;
   const neededVertices = buffer.vertexCount + addedVertexCount;
+  const neededHoles = buffer.holeCount + addedHoleCount;
 
   if (
     neededPrimitives <= buffer.primitiveCountMax &&
-    neededVertices <= buffer.vertexCountMax
+    neededVertices <= buffer.vertexCountMax &&
+    neededHoles <= buffer.holeCountMax
   ) {
     return buffer;
   }
@@ -347,7 +381,7 @@ function reserveBufferCapacity(collection, addedVertexCount) {
     show: false,
     primitiveCountMax: Math.max(2 * buffer.primitiveCountMax, neededPrimitives),
     vertexCountMax: Math.max(2 * buffer.vertexCountMax, neededVertices),
-    holeCountMax: 0,
+    holeCountMax: Math.max(2 * buffer.holeCountMax, neededHoles),
     triangleCountMax: 0,
   });
 
@@ -411,18 +445,17 @@ ClippingPolygonCollection.prototype.add = function (polygon) {
 
   const newPlaneIndex = this._polygons.length;
 
-  const bufferPolygonCollection = reserveBufferCapacity(this, polygon.length);
+  const bufferPolygonCollection = reserveBufferCapacity(
+    this,
+    polygon.length,
+    polygon.holes.length,
+  );
   this._polygons.push({
     clippingPolygon: polygon,
     bufferIndex: bufferPolygonCollection.primitiveCount,
   });
   bufferPolygonCollection.add(
-    {
-      positions: Cartesian3.packArray(
-        polygon.positions,
-        new Float64Array(polygon.positions.length * 3),
-      ),
-    },
+    packClippingPolygon(polygon),
     bufferPolygonScratch,
   );
 

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -23,6 +23,9 @@ describe("Scene/ClippingPolygonCollection", function () {
     -1.3194369277314022, 0.6988062530900625, -1.31941, 0.69879,
     -1.3193931220959367, 0.698743632490865,
   ]);
+  const holePositions = Cartesian3.fromRadiansArray([
+    -1.31942, 0.69879, -1.319405, 0.69879, -1.319412, 0.698763,
+  ]);
 
   it("default constructor", function () {
     const polygons = new ClippingPolygonCollection();
@@ -51,6 +54,47 @@ describe("Scene/ClippingPolygonCollection", function () {
     polygons.add(new ClippingPolygon({ positions }));
 
     expect(polygons.length).toBe(1);
+  });
+
+  it("packs holes from constructor options into the backing collection", function () {
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions, holes: [holePositions] })],
+    });
+
+    const buffer = polygons._bufferPolygonCollection;
+    expect(buffer.holeCount).toBe(1);
+    expect(buffer.vertexCount).toBe(positions.length + holePositions.length);
+  });
+
+  it("packs holes when a polygon is added", function () {
+    const polygons = new ClippingPolygonCollection();
+    polygons.add(new ClippingPolygon({ positions, holes: [holePositions] }));
+
+    const buffer = polygons._bufferPolygonCollection;
+    expect(buffer.holeCount).toBe(1);
+    expect(buffer.vertexCount).toBe(positions.length + holePositions.length);
+  });
+
+  it("requestRectangleData packs textures for a polygon with a hole", function () {
+    const scene = createScene();
+    if (!scene.context.webgl2) {
+      scene.destroyForSpecs();
+      return;
+    }
+
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions, holes: [holePositions] })],
+    });
+
+    const data = polygons.requestRectangleData(
+      Rectangle.MAX_VALUE,
+      scene.context,
+    );
+
+    expect(data.polygonEdgeTexture).toBeDefined();
+
+    ClippingPolygonCollection.releaseRectangleData(data);
+    scene.destroyForSpecs();
   });
 
   it("fires the polygonAdded event when a polygon is added", function () {

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -23,6 +23,9 @@ describe("Scene/ClippingPolygonCollection", function () {
     -1.3194369277314022, 0.6988062530900625, -1.31941, 0.69879,
     -1.3193931220959367, 0.698743632490865,
   ]);
+  const holePositions = Cartesian3.fromRadiansArray([
+    -1.31942, 0.69879, -1.319405, 0.69879, -1.319412, 0.698763,
+  ]);
 
   it("default constructor", function () {
     const polygons = new ClippingPolygonCollection();
@@ -66,6 +69,47 @@ describe("Scene/ClippingPolygonCollection", function () {
     polygons.add(new ClippingPolygon({ positions }));
 
     expect(polygons.length).toBe(1);
+  });
+
+  it("packs holes from constructor options into the backing collection", function () {
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions, holes: [holePositions] })],
+    });
+
+    const buffer = polygons._bufferPolygonCollection;
+    expect(buffer.holeCount).toBe(1);
+    expect(buffer.vertexCount).toBe(positions.length + holePositions.length);
+  });
+
+  it("packs holes when a polygon is added", function () {
+    const polygons = new ClippingPolygonCollection();
+    polygons.add(new ClippingPolygon({ positions, holes: [holePositions] }));
+
+    const buffer = polygons._bufferPolygonCollection;
+    expect(buffer.holeCount).toBe(1);
+    expect(buffer.vertexCount).toBe(positions.length + holePositions.length);
+  });
+
+  it("requestRectangleData packs textures for a polygon with a hole", function () {
+    const scene = createScene();
+    if (!scene.context.webgl2) {
+      scene.destroyForSpecs();
+      return;
+    }
+
+    const polygons = new ClippingPolygonCollection({
+      polygons: [new ClippingPolygon({ positions, holes: [holePositions] })],
+    });
+
+    const data = polygons.requestRectangleData(
+      Rectangle.MAX_VALUE,
+      scene.context,
+    );
+
+    expect(data.polygonEdgeTexture).toBeDefined();
+
+    ClippingPolygonCollection.releaseRectangleData(data);
+    scene.destroyForSpecs();
   });
 
   it("fires the polygonAdded event when a polygon is added", function () {

--- a/packages/engine/Specs/Scene/ClippingPolygonSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonSpec.js
@@ -20,7 +20,48 @@ describe("Scene/ClippingPolygon", function () {
 
     expect(polygon.length).toBe(5);
     expect(polygon.positions).toEqual(positions);
+    expect(polygon.holes).toEqual([]);
     expect(polygon.ellipsoid).toEqual(Ellipsoid.WGS84);
+  });
+
+  it("constructs with holes", function () {
+    const positions = Cartesian3.fromRadiansArray([
+      -1.3194369277314022, 0.6988062530900625, -1.31941, 0.69879,
+      -1.3193955980204217, 0.6988091578771254, -1.3193931220959367,
+      0.698743632490865, -1.3194358224045408, 0.6987471965556998,
+    ]);
+    const hole = Cartesian3.fromRadiansArray([
+      -1.31942, 0.69879, -1.319405, 0.69879, -1.319412, 0.698763,
+    ]);
+
+    const polygon = new ClippingPolygon({
+      positions: positions,
+      holes: [hole],
+    });
+
+    expect(polygon.positions).toEqual(positions);
+    expect(polygon.holes.length).toBe(1);
+    expect(polygon.holes[0]).toEqual(hole);
+    expect(polygon.holes[0]).not.toBe(hole);
+    // length counts the outer ring plus every hole vertex.
+    expect(polygon.length).toBe(positions.length + hole.length);
+  });
+
+  it("clones holes", function () {
+    const positions = Cartesian3.fromRadiansArray([
+      -1.3194369277314022, 0.6988062530900625, -1.31941, 0.69879,
+      -1.3193955980204217, 0.6988091578771254, -1.3193931220959367,
+      0.698743632490865, -1.3194358224045408, 0.6987471965556998,
+    ]);
+    const hole = Cartesian3.fromRadiansArray([
+      -1.31942, 0.69879, -1.319405, 0.69879, -1.319412, 0.698763,
+    ]);
+
+    const polygon = new ClippingPolygon({ positions, holes: [hole] });
+    const cloned = ClippingPolygon.clone(polygon);
+    expect(cloned.holes.length).toBe(1);
+    expect(cloned.holes[0]).toEqual(hole);
+    expect(cloned.holes[0]).not.toBe(polygon.holes[0]);
   });
 
   it("throws when constructing polygon with fewer than 3 positions", function () {


### PR DESCRIPTION
# Description

Clipping polygons with holes (regular and inverse clipping):

<img width="680" height="637" alt="image" src="https://github.com/user-attachments/assets/11174ea8-0b35-4db3-8f47-1ee9bdd475dd" />

<img width="680" height="637" alt="image" src="https://github.com/user-attachments/assets/679ae6b6-1ec8-4982-b441-c7f9c0f3047d" />

This PR adds a "holes" option to the `ClippingPolygons` API. Users specify the positions of the clipping polygon outline, as a list of `Cartesian3`, and a holes as a list of lists of `Cartesian3` (where each sublist represents the outline of one hole). Because we now use `BufferPolygonCollection` as the backing data structure for clipping polygons, alongside the vector shader framework, we get support for holes nearly for free. 

## Issue number and link

#12939

## Testing plan

[This sandcastle](https://ci-builds.cesium.com/cesium/clipping-polygon-holes/Apps/Sandcastle2/index.html#c=pVhZbxs5Ev4rBWEeWnG7JZ87kaxgEzvwGnBgY+yZPIyCNd0sqYlQpEKyrWgD//cFrz6k9pHJi60mWcWv7iqyxVIqA2+AaDhFzcoFzJRcwLSXu69pbzwVzB+6IYLmRBuO8Uy94s5NRS6FNvDAcIUKJiBwFbhmf7m1JPI9lcIQJlBNeyn8mAoAwxbImcARzAjXmNo1ItiCGCZFc1HnKPCTpHjN8q+omlv3ROMlWaPa3hoM4LZAOJdyzhHmKHNJUQHToPBbyRRSMBJKXR25LqSRCgln2rAcDs7glnHUmWUWyUdRugspzv3atZIPjKK6XS8xO7+6Or/8mE7FY38clePgwyQoKXOfTneDAXyWilMwqBRhIrVoqDWMFAhyBqZAMCsJOWfLJbnnCLpUM5I7UEatvR4dwyzwiGhgAmRFmIl4c4XEoLvu1p98r9ciTyzMR8iJyQtIUCmp+p7rigkqVxnhqExyd1ugQlgRDUSAOwaOIxNzWDVlyOC3H27/8c6xDnI+r+JacCsx4QaVIAa35c6mgqPxNzpKNOOGJprr3QrwONowDs4CSeKYAEjB139qJuafmSk8xXllf6NK71/Owu07M13IFUy8E45r2ywVWzDDHlBnhNKkSfKk/q3vSI4Zl/Pk7qPTOJeEWoU/oUUwAUW3CT6UjFMNBBTOS04ULCVfz6UAZXnmKAzamCAGEi5FCpyYfgaXUsyZKan1x5lGo4EodPx0TjhSuF9DLnViT4OWoAuyRA3akDU8MF0SztegZCkoKGIKVGAKIkB/K5kukGZTMStFbiPe4aiuTkERykqdgmbUeoiSxiWGM5zDBIYNLRkL4JJYi38ipsgsnGB0923kH4QyIjxIbzVPF3nCBLoJGpc26XIpFdUwgb+/uNWZVJBYx2QW2hgYnHjYY9jZYQFqJCbCRsKkvnwHEgYDT9CHNy0ot5+v/nt9MY709tpsWerC6skSeiXBm1pyx77fh0HQSr+LmBjYgTatZiLSOopH+0ehKZWIiE6JMqgZEQeZLQdnOFeI+r1SZJ149k1/u+Y2UQF+J4slx+htGpiwPihXtcvZ3JLFbOlXvTkP3mb/Ohpv7Dhz7e4Nj7LhsLEp9anbf9kLqhv6jRxtcGltlw33DsYNn9RcmkspEiYofg+GDEqp4exA4g/ALuxbC1puwQIeVEMt72GGq6gVDStmCqBsNkOFwoAsrQghiIigja1C+mLkAQd1nuHM+WEoeDffSmLztGVqa4j235bUlbEk6cPkXdsfuVNoFHQY/SVIGY4CLKVmViV61AjUSpWpVd3wcD+FwxQOj/ppJHOoR/D3kzR7v0eaL4Ho0ftfP+lXdVwxHzWVYCau/IRoe78i2lEKBym8Hf6EZPv7keZpyf6D34nNwU4wUyjEkCyjtV8j2H4d43bTkdbJqTs9HbRT02Zy6o6ct0PYAQZvYG+/8pPqVh+YIS95yz6Zl6qoaHNwQV8ngB1os6lT1LhlBJ/UnB0sitRxCt6Vwv5hP55/bNv/dT59nMJxPw1a3bbgKVN59EzbqzVC7rX2O/ilmLPB0+GW8RsqUtiN+mzYYDse97ZiuMFi5x+yeDoCrlGYRgisJFBGFvInQ+Dwl1R4nMJRd3BvqyDddtDjytcOu5TWpNh9hqJTR1/ipPDnhW2qDNri4Pq0XEltZ5n7knFb/zhHV7N0aJJJbjvOG984wwSmvdCiu8nNnnDtNRPzj8L22BQmrrkNm0w8oNLY6GYdDDtSec6NK1NQSLRmc4EUVgUKfHCNXujgkcb+HfKCiDlGiBHAdegNGhOllbW0WYzKvFygMNkczUeO9ueH9QVNpj1/ZNrrNwt2uaTE4I3bSkJ68wczg9+NnUJtMZ3AXdDMCH770VLV411X0zxTqIuGyLCUy5ITg9SPxk7YUrlKHRtrijMmWLRJBdEajJ5WnJKNVra6oTVNn7ZV1SAPro7eiKNNqwanCuYcxR/NEcbVB389xZkdPBvdRaN7jVe6IeZpbAnFWUcTWdM39PuHc1/qB7+G7BaSqV0tuo/tiHKORGlgpla8tINFU8VkueTrCKtS8Ia3wWTbFA41m0GyET2TVvxUOvHj3ZzLe4yzXwihzd2Oyzu831lqBrFxdQ6EGwNjo2Y/P3tunejAUIpwR7NCPgJyjc/I2LzjBSE3L+iC3FDZS3g7deZAtwM/utiGI7gEE95hcrJARbIZX99KH0QUtWEiPD89O/MkVfOfuiHFNr7HR8NhFkqIVMyWNc8p6LFAN72PbOYPQblkJi9GTzRbu8cVOwAlOa8pH+MDk0/Jcm6btns0K0TRfo5xEfPi+1ZIud7Zr5YuY8WpIqC3yXME095tjIE0vpVotNEzglaNhhfKTzizZR3ng5WMtvi9Mhza4H1HuAE9CvyPsHvC1yEP3le/ldqEeSslvyfqE4oyaYP1htw8bW36oTRGimTa87m88n77hLqZ5iHJC8y/Iq1F2a7v4ci4Kx1m2HHMyfIstIvQJzSxxRrTgaluK57F0nUsePxWoPfS3ok2a47vLKt/h7frUvEkywYGF0tbpvXgvsy/2qSincJPBpHkhLIHYHTS8VANOSdaT6a9Wcn5DfsfTnvvTgaUPbTIwrPc1QMqTtb2SLH37tIvZll2Mij2OqiM94dpz6Gu12NXU5OE//8H) demonstrates holes -- you can try it out with terrain or 3D tiles, and regular clipping or inverse.


## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->


#### PR Dependency Tree


* **PR #13623**
  * **PR #13635**
    * **PR #13636**
      * **PR #13637**
        * **PR #13638**
          * **PR #13641**
            * **PR #13647**
              * **PR #13654**
                * **PR #13660** 👈
                  * **PR #13665**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)