### PR TITLE
Build: Replace some globby usage with 'node:fs'

### DIFF
--- a/Specs/e2e/sandcastle.spec.js
+++ b/Specs/e2e/sandcastle.spec.js
@@ -1,8 +1,8 @@
 import { test, expect } from "./test.js";
-import { globbySync } from "globby";
+import { globSync } from "node:fs";
 import { basename, dirname } from "node:path";
 
-const gallery = globbySync("packages/sandcastle/gallery/**/*.yaml");
+const gallery = globSync("packages/sandcastle/gallery/**/*.yaml");
 
 for (const example of gallery) {
   const slug = basename(dirname(example));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,10 @@
-import { writeFileSync, copyFileSync, readFileSync, existsSync } from "fs";
+import {
+  writeFileSync,
+  copyFileSync,
+  readFileSync,
+  existsSync,
+  globSync,
+} from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { join, basename, resolve, dirname } from "path";
 import { exec, execSync } from "child_process";
@@ -7,7 +13,6 @@ import { createRequire } from "module";
 import { finished } from "stream/promises";
 
 import gulp from "gulp";
-import { globby } from "globby";
 import open from "open";
 import { rimraf } from "rimraf";
 import karma from "karma";
@@ -286,7 +291,7 @@ const filesToClean = [
 
 export async function clean() {
   await rimraf("Build");
-  const files = await globby(filesToClean);
+  const files = globSync(filesToClean);
   return Promise.all(files.map((file) => rimraf(file)));
 }
 
@@ -362,10 +367,9 @@ export async function prepare() {
   );
 
   // Copy jasmine runner files into Specs
-  const files = await globby([
-    "node_modules/jasmine-core/lib/jasmine-core",
-    "!node_modules/jasmine-core/lib/jasmine-core/example",
-  ]);
+  const files = globSync(["node_modules/jasmine-core/lib/jasmine-core"], {
+    exclude: ["node_modules/jasmine-core/lib/jasmine-core/example"],
+  });
 
   const stream = gulp.src(files).pipe(gulp.dest("Specs/jasmine"));
   await finished(stream);
@@ -471,7 +475,7 @@ export const postversion = async function () {
 
   // Iterate through all package JSONs that may depend on the updated package and
   // update the version of the updated workspace.
-  const packageJsons = await globby([
+  const packageJsons = globSync([
     "./package.json",
     "./packages/*/package.json",
   ]);

--- a/packages/sandcastle/package.json
+++ b/packages/sandcastle/package.json
@@ -43,7 +43,6 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "@vitejs/plugin-react": "^6.1.1",
-    "globby": "16.2.3",
     "pagefind": "^1.3.0",
     "rimraf": "^6.0.1",
     "slugify": "^1.6.6",

--- a/packages/sandcastle/scripts/buildGallery.js
+++ b/packages/sandcastle/scripts/buildGallery.js
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { globSync } from "node:fs";
 import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative } from "node:path";
 import { exit } from "node:process";
@@ -8,7 +9,6 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { rimraf } from "rimraf";
 import { parse } from "yaml";
-import { globby } from "globby";
 import * as pagefind from "pagefind";
 import createGalleryRecord from "./createGalleryRecord.js";
 
@@ -151,10 +151,10 @@ export async function buildGalleryList(options = {}) {
     return condition;
   };
 
-  const galleryFiles = await globby(
+  const galleryFiles = globSync(
     galleryFilesPattern.map((pattern) =>
-      // globby can only work with paths using '/' but node on windows uses '\'
-      // convert them right before passing to globby to ensure all joins work as expected
+      // glob can only work with paths using '/' but node on windows uses '\'
+      // convert them right before passing to glob to ensure all joins work as expected
       join(rootDirectory, pattern, "**/*").replaceAll("\\", "/"),
     ),
   );

--- a/packages/sandcastle/vite.config.dev.ts
+++ b/packages/sandcastle/vite.config.dev.ts
@@ -16,7 +16,7 @@ function getCesiumVersion() {
 
 async function checkForFiles(extraFilesList: Target[]) {
   for (const target of extraFilesList) {
-    // globby requires forward slashes even on Windows
+    // glob requires forward slashes even on Windows
     const toFwd = (s: string) => s.replace(/\\/g, "/");
     const src = Array.isArray(target.src)
       ? target.src.map(toFwd)

--- a/packages/sandcastle/vite.config.dev.ts
+++ b/packages/sandcastle/vite.config.dev.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import { createSandcastleConfig } from "./scripts/buildStatic.js";
 import { readFileSync } from "fs";
 import { Target } from "vite-plugin-static-copy";
-import { globby } from "globby";
+import { globSync } from "node:fs";
 import { exit } from "process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -21,7 +21,7 @@ async function checkForFiles(extraFilesList: Target[]) {
     const src = Array.isArray(target.src)
       ? target.src.map(toFwd)
       : toFwd(target.src);
-    const files = await globby(src);
+    const files = globSync(src);
     if (files.length === 0) {
       // check for at least 1 file in each location. Some of the directories like Assets/
       // will have many and it's hard to offer suggestions for every file that we might need

--- a/scripts/lebab-batch.js
+++ b/scripts/lebab-batch.js
@@ -1,8 +1,7 @@
 // @ts-check
 
 import { transform } from "lebab";
-import { globby } from "globby";
-import { readFile, writeFile } from "node:fs/promises";
+import { glob, readFile, writeFile } from "node:fs/promises";
 import { resolve, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,7 +27,7 @@ let pathsUpdated = 0;
 
 console.log(bright(`Converting...\n`));
 
-for (const path of await globby(resolve(__dirname, "..", pattern))) {
+for await (const path of glob(resolve(__dirname, "..", pattern))) {
   console.log(dim(`  ${path}`));
 
   // Lowercase filenames are assumed to contain functions, not classes. If


### PR DESCRIPTION
# Description

Progress toward removing the `globby` dependency. Node.js now has built-in functionality as part of `node:fs` and `node:fs/promises`, so we can likely do without the dependency. Some `globby` usage is left after this PR, which will require a somewhat more involved replacement, as the Node.js 'exclude' option is not quite the same as globby's negation patterns. See:

- https://github.com/nodejs/node/issues/63959
- https://nodejs.org/api/fs.html#fspromisesglobpattern-options

## Issue number and link

- #13755

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

Gemini CLI

If yes, I used the following Model(s):

Gemini 2.5






#### PR Dependency Tree


* **PR #13756** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)