### PR TITLE
Gallery: Avoid unsupported 'terrainProvider=false' parameter

### DIFF
--- a/packages/sandcastle/gallery/mars/main.js
+++ b/packages/sandcastle/gallery/mars/main.js
@@ -3,7 +3,6 @@ import Sandcastle from "Sandcastle";
 
 Cesium.Ellipsoid.default = Cesium.Ellipsoid.MARS;
 const viewer = new Cesium.Viewer("cesiumContainer", {
-  terrainProvider: false,
   baseLayer: false,
   baseLayerPicker: false,
   geocoder: false,

--- a/packages/sandcastle/gallery/moon/main.js
+++ b/packages/sandcastle/gallery/moon/main.js
@@ -5,7 +5,6 @@ import Sandcastle from "Sandcastle";
 Cesium.Ellipsoid.default = Cesium.Ellipsoid.MOON;
 
 const viewer = new Cesium.Viewer("cesiumContainer", {
-  terrainProvider: false,
   baseLayer: false,
   timeline: false,
   animation: false,

--- a/packages/sandcastle/gallery/moon/main.js
+++ b/packages/sandcastle/gallery/moon/main.js
@@ -14,6 +14,7 @@ const viewer = new Cesium.Viewer("cesiumContainer", {
 });
 
 const scene = viewer.scene;
+scene.globe.show = false;
 
 // Add Moon Terrain 3D Tiles
 try {


### PR DESCRIPTION

# Description

Two sandcastles pass 'terrainProvider: false' as constructor parameters to Viewer, which isn't supported according to the JSDoc types. I believe it was probably accidental that this worked before, as the argument can safely be omitted instead.

## Issue number and link

- Fixes #13733

## Testing plan

See mars and moon sandcastles linked in issue.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->



#### PR Dependency Tree


* **PR #13734** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)