### PR TITLE
Migrate defer usage to native promises

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.145 - 2026-09-01
+
+### @cesium/engine
+
+#### Deprecated :hourglass_flowing_sand:
+
+- Deprecated the private `defer` function. It will be removed in CesiumJS 1.148. Construct a native `Promise` directly instead.
+
 ## 1.144 - 2026-08-01
 
 ### @cesium/engine

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -22,6 +22,7 @@ To some extent, this guide can be summarized as _make new code similar to existi
   - [Type Checking](#type-checking)
   - [Units](#units)
   - [Basic Code Construction](#basic-code-construction)
+    - [Promises](#promises)
   - [Functions](#functions)
     - [`options` Parameters](#options-parameters)
     - [Default Parameter Values](#default-parameter-values)
@@ -239,6 +240,13 @@ Cartesian3.fromDegrees(); // Not Cartesin3.fromAngle()
 ```
 
 ## Basic Code Construction
+
+### Promises
+
+Construct a native `Promise` directly around the asynchronous operation. Do not
+use deferred helpers that expose a separate promise, resolve function, and reject
+function. Keeping the executor and the operation together makes ownership and
+error handling explicit.
 
 - Cesium uses JavaScript's [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) so each module (file) contains
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,6 +94,16 @@ export default [
           message:
             "Avoid Array.push.apply(). Use addAllToArray() for arrays of unknown size, or the spread syntax for arrays that are known to be small",
         },
+        {
+          selector: "ImportSpecifier[imported.name='defer']",
+          message:
+            "defer is deprecated. Construct a Promise directly around the asynchronous operation.",
+        },
+        {
+          selector: "ImportDeclaration[source.value=/defer\\.js$/]",
+          message:
+            "defer is deprecated. Construct a Promise directly around the asynchronous operation.",
+        },
       ],
       // When ES6 class implementations refer to scratch variable instances of
       // the same class, ESLint raises a use-before-define error. At runtime

--- a/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -454,7 +454,7 @@ ArcGISTiledElevationTerrainProvider.prototype.requestTileGeometry = function (
         // Don't reject the promise till the request is actually cancelled
         // Otherwise it will think the request failed, but it didn't.
         try {
-          await request.deferred?.promise;
+          await request.promise;
         } catch {
           // Eat this error
         }

--- a/packages/engine/Source/Core/Request.js
+++ b/packages/engine/Source/Core/Request.js
@@ -116,14 +116,14 @@ function Request(options) {
    */
   this.state = RequestState.UNISSUED;
 
-  /**
-   * The requests's deferred promise.
-   *
-   * @type {object}
-   *
-   * @private
-   */
-  this.deferred = undefined;
+  /** @private */
+  this.promise = undefined;
+
+  /** @private */
+  this.resolve = undefined;
+
+  /** @private */
+  this.reject = undefined;
 
   /**
    * Whether the request was explicitly cancelled.
@@ -168,7 +168,9 @@ Request.prototype.clone = function (result) {
 
   // These get defaulted because the cloned request hasn't been issued
   result.state = RequestState.UNISSUED;
-  result.deferred = undefined;
+  result.promise = undefined;
+  result.resolve = undefined;
+  result.reject = undefined;
   result.cancelled = false;
 
   return result;

--- a/packages/engine/Source/Core/RequestScheduler.js
+++ b/packages/engine/Source/Core/RequestScheduler.js
@@ -1,6 +1,5 @@
 import Uri from "urijs";
 import Check from "./Check.js";
-import defer from "./defer.js";
 import defined from "./defined.js";
 import Event from "./Event.js";
 import Heap from "./Heap.js";
@@ -193,9 +192,12 @@ RequestScheduler.heapHasOpenSlots = function (desiredRequests) {
 function issueRequest(request) {
   if (request.state === RequestState.UNISSUED) {
     request.state = RequestState.ISSUED;
-    request.deferred = defer();
+    request.promise = new Promise(function (resolve, reject) {
+      request.resolve = resolve;
+      request.reject = reject;
+    });
   }
-  return request.deferred.promise;
+  return request.promise;
 }
 
 function getRequestReceivedFunction(request) {
@@ -205,15 +207,17 @@ function getRequestReceivedFunction(request) {
       return;
     }
     // explicitly set to undefined to ensure GC of request response data. See #8843
-    const deferred = request.deferred;
+    const resolve = request.resolve;
 
     --statistics.numberOfActiveRequests;
     --numberOfActiveRequestsByServer[request.serverKey];
     requestCompletedEvent.raiseEvent();
     request.state = RequestState.RECEIVED;
-    request.deferred = undefined;
+    request.promise = undefined;
+    request.resolve = undefined;
+    request.reject = undefined;
 
-    deferred.resolve(results);
+    resolve(results);
   };
 }
 
@@ -229,7 +233,11 @@ function getRequestFailedFunction(request) {
     --numberOfActiveRequestsByServer[request.serverKey];
     requestCompletedEvent.raiseEvent(error);
     request.state = RequestState.FAILED;
-    request.deferred.reject(error);
+    const reject = request.reject;
+    request.promise = undefined;
+    request.resolve = undefined;
+    request.reject = undefined;
+    reject(error);
   };
 }
 
@@ -251,15 +259,18 @@ function cancelRequest(request) {
   const active = request.state === RequestState.ACTIVE;
   request.state = RequestState.CANCELLED;
   ++statistics.numberOfCancelledRequests;
-  // If the request has resolved, request.deferred should now be undefined
+  // If the request has resolved, request.promise should now be undefined
   // If it's in progress, fail the promise immediately and discard it, but ensure the failure is handled so the failure does not bubble up, e.g. by clearForSpecs during tests
-  if (defined(request.deferred)) {
-    const deferred = request.deferred;
-    deferred.promise.catch(() => {
+  if (defined(request.promise)) {
+    const promise = request.promise;
+    const reject = request.reject;
+    promise.catch(() => {
       // noop fallback handler
     });
-    request.deferred = undefined;
-    deferred.reject(new RuntimeError(`Request cancelled: "${request.url}"`));
+    request.promise = undefined;
+    request.resolve = undefined;
+    request.reject = undefined;
+    reject(new RuntimeError(`Request cancelled: "${request.url}"`));
   }
 
   if (active) {

--- a/packages/engine/Source/Core/Resource.js
+++ b/packages/engine/Source/Core/Resource.js
@@ -4,7 +4,6 @@ import Check from "./Check.js";
 import clone from "./clone.js";
 import combine from "./combine.js";
 import Frozen from "./Frozen.js";
-import defer from "./defer.js";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 import getAbsoluteUri from "./getAbsoluteUri.js";
@@ -1019,17 +1018,13 @@ Resource.prototype._fetchImage = function (options) {
       crossOrigin = resource.isCrossOriginUrl;
     }
 
-    const deferred = defer();
-    Resource._Implementations.createImage(
+    return Resource._Implementations.createImage(
       request,
       crossOrigin,
-      deferred,
       flipY,
       skipColorSpaceConversion,
       preferImageBitmap,
     );
-
-    return deferred.promise;
   };
 
   const promise = RequestScheduler.request(request);
@@ -1046,7 +1041,6 @@ Resource.prototype._fetchImage = function (options) {
       if (retry) {
         // Reset request so it can try again
         request.state = RequestState.UNISSUED;
-        request.deferred = undefined;
 
         return resource._fetchImage({
           flipY: flipY,
@@ -1290,21 +1284,22 @@ function fetchJsonp(resource, callbackParameterName, functionName) {
   const url = resource.url;
   request.url = url;
   request.requestFunction = function () {
-    const deferred = defer();
+    return new Promise(function (resolve, reject) {
+      //assign a function with that name in the global scope
+      window[functionName] = function (data) {
+        resolve(data);
 
-    //assign a function with that name in the global scope
-    window[functionName] = function (data) {
-      deferred.resolve(data);
+        try {
+          delete window[functionName];
+        } catch (e) {
+          window[functionName] = undefined;
+        }
+      };
 
-      try {
-        delete window[functionName];
-      } catch (e) {
-        window[functionName] = undefined;
-      }
-    };
-
-    Resource._Implementations.loadAndExecuteScript(url, functionName, deferred);
-    return deferred.promise;
+      Resource._Implementations
+        .loadAndExecuteScript(url, functionName)
+        .catch(reject);
+    });
   };
 
   const promise = RequestScheduler.request(request);
@@ -1321,7 +1316,6 @@ function fetchJsonp(resource, callbackParameterName, functionName) {
       if (retry) {
         // Reset request so it can try again
         request.state = RequestState.UNISSUED;
-        request.deferred = undefined;
 
         return fetchJsonp(resource, callbackParameterName, functionName);
       }
@@ -1368,22 +1362,17 @@ Resource.prototype._makeRequest = function (options) {
     const overrideMimeType = options.overrideMimeType;
     const method = options.method;
     const data = options.data;
-    const deferred = defer();
-    const xhr = Resource._Implementations.loadWithXhr(
+    return Resource._Implementations.loadWithXhr(
       url,
       responseType,
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
+      function (cancelFunction) {
+        request.cancelFunction = cancelFunction;
+      },
     );
-    if (defined(xhr) && defined(xhr.abort)) {
-      request.cancelFunction = function () {
-        xhr.abort();
-      };
-    }
-    return deferred.promise;
   };
 
   const promise = RequestScheduler.request(request);
@@ -1407,7 +1396,6 @@ Resource.prototype._makeRequest = function (options) {
         if (retry) {
           // Reset request so it can try again
           request.state = RequestState.UNISSUED;
-          request.deferred = undefined;
 
           return resource.fetch(options);
         }
@@ -1433,7 +1421,9 @@ function checkAndResetRequest(request) {
   }
 
   request.state = RequestState.UNISSUED;
-  request.deferred = undefined;
+  request.promise = undefined;
+  request.resolve = undefined;
+  request.reject = undefined;
 }
 
 const dataUriRegex = /^data:(.*?)(;base64)?,(.*)$/;
@@ -1908,54 +1898,49 @@ Resource.patch = function (options) {
  */
 Resource._Implementations = {};
 
-Resource._Implementations.loadImageElement = function (
-  url,
-  crossOrigin,
-  deferred,
-) {
-  const image = new Image();
+Resource._Implementations.loadImageElement = function (url, crossOrigin) {
+  return new Promise(function (resolve, reject) {
+    const image = new Image();
 
-  image.onload = function () {
-    // work-around a known issue with Firefox and dimensionless SVG, see:
-    //   - https://github.com/whatwg/html/issues/3510
-    //   - https://bugzilla.mozilla.org/show_bug.cgi?id=700533
-    if (
-      image.naturalWidth === 0 &&
-      image.naturalHeight === 0 &&
-      image.width === 0 &&
-      image.height === 0
-    ) {
-      // these values affect rasterization and will likely mar the content
-      // until Firefox takes a stance on the issue, marred content is better than no content
-      // Chromium uses a more refined heuristic about its choice given nil viewBox, and a better stance and solution is
-      // proposed later in the original issue thread:
-      //   - Chromium behavior: https://github.com/CesiumGS/cesium/issues/9188#issuecomment-704400825
-      //   - Cesium's stance/solve: https://github.com/CesiumGS/cesium/issues/9188#issuecomment-720645777
-      image.width = 300;
-      image.height = 150;
+    image.onload = function () {
+      // work-around a known issue with Firefox and dimensionless SVG, see:
+      //   - https://github.com/whatwg/html/issues/3510
+      //   - https://bugzilla.mozilla.org/show_bug.cgi?id=700533
+      if (
+        image.naturalWidth === 0 &&
+        image.naturalHeight === 0 &&
+        image.width === 0 &&
+        image.height === 0
+      ) {
+        // these values affect rasterization and will likely mar the content
+        // until Firefox takes a stance on the issue, marred content is better than no content
+        // Chromium uses a more refined heuristic about its choice given nil viewBox, and a better stance and solution is
+        // proposed later in the original issue thread:
+        //   - Chromium behavior: https://github.com/CesiumGS/cesium/issues/9188#issuecomment-704400825
+        //   - Cesium's stance/solve: https://github.com/CesiumGS/cesium/issues/9188#issuecomment-720645777
+        image.width = 300;
+        image.height = 150;
+      }
+      resolve(image);
+    };
+
+    image.onerror = reject;
+
+    if (crossOrigin) {
+      if (TrustedServers.contains(url)) {
+        image.crossOrigin = "use-credentials";
+      } else {
+        image.crossOrigin = "";
+      }
     }
-    deferred.resolve(image);
-  };
 
-  image.onerror = function (e) {
-    deferred.reject(e);
-  };
-
-  if (crossOrigin) {
-    if (TrustedServers.contains(url)) {
-      image.crossOrigin = "use-credentials";
-    } else {
-      image.crossOrigin = "";
-    }
-  }
-
-  image.src = url;
+    image.src = url;
+  });
 };
 
 Resource._Implementations.createImage = function (
   request,
   crossOrigin,
-  deferred,
   flipY,
   skipColorSpaceConversion,
   preferImageBitmap,
@@ -1967,43 +1952,32 @@ Resource._Implementations.createImage = function (
   // See:
   //    https://bugzilla.mozilla.org/show_bug.cgi?id=1044102#c38
   //    https://bugs.chromium.org/p/chromium/issues/detail?id=580202#c10
-  Resource.supportsImageBitmapOptions()
-    .then(function (supportsImageBitmap) {
+  return Resource.supportsImageBitmapOptions().then(
+    function (supportsImageBitmap) {
       // We can only use ImageBitmap if we can flip on decode.
       // See: https://github.com/CesiumGS/cesium/pull/7579#issuecomment-466146898
       if (!(supportsImageBitmap && preferImageBitmap)) {
-        Resource._Implementations.loadImageElement(url, crossOrigin, deferred);
-        return;
+        return Resource._Implementations.loadImageElement(url, crossOrigin);
       }
       const responseType = "blob";
       const method = "GET";
-      const xhrDeferred = defer();
-      const xhr = Resource._Implementations.loadWithXhr(
-        url,
-        responseType,
-        method,
-        undefined,
-        headers,
-        xhrDeferred,
-        undefined,
-        undefined,
-        undefined,
-      );
-
-      if (defined(xhr) && defined(xhr.abort)) {
-        request.cancelFunction = function () {
-          xhr.abort();
-        };
-      }
-      return xhrDeferred.promise
+      return Resource._Implementations
+        .loadWithXhr(
+          url,
+          responseType,
+          method,
+          undefined,
+          headers,
+          undefined,
+          function (cancelFunction) {
+            request.cancelFunction = cancelFunction;
+          },
+        )
         .then(function (blob) {
           if (!defined(blob)) {
-            deferred.reject(
-              new RuntimeError(
-                `Successfully retrieved ${url} but it contained no content.`,
-              ),
+            throw new RuntimeError(
+              `Successfully retrieved ${url} but it contained no content.`,
             );
-            return;
           }
 
           return Resource.createImageBitmapFromBlob(blob, {
@@ -2011,14 +1985,9 @@ Resource._Implementations.createImage = function (
             premultiplyAlpha: false,
             skipColorSpaceConversion: skipColorSpaceConversion,
           });
-        })
-        .then(function (image) {
-          deferred.resolve(image);
         });
-    })
-    .catch(function (e) {
-      deferred.reject(e);
-    });
+    },
+  );
 };
 
 /**
@@ -2056,41 +2025,35 @@ function loadWithHttpRequest(
   method,
   data,
   headers,
-  deferred,
   overrideMimeType,
 ) {
   // Note: only the 'json' and 'text' responseTypes transforms the loaded buffer
-  fetch(url, {
+  return fetch(url, {
     method,
     headers,
-  })
-    .then(async (response) => {
+  }).then(
+    async (response) => {
       if (!response.ok) {
         const responseHeaders = {};
         response.headers.forEach((value, key) => {
           responseHeaders[key] = value;
         });
-        deferred.reject(
-          new RequestErrorEvent(response.status, response, responseHeaders),
-        );
-        return;
+        throw new RequestErrorEvent(response.status, response, responseHeaders);
       }
 
       switch (responseType) {
         case "text":
-          deferred.resolve(response.text());
-          break;
+          return response.text();
         case "json":
-          deferred.resolve(response.json());
-          break;
+          return response.json();
         default:
-          deferred.resolve(new Uint8Array(await response.arrayBuffer()).buffer);
-          break;
+          return new Uint8Array(await response.arrayBuffer()).buffer;
       }
-    })
-    .catch(() => {
-      deferred.reject(new RequestErrorEvent());
-    });
+    },
+    function () {
+      throw new RequestErrorEvent();
+    },
+  );
 }
 
 const noXMLHttpRequest = typeof XMLHttpRequest === "undefined";
@@ -2100,145 +2063,140 @@ Resource._Implementations.loadWithXhr = function (
   method,
   data,
   headers,
-  deferred,
   overrideMimeType,
+  registerCancelFunction,
 ) {
   const dataUriRegexResult = dataUriRegex.exec(url);
   if (dataUriRegexResult !== null) {
-    deferred.resolve(decodeDataUri(dataUriRegexResult, responseType));
-    return;
+    return Promise.resolve(decodeDataUri(dataUriRegexResult, responseType));
   }
 
   if (noXMLHttpRequest) {
-    loadWithHttpRequest(
+    return loadWithHttpRequest(
       url,
       responseType,
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     );
-    return;
   }
 
-  const xhr = new XMLHttpRequest();
+  return new Promise(function (resolve, reject) {
+    const xhr = new XMLHttpRequest();
 
-  if (TrustedServers.contains(url)) {
-    xhr.withCredentials = true;
-  }
-
-  xhr.open(method, url, true);
-
-  if (defined(overrideMimeType) && defined(xhr.overrideMimeType)) {
-    xhr.overrideMimeType(overrideMimeType);
-  }
-
-  if (defined(headers)) {
-    for (const key in headers) {
-      if (headers.hasOwnProperty(key)) {
-        xhr.setRequestHeader(key, headers[key]);
-      }
-    }
-  }
-
-  if (defined(responseType)) {
-    xhr.responseType = responseType;
-  }
-
-  // While non-standard, file protocol always returns a status of 0 on success
-  let localFile = false;
-  if (typeof url === "string") {
-    localFile =
-      url.indexOf("file://") === 0 ||
-      (typeof window !== "undefined" && window.location.origin === "file://");
-  }
-
-  xhr.onload = function () {
-    if (
-      (xhr.status < 200 || xhr.status >= 300) &&
-      !(localFile && xhr.status === 0)
-    ) {
-      deferred.reject(
-        new RequestErrorEvent(
-          xhr.status,
-          xhr.response,
-          xhr.getAllResponseHeaders(),
-        ),
-      );
-      return;
-    }
-
-    const response = xhr.response;
-    const browserResponseType = xhr.responseType;
-
-    if (method === "HEAD" || method === "OPTIONS") {
-      const responseHeaderString = xhr.getAllResponseHeaders();
-      const splitHeaders = responseHeaderString.trim().split(/[\r\n]+/);
-
-      const responseHeaders = {};
-      splitHeaders.forEach(function (line) {
-        const parts = line.split(": ");
-        const header = parts.shift();
-        responseHeaders[header] = parts.join(": ");
+    if (defined(registerCancelFunction)) {
+      registerCancelFunction(function () {
+        xhr.abort();
       });
-
-      deferred.resolve(responseHeaders);
-      return;
     }
 
-    //All modern browsers will go into either the first or second if block or last else block.
-    //Other code paths support older browsers that either do not support the supplied responseType
-    //or do not support the xhr.response property.
-    if (xhr.status === 204) {
-      // accept no content
-      deferred.resolve(undefined);
-    } else if (
-      defined(response) &&
-      (!defined(responseType) || browserResponseType === responseType)
-    ) {
-      deferred.resolve(response);
-    } else if (responseType === "json" && typeof response === "string") {
-      try {
-        deferred.resolve(JSON.parse(response));
-      } catch (e) {
-        deferred.reject(e);
+    if (TrustedServers.contains(url)) {
+      xhr.withCredentials = true;
+    }
+
+    xhr.open(method, url, true);
+
+    if (defined(overrideMimeType) && defined(xhr.overrideMimeType)) {
+      xhr.overrideMimeType(overrideMimeType);
+    }
+
+    if (defined(headers)) {
+      for (const key in headers) {
+        if (headers.hasOwnProperty(key)) {
+          xhr.setRequestHeader(key, headers[key]);
+        }
       }
-    } else if (
-      (browserResponseType === "" || browserResponseType === "document") &&
-      defined(xhr.responseXML) &&
-      xhr.responseXML.hasChildNodes()
-    ) {
-      deferred.resolve(xhr.responseXML);
-    } else if (
-      (browserResponseType === "" || browserResponseType === "text") &&
-      defined(xhr.responseText)
-    ) {
-      deferred.resolve(xhr.responseText);
-    } else {
-      deferred.reject(
-        new RuntimeError("Invalid XMLHttpRequest response type."),
-      );
     }
-  };
 
-  xhr.onerror = function (e) {
-    deferred.reject(new RequestErrorEvent());
-  };
+    if (defined(responseType)) {
+      xhr.responseType = responseType;
+    }
 
-  xhr.send(data);
+    // While non-standard, file protocol always returns a status of 0 on success
+    let localFile = false;
+    if (typeof url === "string") {
+      localFile =
+        url.indexOf("file://") === 0 ||
+        (typeof window !== "undefined" && window.location.origin === "file://");
+    }
 
-  return xhr;
+    xhr.onload = function () {
+      if (
+        (xhr.status < 200 || xhr.status >= 300) &&
+        !(localFile && xhr.status === 0)
+      ) {
+        reject(
+          new RequestErrorEvent(
+            xhr.status,
+            xhr.response,
+            xhr.getAllResponseHeaders(),
+          ),
+        );
+        return;
+      }
+
+      const response = xhr.response;
+      const browserResponseType = xhr.responseType;
+
+      if (method === "HEAD" || method === "OPTIONS") {
+        const responseHeaderString = xhr.getAllResponseHeaders();
+        const splitHeaders = responseHeaderString.trim().split(/[\r\n]+/);
+
+        const responseHeaders = {};
+        splitHeaders.forEach(function (line) {
+          const parts = line.split(": ");
+          const header = parts.shift();
+          responseHeaders[header] = parts.join(": ");
+        });
+
+        resolve(responseHeaders);
+        return;
+      }
+
+      //All modern browsers will go into either the first or second if block or last else block.
+      //Other code paths support older browsers that either do not support the supplied responseType
+      //or do not support the xhr.response property.
+      if (xhr.status === 204) {
+        // accept no content
+        resolve(undefined);
+      } else if (
+        defined(response) &&
+        (!defined(responseType) || browserResponseType === responseType)
+      ) {
+        resolve(response);
+      } else if (responseType === "json" && typeof response === "string") {
+        try {
+          resolve(JSON.parse(response));
+        } catch (e) {
+          reject(e);
+        }
+      } else if (
+        (browserResponseType === "" || browserResponseType === "document") &&
+        defined(xhr.responseXML) &&
+        xhr.responseXML.hasChildNodes()
+      ) {
+        resolve(xhr.responseXML);
+      } else if (
+        (browserResponseType === "" || browserResponseType === "text") &&
+        defined(xhr.responseText)
+      ) {
+        resolve(xhr.responseText);
+      } else {
+        reject(new RuntimeError("Invalid XMLHttpRequest response type."));
+      }
+    };
+
+    xhr.onerror = function () {
+      reject(new RequestErrorEvent());
+    };
+
+    xhr.send(data);
+  });
 };
 
-Resource._Implementations.loadAndExecuteScript = function (
-  url,
-  functionName,
-  deferred,
-) {
-  return loadAndExecuteScript(url, functionName).catch(function (e) {
-    deferred.reject(e);
-  });
+Resource._Implementations.loadAndExecuteScript = function (url, functionName) {
+  return loadAndExecuteScript(url, functionName);
 };
 
 /**

--- a/packages/engine/Source/Core/defer.js
+++ b/packages/engine/Source/Core/defer.js
@@ -1,3 +1,5 @@
+import deprecationWarning from "./deprecationWarning.js";
+
 /**
  * A function used to resolve a promise upon completion .
  * @callback defer.resolve
@@ -24,9 +26,15 @@
 /**
  * Creates a deferred object, containing a promise object, and functions to resolve or reject the promise.
  * @returns {defer.deferred}
+ * @deprecated `defer` was deprecated in CesiumJS 1.145 and will be removed in 1.148. Construct a Promise directly instead.
  * @private
  */
 function defer() {
+  deprecationWarning(
+    "defer",
+    "defer was deprecated in CesiumJS 1.145 and will be removed in 1.148. Construct a Promise directly instead.",
+  );
+
   let resolve;
   let reject;
   const promise = new Promise(function (res, rej) {

--- a/packages/engine/Source/DataSources/KmlDataSource.js
+++ b/packages/engine/Source/DataSources/KmlDataSource.js
@@ -12,7 +12,6 @@ import Color from "../Core/Color.js";
 import createGuid from "../Core/createGuid.js";
 import Credit from "../Core/Credit.js";
 import Frozen from "../Core/Frozen.js";
-import defer from "../Core/defer.js";
 import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
@@ -194,7 +193,9 @@ const featureTypes = {
 class DeferredLoading {
   constructor(dataSource) {
     this._dataSource = dataSource;
-    this._deferred = defer();
+    this._promise = new Promise((resolve) => {
+      this._resolve = resolve;
+    });
     this._stack = [];
     this._promises = [];
     this._timeoutSet = false;
@@ -223,12 +224,11 @@ class DeferredLoading {
 
   wait() {
     // Case where we had a non-document/folder as the root
-    const deferred = this._deferred;
     if (!this._used) {
-      deferred.resolve();
+      this._resolve();
     }
 
-    return Promise.all([deferred.promise, Promise.all(this._promises)]);
+    return Promise.all([this._promise, Promise.all(this._promises)]);
   }
 
   process() {
@@ -275,7 +275,7 @@ class DeferredLoading {
 
     // Return false if we are done
     if (stack.length === 0) {
-      this._deferred.resolve();
+      this._resolve();
       return false;
     }
 
@@ -319,31 +319,29 @@ class DeferredLoading {
 
 function isZipFile(blob) {
   const magicBlob = blob.slice(0, Math.min(4, blob.size));
-  const deferred = defer();
-  const reader = new FileReader();
-  reader.addEventListener("load", function () {
-    deferred.resolve(
-      new DataView(reader.result).getUint32(0, false) === 0x504b0304,
-    );
+  return new Promise(function (resolve, reject) {
+    const reader = new FileReader();
+    reader.addEventListener("load", function () {
+      resolve(new DataView(reader.result).getUint32(0, false) === 0x504b0304);
+    });
+    reader.addEventListener("error", function () {
+      reject(reader.error);
+    });
+    reader.readAsArrayBuffer(magicBlob);
   });
-  reader.addEventListener("error", function () {
-    deferred.reject(reader.error);
-  });
-  reader.readAsArrayBuffer(magicBlob);
-  return deferred.promise;
 }
 
 function readBlobAsText(blob) {
-  const deferred = defer();
-  const reader = new FileReader();
-  reader.addEventListener("load", function () {
-    deferred.resolve(reader.result);
+  return new Promise(function (resolve, reject) {
+    const reader = new FileReader();
+    reader.addEventListener("load", function () {
+      resolve(reader.result);
+    });
+    reader.addEventListener("error", function () {
+      reject(reader.error);
+    });
+    reader.readAsText(blob);
   });
-  reader.addEventListener("error", function () {
-    deferred.reject(reader.error);
-  });
-  reader.readAsText(blob);
-  return deferred.promise;
 }
 
 function insertNamespaces(text) {

--- a/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
@@ -149,35 +149,27 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       // Tile request
       if (url.indexOf("/tile/") !== -1) {
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           lercTileUrl,
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
-        return;
       }
 
       // Availability request
       if (url.indexOf("/tilemap/") !== -1) {
-        setTimeout(function () {
-          deferred.resolve(JSON.stringify(availability));
-        }, 1);
-        return;
+        return Promise.resolve(JSON.stringify(availability));
       }
 
       // Metadata
-      setTimeout(function () {
-        deferred.resolve(JSON.stringify(metadata));
-      }, 1);
+      return Promise.resolve(JSON.stringify(metadata));
     };
   });
 
@@ -363,13 +355,14 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
       const baseUrl = "made/up/url";
       const deferreds = [];
 
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
+      Resource._Implementations.createImage = function (request, crossOrigin) {
         // Do nothing, so requests never complete
-        deferreds.push(deferred);
+        let resolveRequest;
+        const promise = new Promise(function (resolve) {
+          resolveRequest = resolve;
+        });
+        deferreds.push({ promise: promise, resolve: resolveRequest });
+        return promise;
       };
 
       const terrainProvider =

--- a/packages/engine/Specs/Core/BingMapsGeocoderServiceSpec.js
+++ b/packages/engine/Specs/Core/BingMapsGeocoderServiceSpec.js
@@ -34,13 +34,13 @@ describe("Core/BingMapsGeocoderService", function () {
     Resource._Implementations.loadAndExecuteScript = function (
       url,
       functionName,
-      deferred,
     ) {
       const parsedUrl = new URL(url);
       expect(parsedUrl.searchParams.get("query")).toEqual(query);
       expect(parsedUrl.searchParams.get("key")).toEqual(key);
       expect(parsedUrl.searchParams.get("culture")).toBe(null);
-      deferred.resolve(data);
+      window[functionName](data);
+      return Promise.resolve();
     };
     const service = new BingMapsGeocoderService({ key: key });
     const results = await service.geocode(query);
@@ -67,13 +67,13 @@ describe("Core/BingMapsGeocoderService", function () {
     Resource._Implementations.loadAndExecuteScript = function (
       url,
       functionName,
-      deferred,
     ) {
       const parsedUrl = new URL(url);
       expect(parsedUrl.searchParams.get("query")).toEqual(query);
       expect(parsedUrl.searchParams.get("key")).toEqual(key);
       expect(parsedUrl.searchParams.get("culture")).toEqual("ja");
-      deferred.resolve(data);
+      window[functionName](data);
+      return Promise.resolve();
     };
     const service = new BingMapsGeocoderService({ key: key, culture: "ja" });
     const results = await service.geocode(query);
@@ -90,9 +90,9 @@ describe("Core/BingMapsGeocoderService", function () {
     Resource._Implementations.loadAndExecuteScript = function (
       url,
       functionName,
-      deferred,
     ) {
-      deferred.resolve(data);
+      window[functionName](data);
+      return Promise.resolve();
     };
     const service = new BingMapsGeocoderService({ key: "" });
     const results = await service.geocode(query);
@@ -111,9 +111,9 @@ describe("Core/BingMapsGeocoderService", function () {
     Resource._Implementations.loadAndExecuteScript = function (
       url,
       functionName,
-      deferred,
     ) {
-      deferred.resolve(data);
+      window[functionName](data);
+      return Promise.resolve();
     };
     const service = new BingMapsGeocoderService({ key: "" });
     const results = await service.geocode(query);

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
@@ -161,31 +161,21 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
 
     let req = 0;
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(responseType).toEqual("arraybuffer");
         if (req === 0) {
           expect(url).toEqual(`${baseurl}dbRoot.v5?output=proto`);
-          deferred.reject(); // Reject dbRoot request and use defaults
-        } else {
-          expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
-          Resource._DefaultImplementations.loadWithXhr(
-            "Data/GoogleEarthEnterprise/gee.metadata",
-            responseType,
-            method,
-            data,
-            headers,
-            deferred,
-          );
+          ++req;
+          return Promise.reject(); // Reject dbRoot request and use defaults
         }
-        ++req;
+        expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
+        return Resource._DefaultImplementations.loadWithXhr(
+          "Data/GoogleEarthEnterprise/gee.metadata",
+          responseType,
+          method,
+          data,
+          headers,
+        );
       },
     );
 
@@ -216,31 +206,21 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
 
     let req = 0;
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(responseType).toEqual("arraybuffer");
         if (req === 0) {
           expect(url).toEqual(`${baseurl}dbRoot.v5?output=proto`);
-          deferred.reject(); // Reject dbRoot request and use defaults
-        } else {
-          expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
-          Resource._DefaultImplementations.loadWithXhr(
-            "Data/GoogleEarthEnterprise/gee.metadata",
-            responseType,
-            method,
-            data,
-            headers,
-            deferred,
-          );
+          ++req;
+          return Promise.reject(); // Reject dbRoot request and use defaults
         }
-        ++req;
+        expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
+        return Resource._DefaultImplementations.loadWithXhr(
+          "Data/GoogleEarthEnterprise/gee.metadata",
+          responseType,
+          method,
+          data,
+          headers,
+        );
       },
     );
 

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -209,16 +209,14 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/GoogleEarthEnterprise/gee.terrain",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
       };
 
@@ -235,16 +233,14 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/GoogleEarthEnterprise/gee.terrain",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
       };
 
@@ -274,11 +270,10 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         if (url.indexOf("dbRoot.v5") !== -1) {
-          return deferred.reject(); // Just reject dbRoot file and use defaults.
+          return Promise.reject(); // Just reject dbRoot file and use defaults.
         }
 
         if (loadRealTile) {
@@ -289,11 +284,12 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
             method,
             data,
             headers,
-            deferred,
           );
         }
         // Do nothing, so requests never complete
-        deferreds.push(deferred);
+        return new Promise(function (resolve, reject) {
+          deferreds.push({ resolve: resolve, reject: reject });
+        });
       };
 
       const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(baseUrl);
@@ -354,16 +350,14 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/CesiumTerrainTileJson/tile.terrain",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
       };
 

--- a/packages/engine/Specs/Core/RequestSchedulerSpec.js
+++ b/packages/engine/Specs/Core/RequestSchedulerSpec.js
@@ -1,4 +1,4 @@
-import { defer, Request, RequestScheduler, RequestState } from "../../index.js";
+import { Request, RequestScheduler, RequestState } from "../../index.js";
 
 describe("Core/RequestScheduler", function () {
   let originalMaximumRequests;
@@ -78,9 +78,9 @@ describe("Core/RequestScheduler", function () {
     const deferreds = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     function createRequest() {
@@ -148,9 +148,9 @@ describe("Core/RequestScheduler", function () {
     const deferreds = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     const url = "http://test.invalid/1";
@@ -215,11 +215,14 @@ describe("Core/RequestScheduler", function () {
   });
 
   it("honors priorityHeapLength", function () {
-    const deferred = defer();
+    let resolveRequests;
+    const requestPromise = new Promise(function (resolve) {
+      resolveRequests = resolve;
+    });
     const requests = [];
 
     function requestFunction() {
-      return deferred.promise;
+      return requestPromise;
     }
 
     function createRequest(priority) {
@@ -257,17 +260,20 @@ describe("Core/RequestScheduler", function () {
     RequestScheduler.priorityHeapLength = 2;
     expect(firstRequest.state).toBe(RequestState.CANCELLED);
 
-    deferred.resolve();
+    resolveRequests();
     RequestScheduler.update();
     return Promise.all([promise, promise2, promise3, promise4, promise5]);
   });
 
   function testImmediateRequest(url, dataOrBlobUri) {
     const statistics = RequestScheduler.statistics;
-    const deferred = defer();
+    let resolveRequest;
+    const requestPromise = new Promise(function (resolve) {
+      resolveRequest = resolve;
+    });
 
     function requestFunction() {
-      return deferred.promise;
+      return requestPromise;
     }
 
     const request = new Request({
@@ -288,7 +294,7 @@ describe("Core/RequestScheduler", function () {
       ).toBe(1);
     }
 
-    deferred.resolve();
+    resolveRequest();
 
     return promise.then(function () {
       expect(request.state).toBe(RequestState.RECEIVED);
@@ -325,9 +331,9 @@ describe("Core/RequestScheduler", function () {
     const deferreds = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     const request = new Request({
@@ -387,7 +393,7 @@ describe("Core/RequestScheduler", function () {
     const cancelFunction = jasmine.createSpy("cancelFunction");
 
     function requestFunction() {
-      return defer().promise;
+      return new Promise(function () {});
     }
 
     const request = new Request({
@@ -429,15 +435,18 @@ describe("Core/RequestScheduler", function () {
       event.preventDefault();
     };
 
-    let deferred;
+    let rejectRequest;
+    let requestPromise;
     let cancelled = false;
     const request = new Request({
       throttle: true,
       url: "https://test.invalid/1",
       requestFunction: function () {
         // Simulate a request failing
-        deferred = defer();
-        return deferred.promise;
+        requestPromise = new Promise(function (resolve, reject) {
+          rejectRequest = reject;
+        });
+        return requestPromise;
       },
       cancelFunction: function () {
         cancelled = true;
@@ -450,9 +459,9 @@ describe("Core/RequestScheduler", function () {
     request.cancel();
     RequestScheduler.update();
 
-    deferred.reject("fail request");
+    rejectRequest("fail request");
 
-    await expectAsync(deferred.promise).toBeRejected();
+    await expectAsync(requestPromise).toBeRejected();
 
     expect(cancelled).toBeTrue();
     expect(unhandledRejection).toBeFalse();
@@ -464,9 +473,9 @@ describe("Core/RequestScheduler", function () {
     const deferreds = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     const request = new Request({
@@ -636,9 +645,9 @@ describe("Core/RequestScheduler", function () {
     const deferreds = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     function createRequest(throttle) {
@@ -662,7 +671,7 @@ describe("Core/RequestScheduler", function () {
 
     // Resolve one of the unthrottled requests
     deferreds[0].resolve();
-    return deferreds[0].promise.then(function () {
+    return promises[1].then(function () {
       RequestScheduler.update();
       expect(throttledRequest.state).toBe(RequestState.ACTIVE);
 
@@ -681,9 +690,9 @@ describe("Core/RequestScheduler", function () {
     const promises = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     function createRequest(throttleByServer) {
@@ -781,9 +790,9 @@ describe("Core/RequestScheduler", function () {
     const promises = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     function createRequest() {
@@ -804,42 +813,43 @@ describe("Core/RequestScheduler", function () {
     requests[1].cancel();
     requests[2].cancel();
 
-    return Promise.all(
-      requests.map(function (request) {
-        return request.deferred;
-      }),
-    ).finally(function () {
-      RequestScheduler.update();
+    return promises[0]
+      .catch(function () {})
+      .finally(function () {
+        RequestScheduler.update();
 
-      expect(console.log).toHaveBeenCalledWith(
-        "Number of attempted requests: 3",
-      );
-      expect(console.log).toHaveBeenCalledWith(
-        "Number of cancelled requests: 3",
-      );
-      expect(console.log).toHaveBeenCalledWith(
-        "Number of cancelled active requests: 2",
-      );
-      expect(console.log).toHaveBeenCalledWith("Number of failed requests: 1");
+        expect(console.log).toHaveBeenCalledWith(
+          "Number of attempted requests: 3",
+        );
+        expect(console.log).toHaveBeenCalledWith(
+          "Number of cancelled requests: 3",
+        );
+        expect(console.log).toHaveBeenCalledWith(
+          "Number of cancelled active requests: 2",
+        );
+        expect(console.log).toHaveBeenCalledWith(
+          "Number of failed requests: 1",
+        );
 
-      RequestScheduler.debugShowStatistics = false;
+        RequestScheduler.debugShowStatistics = false;
 
-      const length = deferreds.length;
-      for (let i = 0; i < length; ++i) {
-        deferreds[i].resolve();
-      }
-      return Promise.all(promises).catch(function (e) {
-        // Ignore the canceled and rejected failures
+        const length = deferreds.length;
+        for (let i = 0; i < length; ++i) {
+          deferreds[i].resolve();
+        }
+        return Promise.all(promises).catch(function (e) {
+          // Ignore the canceled and rejected failures
+        });
       });
-    });
   });
 
   it("successful request causes requestCompletedEvent to be raised", function () {
-    let deferred;
+    let resolveRequest;
 
     function requestFunction() {
-      deferred = defer();
-      return deferred.promise;
+      return new Promise(function (resolve) {
+        resolveRequest = resolve;
+      });
     }
 
     const request = new Request({
@@ -856,7 +866,7 @@ describe("Core/RequestScheduler", function () {
         eventRaised = true;
       });
 
-    deferred.resolve();
+    resolveRequest();
 
     return promise
       .then(function () {
@@ -868,11 +878,12 @@ describe("Core/RequestScheduler", function () {
   });
 
   it("successful data request causes requestCompletedEvent to be raised", function () {
-    let deferred;
+    let resolveRequest;
 
     function requestFunction() {
-      deferred = defer();
-      return deferred.promise;
+      return new Promise(function (resolve) {
+        resolveRequest = resolve;
+      });
     }
 
     const request = new Request({
@@ -889,7 +900,7 @@ describe("Core/RequestScheduler", function () {
     const promise = RequestScheduler.request(request);
     expect(promise).toBeDefined();
 
-    deferred.resolve();
+    resolveRequest();
     RequestScheduler.update();
 
     return promise
@@ -902,11 +913,12 @@ describe("Core/RequestScheduler", function () {
   });
 
   it("successful blob request causes requestCompletedEvent to be raised", function () {
-    let deferred;
+    let resolveRequest;
 
     function requestFunction() {
-      deferred = defer();
-      return deferred.promise;
+      return new Promise(function (resolve) {
+        resolveRequest = resolve;
+      });
     }
 
     const uint8Array = new Uint8Array(4);
@@ -930,7 +942,7 @@ describe("Core/RequestScheduler", function () {
     const promise = RequestScheduler.request(request);
     expect(promise).toBeDefined();
 
-    deferred.resolve();
+    resolveRequest();
     RequestScheduler.update();
 
     return promise
@@ -943,10 +955,11 @@ describe("Core/RequestScheduler", function () {
   });
 
   it("unsuccessful requests raise requestCompletedEvent with error", function () {
-    let deferred;
+    let rejectRequest;
     function requestFunction() {
-      deferred = defer();
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        rejectRequest = reject;
+      });
     }
 
     const request = new Request({
@@ -964,7 +977,7 @@ describe("Core/RequestScheduler", function () {
     const promise = RequestScheduler.request(request);
     expect(promise).toBeDefined();
 
-    deferred.reject({
+    rejectRequest({
       error: "error",
     });
     RequestScheduler.update();
@@ -982,10 +995,11 @@ describe("Core/RequestScheduler", function () {
   });
 
   it("canceled requests do not cause requestCompletedEvent to be raised", function () {
-    let cancelDeferred;
+    let resolveCancelledRequest;
     function requestCancelFunction() {
-      cancelDeferred = defer();
-      return cancelDeferred.promise;
+      return new Promise(function (resolve) {
+        resolveCancelledRequest = resolve;
+      });
     }
 
     const requestToCancel = new Request({
@@ -1002,7 +1016,7 @@ describe("Core/RequestScheduler", function () {
 
     requestToCancel.cancel();
     RequestScheduler.update();
-    cancelDeferred.resolve();
+    resolveCancelledRequest();
     removeListenerCallback();
     return promise
       .then(function () {
@@ -1021,7 +1035,10 @@ describe("Core/RequestScheduler", function () {
 
     RequestScheduler.requestsByServer["test.invalid:80"] = 23;
 
-    const deferred = defer();
+    let resolveRequests;
+    const requestPromise = new Promise(function (resolve) {
+      resolveRequests = resolve;
+    });
     for (let i = 0; i < 23; i++) {
       promise = RequestScheduler.request(
         new Request({
@@ -1029,7 +1046,7 @@ describe("Core/RequestScheduler", function () {
           throttle: true,
           throttleByServer: true,
           requestFunction: function () {
-            return deferred.promise;
+            return requestPromise;
           },
         }),
       );
@@ -1044,13 +1061,13 @@ describe("Core/RequestScheduler", function () {
         throttle: true,
         throttleByServer: true,
         requestFunction: function () {
-          return defer();
+          return new Promise(function () {});
         },
       }),
     );
     expect(promise).toBeUndefined();
 
-    deferred.resolve();
+    resolveRequests();
     return Promise.all(promises);
   });
 
@@ -1059,9 +1076,9 @@ describe("Core/RequestScheduler", function () {
     const promises = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     function createRequest() {
@@ -1095,9 +1112,9 @@ describe("Core/RequestScheduler", function () {
     const promises = [];
 
     function requestFunction() {
-      const deferred = defer();
-      deferreds.push(deferred);
-      return deferred.promise;
+      return new Promise(function (resolve, reject) {
+        deferreds.push({ resolve: resolve, reject: reject });
+      });
     }
 
     function createRequest() {

--- a/packages/engine/Specs/Core/ResourceSpec.js
+++ b/packages/engine/Specs/Core/ResourceSpec.js
@@ -1,7 +1,6 @@
 import Uri from "urijs";
 import {
   DefaultProxy,
-  defer,
   defined,
   queryToObject,
   Request,
@@ -698,15 +697,7 @@ describe("Core/Resource", function () {
     });
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(responseType).toEqual(expectedResponseType);
         expect(method).toEqual("POST");
@@ -714,7 +705,7 @@ describe("Core/Resource", function () {
         expect(headers["X-My-Header"]).toEqual("My-Value");
         expect(headers["X-My-Other-Header"]).toEqual("My-Other-Value");
         expect(overrideMimeType).toBe(expectedMimeType);
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -746,22 +737,14 @@ describe("Core/Resource", function () {
     const expectedMimeType = "application/test-data";
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(responseType).toEqual(expectedResponseType);
         expect(method).toEqual("POST");
         expect(data).toEqual(expectedData);
         expect(headers).toEqual(expectedHeaders);
         expect(overrideMimeType).toBe(expectedMimeType);
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -795,15 +778,7 @@ describe("Core/Resource", function () {
     });
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(responseType).toEqual(expectedResponseType);
         expect(method).toEqual("PUT");
@@ -811,7 +786,7 @@ describe("Core/Resource", function () {
         expect(headers["X-My-Header"]).toEqual("My-Value");
         expect(headers["X-My-Other-Header"]).toEqual("My-Other-Value");
         expect(overrideMimeType).toBe(expectedMimeType);
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -843,22 +818,14 @@ describe("Core/Resource", function () {
     const expectedMimeType = "application/test-data";
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(responseType).toEqual(expectedResponseType);
         expect(method).toEqual("PUT");
         expect(data).toEqual(expectedData);
         expect(headers).toEqual(expectedHeaders);
         expect(overrideMimeType).toBe(expectedMimeType);
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -892,15 +859,7 @@ describe("Core/Resource", function () {
     });
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(responseType).toEqual(expectedResponseType);
         expect(method).toEqual("PATCH");
@@ -908,7 +867,7 @@ describe("Core/Resource", function () {
         expect(headers["X-My-Header"]).toEqual("My-Value");
         expect(headers["X-My-Other-Header"]).toEqual("My-Other-Value");
         expect(overrideMimeType).toBe(expectedMimeType);
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -940,22 +899,14 @@ describe("Core/Resource", function () {
     const expectedMimeType = "application/test-data";
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(responseType).toEqual(expectedResponseType);
         expect(method).toEqual("PATCH");
         expect(data).toEqual(expectedData);
         expect(headers).toEqual(expectedHeaders);
         expect(overrideMimeType).toBe(expectedMimeType);
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -1128,18 +1079,10 @@ describe("Core/Resource", function () {
     };
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(method).toEqual("GET");
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -1164,18 +1107,10 @@ describe("Core/Resource", function () {
     };
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(method).toEqual("DELETE");
-        deferred.resolve(expectedResult);
+        return Promise.resolve(expectedResult);
       },
     );
 
@@ -1228,24 +1163,15 @@ describe("Core/Resource", function () {
     spyOn(window, "XMLHttpRequest").and.returnValue(fakeXHR);
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(method).toEqual("HEAD");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           url,
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       },
@@ -1314,24 +1240,15 @@ describe("Core/Resource", function () {
     spyOn(window, "XMLHttpRequest").and.returnValue(fakeXHR);
 
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(url).toEqual(expectedUrl);
         expect(method).toEqual("OPTIONS");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           url,
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       },
@@ -1607,18 +1524,14 @@ describe("Core/Resource", function () {
 
     it("sets the crossOrigin property for cross-origin images", function () {
       const fakeImage = {};
-      const deferred = defer();
       const imageConstructorSpy = spyOn(window, "Image").and.callFake(
         function () {
-          deferred.resolve();
+          queueMicrotask(function () {
+            fakeImage.onload();
+          });
           return fakeImage;
         },
       );
-
-      // mock image loading so that the promise resolves
-      deferred.promise.then(function () {
-        fakeImage.onload();
-      });
 
       return Resource.fetchImage("http://example.invalid/someImage.png").then(
         function () {
@@ -1630,18 +1543,14 @@ describe("Core/Resource", function () {
 
     it("does not set the crossOrigin property for non-cross-origin images", function () {
       const fakeImage = {};
-      const deferred = defer();
       const imageConstructorSpy = spyOn(window, "Image").and.callFake(
         function () {
-          deferred.resolve();
+          queueMicrotask(function () {
+            fakeImage.onload();
+          });
           return fakeImage;
         },
       );
-
-      // mock image loading so that the promise resolves
-      deferred.promise.then(function () {
-        fakeImage.onload();
-      });
 
       return Resource.fetchImage("./someImage.png").then(function () {
         expect(imageConstructorSpy).toHaveBeenCalled();
@@ -1651,18 +1560,14 @@ describe("Core/Resource", function () {
 
     it("does not set the crossOrigin property for data URIs", function () {
       const fakeImage = {};
-      const deferred = defer();
       const imageConstructorSpy = spyOn(window, "Image").and.callFake(
         function () {
-          deferred.resolve();
+          queueMicrotask(function () {
+            fakeImage.onload();
+          });
           return fakeImage;
         },
       );
-
-      // mock image loading so that the promise resolves
-      deferred.promise.then(function () {
-        fakeImage.onload();
-      });
 
       return Resource.fetchImage(dataUri).then(function () {
         expect(imageConstructorSpy).toHaveBeenCalled();
@@ -1672,23 +1577,20 @@ describe("Core/Resource", function () {
 
     it("resolves the promise when the image loads", function () {
       const fakeImage = {};
-      const deferred = defer();
       spyOn(window, "Image").and.callFake(function () {
-        deferred.resolve();
+        queueMicrotask(function () {
+          // neither callback has fired yet
+          expect(success).toEqual(false);
+          expect(failure).toEqual(false);
+
+          fakeImage.onload();
+        });
         return fakeImage;
       });
 
       let success = false;
       let failure = false;
       let loadedImage;
-
-      deferred.promise.then(function () {
-        // neither callback has fired yet
-        expect(success).toEqual(false);
-        expect(failure).toEqual(false);
-
-        fakeImage.onload();
-      });
 
       const promise = Promise.resolve(Resource.fetchImage(dataUri))
         .then(function (image) {
@@ -1707,24 +1609,21 @@ describe("Core/Resource", function () {
     });
 
     it("rejects the promise when the image errors", function () {
-      const deferred = defer();
       const fakeImage = {};
       spyOn(window, "Image").and.callFake(function () {
-        deferred.resolve();
+        queueMicrotask(function () {
+          // neither callback has fired yet
+          expect(success).toEqual(false);
+          expect(failure).toEqual(false);
+
+          fakeImage.onerror(new Error());
+        });
         return fakeImage;
       });
 
       let success = false;
       let failure = false;
       let loadedImage;
-
-      deferred.promise.then(function () {
-        // neither callback has fired yet
-        expect(success).toEqual(false);
-        expect(failure).toEqual(false);
-
-        fakeImage.onerror(new Error());
-      });
 
       return Resource.fetchImage(dataUri)
         .then(function (image) {
@@ -1747,22 +1646,14 @@ describe("Core/Resource", function () {
         "X-my-header": "my-value",
       };
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
+        function (url, responseType, method, data, headers, overrideMimeType) {
           expect(url).toEqual(expectedUrl);
           expect(headers).toEqual(expectedHeaders);
           expect(responseType).toEqual("blob");
 
           const binary = dataUriToBuffer(dataUri);
 
-          deferred.resolve(new Blob([binary], { type: "image/png" }));
+          return Promise.resolve(new Blob([binary], { type: "image/png" }));
         },
       );
 
@@ -1780,24 +1671,18 @@ describe("Core/Resource", function () {
 
     it("Doesn't call loadWithXhr with blob response type if headers is set but is a data URI", function () {
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
-          deferred.reject("this shouldn't happen");
+        function (url, responseType, method, data, headers, overrideMimeType) {
+          return Promise.reject("this shouldn't happen");
         },
       );
 
-      spyOn(Resource._Implementations, "createImage")
-        .and.callFake(function (url, crossOrigin, deferred) {
-          expect(url).toEqual(dataUri);
-        })
-        .and.callThrough();
+      spyOn(Resource._Implementations, "createImage").and.callFake(function (
+        request,
+        ...args
+      ) {
+        expect(request.url).toEqual(dataUri);
+        return Resource._DefaultImplementations.createImage(request, ...args);
+      });
 
       const testResource = new Resource({
         url: dataUri,
@@ -1815,11 +1700,15 @@ describe("Core/Resource", function () {
 
     describe("retries when Resource has the callback set", function () {
       it("rejects after too many retries", function () {
-        let deferred = defer();
         let fakeImage = {};
+        let attempt = 0;
         spyOn(window, "Image").and.callFake(function () {
-          deferred.resolve();
           fakeImage = {};
+          const image = fakeImage;
+          queueMicrotask(function () {
+            image.onerror(attempt === 1 ? "some error" : undefined);
+          });
+          ++attempt;
           return fakeImage;
         });
 
@@ -1830,17 +1719,6 @@ describe("Core/Resource", function () {
           retryCallback: cb,
           retryAttempts: 1,
         });
-
-        deferred.promise
-          .then(function () {
-            fakeImage.onerror("some error"); // This should retry
-
-            deferred = defer();
-            return deferred.promise;
-          })
-          .then(function () {
-            fakeImage.onerror(); // This fails because we only retry once
-          });
 
         let success = false;
         let failure = false;
@@ -1865,11 +1743,13 @@ describe("Core/Resource", function () {
       });
 
       it("rejects after callback returns false", function () {
-        const deferred = defer();
         let fakeImage = {};
         spyOn(window, "Image").and.callFake(function () {
-          deferred.resolve();
           fakeImage = {};
+          const image = fakeImage;
+          queueMicrotask(function () {
+            image.onerror("some error");
+          });
           return fakeImage;
         });
 
@@ -1879,10 +1759,6 @@ describe("Core/Resource", function () {
           url: "http://example.invalid/image.png",
           retryCallback: cb,
           retryAttempts: 2,
-        });
-
-        deferred.promise.then(function () {
-          fakeImage.onerror("some error"); // This fails because the callback returns false
         });
 
         let success = false;
@@ -1908,11 +1784,19 @@ describe("Core/Resource", function () {
       });
 
       it("resolves after retry", function () {
-        let deferred = defer();
         let fakeImage = {};
+        let attempt = 0;
         spyOn(window, "Image").and.callFake(function () {
-          deferred.resolve();
           fakeImage = {};
+          const image = fakeImage;
+          queueMicrotask(function () {
+            if (attempt === 1) {
+              image.onerror("some error");
+            } else {
+              image.onload();
+            }
+          });
+          ++attempt;
           return fakeImage;
         });
 
@@ -1923,17 +1807,6 @@ describe("Core/Resource", function () {
           retryCallback: cb,
           retryAttempts: 1,
         });
-
-        deferred.promise
-          .then(function () {
-            fakeImage.onerror("some error"); // This should retry
-
-            deferred = defer();
-            return deferred.promise;
-          })
-          .then(function () {
-            fakeImage.onload(); // This succeeds
-          });
 
         let success = false;
         let failure = false;
@@ -1952,7 +1825,6 @@ describe("Core/Resource", function () {
             expect(receivedResource._retryCount).toEqual(1);
             expect(cb.calls.argsFor(0)[1]).toEqual("some error");
 
-            fakeImage.onload();
             expect(success).toBe(true);
             expect(failure).toBe(false);
           });
@@ -2588,11 +2460,13 @@ describe("Core/Resource", function () {
     it("returns a promise that resolves when the request loads", function () {
       const testUrl = "http://example.invalid/testuri";
       spyOn(Resource._Implementations, "loadAndExecuteScript").and.callFake(
-        function (url, name, deferred) {
+        function (url, name) {
           expect(url).toContain(testUrl);
           expect(name).toContain("loadJsonp");
-          expect(deferred).toBeDefined();
-          deferred.resolve();
+          queueMicrotask(function () {
+            window[name]();
+          });
+          return Promise.resolve();
         },
       );
       return Resource.fetchJsonp(testUrl);
@@ -2611,9 +2485,12 @@ describe("Core/Resource", function () {
         callbackParameterName: "testCallback",
       };
       spyOn(Resource._Implementations, "loadAndExecuteScript").and.callFake(
-        function (url, functionName, deferred) {
+        function (url, functionName) {
           expect(url).toContain("callback=loadJsonp");
-          deferred.resolve();
+          queueMicrotask(function () {
+            window[functionName]();
+          });
+          return Promise.resolve();
         },
       );
       return Resource.fetchJsonp(testUrl, options);
@@ -2623,10 +2500,12 @@ describe("Core/Resource", function () {
       it("rejects after too many retries", function () {
         const cb = jasmine.createSpy("retry").and.returnValue(true);
 
-        let lastDeferred;
+        let rejectScript;
         spyOn(Resource._Implementations, "loadAndExecuteScript").and.callFake(
-          function (url, functionName, deferred) {
-            lastDeferred = deferred;
+          function () {
+            return new Promise(function (resolve, reject) {
+              rejectScript = reject;
+            });
           },
         );
 
@@ -2639,12 +2518,12 @@ describe("Core/Resource", function () {
         const promise = resource.fetchJsonp();
         expect(promise).toBeDefined();
 
-        lastDeferred.reject("some error"); // This should retry
-        lastDeferred = undefined;
+        rejectScript("some error"); // This should retry
+        rejectScript = undefined;
         pollToPromise(function () {
-          return defined(lastDeferred);
+          return defined(rejectScript);
         }).then(function () {
-          lastDeferred.reject("another error"); // This fails because we only retry once
+          rejectScript("another error"); // This fails because we only retry once
         });
 
         return promise
@@ -2665,10 +2544,12 @@ describe("Core/Resource", function () {
       it("rejects after callback returns false", function () {
         const cb = jasmine.createSpy("retry").and.returnValue(false);
 
-        let lastDeferred;
+        let rejectScript;
         spyOn(Resource._Implementations, "loadAndExecuteScript").and.callFake(
-          function (url, functionName, deferred) {
-            lastDeferred = deferred;
+          function () {
+            return new Promise(function (resolve, reject) {
+              rejectScript = reject;
+            });
           },
         );
 
@@ -2681,7 +2562,7 @@ describe("Core/Resource", function () {
         const promise = resource.fetchJsonp();
         expect(promise).toBeDefined();
 
-        lastDeferred.reject("some error"); // This fails because the callback returns false
+        rejectScript("some error"); // This fails because the callback returns false
 
         return promise
           .then(function () {
@@ -2700,12 +2581,16 @@ describe("Core/Resource", function () {
       it("resolves after retry", function () {
         const cb = jasmine.createSpy("retry").and.returnValue(true);
 
-        let lastDeferred;
+        let resolveScript;
+        let rejectScript;
         let lastUrl;
         spyOn(Resource._Implementations, "loadAndExecuteScript").and.callFake(
-          function (url, functionName, deferred) {
+          function (url) {
             lastUrl = url;
-            lastDeferred = deferred;
+            return new Promise(function (resolve, reject) {
+              resolveScript = resolve;
+              rejectScript = reject;
+            });
           },
         );
 
@@ -2718,15 +2603,15 @@ describe("Core/Resource", function () {
         const promise = resource.fetchJsonp();
         expect(promise).toBeDefined();
 
-        lastDeferred.reject("some error"); // This should retry
-        lastDeferred = undefined;
+        rejectScript("some error"); // This should retry
+        rejectScript = undefined;
         pollToPromise(function () {
-          return defined(lastDeferred);
+          return defined(rejectScript);
         }).then(function () {
           const uri = new Uri(lastUrl);
           const query = queryToObject(uri.query());
           window[query.callback]("something good");
-          lastDeferred.resolve(); // This should resolve
+          resolveScript();
         });
         return promise.then(function (result) {
           expect(result).toEqual("something good");

--- a/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -20,47 +20,42 @@ describe("Core/VRTheWorldTerrainProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       if (url === imageUrl) {
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           url,
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
-        return;
       }
 
-      setTimeout(function () {
-        const parser = new DOMParser();
-        const xmlString =
-          '<TileMap version="1.0.0" tilemapservice="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/">' +
-          "<!--  Additional data: tms_type is default  -->" +
-          "<Title>Hawaii World elev</Title>" +
-          "<Abstract>layer to make cesium work right</Abstract>" +
-          "<SRS>EPSG:4326</SRS>" +
-          '<BoundingBox minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000"/>' +
-          '<Origin x="-180.000000" y="-90.000000"/>' +
-          '<TileFormat width="32" height="32" mime-type="image/tif" extension="tif"/>' +
-          "<TileSets>" +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/0" units-per-pixel="5.62500000000000000000" order="0"/>' +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/1" units-per-pixel="2.81250000000000000000" order="1"/>' +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/2" units-per-pixel="1.40625000000000000000" order="2"/>' +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/3" units-per-pixel="0.70312500000000000000" order="3"/>' +
-          "</TileSets>" +
-          "<DataExtents>" +
-          '<DataExtent minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000" minlevel="0" maxlevel="9"/>' +
-          '<DataExtent minx="24.999584" miny="-0.000417" maxx="30.000417" maxy="5.000417" minlevel="0" maxlevel="13"/>' +
-          "</DataExtents>" +
-          "</TileMap>";
-        const xml = parser.parseFromString(xmlString, "text/xml");
-        deferred.resolve(xml);
-      }, 1);
+      const parser = new DOMParser();
+      const xmlString =
+        '<TileMap version="1.0.0" tilemapservice="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/">' +
+        "<!--  Additional data: tms_type is default  -->" +
+        "<Title>Hawaii World elev</Title>" +
+        "<Abstract>layer to make cesium work right</Abstract>" +
+        "<SRS>EPSG:4326</SRS>" +
+        '<BoundingBox minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000"/>' +
+        '<Origin x="-180.000000" y="-90.000000"/>' +
+        '<TileFormat width="32" height="32" mime-type="image/tif" extension="tif"/>' +
+        "<TileSets>" +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/0" units-per-pixel="5.62500000000000000000" order="0"/>' +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/1" units-per-pixel="2.81250000000000000000" order="1"/>' +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/2" units-per-pixel="1.40625000000000000000" order="2"/>' +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/3" units-per-pixel="0.70312500000000000000" order="3"/>' +
+        "</TileSets>" +
+        "<DataExtents>" +
+        '<DataExtent minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000" minlevel="0" maxlevel="9"/>' +
+        '<DataExtent minx="24.999584" miny="-0.000417" maxx="30.000417" maxy="5.000417" minlevel="0" maxlevel="13"/>' +
+        "</DataExtents>" +
+        "</TileMap>";
+      const xml = parser.parseFromString(xmlString, "text/xml");
+      return Promise.resolve(xml);
     };
   }
 
@@ -167,34 +162,31 @@ describe("Core/VRTheWorldTerrainProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      setTimeout(function () {
-        const parser = new DOMParser();
-        const xmlString =
-          '<TileMap version="1.0.0" tilemapservice="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/">' +
-          "<!--  Additional data: tms_type is default  -->" +
-          "<Title>Hawaii World elev</Title>" +
-          "<Abstract>layer to make cesium work right</Abstract>" +
-          "<SRS>EPSG:foo</SRS>" +
-          '<BoundingBox minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000"/>' +
-          '<Origin x="-180.000000" y="-90.000000"/>' +
-          '<TileFormat width="32" height="32" mime-type="image/tif" extension="tif"/>' +
-          "<TileSets>" +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/0" units-per-pixel="5.62500000000000000000" order="0"/>' +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/1" units-per-pixel="2.81250000000000000000" order="1"/>' +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/2" units-per-pixel="1.40625000000000000000" order="2"/>' +
-          '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/3" units-per-pixel="0.70312500000000000000" order="3"/>' +
-          "</TileSets>" +
-          "<DataExtents>" +
-          '<DataExtent minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000" minlevel="0" maxlevel="9"/>' +
-          '<DataExtent minx="24.999584" miny="-0.000417" maxx="30.000417" maxy="5.000417" minlevel="0" maxlevel="13"/>' +
-          "</DataExtents>" +
-          "</TileMap>";
-        const xml = parser.parseFromString(xmlString, "text/xml");
-        deferred.resolve(xml);
-      }, 1);
+      const parser = new DOMParser();
+      const xmlString =
+        '<TileMap version="1.0.0" tilemapservice="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/">' +
+        "<!--  Additional data: tms_type is default  -->" +
+        "<Title>Hawaii World elev</Title>" +
+        "<Abstract>layer to make cesium work right</Abstract>" +
+        "<SRS>EPSG:foo</SRS>" +
+        '<BoundingBox minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000"/>' +
+        '<Origin x="-180.000000" y="-90.000000"/>' +
+        '<TileFormat width="32" height="32" mime-type="image/tif" extension="tif"/>' +
+        "<TileSets>" +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/0" units-per-pixel="5.62500000000000000000" order="0"/>' +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/1" units-per-pixel="2.81250000000000000000" order="1"/>' +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/2" units-per-pixel="1.40625000000000000000" order="2"/>' +
+        '<TileSet href="http://www.vr-theworld.com/vr-theworld/tiles/1.0.0/73/3" units-per-pixel="0.70312500000000000000" order="3"/>' +
+        "</TileSets>" +
+        "<DataExtents>" +
+        '<DataExtent minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000" minlevel="0" maxlevel="9"/>' +
+        '<DataExtent minx="24.999584" miny="-0.000417" maxx="30.000417" maxy="5.000417" minlevel="0" maxlevel="13"/>' +
+        "</DataExtents>" +
+        "</TileMap>";
+      const xml = parser.parseFromString(xmlString, "text/xml");
+      return Promise.resolve(xml);
     };
 
     await expectAsync(
@@ -211,20 +203,15 @@ describe("Core/VRTheWorldTerrainProvider", function () {
 
       const baseUrl = "made/up/url";
 
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
+      Resource._Implementations.createImage = function (request, crossOrigin) {
         expect(request.url.indexOf(".tif?cesium=true")).toBeGreaterThanOrEqual(
           0,
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: imageUrl }),
           crossOrigin,
-          deferred,
         );
       };
 

--- a/packages/engine/Specs/Core/sampleTerrainSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainSpec.js
@@ -196,7 +196,6 @@ describe("Core/sampleTerrain", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         // find a key (source path) path in the spec which matches (ends with) the requested url
@@ -227,7 +226,6 @@ describe("Core/sampleTerrain", function () {
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };

--- a/packages/engine/Specs/DataSources/KmlDataSourceSpec.js
+++ b/packages/engine/Specs/DataSources/KmlDataSourceSpec.js
@@ -8,7 +8,6 @@ import {
   Color,
   combine,
   Credit,
-  defer,
   Ellipsoid,
   Event,
   HeadingPitchRange,
@@ -4585,25 +4584,20 @@ describe("DataSources/KmlDataSource", function () {
             </Link>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
     KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(expectedRefreshLinkHref);
     });
   });
@@ -4617,25 +4611,20 @@ describe("DataSources/KmlDataSource", function () {
             </Url>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
     KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(expectedRefreshLinkHref);
     });
   });
@@ -4650,25 +4639,20 @@ describe("DataSources/KmlDataSource", function () {
             </Link>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
     KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(
         `${expectedRefreshLinkHref}?BBOX=-180%2C-90%2C180%2C90`,
       );
@@ -4686,25 +4670,20 @@ describe("DataSources/KmlDataSource", function () {
             </Link>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
     KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(
         `${expectedRefreshLinkHref}?client=Cesium-v1&v=2.2&lang=English`,
       );
@@ -4722,25 +4701,20 @@ describe("DataSources/KmlDataSource", function () {
             </Link>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
     KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(
         `${expectedRefreshLinkHref}?client=Cesium-v1&v=2.2&lang=English`,
       );
@@ -4760,19 +4734,14 @@ describe("DataSources/KmlDataSource", function () {
             </Link>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
@@ -4781,7 +4750,7 @@ describe("DataSources/KmlDataSource", function () {
       Object.assign({ camera: uberCamera, canvas: uberCanvas }, options),
     );
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(
         `${expectedRefreshLinkHref}?BBOX=-180%2C-90%2C180%2C90&CAMERA=0%2C0%2C6378137%2C0%2C0&VIEW=45%2C45%2C512%2C512%2C1`,
       );
@@ -4801,19 +4770,14 @@ describe("DataSources/KmlDataSource", function () {
             </Link>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
@@ -4822,7 +4786,7 @@ describe("DataSources/KmlDataSource", function () {
     src.canvas = uberCanvas;
     src.load(parser.parseFromString(kml, "text/xml"), options);
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(
         `${expectedRefreshLinkHref}?BBOX=-180%2C-90%2C180%2C90&CAMERA=0%2C0%2C6378137%2C0%2C0&VIEW=45%2C45%2C512%2C512%2C1`,
       );
@@ -4841,25 +4805,20 @@ describe("DataSources/KmlDataSource", function () {
             </Link>\
           </NetworkLink>';
 
-    const requestNetworkLink = defer();
+    let resolveRequestNetworkLink;
+    const requestNetworkLink = new Promise((resolve) => {
+      resolveRequestNetworkLink = resolve;
+    });
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        requestNetworkLink.resolve(url);
-        deferred.reject();
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        resolveRequestNetworkLink(url);
+        return Promise.reject();
       },
     );
 
     KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
 
-    return requestNetworkLink.promise.then(function (url) {
+    return requestNetworkLink.then(function (url) {
       expect(url).toEqual(`${expectedRefreshLinkHref}?hq=1&vf=1`);
     });
   });

--- a/packages/engine/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -47,16 +47,8 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
 
   function stubJSONCall(baseUrl, result, withProxy, token) {
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
-        deferred.resolve(JSON.stringify(result));
+      function (url, responseType, method, data, headers, overrideMimeType) {
+        return Promise.resolve(JSON.stringify(result));
       },
     );
   }
@@ -331,28 +323,21 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
     expect(provider.usingPrecachedTiles).toEqual(true);
     expect(provider.hasAlphaChannel).toBeDefined();
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const url = request.url;
       if (/^blob:/.test(url)) {
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
-        );
-      } else {
-        expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
-
-        // Just return any old image.
-        Resource._DefaultImplementations.createImage(
-          new Request({ url: "Data/Images/Red16x16.png" }),
-          crossOrigin,
-          deferred,
         );
       }
+      expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
+
+      // Just return any old image.
+      return Resource._DefaultImplementations.createImage(
+        new Request({ url: "Data/Images/Red16x16.png" }),
+        crossOrigin,
+      );
     };
 
     Resource._Implementations.loadWithXhr = function (
@@ -361,19 +346,17 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
 
       // Just return any old image.
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/Images/Red16x16.png",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -435,32 +418,25 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
     expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
     expect(provider.usingPrecachedTiles).toEqual(true);
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const url = request.url;
       if (/^blob:/.test(url) || supportsImageBitmapOptions) {
         // If ImageBitmap is supported, we expect a loadWithXhr request to fetch it as a blob.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
           true,
           false,
           true,
         );
-      } else {
-        expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
-
-        // Just return any old image.
-        Resource._DefaultImplementations.createImage(
-          new Request({ url: "Data/Images/Red16x16.png" }),
-          crossOrigin,
-          deferred,
-        );
       }
+      expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
+
+      // Just return any old image.
+      return Resource._DefaultImplementations.createImage(
+        new Request({ url: "Data/Images/Red16x16.png" }),
+        crossOrigin,
+      );
     };
 
     Resource._Implementations.loadWithXhr = function (
@@ -469,19 +445,17 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
 
       // Just return any old image.
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/Images/Red16x16.png",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -530,11 +504,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
     expect(provider.usingPrecachedTiles).toEqual(false);
     expect(provider.enablePickFeatures).toBe(true);
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const uri = new Uri(request.url);
       const params = queryToObject(uri.query());
 
@@ -553,10 +523,9 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
       expect(params.size).toEqual("256,256");
 
       // Just return any old image.
-      Resource._DefaultImplementations.createImage(
+      return Resource._DefaultImplementations.createImage(
         new Request({ url: "Data/Images/Red16x16.png" }),
         crossOrigin,
-        deferred,
       );
     };
 
@@ -624,11 +593,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
     expect(provider.enablePickFeatures).toBe(false);
     expect(provider.layers).toEqual("foo,bar");
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const uri = new Uri(request.url);
       const params = queryToObject(uri.query());
 
@@ -649,10 +614,9 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
       expect(params.token).toEqual(token);
 
       // Just return any old image.
-      Resource._DefaultImplementations.createImage(
+      return Resource._DefaultImplementations.createImage(
         new Request({ url: "Data/Images/Red16x16.png" }),
         crossOrigin,
-        deferred,
       );
     };
 
@@ -692,32 +656,25 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
     expect(provider.usingPrecachedTiles).toEqual(true);
     expect(provider.hasAlphaChannel).toBeDefined();
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const url = request.url;
       if (/^blob:/.test(url) || supportsImageBitmapOptions) {
         // If ImageBitmap is supported, we expect a loadWithXhr request to fetch it as a blob.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
           true,
           false,
           true,
         );
-      } else {
-        expect(url).toEqual(expectedTileUrl);
-
-        // Just return any old image.
-        Resource._DefaultImplementations.createImage(
-          new Request({ url: "Data/Images/Red16x16.png" }),
-          crossOrigin,
-          deferred,
-        );
       }
+      expect(url).toEqual(expectedTileUrl);
+
+      // Just return any old image.
+      return Resource._DefaultImplementations.createImage(
+        new Request({ url: "Data/Images/Red16x16.png" }),
+        crossOrigin,
+      );
     };
 
     Resource._Implementations.loadWithXhr = function (
@@ -726,19 +683,17 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       expect(url).toEqual(expectedTileUrl);
 
       // Just return any old image.
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/Images/Red16x16.png",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -1000,17 +955,15 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("identify");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/ArcGIS/identify-WebMercator.json",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1043,17 +996,15 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("identify");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/ArcGIS/identify-Geographic.json",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1116,17 +1067,15 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("identify");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/ArcGIS/identify-WebMercator.json",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1143,20 +1092,18 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         const uri = new Uri(url);
         const query = queryToObject(uri.query());
 
         expect(query.layers).toContain("visible:someLayer,anotherLayerYay");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/ArcGIS/identify-WebMercator.json",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };

--- a/packages/engine/Specs/Scene/Azure2DImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/Azure2DImageryProviderSpec.js
@@ -52,12 +52,11 @@ describe("Scene/Azure2DImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -86,14 +85,13 @@ describe("Scene/Azure2DImageryProvider", function () {
     expect(provider.tileDiscardPolicy).toBeUndefined();
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("zoom=0&x=0&y=0");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -153,24 +151,16 @@ describe("Scene/Azure2DImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);

--- a/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -96,44 +96,37 @@ describe("Scene/BingMapsImageryProvider", function () {
       }
     }
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const { expectedUrl, expectedParams } = imageOptions;
 
       const url = request.url;
       if (/^blob:/.test(url) || supportsImageBitmapOptions) {
         // If ImageBitmap is supported, we expect a loadWithXhr request to fetch it as a blob.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
           true,
           false,
           true,
         );
-      } else {
-        if (defined(expectedUrl)) {
-          const uri = new Uri(url);
+      }
+      if (defined(expectedUrl)) {
+        const uri = new Uri(url);
 
-          const query = queryToObject(uri.query());
-          uri.query("");
-          expect(uri.toString()).toEqual(expectedUrl);
-          for (const param in expectedParams) {
-            if (expectedParams.hasOwnProperty(param)) {
-              expect(query[param]).toEqual(expectedParams[param]);
-            }
+        const query = queryToObject(uri.query());
+        uri.query("");
+        expect(uri.toString()).toEqual(expectedUrl);
+        for (const param in expectedParams) {
+          if (expectedParams.hasOwnProperty(param)) {
+            expect(query[param]).toEqual(expectedParams[param]);
           }
         }
-        // Just return any old image.
-        Resource._DefaultImplementations.createImage(
-          new Request({ url: "Data/Images/Red16x16.png" }),
-          crossOrigin,
-          deferred,
-        );
       }
+      // Just return any old image.
+      return Resource._DefaultImplementations.createImage(
+        new Request({ url: "Data/Images/Red16x16.png" }),
+        crossOrigin,
+      );
     };
 
     Resource._Implementations.loadWithXhr = function (
@@ -142,12 +135,12 @@ describe("Scene/BingMapsImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       const uri = new Uri(url);
       const query = queryToObject(uri.query());
       let { expectedUrl, expectedParams } = imageOptions;
+      let promise;
 
       // Load metadata
       if (url.includes("REST/")) {
@@ -166,16 +159,15 @@ describe("Scene/BingMapsImageryProvider", function () {
           expect(query.culture).toEqual(culture);
         }
 
-        deferred.resolve(metadataResponse);
+        promise = Promise.resolve(metadataResponse);
       } else {
         // Just return any old image.
-        Resource._DefaultImplementations.loadWithXhr(
+        promise = Resource._DefaultImplementations.loadWithXhr(
           "Data/Images/Red16x16.png",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
       }
 
@@ -188,6 +180,7 @@ describe("Scene/BingMapsImageryProvider", function () {
           }
         }
       }
+      return promise;
     };
   }
 
@@ -443,32 +436,23 @@ describe("Scene/BingMapsImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const url = request.url;
       if (/^blob:/.test(url)) {
         // load blob url normally
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
         );
       } else if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     Resource._Implementations.loadWithXhr = function (
@@ -477,25 +461,20 @@ describe("Scene/BingMapsImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/Images/Red16x16.png",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -23,7 +23,6 @@ import {
   Credit,
   CullFace,
   CullingVolume,
-  defer,
   defined,
   findTileMetadata,
   findContentMetadata,
@@ -2261,16 +2260,8 @@ describe(
       const spyUpdate = jasmine.createSpy("listener");
       const tileset = await Cesium3DTilesTester.loadTileset(scene, tilesetUrl);
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
-          deferred.reject("404");
+        function (url, responseType, method, data, headers, overrideMimeType) {
+          return Promise.reject("404");
         },
       );
       tileset.tileFailed.addEventListener(spyUpdate);
@@ -3921,22 +3912,13 @@ describe(
         batchedExpirationUrl,
       );
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
-          Resource._DefaultImplementations.loadWithXhr(
+        function (url, responseType, method, data, headers, overrideMimeType) {
+          return Resource._DefaultImplementations.loadWithXhr(
             batchedColorsB3dmUrl,
             responseType,
             method,
             data,
             headers,
-            deferred,
             overrideMimeType,
           );
         },
@@ -4037,28 +4019,17 @@ describe(
       // Intercept the request and load a subtree with one less child. Still want to make an actual request to simulate
       // real use cases instead of immediately returning a pre-created array buffer.
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
-          const newDeferred = defer();
-          Resource._DefaultImplementations.loadWithXhr(
-            tilesetSubtreeUrl,
-            responseType,
-            method,
-            data,
-            headers,
-            newDeferred,
-            overrideMimeType,
-          );
-          newDeferred.promise.then(function (arrayBuffer) {
-            deferred.resolve(modifySubtreeBuffer(arrayBuffer));
-          });
+        function (url, responseType, method, data, headers, overrideMimeType) {
+          return Resource._DefaultImplementations
+            .loadWithXhr(
+              tilesetSubtreeUrl,
+              responseType,
+              method,
+              data,
+              headers,
+              overrideMimeType,
+            )
+            .then(modifySubtreeBuffer);
         },
       );
 

--- a/packages/engine/Specs/Scene/DiscardMissingTileImagePolicySpec.js
+++ b/packages/engine/Specs/Scene/DiscardMissingTileImagePolicySpec.js
@@ -47,22 +47,19 @@ describe("Scene/DiscardMissingTileImagePolicy", function () {
 
       spyOn(Resource, "createImageBitmapFromBlob").and.callThrough();
       spyOn(Resource._Implementations, "createImage").and.callFake(
-        function (request, crossOrigin, deferred) {
+        function (request, crossOrigin) {
           const url = request.url;
           if (/^blob:/.test(url)) {
-            Resource._DefaultImplementations.createImage(
+            return Resource._DefaultImplementations.createImage(
               request,
               crossOrigin,
-              deferred,
-            );
-          } else {
-            expect(url).toEqual(missingImageUrl);
-            Resource._DefaultImplementations.createImage(
-              new Request({ url: "Data/Images/Red16x16.png" }),
-              crossOrigin,
-              deferred,
             );
           }
+          expect(url).toEqual(missingImageUrl);
+          return Resource._DefaultImplementations.createImage(
+            new Request({ url: "Data/Images/Red16x16.png" }),
+            crossOrigin,
+          );
         },
       );
 
@@ -72,7 +69,6 @@ describe("Scene/DiscardMissingTileImagePolicy", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toEqual(missingImageUrl);
@@ -82,7 +78,6 @@ describe("Scene/DiscardMissingTileImagePolicy", function () {
           method,
           data,
           headers,
-          deferred,
         );
       };
 

--- a/packages/engine/Specs/Scene/Google2DImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/Google2DImageryProviderSpec.js
@@ -82,12 +82,11 @@ describe("Scene/Google2DImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -116,14 +115,13 @@ describe("Scene/Google2DImageryProvider", function () {
     expect(provider.tileDiscardPolicy).toBeUndefined();
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("/0/0/0");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -190,24 +188,16 @@ describe("Scene/Google2DImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);

--- a/packages/engine/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
@@ -88,37 +88,30 @@ describe("Scene/GoogleEarthEnterpriseImageryProvider", function () {
   }
 
   function installFakeImageRequest(expectedUrl, proxy) {
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       let url = request.url;
       if (/^blob:/.test(url) || supportsImageBitmapOptions) {
         // load blob url normally
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
           true,
           false,
           true,
         );
-      } else {
-        if (proxy) {
-          const uri = new Uri(url);
-          url = decodeURIComponent(uri.query());
-        }
-        if (defined(expectedUrl)) {
-          expect(url).toEqual(expectedUrl);
-        }
-        // Just return any old image.
-        Resource._DefaultImplementations.createImage(
-          new Request({ url: "Data/Images/Red16x16.png" }),
-          crossOrigin,
-          deferred,
-        );
       }
+      if (proxy) {
+        const uri = new Uri(url);
+        url = decodeURIComponent(uri.query());
+      }
+      if (defined(expectedUrl)) {
+        expect(url).toEqual(expectedUrl);
+      }
+      // Just return any old image.
+      return Resource._DefaultImplementations.createImage(
+        new Request({ url: "Data/Images/Red16x16.png" }),
+        crossOrigin,
+      );
     };
 
     Resource._Implementations.loadWithXhr = function (
@@ -127,7 +120,6 @@ describe("Scene/GoogleEarthEnterpriseImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       if (defined(expectedUrl) && !/^blob:/.test(url)) {
@@ -140,13 +132,12 @@ describe("Scene/GoogleEarthEnterpriseImageryProvider", function () {
       }
 
       // Just return any old image.
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/Images/Red16x16.png",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
   }
@@ -255,25 +246,20 @@ describe("Scene/GoogleEarthEnterpriseImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/Images/Red16x16.png",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);

--- a/packages/engine/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
+++ b/packages/engine/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
@@ -55,16 +55,14 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/GoogleEarthEnterpriseMapsProvider/good.json",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -90,16 +88,14 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/GoogleEarthEnterpriseMapsProvider/good.json",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -133,16 +129,14 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/GoogleEarthEnterpriseMapsProvider/bad_channel.json",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -162,16 +156,14 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/GoogleEarthEnterpriseMapsProvider/bad_version.json",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -191,16 +183,14 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/GoogleEarthEnterpriseMapsProvider/bad_projection.json",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -224,16 +214,14 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/GoogleEarthEnterpriseMapsProvider/good.json",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -260,16 +248,14 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/GoogleEarthEnterpriseMapsProvider/good.json",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -294,34 +280,27 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
     expect(provider.credit).toBeInstanceOf(Object);
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       const url = request.url;
       if (/^blob:/.test(url) || supportsImageBitmapOptions) {
         // If ImageBitmap is supported, we expect a loadWithXhr request to fetch it as a blob.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
           true,
           false,
           true,
         );
-      } else {
-        expect(url).toEqual(
-          "http://example.invalid/query?request=ImageryMaps&channel=1234&version=1&x=0&y=0&z=1",
-        );
-
-        // Just return any old image.
-        Resource._DefaultImplementations.createImage(
-          new Request({ url: "Data/Images/Red16x16.png" }),
-          crossOrigin,
-          deferred,
-        );
       }
+      expect(url).toEqual(
+        "http://example.invalid/query?request=ImageryMaps&channel=1234&version=1&x=0&y=0&z=1",
+      );
+
+      // Just return any old image.
+      return Resource._DefaultImplementations.createImage(
+        new Request({ url: "Data/Images/Red16x16.png" }),
+        crossOrigin,
+      );
     };
 
     Resource._Implementations.loadWithXhr = function (
@@ -330,7 +309,6 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       expect(url).toEqual(
@@ -338,13 +316,12 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       );
 
       // Just return any old image.
-      Resource._DefaultImplementations.loadWithXhr(
+      return Resource._DefaultImplementations.loadWithXhr(
         "Data/Images/Red16x16.png",
         responseType,
         method,
         data,
         headers,
-        deferred,
       );
     };
 
@@ -365,10 +342,9 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      return deferred.resolve(
+      return Promise.resolve(
         "{\n" +
           "isAuthenticated: true,\n" +
           "layers: [\n" +
@@ -414,10 +390,9 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      return deferred.resolve(
+      return Promise.resolve(
         JSON.stringify({
           isAuthenticated: true,
           layers: [
@@ -452,10 +427,9 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      return deferred.resolve(
+      return Promise.resolve(
         JSON.stringify({
           isAuthenticated: true,
           layers: [
@@ -491,10 +465,9 @@ describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
-      return deferred.resolve(
+      return Promise.resolve(
         JSON.stringify({
           isAuthenticated: true,
           layers: [

--- a/packages/engine/Specs/Scene/ImageryLayerSpec.js
+++ b/packages/engine/Specs/Scene/ImageryLayerSpec.js
@@ -113,15 +113,10 @@ describe(
     });
 
     it("discards tiles when the ImageryProviders discard policy says to do so", function () {
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
-        Resource._DefaultImplementations.createImage(
+      Resource._Implementations.createImage = function (request, crossOrigin) {
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       };
 
@@ -131,16 +126,14 @@ describe(
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/Images/Red16x16.png",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
       };
 
@@ -170,15 +163,10 @@ describe(
     });
 
     async function createWebMercatorProvider() {
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
-        Resource._DefaultImplementations.createImage(
+      Resource._Implementations.createImage = function (request, crossOrigin) {
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       };
 
@@ -188,11 +176,10 @@ describe(
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         if (url.includes("REST/v1/Imagery/Metadata")) {
-          deferred.resolve(
+          return Promise.resolve(
             JSON.stringify({
               authenticationResultCode: "ValidCredentials",
               brandLogoUri:
@@ -227,13 +214,12 @@ describe(
             }),
           );
         }
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/Images/Red16x16.png",
           responseType,
           method,
           data,
           headers,
-          deferred,
         );
       };
 
@@ -366,15 +352,10 @@ describe(
     });
 
     it("assigns texture property when reprojection is skipped because the tile is very small", function () {
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
-        Resource._DefaultImplementations.createImage(
+      Resource._Implementations.createImage = function (request, crossOrigin) {
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red256x256.png" }),
           crossOrigin,
-          deferred,
         );
       };
 

--- a/packages/engine/Specs/Scene/IonImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/IonImageryProviderSpec.js
@@ -246,16 +246,8 @@ describe("Scene/IonImageryProvider", function () {
   describe("ARCGIS_MAPSERVER", function () {
     beforeEach(function () {
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
-          deferred.resolve(
+        function (url, responseType, method, data, headers, overrideMimeType) {
+          return Promise.resolve(
             JSON.stringify({
               imageUrl: "",
               imageUrlSubdomains: [],
@@ -274,16 +266,8 @@ describe("Scene/IonImageryProvider", function () {
   describe("BING", function () {
     beforeEach(function () {
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
-          deferred.resolve(
+        function (url, responseType, method, data, headers, overrideMimeType) {
+          return Promise.resolve(
             JSON.stringify({
               resourceSets: [
                 {
@@ -307,16 +291,8 @@ describe("Scene/IonImageryProvider", function () {
   describe("GOOGLE_EARTH", function () {
     beforeEach(function () {
       spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-        function (
-          url,
-          responseType,
-          method,
-          data,
-          headers,
-          deferred,
-          overrideMimeType,
-        ) {
-          deferred.resolve(
+        function (url, responseType, method, data, headers, overrideMimeType) {
+          return Promise.resolve(
             JSON.stringify({ layers: [{ id: 0, version: "" }] }),
           );
         },
@@ -338,8 +314,8 @@ describe("Scene/IonImageryProvider", function () {
   describe("SINGLE_TILE", function () {
     beforeEach(function () {
       spyOn(Resource._Implementations, "createImage").and.callFake(
-        function (request, crossOrigin, deferred) {
-          deferred.resolve({
+        function (request, crossOrigin) {
+          return Promise.resolve({
             height: 16,
             width: 16,
           });

--- a/packages/engine/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/MapboxImageryProviderSpec.js
@@ -52,14 +52,13 @@ describe("Scene/MapboxImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).not.toContain("//");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -78,14 +77,13 @@ describe("Scene/MapboxImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("made/up/mapbox/server/");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -113,12 +111,11 @@ describe("Scene/MapboxImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -146,14 +143,13 @@ describe("Scene/MapboxImageryProvider", function () {
     expect(provider.tileDiscardPolicy).toBeUndefined();
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("/0/0/0");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -225,24 +221,16 @@ describe("Scene/MapboxImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);
@@ -268,7 +256,7 @@ describe("Scene/MapboxImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(
           /made\/up\/mapbox\/server\/test-id\/0\/0\/0@2x\.png\?access_token=/.test(
             request.url,
@@ -276,10 +264,9 @@ describe("Scene/MapboxImageryProvider", function () {
         ).toBe(true);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -298,7 +285,7 @@ describe("Scene/MapboxImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(
           /made\/up\/mapbox\/server\/test-id\/0\/0\/0\.png\?access_token=/.test(
             request.url,
@@ -306,10 +293,9 @@ describe("Scene/MapboxImageryProvider", function () {
         ).toBe(true);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );

--- a/packages/engine/Specs/Scene/MapboxStyleImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/MapboxStyleImageryProviderSpec.js
@@ -52,14 +52,13 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).not.toContain("//");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -78,14 +77,13 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("made/up/mapbox/server/");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -113,12 +111,11 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -146,14 +143,13 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     expect(provider.tileDiscardPolicy).toBeUndefined();
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("/0/0/0");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -225,24 +221,16 @@ describe("Scene/MapboxStyleImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);
@@ -267,14 +255,13 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("http://fake.map.com");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -290,16 +277,15 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain(
           "https://api.mapbox.com/styles/v1/fakeUsername",
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -315,16 +301,15 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain(
           "https://api.mapbox.com/styles/v1/mapbox/test-id/tiles/256",
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -340,16 +325,15 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain(
           "https://api.mapbox.com/styles/v1/mapbox/test-id/tiles/512/0/0/0@2x",
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );

--- a/packages/engine/Specs/Scene/OpenStreetMapImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/OpenStreetMapImageryProviderSpec.js
@@ -47,14 +47,13 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).not.toContain("//");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -71,14 +70,13 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).not.toContain("//");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -95,14 +93,13 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("made/up/osm/server/");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -126,12 +123,11 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -187,14 +183,13 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
     expect(provider.tileDiscardPolicy).toBeUndefined();
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("/0/0/0");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -228,14 +223,13 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("0/0/0@2x.png");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -264,24 +258,16 @@ describe("Scene/OpenStreetMapImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);

--- a/packages/engine/Specs/Scene/SingleTileImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/SingleTileImageryProviderSpec.js
@@ -122,13 +122,12 @@ describe("Scene/SingleTileImageryProvider", function () {
     const imageUrl = "Data/Images/Red16x16.png";
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const url = request.url;
         expect(url).toEqual(imageUrl);
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -145,13 +144,12 @@ describe("Scene/SingleTileImageryProvider", function () {
     const imageUrl = "Data/Images/Red16x16.png";
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const url = request.url;
         expect(url).toEqual(imageUrl);
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           request,
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -204,24 +202,16 @@ describe("Scene/SingleTileImageryProvider", function () {
       }
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);

--- a/packages/engine/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -46,16 +46,13 @@ describe("Scene/TileMapServiceImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       // We can't resolve the promise immediately, because then the error would be raised
       // before we could subscribe to it.  This a problem particular to tests.
-      setTimeout(function () {
-        const parser = new DOMParser();
-        const xml = parser.parseFromString(xmlResponseString, "text/xml");
-        deferred.resolve(xml);
-      }, 1);
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(xmlResponseString, "text/xml");
+      return Promise.resolve(xml);
     };
   }
 
@@ -66,14 +63,11 @@ describe("Scene/TileMapServiceImageryProvider", function () {
       method,
       data,
       headers,
-      deferred,
       overrideMimeType,
     ) {
       // We can't resolve the promise immediately, because then the error would be raised
       // before we could subscribe to it.  This a problem particular to tests.
-      setTimeout(function () {
-        deferred.reject(new RequestErrorEvent(404));
-      }, 1);
+      return Promise.reject(new RequestErrorEvent(404));
     };
   }
 
@@ -181,14 +175,13 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     const provider = await TileMapServiceImageryProvider.fromUrl(baseUrl);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toStartWith(getAbsoluteUri(baseUrl));
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -205,14 +198,13 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     );
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("made/up/tms/server/");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -230,14 +222,13 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     );
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toStartWith(getAbsoluteUri(baseUrl));
         expect(request.url).toContain("?a=some&b=query");
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -262,12 +253,11 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     expect(provider.tileHeight).toEqual(256);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -299,17 +289,9 @@ describe("Scene/TileMapServiceImageryProvider", function () {
   it("resource request takes a query string", async function () {
     /*eslint-disable no-unused-vars*/
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         expect(/\?query=1$/.test(url)).toEqual(true);
-        deferred.reject(new RequestErrorEvent(404)); //since the TMS server doesn't exist (and doesn't need too) we can just reject here.
+        return Promise.reject(new RequestErrorEvent(404)); //since the TMS server doesn't exist (and doesn't need too) we can just reject here.
       },
     );
 
@@ -354,14 +336,13 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     expect(provider.tileDiscardPolicy).toBeUndefined();
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("/0/0/0");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -402,24 +383,16 @@ describe("Scene/TileMapServiceImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);

--- a/packages/engine/Specs/Scene/TimeDynamicPointCloudSpec.js
+++ b/packages/engine/Specs/Scene/TimeDynamicPointCloudSpec.js
@@ -719,15 +719,15 @@ describe(
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         ) {
           if (request.toString().includes("PointCloudTimeDynamic")) {
-            deferred.reject("404");
+            const promise = Promise.reject("404");
             // Allow the promise a frame to resolve
-            deferred.promise.catch(function () {
+            promise.catch(function () {
               frameRejectedCount++;
             });
+            return promise;
           }
         },
       );

--- a/packages/engine/Specs/Scene/UrlTemplateImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/UrlTemplateImageryProviderSpec.js
@@ -61,12 +61,11 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -108,14 +107,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     expect(provider.tileDiscardPolicy).toBeUndefined();
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toContain("/0/0/0");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -156,24 +154,16 @@ describe("Scene/UrlTemplateImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);
@@ -198,14 +188,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqual("made/up/tms/server/2/3/2/1/4/3.PNG");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -229,16 +218,15 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqual(
           "made/up/tms/server/0002/3/2/0001/4/0003.PNG",
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -262,16 +250,15 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqual(
           "made/up/tms/server/2/0003/0002/1/0004/3.PNG",
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -295,16 +282,15 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqual(
           "made/up/tms/server/0005/0/21/0010/51/0012.PNG",
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -322,14 +308,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(45.0, CesiumMath.EPSILON11);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -347,14 +332,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(0.0, CesiumMath.EPSILON11);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -372,14 +356,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(0.0, CesiumMath.EPSILON11);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -397,14 +380,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(-45.0, CesiumMath.EPSILON11);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -422,17 +404,16 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(
           (Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0,
           CesiumMath.EPSILON11,
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -449,17 +430,16 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(
           (Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0,
           CesiumMath.EPSILON11,
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -476,17 +456,16 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(
           (-Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0,
           CesiumMath.EPSILON11,
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -503,17 +482,16 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqualEpsilon(
           (-Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0,
           CesiumMath.EPSILON11,
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -530,7 +508,7 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqual(
           `-90 ${(-Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0} ` +
             `0 ` +
@@ -544,10 +522,9 @@ describe("Scene/UrlTemplateImageryProvider", function () {
         );
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -564,14 +541,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(["a", "b", "c"].indexOf(request.url)).toBeGreaterThanOrEqual(0);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -589,14 +565,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(["1", "2", "3"].indexOf(request.url)).toBeGreaterThanOrEqual(0);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -614,14 +589,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(["foo", "bar"].indexOf(request.url)).toBeGreaterThanOrEqual(0);
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -648,14 +622,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         expect(request.url).toEqual("made/up/tms/server/foo/bar/2/1/3.PNG");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );

--- a/packages/engine/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -92,7 +92,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.something).toEqual("foo");
@@ -100,7 +100,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.version).toEqual("1.3.0");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -120,14 +120,14 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.crs).toEqual("CRS:27");
         expect(params.version).toEqual("1.3.0");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -147,7 +147,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.crs).toEqual("EPSG:4326");
@@ -155,7 +155,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.bbox).toEqual("-90,-180,90,0");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -175,7 +175,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.crs).toEqual("EPSG:4321");
@@ -183,7 +183,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.bbox).toEqual("-90,-180,90,0");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -203,7 +203,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.crs).toEqual("EPSG:3035");
@@ -211,7 +211,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.bbox).toEqual("-90,-180,90,0");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -231,7 +231,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.crs).toEqual("EPSG:4559");
@@ -239,7 +239,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.bbox).toEqual("-180,-90,0,90");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -259,14 +259,14 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.srs).toEqual("EPSG:4326");
         expect(params.version).toEqual("1.1.0");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -286,14 +286,14 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.srs).toEqual("IAU2000:30118");
         expect(params.version).toEqual("1.1.0");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -313,7 +313,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
         expect(params.srs).toEqual("EPSG:4326");
@@ -321,7 +321,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.bbox).toEqual("-180,-90,0,90");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -366,12 +366,12 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const questionMarkCount = request.url.match(/\?/g).length;
         expect(questionMarkCount).toEqual(1);
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -387,14 +387,14 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const url = request.url;
         const questionMarkCount = url.match(/\?/g).length;
         expect(questionMarkCount).toEqual(1);
         expect(url).not.toContain("&&");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -410,7 +410,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const url = request.url;
         const questionMarkCount = url.match(/\?/g).length;
         expect(questionMarkCount).toEqual(1);
@@ -420,7 +420,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.foo).toEqual("bar");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -436,14 +436,14 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const url = request.url;
         const uri = new Uri(url);
         const params = queryToObject(uri.query());
         expect(params.version).toEqual("1.1.1");
 
         // Don't need to actually load image, but satisfy the request.
-        deferred.resolve(true);
+        return Promise.resolve(true);
       },
     );
 
@@ -468,12 +468,11 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -502,7 +501,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
 
@@ -514,10 +513,9 @@ describe("Scene/WebMapServiceImageryProvider", function () {
           `${rect.west},${rect.south},${rect.east},${rect.north}`,
         );
 
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -549,7 +547,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
 
@@ -561,10 +559,9 @@ describe("Scene/WebMapServiceImageryProvider", function () {
           `${rect.west},${rect.south},${rect.east},${rect.north}`,
         );
 
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -593,7 +590,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
 
@@ -605,10 +602,9 @@ describe("Scene/WebMapServiceImageryProvider", function () {
           `${rect.west},${rect.south},${rect.east},${rect.north}`,
         );
 
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -640,7 +636,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
 
@@ -652,10 +648,9 @@ describe("Scene/WebMapServiceImageryProvider", function () {
           `${rect.west},${rect.south},${rect.east},${rect.north}`,
         );
 
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -687,7 +682,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
 
@@ -699,10 +694,9 @@ describe("Scene/WebMapServiceImageryProvider", function () {
           `${rect.west},${rect.south},${rect.east},${rect.north}`,
         );
 
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -734,7 +728,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
 
@@ -746,10 +740,9 @@ describe("Scene/WebMapServiceImageryProvider", function () {
           `${rect.west},${rect.south},${rect.east},${rect.north}`,
         );
 
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -770,7 +763,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         const uri = new Uri(request.url);
         const params = queryToObject(uri.query());
 
@@ -778,10 +771,9 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(params.format).not.toEqual("image/jpeg");
 
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -888,24 +880,16 @@ describe("Scene/WebMapServiceImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);
@@ -935,17 +919,15 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-GeoJSON.json",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -977,17 +959,15 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1016,17 +996,15 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-Esri.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1055,17 +1033,15 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-THREDDS.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1094,17 +1070,15 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-msGMLOutput.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1133,17 +1107,15 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-Unknown.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1172,17 +1144,15 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-ServiceException.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1250,18 +1220,16 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
         expect(url).not.toContain("json");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1291,25 +1259,22 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
 
         if (url.indexOf("json") >= 0) {
-          deferred.reject();
-        } else {
-          // this should not happen
-          Resource._DefaultImplementations.loadWithXhr(
-            "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
-            responseType,
-            method,
-            data,
-            headers,
-            deferred,
-            overrideMimeType,
-          );
+          return Promise.reject();
         }
+        // this should not happen
+        return Resource._DefaultImplementations.loadWithXhr(
+          "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
+          responseType,
+          method,
+          data,
+          headers,
+          overrideMimeType,
+        );
       };
 
       return provider
@@ -1335,7 +1300,6 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
@@ -1345,13 +1309,12 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(url).toContain("&y=");
         expect(url).not.toContain("&i=");
         expect(url).not.toContain("&j=");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1374,7 +1337,6 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
@@ -1384,13 +1346,12 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(url).not.toContain("&y=");
         expect(url).toContain("&i=");
         expect(url).toContain("&j=");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1410,7 +1371,6 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
@@ -1420,13 +1380,12 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         expect(url).toContain("&y=");
         expect(url).not.toContain("&i=");
         expect(url).not.toContain("&j=");
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1456,13 +1415,12 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
 
         if (url.indexOf(encodeURIComponent("application/foo")) < 0) {
-          deferred.reject();
+          return Promise.reject();
         }
 
         return Resource._DefaultImplementations.loadWithXhr(
@@ -1471,7 +1429,6 @@ describe("Scene/WebMapServiceImageryProvider", function () {
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1494,20 +1451,18 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         method,
         data,
         headers,
-        deferred,
         overrideMimeType,
       ) {
         expect(url).toContain("GetFeatureInfo");
         if (url.indexOf(encodeURIComponent("text/html")) < 0) {
-          deferred.reject();
+          return Promise.reject();
         }
-        Resource._DefaultImplementations.loadWithXhr(
+        return Resource._DefaultImplementations.loadWithXhr(
           "Data/WMS/GetFeatureInfo.html",
           responseType,
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       };
@@ -1560,15 +1515,10 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         times: times,
       });
 
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
-        Resource._DefaultImplementations.createImage(
+      Resource._Implementations.createImage = function (request, crossOrigin) {
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       };
 
@@ -1615,15 +1565,10 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         times: times,
       });
 
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
-        Resource._DefaultImplementations.createImage(
+      Resource._Implementations.createImage = function (request, crossOrigin) {
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       };
 
@@ -1668,15 +1613,10 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         shouldAnimate: true,
       });
 
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
-        Resource._DefaultImplementations.createImage(
+      Resource._Implementations.createImage = function (request, crossOrigin) {
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       };
 
@@ -1726,15 +1666,10 @@ describe("Scene/WebMapServiceImageryProvider", function () {
         shouldAnimate: false,
       });
 
-      Resource._Implementations.createImage = function (
-        request,
-        crossOrigin,
-        deferred,
-      ) {
-        Resource._DefaultImplementations.createImage(
+      Resource._Implementations.createImage = function (request, crossOrigin) {
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       };
 

--- a/packages/engine/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
+++ b/packages/engine/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
@@ -341,12 +341,11 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -370,12 +369,11 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
     });
 
     spyOn(Resource._Implementations, "createImage").and.callFake(
-      function (request, crossOrigin, deferred) {
+      function (request, crossOrigin) {
         // Just return any old image.
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
       },
     );
@@ -408,24 +406,16 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
       }, 1);
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       if (tries === 2) {
         // Succeed after 2 tries
-        Resource._DefaultImplementations.createImage(
+        return Resource._DefaultImplementations.createImage(
           new Request({ url: "Data/Images/Red16x16.png" }),
           crossOrigin,
-          deferred,
         );
-      } else {
-        // fail
-        setTimeout(function () {
-          deferred.reject();
-        }, 1);
       }
+      // fail
+      return Promise.reject();
     };
 
     const imagery = new Imagery(layer, 0, 0, 0);
@@ -465,15 +455,10 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
       times: times,
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
-      Resource._DefaultImplementations.createImage(
+    Resource._Implementations.createImage = function (request, crossOrigin) {
+      return Resource._DefaultImplementations.createImage(
         new Request({ url: "Data/Images/Red16x16.png" }),
         crossOrigin,
-        deferred,
       );
     };
 
@@ -521,15 +506,10 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
       times: times,
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
-      Resource._DefaultImplementations.createImage(
+    Resource._Implementations.createImage = function (request, crossOrigin) {
+      return Resource._DefaultImplementations.createImage(
         new Request({ url: "Data/Images/Red16x16.png" }),
         crossOrigin,
-        deferred,
       );
     };
 
@@ -574,15 +554,10 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
       shouldAnimate: true,
     });
 
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
-      Resource._DefaultImplementations.createImage(
+    Resource._Implementations.createImage = function (request, crossOrigin) {
+      return Resource._DefaultImplementations.createImage(
         new Request({ url: "Data/Images/Red16x16.png" }),
         crossOrigin,
-        deferred,
       );
     };
 
@@ -645,16 +620,11 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
 
   it("dimensions work with RESTful requests", function () {
     let lastUrl;
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       lastUrl = request.url;
-      Resource._DefaultImplementations.createImage(
+      return Resource._DefaultImplementations.createImage(
         new Request({ url: "Data/Images/Red16x16.png" }),
         crossOrigin,
-        deferred,
       );
     };
 
@@ -688,16 +658,11 @@ describe("Scene/WebMapTileServiceImageryProvider", function () {
 
   it("dimensions work with KVP requests", function () {
     let lastUrl;
-    Resource._Implementations.createImage = function (
-      request,
-      crossOrigin,
-      deferred,
-    ) {
+    Resource._Implementations.createImage = function (request, crossOrigin) {
       lastUrl = request.url;
-      Resource._DefaultImplementations.createImage(
+      return Resource._DefaultImplementations.createImage(
         new Request({ url: "Data/Images/Red16x16.png" }),
         crossOrigin,
-        deferred,
       );
     };
 

--- a/packages/engine/Specs/Scene/createWorldImageryAsyncSpec.js
+++ b/packages/engine/Specs/Scene/createWorldImageryAsyncSpec.js
@@ -11,22 +11,13 @@ describe("Core/createWorldImageryAsync", function () {
   it("resolves to IonImageryProvider instance with default parameters", async function () {
     const originalLoadWithXhr = Resource._Implementations.loadWithXhr;
     spyOn(Resource._Implementations, "loadWithXhr").and.callFake(
-      function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType,
-      ) {
+      function (url, responseType, method, data, headers, overrideMimeType) {
         if (url.includes("REST/v1/Imagery/Metadata")) {
-          deferred.resolve(
+          return Promise.resolve(
             JSON.stringify(
               createFakeBingMapsMetadataResponse(BingMapsStyle.AERIAL),
             ),
           );
-          return;
         }
 
         return originalLoadWithXhr(
@@ -35,7 +26,6 @@ describe("Core/createWorldImageryAsync", function () {
           method,
           data,
           headers,
-          deferred,
           overrideMimeType,
         );
       },


### PR DESCRIPTION
# Description

Replaces the remaining production uses of `defer` with native Promise construction and chaining.

This follows up on #8525 and #10149, which replaced `when.js` while introducing `defer.js`, and the later discussion in #12581. The private helper remains temporarily as a deprecated compatibility shim, with linting and contributor guidance discouraging new usage.

## Issue number and link

Fixes #10546
Fixes #10547

## Testing plan

- `npm run prettier`
- `npm run build --workspace @cesium/engine`
- `npm run test-webgl-stub -- --failTaskOnError`
- ESLint and TypeScript checks

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

OpenAI Codex

If yes, I used the following Model(s):

GPT-5
