### PR TITLE
Preserve the wrap mode of feature ID textures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Updated the minimum version of `dompurify` dependency to `3.4.5`, addressing security vulnerability tracked in [CVE-2026-49458](https://github.com/advisories/GHSA-hpcv-96wg-7vj8). [#13646](https://github.com/CesiumGS/cesium/issues/13646)
+- Fixed feature ID textures ignoring the wrap mode declared by the glTF sampler. Forcing nearest filtering no longer replaces `wrapS` and `wrapT` with `CLAMP_TO_EDGE`. [#11574](https://github.com/CesiumGS/cesium/issues/11574)
 
 ## 1.144 - 2026-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.145 - 2026-09-01
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixed feature ID textures ignoring the wrap mode declared by the glTF sampler. Forcing nearest filtering no longer replaces `wrapS` and `wrapT` with `CLAMP_TO_EDGE`. [#11574](https://github.com/CesiumGS/cesium/issues/11574)
+
 ## 1.144 - 2026-08-01
 
 ### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -464,3 +464,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Stephan Cho](https://github.com/stephan271c)
 - [Sam Pomeroy](https://github.com/SamPomeroy)
 - [zhaochen](https://github.com/cyzhao-dad)
+- [Mhayk Whandson](https://github.com/mhayk)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -465,3 +465,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Sam Pomeroy](https://github.com/SamPomeroy)
 - [zhaochen](https://github.com/cyzhao-dad)
 - [Kanchan Basnet](https://github.com/Kanchanbasnet)
+- [Mhayk Whandson](https://github.com/mhayk)

--- a/packages/engine/Source/Scene/GltfLoader.js
+++ b/packages/engine/Source/Scene/GltfLoader.js
@@ -14,6 +14,8 @@ import PrimitiveType from "../Core/PrimitiveType.js";
 import Quaternion from "../Core/Quaternion.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import Sampler from "../Renderer/Sampler.js";
+import TextureMagnificationFilter from "../Renderer/TextureMagnificationFilter.js";
+import TextureMinificationFilter from "../Renderer/TextureMinificationFilter.js";
 import getAccessorByteStride from "./GltfPipeline/getAccessorByteStride.js";
 import getComponentReader from "./GltfPipeline/getComponentReader.js";
 import numberOfComponentsForType from "./GltfPipeline/numberOfComponentsForType.js";
@@ -1570,7 +1572,41 @@ function loadIndices(
   return indicesPlan;
 }
 
-function loadTexture(loader, textureInfo, frameState, samplerOverride) {
+/**
+ * Filters that feature ID textures must be sampled with, regardless of what the
+ * glTF sampler requests. The wrap modes are intentionally left out so that the
+ * ones authored in the glTF are preserved.
+ *
+ * @private
+ */
+const NEAREST_FILTERS = Object.freeze({
+  minificationFilter: TextureMinificationFilter.NEAREST,
+  magnificationFilter: TextureMagnificationFilter.NEAREST,
+});
+
+/**
+ * Returns a copy of <code>sampler</code> with its minification and magnification
+ * filters replaced. Every other property, in particular the wrap modes declared
+ * by the glTF, is carried over unchanged.
+ *
+ * @param {Sampler} sampler The sampler created from the glTF.
+ * @param {object} filters The <code>minificationFilter</code> and <code>magnificationFilter</code> to apply.
+ * @returns {Sampler} A sampler using the given filters and the original wrap modes.
+ *
+ * @private
+ */
+function overrideSamplerFilters(sampler, filters) {
+  return new Sampler({
+    wrapR: sampler.wrapR,
+    wrapS: sampler.wrapS,
+    wrapT: sampler.wrapT,
+    minificationFilter: filters.minificationFilter,
+    magnificationFilter: filters.magnificationFilter,
+    maximumAnisotropy: sampler.maximumAnisotropy,
+  });
+}
+
+function loadTexture(loader, textureInfo, frameState, filterOverride) {
   const gltf = loader.gltfJson;
   const imageId = GltfLoaderUtil.getImageIdFromTexture({
     gltf: gltf,
@@ -1618,9 +1654,10 @@ function loadTexture(loader, textureInfo, frameState, samplerOverride) {
   // Save this finish callback by the loader index so it can be called
   // in process().
   loader._textureCallbacks[index] = () => {
-    textureReader.texture = textureLoader.texture;
-    if (defined(samplerOverride)) {
-      textureReader.texture.sampler = samplerOverride;
+    const texture = textureLoader.texture;
+    textureReader.texture = texture;
+    if (defined(filterOverride)) {
+      texture.sampler = overrideSamplerFilters(texture.sampler, filterOverride);
     }
   };
 
@@ -2013,7 +2050,7 @@ function loadFeatureIdTexture(
     loader,
     textureInfo,
     frameState,
-    Sampler.NEAREST, // Feature ID textures require nearest sampling
+    NEAREST_FILTERS, // Feature ID textures require nearest sampling
   );
 
   // Though the new channel index is more future-proof, this implementation
@@ -2048,7 +2085,7 @@ function loadFeatureIdTextureLegacy(
     loader,
     textureInfo,
     frameState,
-    Sampler.NEAREST, // Feature ID textures require nearest sampling
+    NEAREST_FILTERS, // Feature ID textures require nearest sampling
   );
 
   featureIdTexture.textureReader.channels = featureIds.channels;

--- a/packages/engine/Source/Scene/GltfLoader.js
+++ b/packages/engine/Source/Scene/GltfLoader.js
@@ -1573,40 +1573,40 @@ function loadIndices(
 }
 
 /**
- * Filters that feature ID textures must be sampled with, regardless of what the
- * glTF sampler requests. The wrap modes are intentionally left out so that the
- * ones authored in the glTF are preserved.
- *
- * @private
- */
-const NEAREST_FILTERS = Object.freeze({
-  minificationFilter: TextureMinificationFilter.NEAREST,
-  magnificationFilter: TextureMagnificationFilter.NEAREST,
-});
-
-/**
  * Returns a copy of <code>sampler</code> with its minification and magnification
- * filters replaced. Every other property, in particular the wrap modes declared
- * by the glTF, is carried over unchanged.
+ * filters replaced. Undefined filters keep the value already on the sampler, and
+ * every other property, in particular the wrap modes declared by the glTF, is
+ * carried over unchanged.
  *
  * @param {Sampler} sampler The sampler created from the glTF.
- * @param {object} filters The <code>minificationFilter</code> and <code>magnificationFilter</code> to apply.
+ * @param {TextureMinificationFilter} [minificationFilter] The minification filter to apply instead of the one on <code>sampler</code>.
+ * @param {TextureMagnificationFilter} [magnificationFilter] The magnification filter to apply instead of the one on <code>sampler</code>.
  * @returns {Sampler} A sampler using the given filters and the original wrap modes.
  *
  * @private
  */
-function overrideSamplerFilters(sampler, filters) {
+function overrideSamplerFilters(
+  sampler,
+  minificationFilter,
+  magnificationFilter,
+) {
   return new Sampler({
     wrapR: sampler.wrapR,
     wrapS: sampler.wrapS,
     wrapT: sampler.wrapT,
-    minificationFilter: filters.minificationFilter,
-    magnificationFilter: filters.magnificationFilter,
+    minificationFilter: minificationFilter ?? sampler.minificationFilter,
+    magnificationFilter: magnificationFilter ?? sampler.magnificationFilter,
     maximumAnisotropy: sampler.maximumAnisotropy,
   });
 }
 
-function loadTexture(loader, textureInfo, frameState, filterOverride) {
+function loadTexture(
+  loader,
+  textureInfo,
+  frameState,
+  minificationFilterOverride,
+  magnificationFilterOverride,
+) {
   const gltf = loader.gltfJson;
   const imageId = GltfLoaderUtil.getImageIdFromTexture({
     gltf: gltf,
@@ -1656,8 +1656,15 @@ function loadTexture(loader, textureInfo, frameState, filterOverride) {
   loader._textureCallbacks[index] = () => {
     const texture = textureLoader.texture;
     textureReader.texture = texture;
-    if (defined(filterOverride)) {
-      texture.sampler = overrideSamplerFilters(texture.sampler, filterOverride);
+    if (
+      defined(minificationFilterOverride) ||
+      defined(magnificationFilterOverride)
+    ) {
+      texture.sampler = overrideSamplerFilters(
+        texture.sampler,
+        minificationFilterOverride,
+        magnificationFilterOverride,
+      );
     }
   };
 
@@ -2050,7 +2057,10 @@ function loadFeatureIdTexture(
     loader,
     textureInfo,
     frameState,
-    NEAREST_FILTERS, // Feature ID textures require nearest sampling
+    // Feature ID textures require nearest sampling. Only the filters are
+    // overridden so the wrap modes declared by the glTF are preserved.
+    TextureMinificationFilter.NEAREST,
+    TextureMagnificationFilter.NEAREST,
   );
 
   // Though the new channel index is more future-proof, this implementation
@@ -2085,7 +2095,10 @@ function loadFeatureIdTextureLegacy(
     loader,
     textureInfo,
     frameState,
-    NEAREST_FILTERS, // Feature ID textures require nearest sampling
+    // Feature ID textures require nearest sampling. Only the filters are
+    // overridden so the wrap modes declared by the glTF are preserved.
+    TextureMinificationFilter.NEAREST,
+    TextureMagnificationFilter.NEAREST,
   );
 
   featureIdTexture.textureReader.channels = featureIds.channels;

--- a/packages/engine/Specs/Scene/GltfLoaderSpec.js
+++ b/packages/engine/Specs/Scene/GltfLoaderSpec.js
@@ -29,7 +29,6 @@ import {
   ResourceCache,
   ResourceLoaderState,
   RuntimeError,
-  Sampler,
   Texture,
   TextureMagnificationFilter,
   TextureMinificationFilter,
@@ -108,6 +107,8 @@ describe(
       "./Data/Models/glTF-2.0/BoomBox/glTF-pbrSpecularGlossiness/BoomBox.gltf";
     const largeFeatureIdTexture =
       "./Data/Models/glTF-2.0/LargeFeatureIdTexture/glTF/LargeFeatureIdTexture.gltf";
+    const featureIdTextureWithTextureTransform =
+      "./Data/Models/glTF-2.0/FeatureIdTextureWithTextureTransform/glTF/FeatureIdTextureWithTextureTransform.gltf";
     const boxArticulations =
       "./Data/Models/glTF-2.0/BoxArticulations/glTF/BoxArticulations.gltf";
     const boxWithPrimitiveOutline =
@@ -384,6 +385,21 @@ describe(
       }
 
       return glbBuffer;
+    }
+
+    // Feature ID textures are always sampled with nearest filtering, but they
+    // keep the wrap modes declared by the glTF. When a glTF omits the sampler,
+    // or omits wrapS/wrapT, the glTF default of REPEAT applies.
+    function expectNearestSamplerWithWrap(texture, wrapS, wrapT) {
+      const sampler = texture.sampler;
+      expect(sampler.wrapS).toBe(wrapS);
+      expect(sampler.wrapT).toBe(wrapT);
+      expect(sampler.minificationFilter).toBe(
+        TextureMinificationFilter.NEAREST,
+      );
+      expect(sampler.magnificationFilter).toBe(
+        TextureMagnificationFilter.NEAREST,
+      );
     }
 
     function getAttribute(attributes, semantic, setIndex) {
@@ -1282,6 +1298,37 @@ describe(
       });
     });
 
+    it("does not override the wrap mode of feature ID textures", function () {
+      return loadGltf(microcosm).then(function (gltfLoader) {
+        const primitive = gltfLoader.components.scene.nodes[0].primitives[0];
+        const { texture } = primitive.featureIds[0].textureReader;
+
+        // microcosm.gltf declares no sampler at all, so the glTF default of
+        // REPEAT applies. Forcing nearest filtering must not clamp the texture.
+        expectNearestSamplerWithWrap(
+          texture,
+          TextureWrap.REPEAT,
+          TextureWrap.REPEAT,
+        );
+      });
+    });
+
+    it("keeps the wrap mode a feature ID texture declares explicitly", function () {
+      return loadGltf(featureIdTextureWithTextureTransform).then(
+        function (gltfLoader) {
+          const primitive = gltfLoader.components.scene.nodes[0].primitives[0];
+          const { texture } = primitive.featureIds[0].textureReader;
+
+          // This glTF asks for CLAMP_TO_EDGE, which must be honored as-is.
+          expectNearestSamplerWithWrap(
+            texture,
+            TextureWrap.CLAMP_TO_EDGE,
+            TextureWrap.CLAMP_TO_EDGE,
+          );
+        },
+      );
+    });
+
     it("loads Microcosm", function () {
       return loadGltf(microcosm).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -1309,8 +1356,10 @@ describe(
         expect(featureIdTexture.textureReader.texCoord).toBe(0);
         expect(featureIdTexture.textureReader.texture.width).toBe(256);
         expect(featureIdTexture.textureReader.texture.height).toBe(256);
-        expect(featureIdTexture.textureReader.texture.sampler).toBe(
-          Sampler.NEAREST,
+        expectNearestSamplerWithWrap(
+          featureIdTexture.textureReader.texture,
+          TextureWrap.REPEAT,
+          TextureWrap.REPEAT,
         );
 
         const classDefinition = structuralMetadata.schema.classes.landCover;
@@ -1374,8 +1423,10 @@ describe(
         expect(featureIdTexture.textureReader.texCoord).toBe(0);
         expect(featureIdTexture.textureReader.texture.width).toBe(256);
         expect(featureIdTexture.textureReader.texture.height).toBe(256);
-        expect(featureIdTexture.textureReader.texture.sampler).toBe(
-          Sampler.NEAREST,
+        expectNearestSamplerWithWrap(
+          featureIdTexture.textureReader.texture,
+          TextureWrap.REPEAT,
+          TextureWrap.REPEAT,
         );
 
         const classDefinition = structuralMetadata.schema.classes.landCover;
@@ -1438,7 +1489,11 @@ describe(
         const texture = featureIdTexture.textureReader.texture;
         expect(texture.width).toBe(1024);
         expect(texture.height).toBe(1024);
-        expect(texture.sampler).toBe(Sampler.NEAREST);
+        expectNearestSamplerWithWrap(
+          texture,
+          TextureWrap.REPEAT,
+          TextureWrap.REPEAT,
+        );
 
         featureIdTexture = primitive.featureIds[1];
         expect(featureIdTexture).toBeInstanceOf(


### PR DESCRIPTION
Fixes [#11574](https://github.com/CesiumGS/cesium/issues/11574)

## Problem

Feature ID textures must be sampled with nearest filtering, so `GltfLoader` passed `Sampler.NEAREST` to `loadTexture` as a `samplerOverride`. That override replaced the texture's sampler wholesale:

```js
textureReader.texture.sampler = samplerOverride;
```

Since `Sampler.NEAREST` also declares `wrapS`/`wrapT` as `CLAMP_TO_EDGE`, the wrap modes authored in the glTF were silently discarded. As @j9liu noted when filing the issue, only the minification and magnification filters should be overridden.

## Verification

The bug still reproduces on `main`. `Specs/Data/Models/glTF-2.0/Microcosm/glTF/microcosm.gltf` declares no `samplers` at all, so per the glTF spec its wrap modes default to `REPEAT` — but the loaded feature ID texture came back with `33071` (`CLAMP_TO_EDGE`) instead of `10497` (`REPEAT`) for both `wrapS` and `wrapT`.

Three existing assertions in `GltfLoaderSpec.js` encoded this behavior as `expect(...texture.sampler).toBe(Sampler.NEAREST)`, which is why it went unnoticed.

## Changes

- `loadTexture`'s last parameter is now a `filterOverride` — an object carrying only `minificationFilter` and `magnificationFilter` — instead of a full `Sampler` that replaces everything.
- `overrideSamplerFilters` builds a new `Sampler` from the glTF-authored one, swapping in the requested filters and preserving `wrapR`/`wrapS`/`wrapT` and `maximumAnisotropy`.
- Both feature ID texture call sites (`EXT_mesh_features` and the legacy `EXT_feature_metadata` path) now pass a frozen `NEAREST_FILTERS` constant, so nearest sampling is still guaranteed.

## Testing

- Updated the three assertions that asserted the buggy sampler identity. They now check wrap and filters explicitly via a shared `expectNearestSamplerWithWrap` helper.
- Added `does not override the wrap mode of feature ID textures`, which pins the `REPEAT` default from a glTF with no sampler.
- Added `keeps the wrap mode a feature ID texture declares explicitly`, using `FeatureIdTextureWithTextureTransform` to confirm an explicit `CLAMP_TO_EDGE` is still honored rather than accidentally forced to `REPEAT`.

No regressions: 1237 `Model` specs and 22 `FeatureId` specs pass, and the `GltfLoader` suite is green.

> Note: my local environment has 3 pre-existing Draco failures in `GltfLoader` (`loads Duck`, `loads BoxMixedCompression`, `models share the same resources`) and 2 in `Model` (`renders pnts with point size style`, `Supports back face culling when there are per-point normals`). I confirmed all five fail identically on an unmodified checkout, so they are unrelated to this change.
