### PR TITLE
Use BIM/CAD Database terminology in ion snapping docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 - Added a `heightReference` option to `MVTDataProvider.fromUrl`, draping Mapbox Vector Tiles content onto terrain, 3D Tiles, or both. [#13727](https://github.com/CesiumGS/cesium/pull/13727)
 - Added a `heightReference` option to GeoJsonPrimitive constructor, draping GeoJSON content onto terrain, 3D Tiles, or both. [#13711](https://github.com/CesiumGS/cesium/pull/13711)
 - Added `surfacePosition` to the result of the experimental `Scene.snap` API: the nearest on-surface point of the snapped object, useful as a seed for server-side snap refinement of edge snaps. [#13699](https://github.com/CesiumGS/cesium/pull/13699)
-- Added experimental `IonSnapService` for server-side snap-to-geometry against iModel-backed Cesium ion assets, and the `SnapService` interface it implements. [#13682](https://github.com/CesiumGS/cesium/pull/13682)
+- Added experimental `IonSnapService` for server-side snap-to-geometry against Cesium ion assets backed by a BIM/CAD Database model, and the `SnapService` interface it implements. [#13682](https://github.com/CesiumGS/cesium/pull/13682)
 - Added `BufferPolylineCollection` option `widthUnits`, so a draped polyline's width can be measured in meters on the ground instead of screen pixels. [#13703](https://github.com/CesiumGS/cesium/pull/13703)
 - `ClippingPolygons` now use an algorithm, based on the techniques used for vector tiles, that vastly improves quality across distance scales. Warm-up cost is also modestly decreased. [#13654](https://github.com/CesiumGS/cesium/pull/13654)
 - `ClippingPolygons` now have support for specifying holes (aka islands) within each polygon. This works in inverse clipping workflows as well. [#13660](https://github.com/CesiumGS/cesium/pull/13660)

--- a/packages/engine/Source/Core/IonSnapService.js
+++ b/packages/engine/Source/Core/IonSnapService.js
@@ -110,7 +110,7 @@ const scratchWorldToView = new Matrix4();
  * coordinates. Each snap, it transforms using the ion asset's source
  * reference frame, the camera's transform, and the canvas
  * dimensions so that view-dependent features— such as the pixel aperture,
-* nearest position, or surface tracking— behave correctly.
+ * nearest position, or surface tracking— behave correctly.
  *
  * This object is normally not instantiated directly, use {@link IonSnapService.fromAssetId}.
  *

--- a/packages/engine/Source/Core/IonSnapService.js
+++ b/packages/engine/Source/Core/IonSnapService.js
@@ -145,8 +145,7 @@ class IonSnapService {
     this._resource = options.resource;
 
     /**
-     * The model-space to ECEF transform for this asset, from the model's
-     * geolocation. Constant for a given asset.
+     * A 4x4 transformation matrix from the source BIM/CAD Database reference frame local to the world's fixed reference frame.
      * @type {Matrix4}
      * @readonly
      */

--- a/packages/engine/Source/Core/IonSnapService.js
+++ b/packages/engine/Source/Core/IonSnapService.js
@@ -138,7 +138,7 @@ class IonSnapService {
    * @param {object} options Object with the following properties:
    * @param {number} options.assetId The ion asset id.
    * @param {Resource} options.resource The asset's ion API resource.
-   * @param {Matrix4} options.ecefTransform The model-space to ECEF transform.
+   * @param {Matrix4} options.ecefTransform A 4x4 transformation matrix from the source BIM/CAD Database reference frame local to the world's fixed reference frame.
    */
   constructor(options) {
     this._assetId = options.assetId;

--- a/packages/engine/Source/Core/IonSnapService.js
+++ b/packages/engine/Source/Core/IonSnapService.js
@@ -105,11 +105,12 @@ const scratchWorldToView = new Matrix4();
  * backed by a BIM/CAD Database model, using the ion REST API's element snap
  * endpoint.
  *
- * The native snapper works in model-local coordinates and screen
- * pixels; this class bridges both gaps. It fetches the asset's model-to-ECEF
- * transform once, and per snap composes the required world-to-view matrix
- * from the camera and canvas dimensions so that view-dependent snapping
- * (nearest, pixel apertures, surface tracking) behaves correctly.
+ * This class handles conversions between the reference frame of a
+ * source BIM/CAD Database and the view-dependent screen space pixel
+ * coordinates. Each snap, it transforms using the ion asset's source
+ * reference frame, the camera's transform, and the canvas
+ * dimensions so that view-dependent features— such as the pixel aperture,
+* nearest position, or surface tracking— behave correctly.
  *
  * This object is normally not instantiated directly, use {@link IonSnapService.fromAssetId}.
  *

--- a/packages/engine/Source/Core/IonSnapService.js
+++ b/packages/engine/Source/Core/IonSnapService.js
@@ -202,7 +202,7 @@ class IonSnapService {
 
     if (!defined(ecefResponse?.ecefTransform)) {
       throw new RuntimeError(
-        `Ion asset ${assetId} is not geolocated; snapping requires a geolocated model`,
+        `Cesium ion asset ${assetId} is not geolocated; snapping requires geolocation`,
       );
     }
 

--- a/packages/engine/Source/Core/IonSnapService.js
+++ b/packages/engine/Source/Core/IonSnapService.js
@@ -96,16 +96,17 @@ const scratchWorldToView = new Matrix4();
  * @property {IonSnapHeat} [heat] How close the snap point is to the close point in view space.
  * @property {IonSnapGeometryType} [geometryType] The type of geometry snapped to.
  * @property {IonSnapParentGeometryType} [parentGeometryType] The type of the parent geometry snapped to.
- * @property {object} [normal] The surface normal at the snap point, in the iModel's local cartesian frame.
+ * @property {object} [normal] The surface normal at the snap point, in the model's local cartesian frame.
  * @property {object} [curve] The curve geometry near the snap point, with points as WGS84 degrees objects.
  */
 
 /**
- * Provides interactive snap-to-geometry against an iModel-backed Cesium ion
- * asset using the ion REST API's element snap endpoint.
+ * Provides interactive snap-to-geometry against a Cesium ion 3D Tiles asset
+ * backed by a BIM/CAD Database model, using the ion REST API's element snap
+ * endpoint.
  *
- * The native iTwin snapper works in iModel-local coordinates and screen
- * pixels; this class bridges both gaps. It fetches the asset's iModel-to-ECEF
+ * The native snapper works in model-local coordinates and screen
+ * pixels; this class bridges both gaps. It fetches the asset's model-to-ECEF
  * transform once, and per snap composes the required world-to-view matrix
  * from the camera and canvas dimensions so that view-dependent snapping
  * (nearest, pixel apertures, surface tracking) behaves correctly.
@@ -136,14 +137,14 @@ class IonSnapService {
    * @param {object} options Object with the following properties:
    * @param {number} options.assetId The ion asset id.
    * @param {Resource} options.resource The asset's ion API resource.
-   * @param {Matrix4} options.ecefTransform The iModel-spatial to ECEF transform.
+   * @param {Matrix4} options.ecefTransform The model-space to ECEF transform.
    */
   constructor(options) {
     this._assetId = options.assetId;
     this._resource = options.resource;
 
     /**
-     * The iModel-spatial to ECEF transform for this asset, from the iModel's
+     * The model-space to ECEF transform for this asset, from the model's
      * geolocation. Constant for a given asset.
      * @type {Matrix4}
      * @readonly
@@ -161,12 +162,12 @@ class IonSnapService {
   }
 
   /**
-   * Creates an {@link IonSnapService} for the given iModel-backed ion asset, fetching
+   * Creates an {@link IonSnapService} for the given ion asset, fetching
    * the asset's ECEF transform from the ion REST API.
    *
    * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
    *
-   * @param {number} assetId The ion asset id of an iModel-backed asset.
+   * @param {number} assetId The ion ID of a 3D Tiles asset backed by a BIM/CAD Database model.
    * @param {object} [options] Object with the following properties:
    * @param {string} [options.accessToken=Ion.defaultAccessToken] The ion access token to use.
    * @param {string|Resource} [options.server=Ion.defaultServer] The ion API server to use.
@@ -200,7 +201,7 @@ class IonSnapService {
 
     if (!defined(ecefResponse?.ecefTransform)) {
       throw new RuntimeError(
-        `Ion asset ${assetId} is not geolocated; snapping requires a geolocated iModel`,
+        `Ion asset ${assetId} is not geolocated; snapping requires a geolocated model`,
       );
     }
 
@@ -217,10 +218,10 @@ class IonSnapService {
 
   /**
    * Computes the world-to-view matrix the native snapper needs: a projective
-   * transform from iModel-world coordinates to view (CSS pixel) coordinates,
+   * transform from model-world coordinates to view (CSS pixel) coordinates,
    * composed as <code>V * P * Vm * E</code> where
    * <ul>
-   *   <li><code>E</code>: iModel -> ECEF (this asset's {@link IonSnapService#ecefTransform})</li>
+   *   <li><code>E</code>: model -> ECEF (this asset's {@link IonSnapService#ecefTransform})</li>
    *   <li><code>Vm</code>: ECEF -> eye (<code>camera.viewMatrix</code>)</li>
    *   <li><code>P</code>: eye -> clip (<code>camera.frustum.projectionMatrix</code>)</li>
    *   <li><code>V</code>: clip -> pixels (y-down viewport matrix)</li>
@@ -232,7 +233,7 @@ class IonSnapService {
    * @param {number} canvasWidth The canvas width in CSS pixels.
    * @param {number} canvasHeight The canvas height in CSS pixels.
    * @param {Matrix4} [result] The object onto which to store the result.
-   * @returns {Matrix4} The iModel-world to view (pixels) matrix.
+   * @returns {Matrix4} The model-world to view (pixels) matrix.
    *
    * @private
    */

--- a/packages/sandcastle/gallery/hybrid-snapping-dev/main.js
+++ b/packages/sandcastle/gallery/hybrid-snapping-dev/main.js
@@ -159,7 +159,7 @@ Sandcastle.addToolbarButton("Reset average", function () {
 // ============================ Hybrid Snapping ===============================
 
 // Step 0 — create the server-side snapper once. fromAssetId retrieves the
-// asset's model -> ECEF transform a single time; every snap() reuses it.
+// transform from the asset's source reference frame a single time. Subsequently, every call to snap() reuses it.
 const snapper = await Cesium.IonSnapService.fromAssetId(ASSET_ID);
 
 // This function performs a client-side snap at a requested screen position.

--- a/packages/sandcastle/gallery/hybrid-snapping-dev/main.js
+++ b/packages/sandcastle/gallery/hybrid-snapping-dev/main.js
@@ -14,8 +14,8 @@ import Sandcastle from "Sandcastle";
 //      geometry the user is hovering.
 //
 //   2. Click — calls server-side IonSnapService.snap. The ion element
-//      snap endpoint runs the native iTwin snap functionality against the
-//      true iModel geometry, giving an authoritative, precision result. But it
+//      snap endpoint runs the native snap functionality against the
+//      true source geometry, giving an authoritative, precision result. But it
 //      is per-element. The caller must supply an element id and a world-space
 //      test point. It cannot discover geometry on its own, hence client-side
 //      Scene.snap is used to find the element and seed the test point.
@@ -34,14 +34,14 @@ import Sandcastle from "Sandcastle";
 // the sandcastles shows the client point immediately on click, then replaces
 // it when the server responds.
 //
-// Requires a geolocated iModel-backed asset on an account with the asset
-// elements feature enabled, and, for the client-side half of hybrid snapping
-// to work fully, that tileset must be exported with edge visibility data, as
-// described in this glTF extension:
+// Requires a geolocated asset backed by a BIM/CAD Database model, on an
+// account with the asset elements feature enabled, and, for the client-side
+// half of hybrid snapping to work fully, that tileset must be exported with
+// edge visibility data, as described in this glTF extension:
 // https://github.com/KhronosGroup/glTF/pull/2479
 
-// An iModel-backed ion asset id (numeric), on an account with the asset
-// elements feature enabled.
+// The id (numeric) of an ion asset backed by a BIM/CAD Database model, on an
+// account with the asset elements feature enabled.
 const ASSET_ID = 5161569;
 
 const viewer = new Cesium.Viewer("cesiumContainer");
@@ -159,7 +159,7 @@ Sandcastle.addToolbarButton("Reset average", function () {
 // ============================ Hybrid Snapping ===============================
 
 // Step 0 — create the server-side snapper once. fromAssetId retrieves the
-// asset's iModel -> ECEF transform a single time; every snap() reuses it.
+// asset's model -> ECEF transform a single time; every snap() reuses it.
 const snapper = await Cesium.IonSnapService.fromAssetId(ASSET_ID);
 
 // This function performs a client-side snap at a requested screen position.
@@ -266,7 +266,7 @@ viewer.screenSpaceEventHandler.setInputAction(async function onLeftClick(
   // The click means "commit what the hover showed": the client hit is already
   // on the chosen geometry (and pulled toward its nearest edge), which makes
   // it a far better testPoint than a raw cursor pick. The server then only
-  // has to refine it against the true iModel geometry, and any remaining
+  // has to refine it against the true source geometry, and any remaining
   // client-vs-server separation cleanly measures the client snap's error.
   const clientPosition =
     clientHit?.position ?? viewer.scene.pickPosition(screenPos);

--- a/packages/sandcastle/gallery/hybrid-snapping-dev/sandcastle.yaml
+++ b/packages/sandcastle/gallery/hybrid-snapping-dev/sandcastle.yaml
@@ -1,5 +1,5 @@
 title: Hybrid Snapping - Dev
-description: Hybrid snapping against an iModel-backed ion asset; client-side Scene.snap while hovering, authoritative server-side snap on click, with deviation between the two.
+description: Hybrid snapping against an ion asset backed by a BIM/CAD Database model; client-side Scene.snap while hovering, authoritative server-side snap on click, with deviation between the two.
 labels:
   - Development
 thumbnail: thumbnail.jpg

--- a/packages/sandcastle/gallery/ion-snapping-dev/main.js
+++ b/packages/sandcastle/gallery/ion-snapping-dev/main.js
@@ -68,7 +68,7 @@ const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(ASSET_ID);
 viewer.scene.primitives.add(tileset);
 viewer.zoomTo(tileset);
 
-// Fetches the asset's model -> ECEF transform once; snaps reuse it.
+// Fetches the transform from the asset's source reference frame a single time. Subsequently, every call to snap() reuses it.
 const snapper = await Cesium.IonSnapService.fromAssetId(ASSET_ID);
 
 viewer.screenSpaceEventHandler.setInputAction(async function onLeftClick(

--- a/packages/sandcastle/gallery/ion-snapping-dev/main.js
+++ b/packages/sandcastle/gallery/ion-snapping-dev/main.js
@@ -1,14 +1,15 @@
 import * as Cesium from "cesium";
 import Sandcastle from "Sandcastle";
 
-// Snap-to-geometry against an iModel-backed ion asset. Left-click the tileset
-// to snap: the picked element and cursor position are sent to the ion element
-// snap endpoint via Cesium.IonSnapService, and the returned snap/hit points are
-// plotted. Requires a geolocated iModel-backed asset on an account with the
-// asset elements feature enabled.
+// Snap-to-geometry against an ion asset backed by a BIM/CAD Database model.
+// Left-click the tileset to snap: the picked element and cursor position are
+// sent to the ion element snap endpoint via Cesium.IonSnapService, and the
+// returned snap/hit points are plotted. Requires a geolocated asset backed by
+// a BIM/CAD Database model, on an account with the asset elements feature
+// enabled.
 
-// An iModel-backed ion asset id (numeric), on an account with the asset
-// elements feature enabled.
+// The id (numeric) of an ion asset backed by a BIM/CAD Database model, on an
+// account with the asset elements feature enabled.
 const ASSET_ID = 5161569;
 
 const viewer = new Cesium.Viewer("cesiumContainer", {});
@@ -67,7 +68,7 @@ const tileset = await Cesium.Cesium3DTileset.fromIonAssetId(ASSET_ID);
 viewer.scene.primitives.add(tileset);
 viewer.zoomTo(tileset);
 
-// Fetches the asset's iModel -> ECEF transform once; snaps reuse it.
+// Fetches the asset's model -> ECEF transform once; snaps reuse it.
 const snapper = await Cesium.IonSnapService.fromAssetId(ASSET_ID);
 
 viewer.screenSpaceEventHandler.setInputAction(async function onLeftClick(


### PR DESCRIPTION
# Description

Update ion snapping docs and Sandcastle samples to use "BIM/CAD Database" terminology. Updates `IonSnapService` JSDoc, the CHANGES.md entry, and the `ion-snapping-dev`/`hybrid-snapping-dev` sandcastles.

## Issue number and link

#13708 

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

GitHub Copilot

If yes, I used the following Model(s):

Claude Fable 5