### PR TITLE
Deps: Update ast-grep to v0.45

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,10 +29,10 @@ jobs:
         run: npm run build
       - name: tsc
         run: npm run tsc
-      - name: sg test
-        run: npm exec --package=@ast-grep/cli --offline -- sg test
-      - name: sg scan
-        run: npm exec --package=@ast-grep/cli --offline -- sg scan --context 3
+      - name: ast-grep test
+        run: npm exec --package=@ast-grep/cli --offline -- ast-grep test
+      - name: ast-grep scan
+        run: npm exec --package=@ast-grep/cli --offline -- ast-grep scan --context 3
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -34,10 +34,10 @@ jobs:
         run: npm run build
       - name: tsc
         run: npm run tsc
-      - name: sg test
-        run: npm exec --package=@ast-grep/cli --offline -- sg test
-      - name: sg scan
-        run: npm exec --package=@ast-grep/cli --offline -- sg scan --context 3
+      - name: ast-grep test
+        run: npm exec --package=@ast-grep/cli --offline -- ast-grep test
+      - name: ast-grep scan
+        run: npm exec --package=@ast-grep/cli --offline -- ast-grep scan --context 3
 
   deploy-archive:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "protobufjs": "^8.6.5"
   },
   "devDependencies": {
-    "@ast-grep/cli": "^0.44.0",
+    "@ast-grep/cli": "^0.45.1",
     "@cesium/eslint-config": "^14.0.0",
     "@playwright/test": "^1.59.1",
     "@types/express": "^5.0.6",
@@ -130,7 +130,7 @@
     "build-docs-watch": "gulp buildDocsWatch",
     "eslint": "eslint \"./**/*.*js\" \"./**/*.*ts*\" \"./**/*.html\" --cache --quiet",
     "tsc": "gulp tsc",
-    "sg-scan": "sg scan --context 3",
+    "sg-scan": "ast-grep scan --context 3",
     "make-zip": "gulp -f gulpfile.makezip.js makeZip",
     "markdownlint": "markdownlint \"**/*.md\"",
     "release": "gulp release",


### PR DESCRIPTION

# Description

Updates ast-grep dependency to v0.45.1, following discussion in #13668.

## Issue number and link

- #13668

## Testing plan

Dependency supports a lint stage, which runs in CI but can be confirmed locally with:

```bash
# check codebase against defined rules
npm run sg-scan

# check rule implementations against defined test cases
npm exec --package=@ast-grep/cli --offline -- sg test
```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13679** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)