### PR TITLE
1.144 package updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "protobufjs": "^8.6.5"
   },
   "devDependencies": {
-    "@ast-grep/cli": "^0.44.0",
+    "@ast-grep/cli": "^0.45.0",
     "@cesium/eslint-config": "^14.0.0",
     "@playwright/test": "^1.59.1",
     "@types/express": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "protobufjs": "^8.6.5"
   },
   "devDependencies": {
-    "@ast-grep/cli": "^0.45.0",
+    "@ast-grep/cli": "^0.44.0",
     "@cesium/eslint-config": "^14.0.0",
     "@playwright/test": "^1.59.1",
     "@types/express": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "mkdirp": "^3.0.1",
     "node-fetch": "^3.2.10",
     "open": "^11.0.0",
-    "prettier": "3.9.4",
+    "prettier": "3.9.6",
     "prismjs": "^1.28.0",
     "rimraf": "^6.0.1",
     "tsd-jsdoc": "^2.5.0",

--- a/packages/sandcastle/package.json
+++ b/packages/sandcastle/package.json
@@ -30,7 +30,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "react-stay-scrolled": "^9.0.0",
+    "react-stay-scrolled": "^10.0.0",
     "react-use": "^17.6.0",
     "react-virtuoso": "^4.14.1",
     "remark-gfm": "^4.0.1",

--- a/packages/sandcastle/package.json
+++ b/packages/sandcastle/package.json
@@ -26,7 +26,7 @@
     "fastest-levenshtein": "^1.0.16",
     "monaco-editor": "^0.52.2",
     "pako": "^3.0.0",
-    "prettier": "3.8.3",
+    "prettier": "3.9.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Depended by | Package | Action 
-- | -- | -- 
`cesium` | `@ast-grep/cli` | Held back, see https://github.com/CesiumGS/cesium/issues/13668
 ^ | `jasmine-core` | Held back, see https://github.com/CesiumGS/cesium/issues/11295
 ^ | `jsdoc` | Held back, see https://github.com/CesiumGS/cesium/issues/10455#issuecomment-1359895937
 ^ | `prettier` | - Updated to `3.9.6` (164e6d3)<br/>- Pinned exact version<br/>- Ran `npm run prettier` but no changes
^ | `typescript` | Held back, see https://github.com/CesiumGS/cesium/issues/13666
 `@cesium/engine` | `earcut` | Held back, see https://github.com/CesiumGS/cesium/issues/13603
  ^ | `lerc` | Held back, see https://github.com/CesiumGS/cesium/issues/11034
`sandcastle` | `monaco-editor` | Held back, see https://github.com/CesiumGS/cesium-sandcastle/issues/8
 ^ | `prettier` | - Updated to `3.9.6` (164e6d3)<br/>- Pinned exact version<br/>- Ran `npm run prettier` but no changes
^ | `@stratakit/icons` | Held back, see https://github.com/CesiumGS/cesium-sandcastle/issues/7
^ | `vite` | Held back, see https://github.com/CesiumGS/cesium/issues/13605
^ | `typescript` | Held back, see https://github.com/CesiumGS/cesium/issues/13666
^ | `react-stay-scrolled` | Updated to `10.0.0` (ebc49dd)

## Issue number and link

N/A

## Testing plan

CI should pass

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

AI not used