### PR TITLE
Fix draped polyline width being 2x too large, and antialias line edges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.145 - 2026-09-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixed draped vector polylines rendering at twice their specified width, and antialiased their edges. [#13675](https://github.com/CesiumGS/cesium/pull/13675)
+
 ## 1.144 - 2026-08-01
 
 ### @cesium/engine

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 #### Fixes :wrench:
 
-- Fixed draped vector polylines rendering at twice their specified width, and antialiased their edges. [#13675](https://github.com/CesiumGS/cesium/pull/13675)
+- Fixed draped vector polylines rendering at twice their specified width, and antialiased their edges. Antialiasing can be turned off with `scene.vectorProvider.antialias` if you prefer the extra performance. [#13675](https://github.com/CesiumGS/cesium/pull/13675)
 
 ## 1.144 - 2026-08-01
 

--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -28,10 +28,8 @@ import Rectangle from "./Rectangle.js";
 const GRID_TARGET_SEGMENTS_PER_CELL = 16;
 const GRID_NEIGHBOR_PADDING_SCALE = 0.35;
 
-// Tiles are baked without a camera, but line widths are in screen pixels, so
-// converting between the two needs an assumed tile size. Underestimating is the
-// safe direction: it only widens the clip margin below, keeping a few extra
-// segments that the shader's distance test discards.
+// Tiles are baked without a camera, so screen-pixel widths are converted to tile UV
+// using an assumed tile size. Underestimating only widens the clip margin below.
 const MIN_TILE_SCREEN_PIXELS = 256.0;
 
 const scratchPolyline = new BufferPolyline();
@@ -197,11 +195,8 @@ class VectorPipeline {
       const vertexCount = polyline.vertexCount;
       const vertexOffset = polyline.vertexOffset;
 
-      // Clip to the tile expanded by a margin rather than exactly to [0,1]: a
-      // line whose centerline falls just outside the tile still covers pixels
-      // inside it, out to half its width plus the antialiased edge. The slack
-      // also absorbs floating-point error placing a vertex on the wrong side of
-      // a shared boundary. Widths are bytes, so this never exceeds half a tile.
+      // A line whose centerline lies outside the tile still covers pixels inside it,
+      // out to half its width plus the antialiased edge.
       const margin = Math.max(
         CesiumMath.EPSILON3,
         ((collectionData.widths[i] + 1.0) * 0.5) / MIN_TILE_SCREEN_PIXELS,

--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -28,10 +28,6 @@ import Rectangle from "./Rectangle.js";
 const GRID_TARGET_SEGMENTS_PER_CELL = 16;
 const GRID_NEIGHBOR_PADDING_SCALE = 0.35;
 
-// Tiles are baked without a camera, so screen-pixel widths are converted to tile UV
-// using an assumed tile size. Underestimating only widens the clip margin below.
-const MIN_TILE_SCREEN_PIXELS = 256.0;
-
 const scratchPolyline = new BufferPolyline();
 const scratchPolylineMaterial = new BufferPolylineMaterial();
 const scratchPolygon = new BufferPolygon();
@@ -48,6 +44,8 @@ const scratchSegmentEnd = new Cartesian2();
  * @typedef {object} VectorTileData
  *
  * @property {boolean} show Whether this vector data should be rendered.
+ * @property {number} minimumTileScreenPixels Lower bound on the tile's screen size, in pixels,
+ *   used to convert screen-space line widths into tile UV.
  *
  * Stage 1: Collect vector segments and polygon rings intersecting tile.
  * @property {number[][]} [polylineSegments] Tile-clipped polyline segments as [ax, ay, bx, by] in tile UV space.
@@ -195,11 +193,13 @@ class VectorPipeline {
       const vertexCount = polyline.vertexCount;
       const vertexOffset = polyline.vertexOffset;
 
-      // A line whose centerline lies outside the tile still covers pixels inside it,
-      // out to half its width plus the antialiased edge.
+      // A line whose centerline lies outside the tile still covers pixels inside it.
       const margin = Math.max(
         CesiumMath.EPSILON3,
-        ((collectionData.widths[i] + 1.0) * 0.5) / MIN_TILE_SCREEN_PIXELS,
+        _halfWidthToTileUv(
+          collectionData.widths[i],
+          result.minimumTileScreenPixels,
+        ),
       );
 
       for (let j = 0; j + 1 < vertexCount; j++) {
@@ -263,15 +263,19 @@ class VectorPipeline {
     }
 
     let packedSegmentCount = 0;
-    // Expand each segment's bounding box by the neighbor padding, then assign it
-    // to every grid cell the expanded box overlaps. This includes cells just
-    // outside the segment (so the shader still tests lines near cell borders)
-    // without a per-cell segment-to-rect distance computation. The shader does
-    // the exact distance test, so the slight over-inclusion only costs a few
-    // extra comparisons there.
-    const padding = GRID_NEIGHBOR_PADDING_SCALE / gridSize;
+    // Each segment is assigned to every cell its padded bounding box overlaps, so
+    // the shader also sees lines just outside the cell it samples.
+    const cellPadding = GRID_NEIGHBOR_PADDING_SCALE / gridSize;
+    const widths = _concatByteArrays(result.widths);
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i];
+      const padding = Math.max(
+        cellPadding,
+        _halfWidthToTileUv(
+          widths[segmentPrimitiveIndices[i]],
+          result.minimumTileScreenPixels,
+        ),
+      );
       const minX = Math.max(0.0, Math.min(segment[0], segment[2]) - padding);
       const maxX = Math.min(1.0, Math.max(segment[0], segment[2]) + padding);
       const minY = Math.max(0.0, Math.min(segment[1], segment[3]) - padding);
@@ -730,6 +734,18 @@ class VectorPipeline {
 
 /////////////////////////////////////////////////////////////////////////////
 // INTERNAL METHODS
+
+/**
+ * Converts half of a line's width, plus its antialiased edge, from screen pixels to tile UV.
+ *
+ * @param {number} width Line width in screen pixels.
+ * @param {number} minimumTileScreenPixels Lower bound on the tile's screen size.
+ * @returns {number}
+ * @private
+ */
+function _halfWidthToTileUv(width, minimumTileScreenPixels) {
+  return ((width + 1.0) * 0.5) / minimumTileScreenPixels;
+}
 
 /**
  * Projects a polyline segment (start/end Cartesian2s, x=lng, y=lat, in radians) into the

--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -28,6 +28,12 @@ import Rectangle from "./Rectangle.js";
 const GRID_TARGET_SEGMENTS_PER_CELL = 16;
 const GRID_NEIGHBOR_PADDING_SCALE = 0.35;
 
+// Tiles are baked without a camera, but line widths are in screen pixels, so
+// converting between the two needs an assumed tile size. Underestimating is the
+// safe direction: it only widens the clip margin below, keeping a few extra
+// segments that the shader's distance test discards.
+const MIN_TILE_SCREEN_PIXELS = 256.0;
+
 const scratchPolyline = new BufferPolyline();
 const scratchPolylineMaterial = new BufferPolylineMaterial();
 const scratchPolygon = new BufferPolygon();
@@ -191,6 +197,16 @@ class VectorPipeline {
       const vertexCount = polyline.vertexCount;
       const vertexOffset = polyline.vertexOffset;
 
+      // Clip to the tile expanded by a margin rather than exactly to [0,1]: a
+      // line whose centerline falls just outside the tile still covers pixels
+      // inside it, out to half its width plus the antialiased edge. The slack
+      // also absorbs floating-point error placing a vertex on the wrong side of
+      // a shared boundary. Widths are bytes, so this never exceeds half a tile.
+      const margin = Math.max(
+        CesiumMath.EPSILON3,
+        ((collectionData.widths[i] + 1.0) * 0.5) / MIN_TILE_SCREEN_PIXELS,
+      );
+
       for (let j = 0; j + 1 < vertexCount; j++) {
         const segmentStart = Cartesian2.fromArray(
           // @ts-expect-error https://github.com/CesiumGS/cesium/pull/13302
@@ -208,17 +224,7 @@ class VectorPipeline {
 
         _projectSegmentToTileUv(segmentStart, segmentEnd, rectangle, width);
 
-        // Clip segments to the tile expanded by a small margin instead of exactly to
-        // [0,1], for robustness at the shared tile boundary. The boundary artifacts
-        // observed so far are consistent with floating-point error placing a segment
-        // vertex slightly outside the tile; a segment lying just outside the edge could
-        // also bleed in through its half line-width, though that case is unconfirmed.
-        // The margin is a small fixed fraction of the tile, independent of line width.
-        const clipped = _clipSegmentToTile(
-          segmentStart,
-          segmentEnd,
-          CesiumMath.EPSILON3,
-        );
+        const clipped = _clipSegmentToTile(segmentStart, segmentEnd, margin);
 
         if (clipped) {
           result.polylineSegments.push([

--- a/packages/engine/Source/Core/VectorProvider.js
+++ b/packages/engine/Source/Core/VectorProvider.js
@@ -71,6 +71,8 @@ collectionPackers.set(BufferPolygonCollection, {
  * @property {TilingScheme} tilingScheme
  * @property {boolean} [antialias=true] Whether to fade draped polyline edges over the pixel
  * straddling them. Disabling this is faster but leaves the edges aliased.
+ * @property {number} [minimumTileScreenPixels=256] Lower bound on the screen size, in pixels, of
+ * a tile baked by this provider.
  * @private
  */
 
@@ -91,6 +93,16 @@ class VectorProvider {
      * @default true
      */
     this.antialias = options.antialias ?? true;
+
+    /**
+     * Lower bound on the screen size, in pixels, of a tile baked by this provider. Line widths are
+     * in screen pixels but baking has no camera, so this is what converts them to tile UV. The
+     * surface consuming the tiles is expected to derive it from its own refinement criterion.
+     *
+     * @type {number}
+     * @default 256
+     */
+    this.minimumTileScreenPixels = options.minimumTileScreenPixels ?? 256.0;
 
     /**
      * @type {Set<BufferPrimitiveCollection<BufferPrimitive>>}
@@ -234,7 +246,10 @@ class VectorProvider {
     const tileRectangle = tilingScheme.tileXYToRectangle(x, y, level);
 
     /** @type {VectorTileData} */
-    const result = { show: true };
+    const result = {
+      show: true,
+      minimumTileScreenPixels: this.minimumTileScreenPixels,
+    };
 
     for (const collection of this._collections) {
       const packer = collectionPackers.get(collection.constructor);

--- a/packages/engine/Source/Core/VectorProvider.js
+++ b/packages/engine/Source/Core/VectorProvider.js
@@ -69,6 +69,8 @@ collectionPackers.set(BufferPolygonCollection, {
 /**
  * @typedef {object} VectorProviderConstructorOptions
  * @property {TilingScheme} tilingScheme
+ * @property {boolean} [antialias=true] Whether to fade draped polyline edges over the pixel
+ * straddling them. Disabling this is faster but leaves the edges aliased.
  * @private
  */
 
@@ -80,6 +82,15 @@ class VectorProvider {
   constructor(options) {
     /** @private */
     this._tilingScheme = options.tilingScheme;
+
+    /**
+     * Whether to fade draped polyline edges over the pixel straddling them.
+     * Disabling this is faster but leaves the edges aliased.
+     *
+     * @type {boolean}
+     * @default true
+     */
+    this.antialias = options.antialias ?? true;
 
     /**
      * @type {Set<BufferPrimitiveCollection<BufferPrimitive>>}

--- a/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
@@ -82,6 +82,7 @@ class GlobeSurfaceShader {
  * @property {boolean} [hasExaggeration]
  * @property {boolean} [showUndergroundColor]
  * @property {boolean} [translucent]
+ * @property {boolean} [vectorAntialias]
  * @private
  */
 
@@ -141,6 +142,7 @@ class GlobeSurfaceShaderSet {
     const translucent = options.translucent;
     const vectorData = surfaceTile.vectorData;
     const hasVectorLayer = vectorData?.show;
+    const vectorAntialias = hasVectorLayer && options.vectorAntialias;
 
     let quantization = 0;
     let quantizationDefine = "";
@@ -205,7 +207,8 @@ class GlobeSurfaceShaderSet {
         (+translucent << 31)) >>>
         0) +
       (applyDayNightAlpha ? 0x100000000 : 0) +
-      (hasVectorLayer ? 0x200000000 : 0);
+      (hasVectorLayer ? 0x200000000 : 0) +
+      (vectorAntialias ? 0x400000000 : 0);
 
     let currentClippingShaderState = 0;
     // @ts-expect-error Missing types.
@@ -399,6 +402,9 @@ class GlobeSurfaceShaderSet {
       if (hasVectorLayer) {
         vs.defines.push("HAS_VECTOR_LAYER");
         fs.defines.push("HAS_VECTOR_LAYER");
+        if (vectorAntialias) {
+          fs.defines.push("VECTOR_ANTIALIAS");
+        }
         fs.sources.unshift(VectorCommon); // before GlobeFS.
       }
 

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -384,6 +384,7 @@ class GlobeSurfaceTileProvider {
     // Record regions dirtied by changed collections, re-bake overlapping
     // tiles, and build vector data for new surface tiles.
     const vectorProvider = this._vectorProvider;
+    vectorProvider.minimumTileScreenPixels = minimumTileScreenPixels(this);
     vectorProvider.update();
     this._quadtree.forEachRenderedTile(
       /** @param {QuadtreeTile} tile */
@@ -1323,6 +1324,40 @@ class GlobeSurfaceTileProvider {
       this._onLayerRemoved(layer, index);
     }
   }
+}
+
+const scratchLevelZeroRectangle = new Rectangle();
+
+/**
+ * Estimates the smallest screen size, in pixels, a rendered tile can have. Screen-space error is
+ * the tile's geometric error projected to the screen, so the tile projects to that error scaled by
+ * their ratio in meters, and refinement holds the error above half the maximum.
+ *
+ * @param {GlobeSurfaceTileProvider} tileProvider
+ * @returns {number}
+ * @private
+ */
+function minimumTileScreenPixels(tileProvider) {
+  const geometricError = tileProvider.getLevelMaximumGeometricError(0);
+  if (geometricError <= 0.0) {
+    // No terrain provider yet.
+    return tileProvider._vectorProvider.minimumTileScreenPixels;
+  }
+
+  const tilingScheme = tileProvider.tilingScheme;
+  const rectangle = tilingScheme.tileXYToRectangle(
+    0,
+    0,
+    0,
+    scratchLevelZeroRectangle,
+  );
+  const tileWidth = rectangle.width * tilingScheme.ellipsoid.maximumRadius;
+
+  return (
+    ((tileWidth / geometricError) *
+      tileProvider._quadtree.maximumScreenSpaceError) /
+    2.0
+  );
 }
 
 function sortTileImageryByLayerIndex(a, b) {

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -2312,6 +2312,7 @@ const surfaceShaderSetOptionsScratch = {
   colorToAlpha: undefined,
   hasGeodeticSurfaceNormals: undefined,
   hasExaggeration: undefined,
+  vectorAntialias: undefined,
 };
 
 const defaultUndergroundColor = Color.TRANSPARENT;
@@ -2565,6 +2566,8 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
   surfaceShaderSetOptions.clippedByBoundaries = surfaceTile.clippedByBoundaries;
   surfaceShaderSetOptions.hasGeodeticSurfaceNormals = hasGeodeticSurfaceNormals;
   surfaceShaderSetOptions.hasExaggeration = hasExaggeration;
+  surfaceShaderSetOptions.vectorAntialias =
+    tileProvider.vectorProvider.antialias;
 
   const tileImageryCollection = surfaceTile.imagery;
   let imageryIndex = 0;

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -30,8 +30,7 @@ ivec2 vectorIndexToUv(int index, ivec2 size)
 }
 
 #ifdef VECTOR_ANTIALIAS
-// Half-pixel band around a line's edge over which coverage fades, so a line
-// drifting by a fraction of a pixel does not step a whole one.
+// Half-pixel band across a line's edge over which coverage fades.
 const float vectorCoverageRadius = 0.5;
 #else
 const float vectorCoverageRadius = 0.0;
@@ -71,9 +70,9 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
     ivec2 segmentTextureSize = textureSize(u_vectorSegmentTexture, 0);
     ivec2 primitiveTextureSize = textureSize(u_vectorWidthTexture, 0);
 
-    // Signed distance to the nearest line edge, negative inside the line. The
-    // segments of a polyline overlap at their shared vertices, so the nearest
-    // is composited once instead of each in turn, which would darken joints.
+    // Signed distance to the nearest edge, negative inside the line. Consecutive
+    // segments overlap at their shared vertex, so only the nearest is composited;
+    // compositing each in turn would darken the joints.
     float nearestEdgeDistance = 1.0e30;
     int nearestPrimitiveIndex = -1;
 
@@ -85,8 +84,6 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         int primitiveIndex = int(texelFetch(u_vectorSegmentPrimitiveIndicesTexture, segmentUv, 0).r);
         ivec2 primitiveUv = vectorIndexToUv(primitiveIndex, primitiveTextureSize);
 
-        // Distance is measured from the centerline, so the line reaches half
-        // its width to either side.
         float halfWidth = texelFetch(u_vectorWidthTexture, primitiveUv, 0).r * 255.0 * 0.5;
         float edgeDistance = length(screenFromUv * vectorOffsetToLine(vectorUv, segment)) - halfWidth;
 
@@ -96,9 +93,8 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
             nearestPrimitiveIndex = primitiveIndex;
         }
 
-        // Coverage is already saturated, so no other segment can change the
-        // result. Which segment wins is arbitrary where lines overlap, but the
-        // pixel is fully inside a line either way.
+        // Coverage is saturated; no further segment can raise it. Only the nearest
+        // segment supplies the color, so overlapping translucent lines do not blend.
         if (nearestEdgeDistance <= -vectorCoverageRadius)
         {
             break;

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -63,6 +63,12 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
     ivec2 segmentTextureSize = textureSize(u_vectorSegmentTexture, 0);
     ivec2 primitiveTextureSize = textureSize(u_vectorWidthTexture, 0);
 
+    // Signed distance to the nearest line edge, negative inside the line. The
+    // segments of a polyline overlap at their shared vertices, so the nearest
+    // is composited once instead of each in turn, which would darken joints.
+    float nearestEdgeDistance = 1.0e30;
+    int nearestPrimitiveIndex = -1;
+
     for (int i = indexStart; i < indexEnd; i++)
     {
         ivec2 segmentUv = vectorIndexToUv(i, segmentTextureSize);
@@ -71,16 +77,28 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         int primitiveIndex = int(texelFetch(u_vectorSegmentPrimitiveIndicesTexture, segmentUv, 0).r);
         ivec2 primitiveUv = vectorIndexToUv(primitiveIndex, primitiveTextureSize);
 
-        float lineWidth = texelFetch(u_vectorWidthTexture, primitiveUv, 0).r * 255.0;
+        // Distance is measured from the centerline, so the line reaches half
+        // its width to either side.
+        float halfWidth = texelFetch(u_vectorWidthTexture, primitiveUv, 0).r * 255.0 * 0.5;
+        float edgeDistance = length(screenFromUv * vectorOffsetToLine(vectorUv, segment)) - halfWidth;
 
-        vec2 offsetUv = vectorOffsetToLine(vectorUv, segment);
-        if (length(screenFromUv * offsetUv) < lineWidth)
+        if (edgeDistance < nearestEdgeDistance)
         {
-            // Alpha-composite vector over terrain.
-            vec4 vectorColor = texelFetch(u_vectorColorTexture, primitiveUv, 0);
-            baseColor = vectorColor * vec4(vectorColor.aaa, 1.0) + baseColor * (1.0 - vectorColor.a);
-            break;
+            nearestEdgeDistance = edgeDistance;
+            nearestPrimitiveIndex = primitiveIndex;
         }
+    }
+
+    // Fade over the pixel straddling the edge, so a line drifting by a
+    // fraction of a pixel does not step a whole one.
+    float coverage = 1.0 - smoothstep(-0.5, 0.5, nearestEdgeDistance);
+    if (coverage > 0.0)
+    {
+        // Alpha-composite vector over terrain.
+        ivec2 primitiveUv = vectorIndexToUv(nearestPrimitiveIndex, primitiveTextureSize);
+        vec4 vectorColor = texelFetch(u_vectorColorTexture, primitiveUv, 0);
+        vectorColor.a *= coverage;
+        baseColor = vectorColor * vec4(vectorColor.aaa, 1.0) + baseColor * (1.0 - vectorColor.a);
     }
 
     return baseColor;

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -29,6 +29,14 @@ ivec2 vectorIndexToUv(int index, ivec2 size)
     return ivec2(u, v);
 }
 
+#ifdef VECTOR_ANTIALIAS
+// Half-pixel band around a line's edge over which coverage fades, so a line
+// drifting by a fraction of a pixel does not step a whole one.
+const float vectorCoverageRadius = 0.5;
+#else
+const float vectorCoverageRadius = 0.0;
+#endif
+
 // Drape clamped vector polylines onto the terrain surface. The fragment's
 // tile UV picks a grid cell, then only that cell's line segments (packed in
 // tile-local UV space) are tested for proximity. Within the line width, the
@@ -91,20 +99,22 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
         // Coverage is already saturated, so no other segment can change the
         // result. Which segment wins is arbitrary where lines overlap, but the
         // pixel is fully inside a line either way.
-        if (nearestEdgeDistance <= -0.5)
+        if (nearestEdgeDistance <= -vectorCoverageRadius)
         {
             break;
         }
     }
 
-    if (nearestEdgeDistance > 0.5)
+    if (nearestEdgeDistance > vectorCoverageRadius)
     {
         return baseColor;
     }
 
-    // Fade over the pixel straddling the edge, so a line drifting by a
-    // fraction of a pixel does not step a whole one.
-    float coverage = 1.0 - smoothstep(-0.5, 0.5, nearestEdgeDistance);
+#ifdef VECTOR_ANTIALIAS
+    float coverage = 1.0 - smoothstep(-vectorCoverageRadius, vectorCoverageRadius, nearestEdgeDistance);
+#else
+    float coverage = 1.0;
+#endif
 
     // Alpha-composite vector over terrain.
     ivec2 primitiveUv = vectorIndexToUv(nearestPrimitiveIndex, primitiveTextureSize);

--- a/packages/engine/Source/Shaders/VectorCommon.glsl
+++ b/packages/engine/Source/Shaders/VectorCommon.glsl
@@ -87,21 +87,30 @@ vec4 vectorPolylineRender(vec2 vectorUv, vec4 baseColor)
             nearestEdgeDistance = edgeDistance;
             nearestPrimitiveIndex = primitiveIndex;
         }
+
+        // Coverage is already saturated, so no other segment can change the
+        // result. Which segment wins is arbitrary where lines overlap, but the
+        // pixel is fully inside a line either way.
+        if (nearestEdgeDistance <= -0.5)
+        {
+            break;
+        }
+    }
+
+    if (nearestEdgeDistance > 0.5)
+    {
+        return baseColor;
     }
 
     // Fade over the pixel straddling the edge, so a line drifting by a
     // fraction of a pixel does not step a whole one.
     float coverage = 1.0 - smoothstep(-0.5, 0.5, nearestEdgeDistance);
-    if (coverage > 0.0)
-    {
-        // Alpha-composite vector over terrain.
-        ivec2 primitiveUv = vectorIndexToUv(nearestPrimitiveIndex, primitiveTextureSize);
-        vec4 vectorColor = texelFetch(u_vectorColorTexture, primitiveUv, 0);
-        vectorColor.a *= coverage;
-        baseColor = vectorColor * vec4(vectorColor.aaa, 1.0) + baseColor * (1.0 - vectorColor.a);
-    }
 
-    return baseColor;
+    // Alpha-composite vector over terrain.
+    ivec2 primitiveUv = vectorIndexToUv(nearestPrimitiveIndex, primitiveTextureSize);
+    vec4 vectorColor = texelFetch(u_vectorColorTexture, primitiveUv, 0);
+    vectorColor.a *= coverage;
+    return vectorColor * vec4(vectorColor.aaa, 1.0) + baseColor * (1.0 - vectorColor.a);
 }
 
 // Composites a polygon's fill over baseColor when the pixel is inside it. A

--- a/packages/engine/Specs/Core/VectorProviderSpec.js
+++ b/packages/engine/Specs/Core/VectorProviderSpec.js
@@ -46,9 +46,9 @@ describe("Core/VectorProvider", function () {
   it("returns hidden vector data with no collections", function () {
     const provider = new VectorProvider({ tilingScheme });
     const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
-    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual({
-      show: false,
-    });
+    expect(provider.requestTileData(xy.x, xy.y, level, context).show).toBe(
+      false,
+    );
   });
 
   it("returns packed lookup data for a tile overlapping a polyline", function () {
@@ -104,10 +104,9 @@ describe("Core/VectorProvider", function () {
   });
 
   it("widens the clip margin so a wide line just outside a tile is kept", function () {
-    // Level 4 tile rows are 11.25 degrees tall, so the tile holding lat 40 runs
-    // from 33.75 to 45. The polyline's last segment sits 0.5625 degrees below
-    // that edge, 5% of the tile, and is only kept if the line is wide enough
-    // to reach back into the tile.
+    // The tile holding lat 40 runs from 33.75 to 45, so the polyline's last
+    // segment lies wholly 5% of a tile below its bottom edge.
+    const outsideV = -0.05;
     function minPackedV(width) {
       const collection = new BufferPolylineCollection({
         primitiveCountMax: 1,
@@ -147,8 +146,8 @@ describe("Core/VectorProvider", function () {
       return minV;
     }
 
-    expect(minPackedV(1)).toBeGreaterThan(-0.01);
-    expect(minPackedV(60)).toBeLessThan(-0.04);
+    expect(minPackedV(1)).toBeGreaterThan(outsideV);
+    expect(minPackedV(60)).toBeCloseTo(outsideV, 3);
   });
 
   it("returns hidden vector data for a tile not overlapping any polyline", function () {
@@ -156,9 +155,9 @@ describe("Core/VectorProvider", function () {
     provider.add(createPolylineCollection());
 
     const xy = tilingScheme.positionToTileXY(farPoint, level);
-    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual({
-      show: false,
-    });
+    expect(provider.requestTileData(xy.x, xy.y, level, context).show).toBe(
+      false,
+    );
   });
 
   it("stops returning data after a collection is removed", function () {
@@ -168,9 +167,9 @@ describe("Core/VectorProvider", function () {
     provider.remove(collection);
 
     const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
-    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual({
-      show: false,
-    });
+    expect(provider.requestTileData(xy.x, xy.y, level, context).show).toBe(
+      false,
+    );
   });
 
   it("keeps existing tile data when no dirty regions are recorded", function () {
@@ -374,9 +373,9 @@ describe("Core/VectorProvider", function () {
     provider.add(createPolygonCollection());
 
     const xy = tilingScheme.positionToTileXY(farPoint, level);
-    expect(provider.requestTileData(xy.x, xy.y, level, context)).toEqual({
-      show: false,
-    });
+    expect(provider.requestTileData(xy.x, xy.y, level, context).show).toBe(
+      false,
+    );
   });
 
   it("packs polylines and polygons into a shared primitive index space", function () {

--- a/packages/engine/Specs/Core/VectorProviderSpec.js
+++ b/packages/engine/Specs/Core/VectorProviderSpec.js
@@ -4,6 +4,7 @@ import {
   BufferPolygonCollection,
   BufferPolyline,
   BufferPolylineCollection,
+  BufferPolylineMaterial,
   Cartesian3,
   Cartographic,
   GeographicTilingScheme,
@@ -100,6 +101,54 @@ describe("Core/VectorProvider", function () {
         );
       }
     }
+  });
+
+  it("widens the clip margin so a wide line just outside a tile is kept", function () {
+    // Level 4 tile rows are 11.25 degrees tall, so the tile holding lat 40 runs
+    // from 33.75 to 45. The polyline's last segment sits 0.5625 degrees below
+    // that edge, 5% of the tile, and is only kept if the line is wide enough
+    // to reach back into the tile.
+    function minPackedV(width) {
+      const collection = new BufferPolylineCollection({
+        primitiveCountMax: 1,
+        vertexCountMax: 3,
+        heightReference: HeightReference.CLAMP_TO_TERRAIN,
+      });
+      const positions = new Float64Array(9);
+      Cartesian3.pack(Cartesian3.fromDegrees(-95.0, 40.0), positions, 0);
+      Cartesian3.pack(Cartesian3.fromDegrees(-95.0, 33.1875), positions, 3);
+      Cartesian3.pack(Cartesian3.fromDegrees(-90.0, 33.1875), positions, 6);
+      collection.add(
+        {
+          positions: positions,
+          material: new BufferPolylineMaterial({ width: width }),
+        },
+        new BufferPolyline(),
+      );
+
+      const provider = new VectorProvider({ tilingScheme });
+      provider.add(collection);
+
+      const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
+      const texels = provider.requestTileData(
+        xy.x,
+        xy.y,
+        level,
+        context,
+      ).polylineSegmentTexels;
+
+      // Segments are packed as [ax, ay, bx, by]; fill texels are -1.
+      let minV = Number.POSITIVE_INFINITY;
+      for (let i = 1; i < texels.length; i += 2) {
+        if (texels[i] > -0.5) {
+          minV = Math.min(minV, texels[i]);
+        }
+      }
+      return minV;
+    }
+
+    expect(minPackedV(1)).toBeGreaterThan(-0.01);
+    expect(minPackedV(60)).toBeLessThan(-0.04);
   });
 
   it("returns hidden vector data for a tile not overlapping any polyline", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
<img width="913" height="454" alt="image" src="https://github.com/user-attachments/assets/adb6843d-c18f-4ad9-9e4b-4a937081f79c" />

Two fixes to `vectorPolylineRender` in `VectorCommon.glsl`, the fragment shader
shared by the globe (`GlobeFS.glsl`) and 3D Tiles (`ModelVectorLookupStageFS.glsl`)
draped-vector paths.
### 1. Lines rendered at twice their authored width

`vectorOffsetToLine` returns the perpendicular offset from the segment
**centerline**, but the result was compared against the full `lineWidth`. A line
therefore extended a full width to either side and rendered exactly 2x too fat.

The comparison is now against `halfWidth`. The fix is in the shader rather than
in `VectorPipeline.packPolylineCollectionData` because `widths` is a `Uint8Array`
and halving on the CPU would lose odd widths.

Measured on a black draped polyline against a white globe, camera 20,000 m
straight down, sampling coverage-weighted pixel width at the center column:

| Expected| Before | After |
| --- | --- | --- |
| 3 | 6 | 3 |
| 7 | 14 | 7 |
| 16 | 32 | 16 |
| 31 | 62 | 31 |


### 2. Hard edges caused a 1-pixel staircase

The edges previously used a binary threshold. As the line moved by less than a pixel across the screen, the rendered edge would suddenly snap from one pixel to the next. This was especially noticeable for constant-latitude lines, which appear curved after projection. On a 31 px line, the result looked like small 1 px steps that did not line up with any tile boundary.

The edge now uses `smoothstep` across the pixel that contains the boundary, and the result is applied to the vector alpha. This makes the transition gradual instead of snapping between pixels.

The loop also no longer stops at the first segment that covers the pixel. It now finds the nearest edge and composites only once. Blending every overlapping segment would cause adjacent segments to be blended twice at shared vertices, making the joints of translucent lines appear darker.

After this change, the 31 px line measures between 30.96 px and 31.20 px across all sampled columns, with no visible stair steps.

Update:
Added a `VECTOR_ANTIALIAS` compiler macro, toggled by `VectorProvider#antialias` (defaults to `true`):

```js
scene.vectorProvider.antialias = false;
```

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan
[Sandcastle](https://ci-builds.cesium.com/cesium/DanielZ/fix/vector-polyline/Apps/Sandcastle2/index.html#c=pVVtb+I4EP4rIz6F3awJS697BKi2pT21UjkQV+1+KBUyyQCjOnZkm1AW8d9XTszb3lY66T5EjsfPPBnPPDOhLFfawgfgBvpoaJXBXKsMJrWk3E1qnYmeSPckShoLBeEaNfRA4tp7sG+lLdj79JW0nCTqSS2ErXMFSJS0+GaHuSUlTQxbWONsIdxLrtGgLvBW8zXJxc1qPkcdg9UrhB3swopgxg0+8g3qESWv7nzOhcEQuKSMO9KDxVKGgiQeDAtUiUqPPhWhSVDiQKX4C6HkBS1KxnsU+c3K2hPupcrw3FSRzVdCmEQjyl8cSM7VjXo77A0KTBz5g0wp4VadRbWrd46ZLgOEns84K7flsTdQxheoN2VSDNOYqQKvhQgqjhLOFkLNkLnc9ZVQrmy+ZOWWfb9/eLo7gReYWKVHWhWUomZcWuKCuIFeFeRBC8co15TapQM8t0L4EkLzMoRW8+XkHoLb8vwiYtEfIbjlcwitNmu3q+XyFJ0o4TN0rrFKFiMlNq62/QMq8ALLNWVkqcC+Wkk74G8xXIRQoLb4djT96eu1RFos7RjnqFEmGO+/cn9uZ/3H68Fo+jScPt2Nx9cPf59Waa40BAItEPQg6gBBFy46QB8/1k9UbyzkylApe3+jv4Ti9vLiWmu+CS4rMjgUhmuLhrhssZwnr8G/za4/b3GhEU3wqRlFrBWWOX6ml3p4/FgI0f+jbrfZl3eYW3vmY7UYT9OgMoJr6j04PvXLuEVNXMTvV3bgIcHWkbv2OFPs+O42rDQXe+k90wvs6oc5Ae9TB3WPqaLfva/7NA2ON6sfVO8bL+EZas4MWjf49gJM0ViSfhT9h6pFVSuE8DmKomgfmtKE0nqWLSyRpyQXMZTInGyyjOGTZx9wu2Sjh+nw2914+vR9GIJWQpRYnw6v1DXJVK3ZdJprNXMjZeuHSuxXn1KzzynsSr9aWOsauxF45UL7StW/YqVFwFjDYpYLbtE0ZqvkFS1LjKl3JrLb2Lt0UyqA0t5v/guQCG5Mb1Jzg/Mf+oGT2lW3kVJx5iZUefthgVrwjYMsm1ePlZEx1m0sm7/xskqJGdcnjD8B)
<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):
Github Copilot
<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):
Cluade Opus5
<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
