### PR TITLE
Bump dompurify minimum version to 3.4.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.145 - 2026-09-02
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Updated the minimum version of `dompurify` dependency to `3.4.5`, addressing security vulnerability tracked in [CVE-2026-49458](https://github.com/advisories/GHSA-hpcv-96wg-7vj8). [#13646](https://github.com/CesiumGS/cesium/issues/13646)
+
 ## 1.144 - 2026-08-01
 
 ### @cesium/engine

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -39,7 +39,7 @@
     "@zip.js/zip.js": "^2.8.1",
     "autolinker": "^4.0.0",
     "bitmap-sdf": "^1.0.3",
-    "dompurify": "^3.3.0",
+    "dompurify": "^3.4.5",
     "draco3d": "^1.5.1",
     "earcut": "3.0.2",
     "grapheme-splitter": "^1.0.4",

--- a/packages/sandcastle/package.json
+++ b/packages/sandcastle/package.json
@@ -22,7 +22,7 @@
     "@stratakit/structures": "^0.5.5",
     "allotment": "^1.20.4",
     "classnames": "^2.5.1",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.5",
     "fastest-levenshtein": "^1.0.16",
     "monaco-editor": "^0.52.2",
     "pako": "^3.0.0",


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Updates the minimum version of `dompurify` dependency to [`3.4.5`](https://github.com/cure53/DOMPurify/releases#release-3.4.5), addressing security vulnerability tracked in [CVE-2026-49458](https://github.com/advisories/GHSA-hpcv-96wg-7vj8).

## Issue number and link

#13646

## Testing plan

1. Confirm Sandcastle edit and share functionality works as before
2. Confirm custom infobox output, such as what is demonstrated in [the KML Sandcastle example](https://sandcastle.cesium.com/?id=kml) works as before

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [ ] ~I have added or updated unit tests to ensure consistent code coverage~
- [ ] ~I have updated the inline documentation, and included code examples where relevant~
- [x] I have performed a self-review of my code

## AI acknowledgment

None used
