### PR TITLE
Fix BillboardCollection vertex array lifetime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 #### Fixes :wrench:
 
+- Fixed a render crash caused by billboard vertex arrays being destroyed while retained draw commands still referenced them.
 - Fixed draped vector polylines rendering at twice their specified width, and antialiased their edges. Antialiasing can be turned off with `scene.vectorProvider.antialias` if you prefer the extra performance. [#13675](https://github.com/CesiumGS/cesium/pull/13675)
 - Updated the minimum version of `dompurify` dependency to `3.4.5`, addressing security vulnerability tracked in [CVE-2026-49458](https://github.com/advisories/GHSA-hpcv-96wg-7vj8). [#13646](https://github.com/CesiumGS/cesium/issues/13646)
 - Fixed feature ID textures ignoring the wrap mode declared by the glTF sampler. Forcing nearest filtering no longer replaces `wrapS` and `wrapT` with `CLAMP_TO_EDGE`. [#11574](https://github.com/CesiumGS/cesium/issues/11574)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 #### Fixes :wrench:
 
-- Fixed a render crash caused by billboard vertex arrays being destroyed while retained draw commands still referenced them.
+- Fixed a render crash caused by billboard vertex arrays being destroyed while retained draw commands still referenced them. [#13697](https://github.com/CesiumGS/cesium/pull/13697)
 - Fixed draped vector polylines rendering at twice their specified width, and antialiased their edges. Antialiasing can be turned off with `scene.vectorProvider.antialias` if you prefer the extra performance. [#13675](https://github.com/CesiumGS/cesium/pull/13675)
 - Updated the minimum version of `dompurify` dependency to `3.4.5`, addressing security vulnerability tracked in [CVE-2026-49458](https://github.com/advisories/GHSA-hpcv-96wg-7vj8). [#13646](https://github.com/CesiumGS/cesium/issues/13646)
 - Fixed feature ID textures ignoring the wrap mode declared by the glTF sampler. Forcing nearest filtering no longer replaces `wrapS` and `wrapT` with `CLAMP_TO_EDGE`. [#11574](https://github.com/CesiumGS/cesium/issues/11574)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -468,3 +468,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [zhaochen](https://github.com/cyzhao-dad)
 - [Kanchan Basnet](https://github.com/Kanchanbasnet)
 - [Mhayk Whandson](https://github.com/mhayk)
+- [Raphi](https://github.com/rotwurstesser)

--- a/packages/engine/Source/Scene/BillboardCollection.js
+++ b/packages/engine/Source/Scene/BillboardCollection.js
@@ -147,6 +147,7 @@ function BillboardCollection(options) {
   this._rsOpaque = undefined;
   this._rsTranslucent = undefined;
   this._vaf = undefined;
+  this._vafsToDestroy = [];
 
   this._billboards = [];
   this._billboardsToUpdate = [];
@@ -1565,6 +1566,21 @@ const scratchWriterArray = [];
  * @exception {RuntimeError} image with id must be in the atlas.
  */
 BillboardCollection.prototype.update = function (frameState) {
+  // A pick pass can retain and execute commands from the previous render frame.
+  // Wait until a later render frame rebuilds the command list before destroying
+  // the vertex arrays referenced by those commands.
+  const vafsToDestroy = this._vafsToDestroy;
+  for (let i = vafsToDestroy.length - 1; i >= 0; --i) {
+    const entry = vafsToDestroy[i];
+    if (
+      frameState.passes.render &&
+      entry.frameNumber !== frameState.frameNumber
+    ) {
+      entry.vaf.destroy();
+      vafsToDestroy.splice(i, 1);
+    }
+  }
+
   removeBillboards(this);
 
   if (!this.show) {
@@ -1647,7 +1663,14 @@ BillboardCollection.prototype.update = function (frameState) {
       properties[k] = 0;
     }
 
-    this._vaf = this._vaf && this._vaf.destroy();
+    const vertexArrayFacade = this._vaf;
+    if (defined(vertexArrayFacade)) {
+      vafsToDestroy.push({
+        vaf: vertexArrayFacade,
+        frameNumber: frameState.frameNumber,
+      });
+      this._vaf = undefined;
+    }
 
     if (billboardsLength > 0) {
       // PERFORMANCE_IDEA:  Instead of creating a new one, resize like std::vector.
@@ -2147,6 +2170,10 @@ BillboardCollection.prototype.destroy = function () {
   this._sp = this._sp && this._sp.destroy();
   this._spTranslucent = this._spTranslucent && this._spTranslucent.destroy();
   this._vaf = this._vaf && this._vaf.destroy();
+  const vafsToDestroy = this._vafsToDestroy;
+  for (let i = 0; i < vafsToDestroy.length; ++i) {
+    vafsToDestroy[i].vaf.destroy();
+  }
   destroyBillboards(this._billboards);
 
   return destroyObject(this);

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -1525,6 +1525,68 @@ describe("Scene/BillboardCollection", function () {
         expect(scene).toRender([0, 0, 255, 255]);
       });
 
+      it("keeps replaced vertex arrays alive until the next render frame", async function () {
+        const billboard = billboards.add({
+          position: Cartesian3.ZERO,
+          image: greenImage,
+        });
+
+        await pollToPromise(() => {
+          scene.renderForSpecs();
+          return billboard.ready;
+        });
+
+        const oldVertexArrayFacade = billboards._vaf;
+        billboards.add({
+          position: Cartesian3.UNIT_X,
+          image: blueImage,
+        });
+        billboards.update(scene.frameState);
+
+        expect(oldVertexArrayFacade.isDestroyed()).toBeFalse();
+
+        billboards.update(scene.frameState);
+        expect(oldVertexArrayFacade.isDestroyed()).toBeFalse();
+
+        scene.clearPasses(scene.frameState.passes);
+        scene.frameState.passes.pick = true;
+        billboards.update(scene.frameState);
+        expect(oldVertexArrayFacade.isDestroyed()).toBeFalse();
+
+        const afterRender = scene.frameState.afterRender.splice(0);
+        for (const callback of afterRender) {
+          callback();
+        }
+        expect(oldVertexArrayFacade.isDestroyed()).toBeFalse();
+
+        scene.renderForSpecs();
+        expect(oldVertexArrayFacade.isDestroyed()).toBeTrue();
+      });
+
+      it("destroys deferred vertex arrays when destroyed", async function () {
+        const billboard = billboards.add({
+          position: Cartesian3.ZERO,
+          image: greenImage,
+        });
+
+        await pollToPromise(() => {
+          scene.renderForSpecs();
+          return billboard.ready;
+        });
+
+        const oldVertexArrayFacade = billboards._vaf;
+        billboards.add({
+          position: Cartesian3.UNIT_X,
+          image: blueImage,
+        });
+        billboards.update(scene.frameState);
+
+        expect(oldVertexArrayFacade.isDestroyed()).toBeFalse();
+
+        scene.primitives.remove(billboards);
+        expect(oldVertexArrayFacade.isDestroyed()).toBeTrue();
+      });
+
       it("removes and renders a billboard", async function () {
         const greenBillboard = billboards.add({
           position: Cartesian3.ZERO,


### PR DESCRIPTION
# Description

`BillboardCollection` currently destroys its `VertexArrayFacade` immediately when rebuilding billboard buffers. Cesium can retain draw commands from the previous render and execute them again in a translucent-depth pick pass. A retained command can therefore reference a vertex array that the collection has already destroyed, causing rendering to stop with:

```text
DeveloperError: This object was destroyed, i.e., destroy() was called.
at VertexArray.throwOnDestroyed
at Context.draw
at DrawCommand.execute
```

We encountered this failure while pressure-testing the swisstopo GeoAdmin 3D viewer. The corresponding scene is available in the official viewer: [open map.geo.admin.ch in 3D](https://map.geo.admin.ch/#/map?lang=en&sr=3857&camera=7.915982,46.706029,951.3,-8,58,&3d&topic=ech&layers=ch.swisstopo.swisstlm3d-wanderwege,f&bgLayer=ch.swisstopo.pixelkarte-farbe).

This change queues superseded billboard vertex-array facades and destroys them only during a later render frame, after `Scene.updateFrameState` has cleared the previous command list. Same-frame updates and pick passes keep the retired arrays alive. Destroying the collection still releases both its current and deferred resources.

This follows the lifecycle principle used by the terrain fixes in [#6918](https://github.com/CesiumGS/cesium/pull/6918) and [#3900](https://github.com/CesiumGS/cesium/pull/3900): resources referenced by previous-frame commands must outlive passes that can replay those commands.

Related: [#7055](https://github.com/CesiumGS/cesium/issues/7055) reports the same low-level symptom—a destroyed vertex array on a draw command owned by `BillboardCollection`. This PR does not close that broader diagnostics request.

## Issue number and link

Related to [#7055](https://github.com/CesiumGS/cesium/issues/7055).

## Testing plan

The regression spec verifies that a replaced billboard vertex array:

1. survives another update in the same render frame;
2. survives a pick pass;
3. survives `afterRender` callbacks;
4. is destroyed when the next render frame rebuilds the command list; and
5. is still released if the collection is destroyed first.

Negative controls:

- The original immediate-destruction implementation fails the new lifetime spec at the first survival assertion.
- Deferring destruction only to `afterRender` fails the same spec after the callbacks run (`Expected true to be false`).

Commands run:

```bash
npm run test -- --includeName "Scene/BillboardCollection" --failTaskOnError --suppressPassed
CI=1 npm run coverage -- --workspace engine --webglStub --failTaskOnError --suppressPassed
npm run eslint
npm run build
npx prettier --check CHANGES.md CONTRIBUTORS.md packages/engine/Source/Scene/BillboardCollection.js packages/engine/Specs/Scene/BillboardCollectionSpec.js
git diff --check
```

Results:

- `BillboardCollection`: 142/142 passed.
- Engine coverage with WebGL stub: 15,344/15,344 passed; all new statements and branches covered.
- ESLint, build, targeted Prettier, and `git diff --check`: passed.
- Full hardware-WebGL suite: 15,687 passed and 4 unrelated GPU-rendering assertions failed locally (one `AutomaticUniforms` overlay assertion and three `pnts` assertions). The overlay assertion also fails when rerun alone; none of the four failures exercise `BillboardCollection`.

GeoAdmin 3D viewer pressure test against a verified Vite bundle containing this patch:

- 32 deterministic runs at four workers: no render crash; 29 passed, with three independent camera-jump failures.
- Previously crashing seed `804409145`: 10/10 repetitions passed at four workers.
- 8 seeded random runs at four workers: no render crash; 6 passed, with two `ERR_NETWORK_CHANGED` failures.
- Peak browser RSS: 10,425.70 MB; peak system use: 80,138.91 MB; swap: 0 MB.

This patch addresses the destroyed billboard vertex-array crash only. It does not claim to fix the separate camera-navigation jump.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

OpenAI Codex; Agon for peer-review orchestration.

If yes, I used the following Model(s):

GPT-5; Codex; Kimi `kimi-for-coding`; Claude CLI default. MiniMax M3 was invoked for review but produced no usable output.
