### PR TITLE
Add defined guards against variables that may be undefined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+### @cesium/engine
+
+#### Fixes :wrench:
+
+- Fixed a crash in `ImageryLayer` when computing tile imagery skeletons for rectangles that do not intersect the imagery provider's bounds.
+
 ## 1.145 - 2026-09-02
 
 ### @cesium/engine

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -467,3 +467,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Sam Pomeroy](https://github.com/SamPomeroy)
 - [zhaochen](https://github.com/cyzhao-dad)
 - [Kanchan Basnet](https://github.com/Kanchanbasnet)
+- [skabra](https://github.com/silvikabra1)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -467,4 +467,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Sam Pomeroy](https://github.com/SamPomeroy)
 - [zhaochen](https://github.com/cyzhao-dad)
 - [Kanchan Basnet](https://github.com/Kanchanbasnet)
-- [skabra](https://github.com/silvikabra1)
+- [Silvi Kabra](https://github.com/silvikabra1)

--- a/packages/engine/Source/Scene/ImageryLayer.js
+++ b/packages/engine/Source/Scene/ImageryLayer.js
@@ -735,6 +735,11 @@ ImageryLayer.prototype._createTileImagerySkeletons = function (
     this._rectangle,
     imageryBoundsScratch,
   );
+
+  if (!defined(imageryBounds)) {
+    return false;
+  }
+
   let rectangle = Rectangle.intersection(
     tile.rectangle,
     imageryBounds,
@@ -902,10 +907,12 @@ ImageryLayer.prototype._createTileImagerySkeletons = function (
       imageryRectangle,
       imageryRectangle,
     );
-    imageryTilingScheme.rectangleToNativeRectangle(
-      clippedImageryRectangle,
-      clippedImageryRectangle,
-    );
+    if (defined(clippedImageryRectangle)) {
+      imageryTilingScheme.rectangleToNativeRectangle(
+        clippedImageryRectangle,
+        clippedImageryRectangle,
+      );
+    }
     imageryTilingScheme.rectangleToNativeRectangle(
       imageryBounds,
       imageryBounds,
@@ -930,6 +937,7 @@ ImageryLayer.prototype._createTileImagerySkeletons = function (
   // Calculate where it does start.
   if (
     !this.isBaseLayer() &&
+    defined(clippedImageryRectangle) &&
     Math.abs(clippedImageryRectangle.west - terrainRectangle.west) >= veryCloseX
   ) {
     maxU = Math.min(
@@ -941,6 +949,7 @@ ImageryLayer.prototype._createTileImagerySkeletons = function (
 
   if (
     !this.isBaseLayer() &&
+    defined(clippedImageryRectangle) &&
     Math.abs(clippedImageryRectangle.north - terrainRectangle.north) >=
       veryCloseY
   ) {

--- a/packages/engine/Specs/Scene/ImageryLayerSpec.js
+++ b/packages/engine/Specs/Scene/ImageryLayerSpec.js
@@ -815,6 +815,39 @@ describe(
         expect(textureCoordinates.z).toBeLessThan(1.0);
         expect(textureCoordinates.w).toBeLessThan(1.0);
       });
+
+      it("does not throw when the imagery provider's rectangle does not overlap the layer's rectangle", async function () {
+        // The provider's own rectangle and the layer's rectangle don't overlap at all, so their
+        // intersection (imageryBounds) is undefined. Prior to the fix, this undefined value was
+        // passed straight into Rectangle.intersection() without a defined check, which throws.
+        const provider = await SingleTileImageryProvider.fromUrl(
+          "Data/Images/Green4x4.png",
+          {
+            rectangle: Rectangle.fromDegrees(7.2, 60.9, 9.0, 61.7),
+          },
+        );
+
+        const layer = new ImageryLayer(provider, {
+          rectangle: Rectangle.fromDegrees(-20.0, -20.0, -10.0, -10.0),
+        });
+
+        const terrainProvider = new EllipsoidTerrainProvider();
+        const tiles = QuadtreeTile.createLevelZeroTiles(
+          terrainProvider.tilingScheme,
+        );
+        tiles[0].data = new GlobeSurfaceTile();
+        tiles[1].data = new GlobeSurfaceTile();
+
+        expect(
+          layer._createTileImagerySkeletons(tiles[0], terrainProvider),
+        ).toBe(false);
+        expect(
+          layer._createTileImagerySkeletons(tiles[1], terrainProvider),
+        ).toBe(false);
+
+        expect(tiles[0].data.imagery.length).toBe(0);
+        expect(tiles[1].data.imagery.length).toBe(0);
+      });
     });
   },
   "WebGL",


### PR DESCRIPTION
# Description

Added defined checks for variables returned from `Rectangle.intersection`, because it can return undefined.

## Testing plan

Observed 2 Cesium map rendering errors intermittently with the following stack traces:
<img width="5549" height="2694" alt="IMG_0025" src="https://github.com/user-attachments/assets/feb70a92-60fb-457e-82c3-22b09701ff6c" />
<img width="5360" height="2250" alt="IMG_0023" src="https://github.com/user-attachments/assets/fe4d3a55-3559-4fa4-a505-36a4e0069efb" />
Tested by locally patching Cesium with these fixes and did not observe these issues.
Ran test suite against this branch, all succeeded except for 3 tests that fail on my machine even on main.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

Claude

If yes, I used the following Model(s):

Sonnet 5
