### PR TITLE
Add surfacePosition to Scene.snap

### DIFF
--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -4777,6 +4777,7 @@ Scene.prototype.pick = function (windowPosition, width, height) {
  * @typedef {object} SceneSnapResult
  * @property {object} object The snapped primitive or feature.
  * @property {Cartesian3} position The world-space position of the snap point, un-projected from the snap framebuffer's eye-space depth.
+ * @property {Cartesian3|undefined} surfacePosition The world-space position of the same object's surface fragment nearest the snap point. For a surface snap this equals <code>position</code>; for an edge snap it is a point on a face of the object rather than on its silhouette, or <code>undefined</code> if no surface fragment of the object is visible in the search region.
  * @property {Cartesian2} screenPosition The window coordinates of the snap point.
  * @property {boolean} isEdge <code>true</code> if the snap point lies on an edge; <code>false</code> if it lies on a surface.
  *

--- a/packages/engine/Source/Scene/Snapping.js
+++ b/packages/engine/Source/Scene/Snapping.js
@@ -76,6 +76,27 @@ function selectBestHit(hits) {
   );
 }
 
+// Find the surface hit belonging to the same object that lies closest to the
+// winning hit, if any. Unlike an edge hit, whose position lies exactly on the
+// object's silhouette, this point is unambiguously on the object.
+function nearestSurfaceHit(hits, target) {
+  let best;
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (const hit of hits) {
+    if (hit.isEdge || hit.object !== target.object) {
+      continue;
+    }
+    const dx = hit.x - target.x;
+    const dy = hit.y - target.y;
+    const dist = dx * dx + dy * dy;
+    if (dist < bestDist) {
+      best = hit;
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
 // Unproject a snap hit's eye-space depth (channel B of the snap framebuffer,
 // written by the snap shader at the edge fragment itself) into a world
 // position.
@@ -166,10 +187,21 @@ Snapping.snap = function (scene, windowPosition, options) {
     return undefined;
   }
 
+  // For edge hits, also unproject the nearest same-object surface fragment so
+  // consumers have a seed point that is on the object but off its silhouette.
+  let surfacePosition = position;
+  if (best.isEdge) {
+    const surfaceHit = nearestSurfaceHit(hits, best);
+    surfacePosition = defined(surfaceHit)
+      ? snapHitToWorld(scene, windowPosition, surfaceHit)
+      : undefined;
+  }
+
   return {
     object: best.object,
     isEdge: best.isEdge,
     position: position,
+    surfacePosition: surfacePosition,
     screenPosition: new Cartesian2(
       windowPosition.x + best.x,
       windowPosition.y + best.y,
@@ -179,6 +211,7 @@ Snapping.snap = function (scene, windowPosition, options) {
 
 // Exposed for testing.
 Snapping._selectBestHit = selectBestHit;
+Snapping._nearestSurfaceHit = nearestSurfaceHit;
 Snapping._snapHitToWorld = snapHitToWorld;
 
 export default Snapping;


### PR DESCRIPTION
# Description

Adds `surfacePosition` to `SceneSnapResult`. This variable contains, for edge snaps, the nearest same-object surface hit's world position (or `undefined`). For surface snaps, this property equals `position`. This is needed by the hybrid snapping sandcastle (#13699) to seed even more accurate server-side snaps with surface positions off the silhouette in some knife-edge situations.

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

I tested these changes manually using the dev sandcastle in #13699.
TODO:
- [ ] Verify snapping unit test pass
- [ ] Expand snapping unit tests to contain this property?

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

GitHub Copilot

If yes, I used the following Model(s):

Claude Fable 5