### PR TITLE
Make the credit display usable with a keyboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Updated the minimum version of `dompurify` dependency to `3.4.5`, addressing security vulnerability tracked in [CVE-2026-49458](https://github.com/advisories/GHSA-hpcv-96wg-7vj8). [#13646](https://github.com/CesiumGS/cesium/issues/13646)
+- Fixed the "Data attribution" credit link and the credit lightbox not being usable with a keyboard. Both the link and the lightbox close button are now focusable and can be activated with `Enter` or `Space`, the lightbox is exposed as a modal dialog and can be dismissed with `Escape`, and focus is moved into the lightbox when it opens and restored when it closes. [#13670](https://github.com/CesiumGS/cesium/issues/13670)
 
 ## 1.144 - 2026-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.145 - 2026-09-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixed the "Data attribution" credit link and the credit lightbox not being usable with a keyboard. Both the link and the lightbox close button are now focusable and can be activated with `Enter` or `Space`, the lightbox is exposed as a modal dialog and can be dismissed with `Escape`, and focus is moved into the lightbox when it opens and restored when it closes. [#13670](https://github.com/CesiumGS/cesium/issues/13670)
+
 ## 1.144 - 2026-08-01
 
 ### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -464,3 +464,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Stephan Cho](https://github.com/stephan271c)
 - [Sam Pomeroy](https://github.com/SamPomeroy)
 - [zhaochen](https://github.com/cyzhao-dad)
+- [Mhayk Whandson](https://github.com/mhayk)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -465,3 +465,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Sam Pomeroy](https://github.com/SamPomeroy)
 - [zhaochen](https://github.com/cyzhao-dad)
 - [Kanchan Basnet](https://github.com/Kanchanbasnet)
+- [Mhayk Whandson](https://github.com/mhayk)

--- a/packages/engine/Source/Scene/CreditDisplay.js
+++ b/packages/engine/Source/Scene/CreditDisplay.js
@@ -162,6 +162,29 @@ function styleLightboxContainer(that) {
   }
 }
 
+/**
+ * Wraps a callback so that it also runs when a keyboard user activates an element
+ * with <code>Enter</code> or <code>Space</code>. Elements exposed as <code>role="button"</code>
+ * are expected to respond to both keys, which anchors without an <code>href</code> do not do natively.
+ *
+ * @param {Function} callback The function to invoke when the element is activated.
+ * @returns {Function} A <code>keydown</code> handler.
+ *
+ * @private
+ */
+function activateOnKeydown(callback) {
+  return function (event) {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+    // Prevent Space from scrolling the page and stop the event from also
+    // reaching the overlay, which would immediately close the lightbox again.
+    event.preventDefault();
+    event.stopPropagation();
+    callback();
+  };
+}
+
 function appendCss(container) {
   const style = /*css*/ `
 .cesium-credit-lightbox-overlay {
@@ -235,6 +258,12 @@ function appendCss(container) {
 }
 .cesium-credit-expand-link:hover {
   color: ${highlightColor};
+}
+
+.cesium-credit-expand-link:focus-visible,
+.cesium-credit-lightbox-close:focus-visible {
+  outline: 2px solid ${highlightColor};
+  outline-offset: 2px;
 }
 
 .cesium-credit-text {
@@ -312,6 +341,9 @@ function CreditDisplay(container, delimiter, viewport) {
 
   const lightboxCredits = document.createElement("div");
   lightboxCredits.className = "cesium-credit-lightbox";
+  lightboxCredits.setAttribute("role", "dialog");
+  lightboxCredits.setAttribute("aria-modal", "true");
+  lightboxCredits.setAttribute("aria-label", "Data attribution");
   lightbox.appendChild(lightboxCredits);
 
   function hideLightbox(event) {
@@ -322,6 +354,14 @@ function CreditDisplay(container, delimiter, viewport) {
   }
   lightbox.addEventListener("click", hideLightbox, false);
 
+  function hideLightboxOnEscape(event) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      that.hideLightbox();
+    }
+  }
+  lightbox.addEventListener("keydown", hideLightboxOnEscape, false);
+
   const title = document.createElement("div");
   title.className = "cesium-credit-lightbox-title";
   title.textContent = "Data provided by:";
@@ -329,8 +369,12 @@ function CreditDisplay(container, delimiter, viewport) {
 
   const closeButton = document.createElement("a");
   closeButton.onclick = this.hideLightbox.bind(this);
+  closeButton.onkeydown = activateOnKeydown(this.hideLightbox.bind(this));
   closeButton.innerHTML = "&times;";
   closeButton.className = "cesium-credit-lightbox-close";
+  closeButton.setAttribute("role", "button");
+  closeButton.setAttribute("tabindex", "0");
+  closeButton.setAttribute("aria-label", "Close data attribution");
   lightboxCredits.appendChild(closeButton);
 
   const creditList = document.createElement("ul");
@@ -349,7 +393,12 @@ function CreditDisplay(container, delimiter, viewport) {
   const expandLink = document.createElement("a");
   expandLink.className = "cesium-credit-expand-link";
   expandLink.onclick = this.showLightbox.bind(this);
+  expandLink.onkeydown = activateOnKeydown(this.showLightbox.bind(this));
   expandLink.textContent = "Data attribution";
+  expandLink.setAttribute("role", "button");
+  expandLink.setAttribute("tabindex", "0");
+  expandLink.setAttribute("aria-haspopup", "dialog");
+  expandLink.setAttribute("aria-expanded", "false");
   container.appendChild(expandLink);
 
   appendCss(container);
@@ -364,7 +413,9 @@ function CreditDisplay(container, delimiter, viewport) {
   this._creditList = creditList;
   this._lightbox = lightbox;
   this._hideLightbox = hideLightbox;
+  this._hideLightboxOnEscape = hideLightboxOnEscape;
   this._expandLink = expandLink;
+  this._closeButton = closeButton;
   this._expanded = false;
   this._staticCredits = [];
   this._cesiumCredit = cesiumCredit;
@@ -492,6 +543,9 @@ CreditDisplay.prototype.removeStaticCredit = function (credit) {
 CreditDisplay.prototype.showLightbox = function () {
   this._lightbox.style.display = "block";
   this._expanded = true;
+  this._expandLink.setAttribute("aria-expanded", "true");
+  // Move focus into the dialog so keyboard users can reach its contents.
+  this._closeButton.focus();
 };
 
 /**
@@ -500,6 +554,9 @@ CreditDisplay.prototype.showLightbox = function () {
 CreditDisplay.prototype.hideLightbox = function () {
   this._lightbox.style.display = "none";
   this._expanded = false;
+  this._expandLink.setAttribute("aria-expanded", "false");
+  // Restore focus to the element that opened the dialog.
+  this._expandLink.focus();
 };
 
 /**
@@ -581,6 +638,11 @@ CreditDisplay.prototype.endFrame = function () {
  */
 CreditDisplay.prototype.destroy = function () {
   this._lightbox.removeEventListener("click", this._hideLightbox, false);
+  this._lightbox.removeEventListener(
+    "keydown",
+    this._hideLightboxOnEscape,
+    false,
+  );
 
   this.container.removeChild(this._cesiumCreditContainer);
   this.container.removeChild(this._screenContainer);

--- a/packages/engine/Specs/Scene/CreditDisplaySpec.js
+++ b/packages/engine/Specs/Scene/CreditDisplaySpec.js
@@ -87,6 +87,24 @@ describe("Scene/CreditDisplay", function () {
       creditDisplay.beginFrame();
     }
 
+    function keydownEvent(key) {
+      return new KeyboardEvent("keydown", {
+        key: key,
+        bubbles: true,
+        cancelable: true,
+      });
+    }
+
+    // document.activeElement only reports the shadow host, so descend into any
+    // shadow roots to find the element that actually holds focus.
+    function deepActiveElement() {
+      let element = document.activeElement;
+      while (defined(element?.shadowRoot?.activeElement)) {
+        element = element.shadowRoot.activeElement;
+      }
+      return element;
+    }
+
     it("addCreditToNextFrame throws when credit is undefined", function () {
       expect(function () {
         creditDisplay = new CreditDisplay(container);
@@ -610,6 +628,117 @@ describe("Scene/CreditDisplay", function () {
       );
       expect(creditDisplay._currentCesiumCredit).not.toBe(
         creditDisplay2._currentCesiumCredit,
+      );
+    });
+
+    it("exposes the expand link as a focusable button", function () {
+      creditDisplay = new CreditDisplay(container);
+      const expandLink = creditDisplay._expandLink;
+
+      expect(expandLink.getAttribute("role")).toEqual("button");
+      expect(expandLink.getAttribute("tabindex")).toEqual("0");
+      expect(expandLink.getAttribute("aria-haspopup")).toEqual("dialog");
+      expect(expandLink.getAttribute("aria-expanded")).toEqual("false");
+    });
+
+    it("exposes the lightbox as a labelled modal dialog", function () {
+      creditDisplay = new CreditDisplay(container);
+      const lightboxCredits = creditDisplay._lightboxCredits;
+
+      expect(lightboxCredits.getAttribute("role")).toEqual("dialog");
+      expect(lightboxCredits.getAttribute("aria-modal")).toEqual("true");
+      expect(lightboxCredits.getAttribute("aria-label")).toBeDefined();
+    });
+
+    it("exposes the close button as a focusable button", function () {
+      creditDisplay = new CreditDisplay(container);
+      const closeButton = creditDisplay._closeButton;
+
+      expect(closeButton.getAttribute("role")).toEqual("button");
+      expect(closeButton.getAttribute("tabindex")).toEqual("0");
+      expect(closeButton.getAttribute("aria-label")).toBeDefined();
+    });
+
+    it("opens the lightbox when the expand link is activated with the keyboard", function () {
+      creditDisplay = new CreditDisplay(container);
+      const expandLink = creditDisplay._expandLink;
+
+      ["Enter", " "].forEach(function (key) {
+        creditDisplay.hideLightbox();
+        expect(creditDisplay._expanded).toBe(false);
+
+        expandLink.dispatchEvent(keydownEvent(key));
+
+        expect(creditDisplay._expanded).toBe(true);
+        expect(expandLink.getAttribute("aria-expanded")).toEqual("true");
+      });
+
+      creditDisplay.hideLightbox();
+    });
+
+    it("closes the lightbox when the close button is activated with the keyboard", function () {
+      creditDisplay = new CreditDisplay(container);
+      const closeButton = creditDisplay._closeButton;
+
+      ["Enter", " "].forEach(function (key) {
+        creditDisplay.showLightbox();
+        expect(creditDisplay._expanded).toBe(true);
+
+        closeButton.dispatchEvent(keydownEvent(key));
+
+        expect(creditDisplay._expanded).toBe(false);
+        expect(creditDisplay._expandLink.getAttribute("aria-expanded")).toEqual(
+          "false",
+        );
+      });
+    });
+
+    it("closes the lightbox when Escape is pressed", function () {
+      creditDisplay = new CreditDisplay(container);
+      creditDisplay.showLightbox();
+      expect(creditDisplay._expanded).toBe(true);
+
+      creditDisplay._closeButton.dispatchEvent(keydownEvent("Escape"));
+
+      expect(creditDisplay._expanded).toBe(false);
+    });
+
+    it("does not close the lightbox for unrelated keys", function () {
+      creditDisplay = new CreditDisplay(container);
+      creditDisplay.showLightbox();
+
+      creditDisplay._closeButton.dispatchEvent(keydownEvent("a"));
+
+      expect(creditDisplay._expanded).toBe(true);
+
+      creditDisplay.hideLightbox();
+    });
+
+    it("moves focus into the lightbox and restores it when closed", function () {
+      creditDisplay = new CreditDisplay(container);
+
+      creditDisplay._expandLink.focus();
+      expect(deepActiveElement()).toBe(creditDisplay._expandLink);
+
+      creditDisplay.showLightbox();
+      expect(deepActiveElement()).toBe(creditDisplay._closeButton);
+
+      creditDisplay.hideLightbox();
+      expect(deepActiveElement()).toBe(creditDisplay._expandLink);
+    });
+
+    it("removes the escape key listener when destroyed", function () {
+      creditDisplay = new CreditDisplay(container);
+      const lightbox = creditDisplay._lightbox;
+      spyOn(lightbox, "removeEventListener").and.callThrough();
+
+      creditDisplay.destroy();
+      creditDisplay = undefined;
+
+      expect(lightbox.removeEventListener).toHaveBeenCalledWith(
+        "keydown",
+        jasmine.any(Function),
+        false,
       );
     });
   }


### PR DESCRIPTION
Fixes [#13670](https://github.com/CesiumGS/cesium/issues/13670)

## Problem

The "Data attribution" link is created as an `<a>` with an `onclick` handler but no `href`, which means it is not in the tab order and cannot be focused or activated with a keyboard. The lightbox close button (`×`) has the same problem, so even a user who managed to open the lightbox had no keyboard way out of it.

## Changes

`CreditDisplay`:

- The expand link and the close button are exposed as `role="button"` with `tabindex="0"`, so they are reachable with <kbd>Tab</kbd>, and are activated with <kbd>Enter</kbd> or <kbd>Space</kbd> in addition to a click.
- The lightbox is exposed as `role="dialog"` with `aria-modal="true"` and an accessible name, and can be dismissed with <kbd>Esc</kbd>.
- The expand link carries `aria-haspopup="dialog"` and an `aria-expanded` state that tracks whether the lightbox is open.
- Focus moves to the close button when the lightbox opens and returns to the expand link when it closes, so keyboard focus never gets stranded behind the overlay.
- A `:focus-visible` outline was added so the focused control is visible to keyboard users. It uses `:focus-visible` rather than `:focus` so mouse users see no change.

The elements keep their existing tag names and class names, so no styling or DOM-structure expectations change for downstream users.

## Testing

Added specs to `CreditDisplaySpec.js` covering the ARIA attributes, <kbd>Enter</kbd>/<kbd>Space</kbd> activation of both controls, <kbd>Esc</kbd> dismissal, the fact that unrelated keys do nothing, the focus move/restore behavior, and listener cleanup on `destroy`. These run in both the `document.head` and `shadowRoot` variants of the suite.

Without the source change, 18 of the new assertions fail; with it, all 65 `CreditDisplay` specs pass. The `widgets` `Viewer` specs (82) also pass.

To verify manually: open any Sandcastle example, press <kbd>Tab</kbd> until the "Data attribution" link is focused, press <kbd>Enter</kbd>, and confirm the lightbox opens with focus on the close button and that <kbd>Esc</kbd> or <kbd>Enter</kbd> on the close button returns focus to the link.
