### PR TITLE
ClippingPolygon immutable positions (performance)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ### @cesium/engine
 
+#### Breaking Changes :mega:
+
+- The positions of `ClippingPolygons` in a `ClippingPolygonCollection` are now considered immutable (via `Object.freeze`) and will throw if changed. Instead of changing positions directly, remove and re-add a new polygon. This breaking change allows us to remove per-frame, per-polygon-vertex checks that ultimately offer vast performance improvements. [#13665](https://github.com/CesiumGS/cesium/pull/13665)
+
 #### Additions :tada:
 
 - Added two sandcastles for a 3D native vector data showcase and a large river data with semantic-based LOD
@@ -25,7 +29,7 @@
 
 #### Deprecated :hourglass_flowing_sand:
 
-- Deprecates the recently added `quality` field on `ClippingPolygonCollection`. The new implementation of `ClippingPolygons` offers the highest possibly quality by default. The `debugShowDistanceTexture` field is also deprecated, as the new implementation no longer uses a distance texture. Similarly, the `destroy` and `isDestroyed` methods have been deprecated, since the class no longer owns its own resources which require release or destruction.
+- Deprecates the recently added `quality` field on `ClippingPolygonCollection`. The new implementation of `ClippingPolygons` offers the highest possibly quality by default. The `debugShowDistanceTexture` field is also deprecated, as the new implementation no longer uses a distance texture. The `destroy` and `isDestroyed` methods have been deprecated, since the class no longer owns its own resources which require release or destruction. `ClippingPolygon.computeRectangle` has been deprecated in favor of a class-level `rectangle` property.
 
 ## 1.144 - 2026-08-01
 

--- a/packages/engine/Source/Scene/ClippingPolygon.js
+++ b/packages/engine/Source/Scene/ClippingPolygon.js
@@ -343,12 +343,12 @@ ClippingPolygon.equals = function (left, right) {
  * @param {Rectangle} [result] An object in which to store the result.
  * @returns {Rectangle} The result rectangle
  *
- * @deprecated This function is deprecated and will be removed in CesiumJS 1.146. Use {@link ClippingPolygon#rectangle} instead.
+ * @deprecated This function is deprecated and will be removed in CesiumJS 1.147. Use {@link ClippingPolygon#rectangle} instead.
  */
 ClippingPolygon.prototype.computeRectangle = function (result) {
   deprecationWarning(
     "ClippingPolygon.computeRectangle",
-    "ClippingPolygon.computeRectangle is deprecated as of CesiumJS 1.144 and will be removed in 1.146. Use the ClippingPolygon.rectangle property instead.",
+    "ClippingPolygon.computeRectangle is deprecated as of CesiumJS 1.145 and will be removed in 1.147. Use the ClippingPolygon.rectangle property instead.",
   );
   return Rectangle.clone(this._rectangle, result);
 };

--- a/packages/engine/Source/Scene/ClippingPolygon.js
+++ b/packages/engine/Source/Scene/ClippingPolygon.js
@@ -1,6 +1,7 @@
 import Check from "../Core/Check.js";
 import Cartesian3 from "../Core/Cartesian3.js";
 import defined from "../Core/defined.js";
+import deprecationWarning from "../Core/deprecationWarning.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import PolygonGeometry from "../Core/PolygonGeometry.js";
 import Rectangle from "../Core/Rectangle.js";
@@ -51,29 +52,20 @@ function ClippingPolygon(options) {
     : [];
 
   /**
-   * A copy of the input positions.
+   * The cartographic rectangle enclosing the outer ring
    *
-   * This is used to detect modifications of the positions in
-   * <code>coputeRectangle</code>: The rectangle only has
-   * to be re-computed when these positions have changed.
-   *
-   * @type {Cartesian3[]|undefined}
+   * @type {Rectangle}
    * @private
    */
-  this._cachedPositions = undefined;
+  this._rectangle = PolygonGeometry.computeRectangleFromPositions(
+    this._positions,
+    this._ellipsoid,
+  );
 
-  /**
-   * A cached version of the rectangle that is computed in
-   * <code>computeRectangle</code>.
-   *
-   * This is only re-computed when the positions have changed, as
-   * determined  by comparing the <code>_positions</code> to the
-   * <code>_cachedPositions</code>
-   *
-   * @type {Rectangle|undefined}
-   * @private
-   */
-  this._cachedRectangle = undefined;
+  // Freeze the geometry so it cannot change after construction. To change a
+  // polygon, remove it from the collection and add a new one.
+  deepFreeze(this._positions);
+  deepFreezeHoles(this._holes);
 }
 
 /**
@@ -98,6 +90,35 @@ function copyArrayCartesian3(input) {
     output[i] = Cartesian3.clone(input[i]);
   }
   return output;
+}
+
+/**
+ * Freezes an array of positions and each Cartesian3 it contains, so that the
+ * polygon's geometry cannot be mutated in place. Returns the same array.
+ *
+ * @param {Cartesian3[]} positions The array to freeze
+ * @returns {Cartesian3[]} The frozen array
+ * @ignore
+ */
+function deepFreeze(positions) {
+  for (let i = 0; i < positions.length; i++) {
+    Object.freeze(positions[i]);
+  }
+  return Object.freeze(positions);
+}
+
+/**
+ * Freezes an array of rings (holes) and their contents. Returns the same array.
+ *
+ * @param {Cartesian3[][]} holes The rings to freeze
+ * @returns {Cartesian3[][]} The frozen array
+ * @ignore
+ */
+function deepFreezeHoles(holes) {
+  for (let i = 0; i < holes.length; i++) {
+    deepFreeze(holes[i]);
+  }
+  return Object.freeze(holes);
 }
 
 /**
@@ -175,7 +196,8 @@ Object.defineProperties(ClippingPolygon.prototype, {
     },
   },
   /**
-   * Returns the outer ring of positions.
+   * Returns the outer ring of positions. A ClippingPolygon's geometry is
+   * immutable; the returned array and its coordinates are frozen.
    *
    * @memberof ClippingPolygon.prototype
    * @type {Cartesian3[]}
@@ -210,6 +232,20 @@ Object.defineProperties(ClippingPolygon.prototype, {
       return this._ellipsoid;
     },
   },
+  /**
+   * Returns the cartographic rectangle enclosing the polygon, computed once on
+   * construction. Since a ClippingPolygon's geometry is immutable, this rectangle
+   * never changes.
+   *
+   * @memberof ClippingPolygon.prototype
+   * @type {Rectangle}
+   * @readonly
+   */
+  rectangle: {
+    get: function () {
+      return this._rectangle;
+    },
+  },
 });
 
 /**
@@ -232,9 +268,14 @@ ClippingPolygon.clone = function (polygon, result) {
   }
 
   result._ellipsoid = polygon.ellipsoid;
-  result._positions.length = 0;
-  result._positions.push(...polygon.positions);
+  result._positions = copyArrayCartesian3(polygon.positions);
   result._holes = polygon.holes.map(copyArrayCartesian3);
+  result._rectangle = PolygonGeometry.computeRectangleFromPositions(
+    result._positions,
+    result._ellipsoid,
+  );
+  deepFreeze(result._positions);
+  deepFreezeHoles(result._holes);
   return result;
 };
 
@@ -264,20 +305,15 @@ ClippingPolygon.equals = function (left, right) {
  *
  * @param {Rectangle} [result] An object in which to store the result.
  * @returns {Rectangle} The result rectangle
+ *
+ * @deprecated This function is deprecated and will be removed in CesiumJS 1.146. Use {@link ClippingPolygon#rectangle} instead.
  */
 ClippingPolygon.prototype.computeRectangle = function (result) {
-  if (equalsArrayCartesian3(this._positions, this._cachedPositions)) {
-    return Rectangle.clone(this._cachedRectangle, result);
-  }
-  const rectangle = PolygonGeometry.computeRectangleFromPositions(
-    this.positions,
-    this.ellipsoid,
-    undefined,
-    result,
+  deprecationWarning(
+    "ClippingPolygon.computeRectangle",
+    "ClippingPolygon.computeRectangle is deprecated as of CesiumJS 1.144 and will be removed in 1.146. Use the ClippingPolygon.rectangle property instead.",
   );
-  this._cachedPositions = copyArrayCartesian3(this._positions);
-  this._cachedRectangle = Rectangle.clone(rectangle);
-  return rectangle;
+  return Rectangle.clone(this._rectangle, result);
 };
 
 export default ClippingPolygon;

--- a/packages/engine/Source/Scene/ClippingPolygon.js
+++ b/packages/engine/Source/Scene/ClippingPolygon.js
@@ -1,6 +1,7 @@
 import Check from "../Core/Check.js";
 import Cartesian3 from "../Core/Cartesian3.js";
 import defined from "../Core/defined.js";
+import deprecationWarning from "../Core/deprecationWarning.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import PolygonGeometry from "../Core/PolygonGeometry.js";
 import Rectangle from "../Core/Rectangle.js";
@@ -88,29 +89,20 @@ function ClippingPolygon(options) {
     : [];
 
   /**
-   * A copy of the input positions.
+   * The cartographic rectangle enclosing the outer ring
    *
-   * This is used to detect modifications of the positions in
-   * <code>coputeRectangle</code>: The rectangle only has
-   * to be re-computed when these positions have changed.
-   *
-   * @type {Cartesian3[]|undefined}
+   * @type {Rectangle}
    * @private
    */
-  this._cachedPositions = undefined;
+  this._rectangle = PolygonGeometry.computeRectangleFromPositions(
+    this._positions,
+    this._ellipsoid,
+  );
 
-  /**
-   * A cached version of the rectangle that is computed in
-   * <code>computeRectangle</code>.
-   *
-   * This is only re-computed when the positions have changed, as
-   * determined  by comparing the <code>_positions</code> to the
-   * <code>_cachedPositions</code>
-   *
-   * @type {Rectangle|undefined}
-   * @private
-   */
-  this._cachedRectangle = undefined;
+  // Freeze the geometry so it cannot change after construction. To change a
+  // polygon, remove it from the collection and add a new one.
+  deepFreeze(this._positions);
+  deepFreezeHoles(this._holes);
 }
 
 /**
@@ -135,6 +127,35 @@ function copyArrayCartesian3(input) {
     output[i] = Cartesian3.clone(input[i]);
   }
   return output;
+}
+
+/**
+ * Freezes an array of positions and each Cartesian3 it contains, so that the
+ * polygon's geometry cannot be mutated in place. Returns the same array.
+ *
+ * @param {Cartesian3[]} positions The array to freeze
+ * @returns {Cartesian3[]} The frozen array
+ * @ignore
+ */
+function deepFreeze(positions) {
+  for (let i = 0; i < positions.length; i++) {
+    Object.freeze(positions[i]);
+  }
+  return Object.freeze(positions);
+}
+
+/**
+ * Freezes an array of rings (holes) and their contents. Returns the same array.
+ *
+ * @param {Cartesian3[][]} holes The rings to freeze
+ * @returns {Cartesian3[][]} The frozen array
+ * @ignore
+ */
+function deepFreezeHoles(holes) {
+  for (let i = 0; i < holes.length; i++) {
+    deepFreeze(holes[i]);
+  }
+  return Object.freeze(holes);
 }
 
 /**
@@ -212,7 +233,8 @@ Object.defineProperties(ClippingPolygon.prototype, {
     },
   },
   /**
-   * Returns the outer ring of positions.
+   * Returns the outer ring of positions. A ClippingPolygon's geometry is
+   * immutable; the returned array and its coordinates are frozen.
    *
    * @memberof ClippingPolygon.prototype
    * @type {Cartesian3[]}
@@ -247,6 +269,20 @@ Object.defineProperties(ClippingPolygon.prototype, {
       return this._ellipsoid;
     },
   },
+  /**
+   * Returns the cartographic rectangle enclosing the polygon, computed once on
+   * construction. Since a ClippingPolygon's geometry is immutable, this rectangle
+   * never changes.
+   *
+   * @memberof ClippingPolygon.prototype
+   * @type {Rectangle}
+   * @readonly
+   */
+  rectangle: {
+    get: function () {
+      return this._rectangle;
+    },
+  },
 });
 
 /**
@@ -269,9 +305,14 @@ ClippingPolygon.clone = function (polygon, result) {
   }
 
   result._ellipsoid = polygon.ellipsoid;
-  result._positions.length = 0;
-  result._positions.push(...polygon.positions);
+  result._positions = copyArrayCartesian3(polygon.positions);
   result._holes = polygon.holes.map(copyArrayCartesian3);
+  result._rectangle = PolygonGeometry.computeRectangleFromPositions(
+    result._positions,
+    result._ellipsoid,
+  );
+  deepFreeze(result._positions);
+  deepFreezeHoles(result._holes);
   return result;
 };
 
@@ -301,20 +342,15 @@ ClippingPolygon.equals = function (left, right) {
  *
  * @param {Rectangle} [result] An object in which to store the result.
  * @returns {Rectangle} The result rectangle
+ *
+ * @deprecated This function is deprecated and will be removed in CesiumJS 1.146. Use {@link ClippingPolygon#rectangle} instead.
  */
 ClippingPolygon.prototype.computeRectangle = function (result) {
-  if (equalsArrayCartesian3(this._positions, this._cachedPositions)) {
-    return Rectangle.clone(this._cachedRectangle, result);
-  }
-  const rectangle = PolygonGeometry.computeRectangleFromPositions(
-    this.positions,
-    this.ellipsoid,
-    undefined,
-    result,
+  deprecationWarning(
+    "ClippingPolygon.computeRectangle",
+    "ClippingPolygon.computeRectangle is deprecated as of CesiumJS 1.144 and will be removed in 1.146. Use the ClippingPolygon.rectangle property instead.",
   );
-  this._cachedPositions = copyArrayCartesian3(this._positions);
-  this._cachedRectangle = Rectangle.clone(rectangle);
-  return rectangle;
+  return Rectangle.clone(this._rectangle, result);
 };
 
 export default ClippingPolygon;

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -601,7 +601,6 @@ ClippingPolygonCollection.prototype.update = function (frameState) {
 
 const scratchRectangleTile = new Rectangle();
 const scratchRectangleIntersection = new Rectangle();
-const scratchRectanglePolygon = new Rectangle();
 /**
  * Determines the type intersection with the polygons of this ClippingPolygonCollection instance and the specified {@link TileBoundingVolume}.
  * @ignore
@@ -645,13 +644,9 @@ ClippingPolygonCollection.prototype.computeIntersectionWithBoundingVolume =
     for (let i = 0; i < length; ++i) {
       const polygon = polygons[i].clippingPolygon;
 
-      const polygonBoundingRectangle = polygon.computeRectangle(
-        scratchRectanglePolygon,
-      );
-
       const result = Rectangle.intersection(
         tileBoundingRectangle,
-        polygonBoundingRectangle,
+        polygon.rectangle,
         scratchRectangleIntersection,
       );
 

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -97,6 +97,8 @@ function ClippingPolygonCollection(options) {
   // Note: update uses this as a sentinel for tracking changes to the collections. Leave it as 0 for now so that
   // the first update loop always runs, even though we already know the value (numVertices).
   this._totalPositions = 0;
+  // Marks the packed vector data as stale.
+  this._dirty = false;
 
   // For now: this is a write-through mirror of the polygons array. In upcoming work,
   // this will be the source of truth. To maintain backwards compatibility, though, we will still
@@ -258,20 +260,6 @@ Object.defineProperties(ClippingPolygonCollection.prototype, {
         qualityDeprecationMessage,
       );
       this._quality = value;
-    },
-  },
-
-  /**
-   * Returns the total number of positions in all polygons in the collection.
-   *
-   * @memberof ClippingPolygonCollection.prototype
-   * @type {number}
-   * @readonly
-   * @private
-   */
-  totalPositions: {
-    get: function () {
-      return this._totalPositions;
     },
   },
 
@@ -467,6 +455,7 @@ ClippingPolygonCollection.prototype.add = function (polygon) {
     bufferPolygonScratch,
   );
 
+  this._dirty = true;
   this.polygonAdded.raiseEvent(polygon, newPlaneIndex);
   return polygon;
 };
@@ -537,6 +526,7 @@ ClippingPolygonCollection.prototype.remove = function (polygon) {
 
   hideBufferPolygon(this, entry);
 
+  this._dirty = true;
   this.polygonRemoved.raiseEvent(entry.clippingPolygon, index);
   return true;
 };
@@ -555,6 +545,7 @@ ClippingPolygonCollection.prototype.removeAll = function () {
     hideBufferPolygon(this, entry);
     this.polygonRemoved.raiseEvent(entry.clippingPolygon, i);
   }
+  this._dirty = true;
   this._polygons = [];
 };
 
@@ -575,17 +566,11 @@ ClippingPolygonCollection.prototype.update = function (frameState) {
     );
   }
 
-  // It'd be expensive to validate any individual position has changed. Instead verify if the list of polygon positions has had elements added or removed, which should be good enough for most cases.
-  const totalPositions = this._polygons.reduce(
-    (totalPositions, entry) => totalPositions + entry.clippingPolygon.length,
-    0,
-  );
-
-  if (totalPositions === this.totalPositions) {
+  if (!this._dirty) {
     return;
   }
 
-  this._totalPositions = totalPositions;
+  this._dirty = false;
 
   // If there are no clipping polygons, there's nothing to update.
   if (this.length === 0) {

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -592,7 +592,6 @@ ClippingPolygonCollection.prototype.update = function (frameState) {
 
 const scratchRectangleTile = new Rectangle();
 const scratchRectangleIntersection = new Rectangle();
-const scratchRectanglePolygon = new Rectangle();
 /**
  * Determines the type intersection with the polygons of this ClippingPolygonCollection instance and the specified {@link TileBoundingVolume}.
  * @ignore
@@ -636,13 +635,9 @@ ClippingPolygonCollection.prototype.computeIntersectionWithBoundingVolume =
     for (let i = 0; i < length; ++i) {
       const polygon = polygons[i].clippingPolygon;
 
-      const polygonBoundingRectangle = polygon.computeRectangle(
-        scratchRectanglePolygon,
-      );
-
       const result = Rectangle.intersection(
         tileBoundingRectangle,
-        polygonBoundingRectangle,
+        polygon.rectangle,
         scratchRectangleIntersection,
       );
 

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -99,9 +99,8 @@ function ClippingPolygonCollection(options) {
     }
   }
 
-  // Note: update uses this as a heuristic for tracking changes to the collections. Leave it as 0 for now so that
-  // the first update loop always runs.
-  this._totalPositions = 0;
+  // Marks the packed vector data as stale.
+  this._dirty = false;
 
   // For now: this is a write-through mirror of the polygons array. In upcoming work,
   // this will be the source of truth. To maintain backwards compatibility, though, we will still
@@ -268,20 +267,6 @@ Object.defineProperties(ClippingPolygonCollection.prototype, {
         qualityDeprecationMessage,
       );
       this._quality = value;
-    },
-  },
-
-  /**
-   * Returns the total number of positions in all polygons in the collection.
-   *
-   * @memberof ClippingPolygonCollection.prototype
-   * @type {number}
-   * @readonly
-   * @private
-   */
-  totalPositions: {
-    get: function () {
-      return this._totalPositions;
     },
   },
 
@@ -459,6 +444,7 @@ ClippingPolygonCollection.prototype.add = function (polygon) {
     bufferPolygonScratch,
   );
 
+  this._dirty = true;
   this.polygonAdded.raiseEvent(polygon, newPlaneIndex);
   return polygon;
 };
@@ -529,6 +515,7 @@ ClippingPolygonCollection.prototype.remove = function (polygon) {
 
   hideBufferPolygon(this, entry);
 
+  this._dirty = true;
   this.polygonRemoved.raiseEvent(entry.clippingPolygon, index);
   return true;
 };
@@ -547,6 +534,7 @@ ClippingPolygonCollection.prototype.removeAll = function () {
     hideBufferPolygon(this, entry);
     this.polygonRemoved.raiseEvent(entry.clippingPolygon, i);
   }
+  this._dirty = true;
   this._polygons = [];
 };
 
@@ -566,17 +554,11 @@ ClippingPolygonCollection.prototype.update = function (frameState) {
     );
   }
 
-  // It'd be expensive to validate any individual position has changed. Instead verify if the list of polygon positions has had elements added or removed, which should be good enough for most cases.
-  const totalPositions = this._polygons.reduce(
-    (totalPositions, entry) => totalPositions + entry.clippingPolygon.length,
-    0,
-  );
-
-  if (totalPositions === this.totalPositions) {
+  if (!this._dirty) {
     return;
   }
 
-  this._totalPositions = totalPositions;
+  this._dirty = false;
 
   // If there are no clipping polygons, there's nothing to update.
   if (this.length === 0) {

--- a/packages/engine/Source/Scene/ClippingPolygonCollection.js
+++ b/packages/engine/Source/Scene/ClippingPolygonCollection.js
@@ -94,9 +94,6 @@ function ClippingPolygonCollection(options) {
     numHoles += polygons[i].holes.length;
   }
 
-  // Note: update uses this as a sentinel for tracking changes to the collections. Leave it as 0 for now so that
-  // the first update loop always runs, even though we already know the value (numVertices).
-  this._totalPositions = 0;
   // Marks the packed vector data as stale.
   this._dirty = false;
 

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -384,8 +384,16 @@ describe("Scene/ClippingPolygonCollection", function () {
       rectangle: Rectangle.fromCartesianArray(positions),
     });
 
-    // Spy on the rectangle getter to verify early return behavior
-    const spyB = spyOnProperty(polygonB, "rectangle", "get").and.callThrough();
+    // Spy on the rectangle getter to verify early return behavior. The
+    // property is a non-configurable prototype getter, so shadow it with a
+    // configurable own getter that can be spied on.
+    const spyB = jasmine
+      .createSpy("rectangle")
+      .and.returnValue(polygonB.rectangle);
+    Object.defineProperty(polygonB, "rectangle", {
+      configurable: true,
+      get: spyB,
+    });
 
     const intersect =
       polygons.computeIntersectionWithBoundingVolume(boundingVolume);

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -399,8 +399,16 @@ describe("Scene/ClippingPolygonCollection", function () {
       rectangle: Rectangle.fromCartesianArray(positions),
     });
 
-    // Spy on the rectangle getter to verify early return behavior
-    const spyB = spyOnProperty(polygonB, "rectangle", "get").and.callThrough();
+    // Spy on the rectangle getter to verify early return behavior. The
+    // property is a non-configurable prototype getter, so shadow it with a
+    // configurable own getter that can be spied on.
+    const spyB = jasmine
+      .createSpy("rectangle")
+      .and.returnValue(polygonB.rectangle);
+    Object.defineProperty(polygonB, "rectangle", {
+      configurable: true,
+      get: spyB,
+    });
 
     const intersect =
       polygons.computeIntersectionWithBoundingVolume(boundingVolume);

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -385,15 +385,15 @@ describe("Scene/ClippingPolygonCollection", function () {
       rectangle: Rectangle.fromCartesianArray(positions),
     });
 
-    // Spy on computeRectangle to verify early return behavior
-    const spyB = spyOn(polygonB, "computeRectangle").and.callThrough();
+    // Spy on the rectangle getter to verify early return behavior
+    const spyB = spyOnProperty(polygonB, "rectangle", "get").and.callThrough();
 
     const intersect =
       polygons.computeIntersectionWithBoundingVolume(boundingVolume);
     expect(intersect).toEqual(Intersect.INTERSECTING);
 
     // Because the first polygon intersects, the second polygon's
-    // computeRectangle should never be called (early return optimization)
+    // rectangle should never be accessed (early return optimization)
     expect(spyB).not.toHaveBeenCalled();
   });
 

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -400,15 +400,15 @@ describe("Scene/ClippingPolygonCollection", function () {
       rectangle: Rectangle.fromCartesianArray(positions),
     });
 
-    // Spy on computeRectangle to verify early return behavior
-    const spyB = spyOn(polygonB, "computeRectangle").and.callThrough();
+    // Spy on the rectangle getter to verify early return behavior
+    const spyB = spyOnProperty(polygonB, "rectangle", "get").and.callThrough();
 
     const intersect =
       polygons.computeIntersectionWithBoundingVolume(boundingVolume);
     expect(intersect).toEqual(Intersect.INTERSECTING);
 
     // Because the first polygon intersects, the second polygon's
-    // computeRectangle should never be called (early return optimization)
+    // rectangle should never be accessed (early return optimization)
     expect(spyB).not.toHaveBeenCalled();
   });
 

--- a/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonCollectionSpec.js
@@ -32,7 +32,6 @@ describe("Scene/ClippingPolygonCollection", function () {
     expect(polygons.length).toEqual(0);
     expect(polygons.enabled).toBeTrue();
     expect(polygons.inverse).toBeFalse();
-    expect(polygons.totalPositions).toBe(0);
   });
 
   it("gets the length of the list of polygons", function () {

--- a/packages/engine/Specs/Scene/ClippingPolygonSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonSpec.js
@@ -172,7 +172,7 @@ describe("Scene/ClippingPolygon", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computeRectangle returns rectangle enclosing the polygon", function () {
+  it("rectangle getter returns rectangle enclosing the polygon", function () {
     const positions = Cartesian3.fromRadiansArray([
       -1.3194369277314022, 0.6988062530900625, -1.31941, 0.69879,
       -1.3193955980204217, 0.6988091578771254, -1.3193931220959367,
@@ -183,7 +183,7 @@ describe("Scene/ClippingPolygon", function () {
       positions: positions,
     });
 
-    const result = polygon.computeRectangle();
+    const result = polygon.rectangle;
     expect(result).toBeInstanceOf(Rectangle);
     expect(result.west).toEqualEpsilon(
       -1.3194369277314024,
@@ -203,7 +203,8 @@ describe("Scene/ClippingPolygon", function () {
     );
   });
 
-  it("computeRectangle uses result parameter", function () {
+  it("computeRectangle is deprecated but still returns a clone", function () {
+    spyOn(console, "warn");
     const positions = Cartesian3.fromRadiansArray([
       -1.3194369277314022, 0.6988062530900625, -1.31941, 0.69879,
       -1.3193955980204217, 0.6988091578771254, -1.3193931220959367,
@@ -217,21 +218,32 @@ describe("Scene/ClippingPolygon", function () {
     const result = new Rectangle();
     const returnedValue = polygon.computeRectangle(result);
     expect(returnedValue).toBe(result);
-    expect(result.west).toEqualEpsilon(
-      -1.3194369277314024,
-      CesiumMath.EPSILON10,
-    );
-    expect(result.south).toEqualEpsilon(
-      0.6987436324908647,
-      CesiumMath.EPSILON10,
-    );
-    expect(result.east).toEqualEpsilon(
-      -1.3193931220959367,
-      CesiumMath.EPSILON10,
-    );
-    expect(result.north).toEqualEpsilon(
-      0.6988091578771254,
-      CesiumMath.EPSILON10,
-    );
+    expect(returnedValue).not.toBe(polygon.rectangle);
+    expect(returnedValue).toEqual(polygon.rectangle);
+  });
+
+  it("freezes positions so the geometry is immutable", function () {
+    const positions = Cartesian3.fromRadiansArray([
+      -1.3194369277314022, 0.6988062530900625, -1.31941, 0.69879,
+      -1.3193955980204217, 0.6988091578771254,
+    ]);
+    const hole = Cartesian3.fromRadiansArray([
+      -1.31942, 0.69879, -1.319405, 0.69879, -1.319412, 0.698763,
+    ]);
+    const polygon = new ClippingPolygon({ positions, holes: [hole] });
+
+    expect(Object.isFrozen(polygon.positions)).toBeTrue();
+    expect(Object.isFrozen(polygon.holes)).toBeTrue();
+    expect(Object.isFrozen(polygon.holes[0])).toBeTrue();
+
+    expect(() => {
+      polygon.positions[0].x = 1.0;
+    }).toThrow();
+    expect(() => {
+      polygon.positions.push(new Cartesian3());
+    }).toThrow();
+    expect(() => {
+      polygon.holes[0][0].x = 1.0;
+    }).toThrow();
   });
 });

--- a/packages/engine/Specs/Scene/ClippingPolygonSpec.js
+++ b/packages/engine/Specs/Scene/ClippingPolygonSpec.js
@@ -99,7 +99,7 @@ describe("Scene/ClippingPolygon", function () {
     expect(polygon.ellipsoid).toEqual(clonedPolygon.ellipsoid);
 
     const scratchClippingPolygon = new ClippingPolygon({
-      positions: [new Cartesian3(), new Cartesian3(), new Cartesian3()],
+      positions: positions,
     });
     clonedPolygon = ClippingPolygon.clone(polygon, scratchClippingPolygon);
     expect(polygon.positions).toEqual(clonedPolygon.positions);


### PR DESCRIPTION
# Description

Inspired by #13273 (which has drifted significantly in light of the new clipping polygon implementation this PR builds on). This PR makes the positions of `ClippingPolgyons` immutable (which is a breaking change!). The reason: if we can guarantee these positions do not change, we can get rid of dirty checks that occur per-vertex-per-frame. These checks are expensive for large collections (and at the high frequency of 60+ FPS). Instead, users can remove-and-readd (new) polygons. This isn't cheap (requires texture rebakes), but it's at least explicit / easier to detect (and respond to once rather than 60 times a second).

The original PR didn't *quite* land on a consensus of how to implement this. See [my comment here](https://github.com/CesiumGS/cesium/pull/13273#issuecomment-5169624056) on how I've decided to approach it. 


## Issue number and link

Part of #12258

## Testing plan

[This sandcastle](https://ci-builds.cesium.com/cesium/clipping-polygons-performance/Apps/Sandcastle2/index.html?id=clipping-performance-dev) (link is for this branch), is good for testing. It allows you to vary polygon count and polygon vertex count. Try it here and on main and compare the FPS -- it should be a pretty obvious difference. 

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->


#### PR Dependency Tree


* **PR #13623**
  * **PR #13635**
    * **PR #13636**
      * **PR #13637**
        * **PR #13638**
          * **PR #13641**
            * **PR #13647**
              * **PR #13654**
                * **PR #13660**
                  * **PR #13665** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)