### PR TITLE
Support draping MVT vector data onto terrain and 3D Tiles

### DIFF
--- a/packages/engine/Source/Scene/BufferPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/BufferPrimitiveCollection.js
@@ -724,12 +724,13 @@ class BufferPrimitiveCollection {
    * textures sampled by terrain and model surfaces.
    *
    * @param {FrameState} frameState
+   * @returns {boolean} Whether the collection is draped, and so must not render itself.
    * @protected
    * @ignore
    */
   _updateHeightReference(frameState) {
     if (!isHeightReferenceClamp(this._heightReference)) {
-      return;
+      return false;
     }
 
     // Scene declares its properties with Object.defineProperties, which the type checker does not see.
@@ -742,6 +743,8 @@ class BufferPrimitiveCollection {
       frameState.frameNumber,
       this._heightReference,
     );
+
+    return true;
   }
 
   /** @param {object} frameState */

--- a/packages/engine/Source/Scene/MVTDataProvider.js
+++ b/packages/engine/Source/Scene/MVTDataProvider.js
@@ -12,8 +12,10 @@ import defined from "../Core/defined.js";
 
 /** @import Cesium3DTile from "./Cesium3DTile.js"; */
 /** @import Cesium3DTileset from "./Cesium3DTileset.js"; */
+/** @import HeightReference from "./HeightReference.js"; */
 /** @import Rectangle from "../Core/Rectangle.js"; */
 /** @import Resource from "../Core/Resource.js"; */
+/** @import Scene from "./Scene.js"; */
 
 /**
  * A Mapbox Vector Tiles (MVT) data provider. Loads .mvt or .pbf tiles, converting tiles
@@ -36,6 +38,12 @@ class MVTDataProvider extends UrlTemplate3DTilesDataProvider {
    * @param {number} [options.maxZoom=14] Maximum zoom level represented in the generated tileset.
    * @param {Rectangle} [options.extent] Optional geographic extent in radians to constrain the generated tile tree.
    * @param {string} [options.featureIdProperty] MVT property name to use as feature ID.
+   * @param {HeightReference} [options.heightReference] Drapes the decoded points, lines and polygons onto the
+   *   surfaces selected by the value: {@link HeightReference.CLAMP_TO_TERRAIN} drapes onto the globe,
+   *   {@link HeightReference.CLAMP_TO_3D_TILE} drapes onto 3D Tiles and models, and
+   *   {@link HeightReference.CLAMP_TO_GROUND} drapes onto both. Requires <code>options.scene</code>.
+   * @param {Scene} [options.scene] The scene the generated tileset is rendered in, required when
+   *   <code>options.heightReference</code> is a clamping value.
    * @returns {Promise<MVTDataProvider>}
    */
   static async fromUrl(url, options) {
@@ -51,6 +59,7 @@ class MVTDataProvider extends UrlTemplate3DTilesDataProvider {
    */
   _createTilesetLoadOptions() {
     return {
+      ...super._createTilesetLoadOptions(),
       skipLevelOfDetail: false,
       enablePick: true,
       featureIdLabel: "featureId_0",

--- a/packages/engine/Source/Scene/UrlTemplate3DTilesDataProvider.js
+++ b/packages/engine/Source/Scene/UrlTemplate3DTilesDataProvider.js
@@ -13,7 +13,9 @@ import destroyObject from "../Core/destroyObject.js";
 import CesiumMath from "../Core/Math.js";
 
 /** @import FrameState from "./FrameState.js"; */
+/** @import HeightReference from "./HeightReference.js"; */
 /** @import PassState from "../Renderer/PassState.js"; */
+/** @import Scene from "./Scene.js"; */
 /** @import TilingScheme from "../Core/TilingScheme.js"; */
 
 /**
@@ -51,6 +53,10 @@ class UrlTemplate3DTilesDataProvider {
    * @param {number} [options.maxZoom=14] Maximum zoom level represented in the generated tileset.
    * @param {Rectangle} [options.extent] Optional geographic extent in radians to constrain the generated tile tree.
    * @param {string} [options.featureIdProperty] Feature property name to use as feature ID when supported by content decoding.
+   * @param {HeightReference} [options.heightReference] Drapes the vector content onto the surfaces selected by the
+   *   value. Requires <code>options.scene</code>.
+   * @param {Scene} [options.scene] The scene the generated tileset is rendered in, required when
+   *   <code>options.heightReference</code> is a clamping value.
    */
   constructor(urlTemplate, options) {
     options = options ?? {};
@@ -61,6 +67,8 @@ class UrlTemplate3DTilesDataProvider {
     this._minZoom = options.minZoom ?? DEFAULT_MIN_ZOOM;
     this._maxZoom = options.maxZoom ?? DEFAULT_MAX_ZOOM;
     this._featureIdProperty = options.featureIdProperty;
+    this._heightReference = options.heightReference;
+    this._scene = options.scene;
     this._show = true;
     this._tileset = undefined;
     this._tilesetJsonUrl = undefined;
@@ -149,7 +157,10 @@ class UrlTemplate3DTilesDataProvider {
    * @returns {object}
    */
   _createTilesetLoadOptions() {
-    return {};
+    return {
+      heightReference: this._heightReference,
+      scene: this._scene,
+    };
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->


# Description
<img width="2253" height="1826" alt="image" src="https://github.com/user-attachments/assets/5521afbf-fa17-4355-91f1-1ffb6316101f" />
<img width="2242" height="1839" alt="image" src="https://github.com/user-attachments/assets/d6e18a16-b797-4e5a-8f27-6090881d4bcb" />
Adds `scene` and `heightReference` options to `MVTDataProvider.fromUrl`, so MVT points, lines and polygons can be draped rather than drawn at their own height.

```js
const provider = await Cesium.MVTDataProvider.fromUrl(url, {
  scene: viewer.scene,
  heightReference: Cesium.HeightReference.CLAMP_TO_TERRAIN,
});
```

Note:
There are a few performance and latency issues worth optimizing and revisiting later.
<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan
[DEMO
](http://localhost:8080/Apps/Sandcastle2/index.html#c=vVhtb9s2EP4rN29A5VWl1LnNGicu1jXFNiAvReKuwOoho6WzRYQiDZKy6xr+7wMp6s12+rIW+xA4Jo/H4z3H5zma5QupDPwIVMNL1KzIYaZkDpNe4r5NeicTNRGsNLuhIk2oNhwrq2bEW9q/RAptYMlwhQpGIHDlfZM/3VhQeX8phaFMoJr0QtjYpQCG5ciZwCHMKNcYlqNUsJwaJkV3WCco8EKm+Jold6i6k1Oq8ZyuUe1PbvsnTaDOCYx8wMR9rc9i1LqKzE0Qg0pRJl4ruWSpOx9dUWaqEyYKqcG3UvF0XFq+0GuRBOWGW0ioSTIIUCmp+pVnG4fkSLicB/+8slPAJU2ZmMPKegK/KYEfNm7l9h/vr5vylBqq0WgYVZ6jCN7cQMbm2YqudQjnTOCNUdazFHwdwof40REpbb3VsFoLUCg+hEmPkIiQ6IbmC45n1NAoX5rIW0ebD9to834bbdZbspjOJr2wWp3T939JmQ/hqB7SZs1x2K6I8mNwNmYcb+xsUO9u88KlshG4f4IH389m6VFMH/RbuwDYannLUpNZy0Fratuv/40iGGcI1zK5Y6hDWGWoEEyGVWqBadAGcQEoZDHPwEhQSFNnk7LZDBWKBEnl0BZLK1MAKWrDhK/R6nBUGdSMigGx9+UM5wpRB48ex0/JcQiDZ+QohKM4jmMS91snkoqhMN5Xaw+ADF1ZDCEmcdieWDCTZPXGF9RkxMhrmjIqdPBosLMBgJKc73rZNpnz/1WfZRlpQw3CVBYipYqhtqSxkHw9l0J3KskZ6s8spNL4/62jmD57Mps9CCEmT572D5fMVyL8hBwfPw1hcEx+/ulZCIMn/wHkw2j+tAfmJ8B/+jXgb2sqjCI4kyth5ErAGYolqhC4XNUXJqMGUkUXmLorqUEVAmiipNYwLRh3fKaknGlSuXNeQDOjgRqgU1kYeHwUx5CHoKW7ewnNUVHIkM0zAwlHqnS514wpbUjDftUe2qpMQ4HfELbDkH0RXF8C1S5Mu4BwNLDwOnRSDdRZqEe8KlzS3KrcpFdeOK/X1qDM7TV6joNRFd7v3Qny8vzFxevb8dXt4Ox2/Mf5qxOP4zXOmTboZMVilqMotMUHLVTIVIkVoJVTh6zGJSrKQaEVOg1yiYrTBciq0rShyhSLE1gxk9myMBlzzkBzuUJtQAqEFRMaqChZ2kjJp1Q52nbcRIGzkrHtKcutxvIOBYwgrrNIrT7DrBCJxdWbBTO+HsuOQBswfu3Dhy1ftR8ANoPAZy7FGROYBhU8/X5TL2UfsVAsZ4YtUROFuVxiY3tSF0vTZBTCu/ST22bbjvbDqO4C3rWA//ukbWuDx3S3dbn4c2xJueps3M14o3jg3ZBC8bA5Rc3K1bQfCDvHHJYfYXNXOhU13B2oKr2/k9Yy9d+NRm0YWzktT0TsXVdyHTQpVGgKJfaT1krtHh40TYPSYeWnsiaGcbSHdQLU5Lr8vhNzt4Qq3Es+I24y2AAhpPJhBSeEtFCeYGISV4nwodfxN223DXZcFv4FiiJ4V5pvwOB7YyXvxt12CCqhtmoHUmjkmJghBH0YPYfyW9BwQ79WgcbT776LhMDR+8cd+faw8fR3A+mno69SVm39ktN8YVuywRlYhdeue23p9n4cZoe8gs/ktP5O63N/LHNlOyEIqg7yYR1d/9tG9tv11ZvLs88PrAro2+do/Or6+sUfl58M5VJCYqNhYv5NAri8utwB5iPlNJ9z/LUwRopg0ru6uYBfK0m0FVs+AqFk/SDJMLnD1IWzaa7ud/V4fbQD5F5LbZvd7+f3xvykMa4HD3C8v/Ufo7HW87R+5ChMkC2dFpdsBQIx9eLp3rpGyiHYpiuXKXJtFTPJ3PwSEyNVy2HNkyZTrs1jJnSKW+mylWGT4RqoQtB3bGH7v1WGAqb0jol5/WJqn/Qg5TZJOfCivtJ5DWP5ot50FKbdudecefi1/dH3dqde9t7bh6G4n9o7Lek93N7SuroJ8TQqaI512N02zk75GHzHYlSBO78KtPzt3bQl5UXjfL8FdPPdHdzV2dlixUQqV+T2Np3Om577gPbPW81q0MKiTGe3j91vdcuK2DtpL+ydOul9Xi77xf9QVSgeEBIZzBfcvS6nRXKHhiTaX77TqFl2mrIlsHR04Fcpy2Jajya9WcH5DfuAk97z0yhly52FvnquXBe7tkbZ4+fn5SAh5DTKHh9c51vWjtd/AQ)<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
