### PR TITLE
VectorProvider: Move VectorProvider ownership to Scene, add .texturesByteLength 

### DIFF
--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -42,6 +42,8 @@ const scratchSegmentEnd = new Cartesian2();
  *
  * @typedef {object} VectorTileData
  *
+ * @property {Function} destroy Destroys the vector data and frees GPU resources.
+ *
  * @property {boolean} show Whether this vector data should be rendered.
  * @property {boolean} hasPolylines Whether polyline lookup data was baked.
  * @property {boolean} hasPolygons Whether polygon lookup data was baked.

--- a/packages/engine/Source/Core/VectorPipeline.js
+++ b/packages/engine/Source/Core/VectorPipeline.js
@@ -23,7 +23,6 @@ import Rectangle from "./Rectangle.js";
 /** @import BufferPolylineCollection from "../Scene/BufferPolylineCollection.js"; */
 /** @import Context from "../Renderer/Context.js"; */
 /** @import Ellipsoid from "./Ellipsoid.js"; */
-/** @import TilingScheme from "./TilingScheme.js"; */
 
 const GRID_TARGET_SEGMENTS_PER_CELL = 16;
 const GRID_NEIGHBOR_PADDING_SCALE = 0.35;
@@ -114,11 +113,11 @@ const scratchSegmentEnd = new Cartesian2();
 class VectorPipeline {
   /**
    * @param {BufferPolylineCollection} collection
-   * @param {TilingScheme} tilingScheme
+   * @param {Ellipsoid} ellipsoid
    * @param {VectorCollectionData} [result]
    * @returns {VectorCollectionData}
    */
-  static packPolylineCollectionData(collection, tilingScheme, result) {
+  static packPolylineCollectionData(collection, ellipsoid, result) {
     if (
       defined(result) &&
       collection._dirtyCount === 0 &&
@@ -129,7 +128,6 @@ class VectorPipeline {
 
     const primitiveCount = collection.primitiveCount;
     const boundingVolume = collection.boundingVolume;
-    const ellipsoid = tilingScheme.ellipsoid;
 
     const rectangle = Rectangle.fromBoundingSphere(boundingVolume, ellipsoid);
     const positions = _getProjectedPositions(collection, ellipsoid);
@@ -339,11 +337,11 @@ class VectorPipeline {
 
   /**
    * @param {BufferPolygonCollection} collection
-   * @param {TilingScheme} tilingScheme
+   * @param {Ellipsoid} ellipsoid
    * @param {VectorCollectionData} [result]
    * @returns {VectorCollectionData}
    */
-  static packPolygonCollectionData(collection, tilingScheme, result) {
+  static packPolygonCollectionData(collection, ellipsoid, result) {
     if (
       defined(result) &&
       collection._dirtyCount === 0 &&
@@ -354,7 +352,6 @@ class VectorPipeline {
 
     const primitiveCount = collection.primitiveCount;
     const boundingVolume = collection.boundingVolume;
-    const ellipsoid = tilingScheme.ellipsoid;
 
     const rectangle = Rectangle.fromBoundingSphere(boundingVolume, ellipsoid);
     const positions = _getProjectedPositions(collection, ellipsoid);

--- a/packages/engine/Source/Core/VectorProvider.js
+++ b/packages/engine/Source/Core/VectorProvider.js
@@ -321,6 +321,7 @@ class VectorProvider {
       rectangle: Rectangle.clone(rectangle),
       collectionVersions: new Map(),
       minimumTileScreenPixels: this.minimumTileScreenPixels,
+      destroy: () => this.releaseTileData(result),
     };
 
     this._tileDataCache.add(result);

--- a/packages/engine/Source/Core/VectorProvider.js
+++ b/packages/engine/Source/Core/VectorProvider.js
@@ -28,7 +28,7 @@ const scratchIntersectRectangle = new Rectangle();
  *
  * @callback PackCollectionData
  * @param {*} collection
- * @param {TilingScheme} tilingScheme
+ * @param {Ellipsoid} ellipsoid
  * @param {VectorCollectionData} [result]
  * @returns {VectorCollectionData}
  * @private
@@ -72,7 +72,7 @@ collectionPackers.set(BufferPolygonCollection, {
 
 /**
  * @typedef {object} VectorProviderConstructorOptions
- * @property {TilingScheme} tilingScheme
+ * @property {Ellipsoid} ellipsoid
  * @property {boolean} [antialias=true] Whether to fade draped polyline edges over the pixel
  * straddling them. Disabling this is faster but leaves the edges aliased.
  * @property {number} [minimumTileScreenPixels=256] Lower bound on the screen size, in pixels, of
@@ -87,7 +87,7 @@ class VectorProvider {
   /** @param {VectorProviderConstructorOptions} options */
   constructor(options) {
     /** @private */
-    this._tilingScheme = options.tilingScheme;
+    this._ellipsoid = options.ellipsoid;
 
     /**
      * Whether to fade draped polyline edges over the pixel straddling them.
@@ -125,6 +125,14 @@ class VectorProvider {
     this._collectionDataCache = new WeakMap();
 
     /**
+     * VectorTileData created by this provider but not yet released. Tracked
+     * so resources can be freed if the VectorProvider is destroyed.
+     * @type {Set<VectorTileData>}
+     * @private
+     */
+    this._tileDataCache = new Set();
+
+    /**
      * Collections marked this frame (only these are baked).
      * @type {Set<BufferPrimitiveCollection<BufferPrimitive>>}
      * @private
@@ -144,18 +152,9 @@ class VectorProvider {
     this._dirtyRectangles = [];
   }
 
-  /** @type {TilingScheme} */
-  get tilingScheme() {
-    return this._tilingScheme;
-  }
-
-  set tilingScheme(value) {
-    this._tilingScheme = value;
-  }
-
   /** @type {Ellipsoid} */
   get ellipsoid() {
-    return this._tilingScheme.ellipsoid;
+    return this._ellipsoid;
   }
 
   /**
@@ -267,7 +266,7 @@ class VectorProvider {
   _markCollectionRegionDirty(collection) {
     const collectionRectangle = Rectangle.fromBoundingSphere(
       collection.boundingVolume,
-      this._tilingScheme.ellipsoid,
+      this._ellipsoid,
       new Rectangle(),
     );
     this._dirtyRectangles.push(collectionRectangle);
@@ -277,6 +276,7 @@ class VectorProvider {
    * @param {number} x
    * @param {number} y
    * @param {number} level
+   * @param {TilingScheme} tilingScheme
    * @param {Context} context
    * @param {HeightReference} targetHeightReference The kind of
    *   surface the data is baked for, either {@link HeightReference.CLAMP_TO_TERRAIN} or
@@ -284,8 +284,8 @@ class VectorProvider {
    *   included.
    * @returns {VectorTileData}
    */
-  requestTileData(x, y, level, context, targetHeightReference) {
-    const tileRectangle = this._tilingScheme.tileXYToRectangle(
+  requestTileData(x, y, level, tilingScheme, context, targetHeightReference) {
+    const tileRectangle = tilingScheme.tileXYToRectangle(
       x,
       y,
       level,
@@ -311,7 +311,6 @@ class VectorProvider {
    * @returns {VectorTileData}
    */
   requestDataForRectangle(rectangle, context, targetHeightReference) {
-    const tilingScheme = this._tilingScheme;
     const heightReferenceByCollection = this._heightReferenceByCollection;
 
     /** @type {VectorTileData} */
@@ -324,6 +323,8 @@ class VectorProvider {
       minimumTileScreenPixels: this.minimumTileScreenPixels,
     };
 
+    this._tileDataCache.add(result);
+
     for (const [collection, heightReference] of heightReferenceByCollection) {
       if (!targetsSurface(heightReference, targetHeightReference)) {
         continue;
@@ -331,7 +332,7 @@ class VectorProvider {
 
       const collectionRectangle = Rectangle.fromBoundingSphere(
         collection.boundingVolume,
-        tilingScheme.ellipsoid,
+        this._ellipsoid,
         scratchCollectionRectangle,
       );
 
@@ -390,6 +391,7 @@ class VectorProvider {
    */
   releaseTileData(data) {
     VectorPipeline.freeResources(data);
+    this._tileDataCache.delete(data);
   }
 
   /**
@@ -401,22 +403,37 @@ class VectorProvider {
    * @param {number} x
    * @param {number} y
    * @param {number} level
+   * @param {TilingScheme} tilingScheme
    * @param {Context} context
    * @param {VectorTileData} currentData
    * @param {HeightReference} targetHeightReference Either
    *   {@link HeightReference.CLAMP_TO_TERRAIN} or {@link HeightReference.CLAMP_TO_3D_TILE}.
    * @returns {VectorTileData}
    */
-  updateTileData(x, y, level, context, currentData, targetHeightReference) {
+  updateTileData(
+    x,
+    y,
+    level,
+    tilingScheme,
+    context,
+    currentData,
+    targetHeightReference,
+  ) {
     const dirtyRectangles = this._dirtyRectangles;
-    const tilingScheme = this._tilingScheme;
     if (!intersectRectangles(x, y, level, dirtyRectangles, tilingScheme)) {
       return currentData;
     }
 
     this.releaseTileData(currentData);
 
-    return this.requestTileData(x, y, level, context, targetHeightReference);
+    return this.requestTileData(
+      x,
+      y,
+      level,
+      tilingScheme,
+      context,
+      targetHeightReference,
+    );
   }
 
   /**
@@ -482,7 +499,7 @@ class VectorProvider {
 
       const collectionRectangle = Rectangle.fromBoundingSphere(
         collection.boundingVolume,
-        this._tilingScheme.ellipsoid,
+        this._ellipsoid,
         scratchCollectionRectangle,
       );
       const isIntersected = !!Rectangle.intersection(
@@ -577,7 +594,7 @@ class VectorProvider {
       return cache;
     }
 
-    const data = packCollectionData(collection, this._tilingScheme, cache);
+    const data = packCollectionData(collection, this._ellipsoid, cache);
 
     // If dirty, the version increments +1 when marked clean below.
     data.version = collection._version + (dirty ? 1 : 0);
@@ -591,6 +608,40 @@ class VectorProvider {
     collection._makeClean();
 
     return data;
+  }
+
+  get texturesByteLength() {
+    let byteLength = 0;
+
+    for (const data of this._tileDataCache) {
+      const textures = [
+        data.colorTexture,
+        data.widthTexture,
+
+        data.polylineSegmentTexture,
+        data.polylineGridCellIndicesTexture,
+        data.polylineSegmentPrimitiveIndicesTexture,
+
+        data.polygonEdgeTexture,
+        data.polygonEdgePrimitiveIndicesTexture,
+        data.polygonGridCellIndicesTexture,
+      ];
+
+      for (const texture of textures) {
+        if (defined(texture)) {
+          byteLength += texture._sizeInBytes;
+        }
+      }
+    }
+
+    return byteLength;
+  }
+
+  destroy() {
+    for (const data of this._tileDataCache) {
+      VectorPipeline.freeResources(data);
+      this._tileDataCache.delete(data);
+    }
   }
 }
 

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -521,9 +521,6 @@ Object.defineProperties(Globe.prototype, {
     set: function (value) {
       if (value !== this._terrainProvider) {
         this._terrainProvider = value;
-        if (defined(value)) {
-          this._vectorProvider.tilingScheme = value.tilingScheme;
-        }
         this._terrainProviderChanged.raiseEvent(value);
         if (defined(this._material)) {
           makeShadersDirty(this);

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -28,7 +28,8 @@ import QuadtreePrimitive from "./QuadtreePrimitive.js";
 import SceneMode from "./SceneMode.js";
 import ShadowMode from "./ShadowMode.js";
 import CesiumMath from "../Core/Math.js";
-import VectorProvider from "../Core/VectorProvider.js";
+
+/** @import VectorProvider from "../Core/VectorProvider.js"; */
 
 /**
  * The globe rendered in the scene, including its terrain ({@link Globe#terrainProvider})
@@ -42,13 +43,8 @@ import VectorProvider from "../Core/VectorProvider.js";
  */
 function Globe(ellipsoid) {
   ellipsoid = ellipsoid ?? Ellipsoid.default;
-  const terrainProvider = new EllipsoidTerrainProvider({
-    ellipsoid: ellipsoid,
-  });
+  const terrainProvider = new EllipsoidTerrainProvider({ ellipsoid });
   const imageryLayerCollection = new ImageryLayerCollection();
-  const vectorProvider = new VectorProvider({
-    tilingScheme: terrainProvider.tilingScheme,
-  });
 
   this._ellipsoid = ellipsoid;
   this._imageryLayerCollection = imageryLayerCollection;
@@ -61,14 +57,14 @@ function Globe(ellipsoid) {
       terrainProvider: terrainProvider,
       imageryLayers: imageryLayerCollection,
       surfaceShaderSet: this._surfaceShaderSet,
-      vectorProvider,
     }),
   });
 
   this._terrainProvider = terrainProvider;
   this._terrainProviderChanged = new Event();
 
-  this._vectorProvider = vectorProvider;
+  /** @type {VectorProvider} */
+  this._vectorProvider = undefined;
 
   this._undergroundColor = Color.clone(Color.BLACK);
   this._undergroundColorAlphaByDistance = new NearFarScalar(
@@ -552,6 +548,10 @@ Object.defineProperties(Globe.prototype, {
   vectorProvider: {
     get: function () {
       return this._vectorProvider;
+    },
+    set: function (value) {
+      this._vectorProvider = value;
+      this._surface.tileProvider.vectorProvider = value;
     },
   },
   /**

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -63,7 +63,10 @@ function Globe(ellipsoid) {
   this._terrainProvider = terrainProvider;
   this._terrainProviderChanged = new Event();
 
-  /** @type {VectorProvider} */
+  /**
+   * @type {VectorProvider}
+   * @ignore
+   */
   this._vectorProvider = undefined;
 
   this._undergroundColor = Color.clone(Color.BLACK);

--- a/packages/engine/Source/Scene/GlobeSurfaceTile.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTile.js
@@ -9,7 +9,6 @@ import RequestState from "../Core/RequestState.js";
 import RequestType from "../Core/RequestType.js";
 import TerrainEncoding from "../Core/TerrainEncoding.js";
 import TileProviderError from "../Core/TileProviderError.js";
-import VectorPipeline from "../Core/VectorPipeline.js";
 import Buffer from "../Renderer/Buffer.js";
 import BufferUsage from "../Renderer/BufferUsage.js";
 import PixelDatatype from "../Renderer/PixelDatatype.js";
@@ -165,7 +164,7 @@ class GlobeSurfaceTile {
     }
 
     if (defined(this.vectorData)) {
-      VectorPipeline.freeResources(this.vectorData);
+      this.vectorData.destroy();
       this.vectorData = undefined;
     }
 

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -79,7 +79,7 @@ class GlobeSurfaceTileProvider {
    * @param {TerrainProvider} options.terrainProvider The terrain provider that describes the surface geometry.
    * @param {ImageryLayerCollection} options.imageryLayers The collection of imagery layers describing the shading of the surface.
    * @param {GlobeSurfaceShaderSet} options.surfaceShaderSet The set of shaders used to render the surface.
-   * @param {VectorProvider} options.vectorProvider
+   * @param {VectorProvider} [options.vectorProvider]
    */
   constructor(options) {
     //>>includeStart('debug', pragmas.debug);
@@ -92,8 +92,6 @@ class GlobeSurfaceTileProvider {
       throw new DeveloperError("options.imageryLayers is required.");
     } else if (!defined(options.surfaceShaderSet)) {
       throw new DeveloperError("options.surfaceShaderSet is required.");
-    } else if (!defined(options.vectorProvider)) {
-      throw new DeveloperError("options.vectorProvider is required.");
     }
     //>>includeEnd('debug');
 
@@ -322,6 +320,10 @@ class GlobeSurfaceTileProvider {
     return this._vectorProvider;
   }
 
+  set vectorProvider(value) {
+    this._vectorProvider = value;
+  }
+
   /**
    * The {@link ClippingPlaneCollection} used to selectively disable rendering.
    *
@@ -390,6 +392,7 @@ class GlobeSurfaceTileProvider {
     this._quadtree.forEachRenderedTile(
       /** @param {QuadtreeTile} tile */
       (tile) => {
+        const tilingScheme = this.tilingScheme;
         const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
 
         if (defined(surfaceTile.vectorData)) {
@@ -397,6 +400,7 @@ class GlobeSurfaceTileProvider {
             tile.x,
             tile.y,
             tile.level,
+            tilingScheme,
             frameState.context,
             surfaceTile.vectorData,
             HeightReference.CLAMP_TO_TERRAIN,
@@ -406,6 +410,7 @@ class GlobeSurfaceTileProvider {
             tile.x,
             tile.y,
             tile.level,
+            tilingScheme,
             frameState.context,
             HeightReference.CLAMP_TO_TERRAIN,
           );

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -2612,7 +2612,7 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
   surfaceShaderSetOptions.hasGeodeticSurfaceNormals = hasGeodeticSurfaceNormals;
   surfaceShaderSetOptions.hasExaggeration = hasExaggeration;
   surfaceShaderSetOptions.vectorAntialias =
-    tileProvider.vectorProvider.antialias;
+    tileProvider.vectorProvider?.antialias ?? false;
 
   const tileImageryCollection = surfaceTile.imagery;
   let imageryIndex = 0;

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -387,37 +387,39 @@ class GlobeSurfaceTileProvider {
     // Record regions dirtied by changed collections, re-bake overlapping
     // tiles, and build vector data for new surface tiles.
     const vectorProvider = this._vectorProvider;
-    vectorProvider.minimumTileScreenPixels = minimumTileScreenPixels(this);
-    vectorProvider.update(frameState.frameNumber);
-    this._quadtree.forEachRenderedTile(
-      /** @param {QuadtreeTile} tile */
-      (tile) => {
-        const tilingScheme = this.tilingScheme;
-        const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
+    if (defined(vectorProvider)) {
+      vectorProvider.minimumTileScreenPixels = minimumTileScreenPixels(this);
+      vectorProvider.update(frameState.frameNumber);
+      this._quadtree.forEachRenderedTile(
+        /** @param {QuadtreeTile} tile */
+        (tile) => {
+          const tilingScheme = this.tilingScheme;
+          const surfaceTile = /** @type {GlobeSurfaceTile} */ (tile.data);
 
-        if (defined(surfaceTile.vectorData)) {
-          surfaceTile.vectorData = vectorProvider.updateTileData(
-            tile.x,
-            tile.y,
-            tile.level,
-            tilingScheme,
-            frameState.context,
-            surfaceTile.vectorData,
-            HeightReference.CLAMP_TO_TERRAIN,
-          );
-        } else {
-          surfaceTile.vectorData = vectorProvider.requestTileData(
-            tile.x,
-            tile.y,
-            tile.level,
-            tilingScheme,
-            frameState.context,
-            HeightReference.CLAMP_TO_TERRAIN,
-          );
-        }
-      },
-    );
-    vectorProvider.makeClean();
+          if (defined(surfaceTile.vectorData)) {
+            surfaceTile.vectorData = vectorProvider.updateTileData(
+              tile.x,
+              tile.y,
+              tile.level,
+              tilingScheme,
+              frameState.context,
+              surfaceTile.vectorData,
+              HeightReference.CLAMP_TO_TERRAIN,
+            );
+          } else {
+            surfaceTile.vectorData = vectorProvider.requestTileData(
+              tile.x,
+              tile.y,
+              tile.level,
+              tilingScheme,
+              frameState.context,
+              HeightReference.CLAMP_TO_TERRAIN,
+            );
+          }
+        },
+      );
+      vectorProvider.makeClean();
+    }
 
     // Add credits for terrain and imagery providers.
     updateCredits(this, frameState);

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -252,6 +252,10 @@ function Scene(options) {
 
   this._msaaSamples = options.msaaSamples ?? 4;
 
+  this._vectorProvider = new VectorProvider({
+    ellipsoid: this._ellipsoid,
+  });
+
   /**
    * Exceptions occurring in <code>render</code> are always caught in order to raise the
    * <code>renderError</code> event.  If this property is true, the error is rethrown
@@ -1268,7 +1272,7 @@ Object.defineProperties(Scene.prototype, {
    */
   vectorProvider: {
     get: function () {
-      return this.globe?.vectorProvider;
+      return this._vectorProvider;
     },
   },
 
@@ -5563,6 +5567,8 @@ Scene.prototype.destroy = function () {
     this._removeUpdateHeightCallback();
     this._removeUpdateHeightCallback = undefined;
   }
+
+  this._vectorProvider.destroy();
 
   return destroyObject(this);
 };

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -343,6 +343,7 @@ function CesiumWidget(container, options) {
     if (globe !== false) {
       scene.globe = globe;
       scene.globe.shadows = options.terrainShadows ?? ShadowMode.RECEIVE_ONLY;
+      scene.globe.vectorProvider = scene.vectorProvider;
     }
 
     let skyBox = options.skyBox;

--- a/packages/engine/Specs/Core/VectorProviderSpec.js
+++ b/packages/engine/Specs/Core/VectorProviderSpec.js
@@ -17,6 +17,7 @@ import createContext from "../../../../Specs/createContext.js";
 
 describe("Core/VectorProvider", function () {
   const tilingScheme = new GeographicTilingScheme();
+  const ellipsoid = tilingScheme.ellipsoid;
   const level = 4;
 
   let context;
@@ -72,13 +73,14 @@ describe("Core/VectorProvider", function () {
   }
 
   it("returns hidden vector data with no collections", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
     expect(
       provider.requestTileData(
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ),
@@ -86,7 +88,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("returns packed lookup data for a tile overlapping a polyline", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -95,6 +97,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       HeightReference.CLAMP_TO_TERRAIN,
     );
@@ -124,7 +127,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("clips segments to the tile UV domain plus a small margin", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -133,6 +136,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       HeightReference.CLAMP_TO_TERRAIN,
     );
@@ -173,7 +177,7 @@ describe("Core/VectorProvider", function () {
         new BufferPolyline(),
       );
 
-      const provider = new VectorProvider({ tilingScheme });
+      const provider = new VectorProvider({ ellipsoid });
       provider.markForFrame(collection, 0, collection.heightReference);
 
       const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
@@ -181,6 +185,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ).polylineSegmentTexels;
@@ -200,7 +205,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("returns hidden vector data for a tile not overlapping any polyline", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -210,6 +215,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ),
@@ -217,7 +223,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("stops returning data after a collection is removed", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
     provider.remove(collection);
@@ -228,6 +234,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ),
@@ -235,7 +242,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("reports whether a collection is being draped", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     expect(provider.has(collection)).toBe(false);
 
@@ -247,7 +254,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("stops reporting a collection once it is pruned", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -261,7 +268,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("keeps existing tile data when no dirty regions are recorded", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -270,6 +277,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       HeightReference.CLAMP_TO_TERRAIN,
     );
@@ -280,6 +288,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       data,
       HeightReference.CLAMP_TO_TERRAIN,
@@ -288,7 +297,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("re-bakes overlapping tiles after a collection's content changes", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -297,6 +306,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       HeightReference.CLAMP_TO_TERRAIN,
     );
@@ -312,6 +322,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       data,
       HeightReference.CLAMP_TO_TERRAIN,
@@ -321,7 +332,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("records and clears a dirty rectangle for a collection with a local region", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = new BufferPolylineCollection({
       primitiveCountMax: 1,
       vertexCountMax: 3,
@@ -374,7 +385,7 @@ describe("Core/VectorProvider", function () {
   }
 
   it("returns packed polygon lookup data for a tile overlapping a polygon", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolygonCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -383,6 +394,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       HeightReference.CLAMP_TO_TERRAIN,
     );
@@ -459,7 +471,7 @@ describe("Core/VectorProvider", function () {
   }
 
   it("packs hole rings so interior fragments resolve to even parity", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolygonCollection({ withHole: true });
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -468,6 +480,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       HeightReference.CLAMP_TO_TERRAIN,
     );
@@ -495,7 +508,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("returns hidden vector data for a tile not overlapping any polygon", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolygonCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -505,6 +518,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ),
@@ -512,7 +526,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("packs polylines and polygons into a shared primitive index space", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const polylines = createPolylineCollection();
     const polygons = createPolygonCollection();
     provider.markForFrame(polylines, 0, polylines.heightReference);
@@ -523,6 +537,7 @@ describe("Core/VectorProvider", function () {
       xy.x,
       xy.y,
       level,
+      tilingScheme,
       context,
       HeightReference.CLAMP_TO_TERRAIN,
     );
@@ -546,7 +561,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("bakes a terrain-clamped collection only for terrain targets", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection({
       heightReference: HeightReference.CLAMP_TO_TERRAIN,
     });
@@ -558,6 +573,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ).show,
@@ -567,6 +583,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_3D_TILE,
       ).show,
@@ -574,7 +591,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("bakes a 3D Tiles-clamped collection only for model targets", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection({
       heightReference: HeightReference.CLAMP_TO_3D_TILE,
     });
@@ -586,6 +603,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ).show,
@@ -595,6 +613,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_3D_TILE,
       ).show,
@@ -602,7 +621,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("bakes a ground-clamped collection for both terrain and model targets", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection({
       heightReference: HeightReference.CLAMP_TO_GROUND,
     });
@@ -614,6 +633,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ).show,
@@ -623,6 +643,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_3D_TILE,
       ).show,
@@ -630,7 +651,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("prunes a collection once a frame passes without it being marked", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -640,6 +661,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ).show,
@@ -652,6 +674,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ).show,
@@ -664,6 +687,7 @@ describe("Core/VectorProvider", function () {
         xy.x,
         xy.y,
         level,
+        tilingScheme,
         context,
         HeightReference.CLAMP_TO_TERRAIN,
       ).show,
@@ -676,7 +700,7 @@ describe("Core/VectorProvider", function () {
   const farRectangle = Rectangle.fromDegrees(90.0, -45.0, 110.0, -35.0);
 
   it("keeps baked rectangle data when only a non-overlapping collection changes", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const near = createPolylineCollection();
     const far = createPolylineCollection({ longitude: 100.0, latitude: -40.0 });
     provider.markForFrame(near, 0, near.heightReference);
@@ -711,7 +735,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("re-bakes rectangle data when an overlapping collection changes", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const near = createPolylineCollection();
     provider.markForFrame(near, 0, near.heightReference);
 
@@ -736,7 +760,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("re-bakes rectangle data when the rectangle changes", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const collection = createPolylineCollection();
     provider.markForFrame(collection, 0, collection.heightReference);
 
@@ -759,7 +783,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("re-bakes rectangle data when a collection it was baked from is removed", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const near = createPolylineCollection();
     provider.markForFrame(near, 0, near.heightReference);
 
@@ -781,7 +805,7 @@ describe("Core/VectorProvider", function () {
   });
 
   it("re-bakes rectangle data when a collection moves into the rectangle", function () {
-    const provider = new VectorProvider({ tilingScheme });
+    const provider = new VectorProvider({ ellipsoid });
     const far = createPolylineCollection({ longitude: 100.0, latitude: -40.0 });
     provider.markForFrame(far, 0, far.heightReference);
 
@@ -804,5 +828,51 @@ describe("Core/VectorProvider", function () {
     );
     expect(updated).not.toBe(data);
     expect(updated.show).toBe(true);
+  });
+
+  it("computes .texturesByteLength for tile", function () {
+    const provider = new VectorProvider({ ellipsoid });
+    const collection = createPolylineCollection();
+    provider.markForFrame(collection, 0, collection.heightReference);
+
+    expect(provider.texturesByteLength).toBe(0);
+
+    const xy = tilingScheme.positionToTileXY(lineMidpoint, level);
+    const data = provider.requestTileData(
+      xy.x,
+      xy.y,
+      level,
+      tilingScheme,
+      context,
+      HeightReference.CLAMP_TO_TERRAIN,
+    );
+
+    // check that a non-trivial amount of memory was allocated (32 bytes is arbitrary).
+    expect(provider.texturesByteLength).toBeGreaterThan(32);
+
+    provider.releaseTileData(data);
+
+    expect(provider.texturesByteLength).toBe(0);
+  });
+
+  it("computes .texturesByteLength for rectangle", function () {
+    const provider = new VectorProvider({ ellipsoid });
+    const collection = createPolylineCollection();
+    provider.markForFrame(collection, 0, collection.heightReference);
+
+    expect(provider.texturesByteLength).toBe(0);
+
+    const data = provider.requestDataForRectangle(
+      nearRectangle,
+      context,
+      HeightReference.CLAMP_TO_TERRAIN,
+    );
+
+    // check that a non-trivial amount of memory was allocated (32 bytes is arbitrary).
+    expect(provider.texturesByteLength).toBeGreaterThan(32);
+
+    provider.releaseTileData(data);
+
+    expect(provider.texturesByteLength).toBe(0);
   });
 });


### PR DESCRIPTION
# Description

Changes:
- The Scene now owns the VectorProvider, not the Globe, and is responsible for both creating and destroying the VectorProvider.
- Adds `VectorProvider#destroy` method, to free all resources created by the provider.
- Adds `VectorProvider#texturesByteLength` accessor, allowing visibility into memory allocation.

Currently VectorProvider is associated with `scene.globe`. A problem with this (I suspect, but have not tested) is that vectors cannot draped onto 3D Tiles if no globe is enabled, and that showing/hiding the Globe would unnecessarily destroy a VectorProvider that might be in use elsewhere.

Perhaps more importantly I think this simplifies VectorProvider usage. VectorProvider only needs to be configured with an Ellipsoid, not a TilingScheme. The TilingScheme is associated with the draping _target_, and should be provided when requesting tile data for that target.

Part of the motivation here was that "something" in the library should be responsible for cleaning up a VectorProvider's resources when a Scene is destroyed, and that something made more sense as Scene than Globe. 

Finally, I added a `.destroy() and `.texturesByteLength` to VectorProvider so we can clean up its resources if the scene is destroyed, and monitor for optimizations and/or memory leaks in the future.

## Issue number and link

n/a

## Testing plan

```javascript
import * as Cesium from "cesium";

const terrain = await Cesium.Terrain.fromWorldTerrain();
const viewer = new Cesium.Viewer("cesiumContainer", {terrain});

const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(4854512, {
  heightReference: Cesium.HeightReference.CLAMP_TO_TERRAIN,
  scene: viewer.scene,
});

tileset.style = new Cesium.Cesium3DTileStyle({
  color: {
    conditions: [
      [
        "Number(${cnstrct_yr}) === 0 || ${cnstrct_yr} === null",
        "color('grey', 0.6)",
      ],
      ["Number(${cnstrct_yr}) < 1900", "color('#4b0082', 0.8)"],
      ["Number(${cnstrct_yr}) < 1940", "color('#0000cd', 0.8)"],
      ["Number(${cnstrct_yr}) < 1970", "color('#008080', 0.8)"],
      ["Number(${cnstrct_yr}) < 1990", "color('#228b22', 0.8)"],
      ["Number(${cnstrct_yr}) < 2000", "color('#ffd700', 0.8)"],
      ["Number(${cnstrct_yr}) < 2010", "color('#ff8c00', 0.8)"],
      ["true", "color('#ff3300', 0.8)"],
    ],
  },
});

viewer.scene.primitives.add(tileset);
viewer.zoomTo(tileset);

window.scene = viewer.scene;

setInterval(() => {
  const byteLength = viewer.scene.vectorProvider.texturesByteLength;
  console.log(`Memory: ${formatBytes(byteLength)}`)
}, 1000);

function formatBytes(bytes, decimals = 2) {
	if (bytes === 0) return '0 Bytes';

	const k = 1000;
	const dm = decimals < 0 ? 0 : decimals;
	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];

	const i = Math.floor(Math.log(bytes) / Math.log(k));

	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
}

viewer.flyTo(tileset, {
  offset: new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(-45), 8000),
});

```

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13729** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)