### PR TITLE
docs: fix typo controling -> controlling

### DIFF
--- a/packages/engine/Source/Scene/Model/CustomShaderTranslucencyMode.js
+++ b/packages/engine/Source/Scene/Model/CustomShaderTranslucencyMode.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * An enum for controling how {@link CustomShader} handles translucency compared with the original
+ * An enum for controlling how {@link CustomShader} handles translucency compared with the original
  * primitive.
  *
  * @enum {number}


### PR DESCRIPTION
Corrects the misspelling `controling` -> `controlling` in `packages/engine/Source/Scene/Model/CustomShaderTranslucencyMode.js`.

Documentation only, no behaviour change.