### PR TITLE
Pins globby to avoid playwright bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-seatbelt": "^0.1.3",
     "express": "^5.1.0",
     "globals": "^17.11.0",
-    "globby": "^16.2.4",
+    "globby": "16.2.3",
     "glsl-strip-comments": "^1.0.0",
     "gulp": "^5.0.0",
     "gulp-clean-css": "^4.3.0",

--- a/packages/sandcastle/package.json
+++ b/packages/sandcastle/package.json
@@ -43,7 +43,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "@vitejs/plugin-react": "^6.1.1",
-    "globby": "^16.2.4",
+    "globby": "16.2.3",
     "pagefind": "^1.3.0",
     "rimraf": "^6.0.1",
     "slugify": "^1.6.6",


### PR DESCRIPTION
# Description

#13746 updated the globby dependency to ^16.2.4. Tests and CI were fine, but it turns out it breaks playwright's e2e testing. globby 16.2.3 is fine, so I'm pinning the version and opening an issue with playwright.

## Issue number and link

[An issue on our side to track the pinned dependency](https://github.com/CesiumGS/cesium/issues/13755). This PR does not resolve that issue.

## Testing plan

Try running `npm run test-e2e-release`

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

Github copilot

If yes, I used the following Model(s):

Claude Opus 4.8 - to diagnose which version of globby was breaking and help me identify who to submit the issue to (it claim playwright is the responsible party here)