### PR TITLE
Only update animations when model is shown

### DIFF
--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -2716,8 +2716,9 @@ function updateSceneGraph(model, frameState) {
   }
 
   let updateForAnimations = false;
-  // Animations are disabled for classification models.
-  if (!defined(model.classificationType)) {
+  // Animations are only applied to models that are shown,
+  // but always disabled for classification models.
+  if (model.show && !defined(model.classificationType)) {
     updateForAnimations =
       model._userAnimationDirty || model._activeAnimations.update(frameState);
   }

--- a/packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelAnimationCollectionSpec.js
@@ -906,6 +906,42 @@ describe(
         expect(spyUpdate.calls.argsFor(4)[2]).toEqual(0.0);
       });
     });
+
+    it("does not animate when model.show is false", async function () {
+      const model = await loadAndZoomToModelAsync(
+        {
+          gltf: animatedTriangleUrl,
+        },
+        scene,
+      );
+      const time = defaultDate;
+      const animationCollection = model.activeAnimations;
+      const animation = animationCollection.add({
+        index: 0,
+        startTime: time,
+      });
+
+      const spyUpdate = jasmine.createSpy("listener");
+      animation.update.addEventListener(spyUpdate);
+
+      // Render with model shown - animation should update
+      scene.renderForSpecs(time);
+      expect(spyUpdate.calls.count()).toEqual(1);
+
+      // Hide the model
+      model.show = false;
+
+      // Render with model hidden - animation should NOT update
+      scene.renderForSpecs(JulianDate.addSeconds(time, 1.0, scratchJulianDate));
+      expect(spyUpdate.calls.count()).toEqual(1); // Still 1, no new updates
+
+      // Show the model again
+      model.show = true;
+
+      // Render with model shown again - animation should update
+      scene.renderForSpecs(JulianDate.addSeconds(time, 2.0, scratchJulianDate));
+      expect(spyUpdate.calls.count()).toEqual(2); // Now 2, animation updated
+    });
   },
   "WebGL",
 );


### PR DESCRIPTION
# Description

Previously, animations in a `Model` had been updated in each frame, regardless of whether the model was shown (as of `model.show`) or not. This caused an unnecessary computational overhead. This PR changes the update mechanism to only update the animations when `model.show` is `true`. 

## Issue number and link

Fixes https://github.com/CesiumGS/cesium/issues/12633 
Replaces https://github.com/CesiumGS/cesium/pull/13278 (closed due to missing CLA)
Replaces https://github.com/CesiumGS/cesium/pull/13500 (closed due to missing CLA)

## Testing plan

Run the `ModelAnimationCollection does not animate when model.show is false` spec

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

Whether it's worth an entry in CHANGES.md is up for debate. It should not have any implications on the behavior (and even less on the API). (If it _does_ affect the behavior is hard to say - if so, we can track it in an issue). It is only a "performance optimization". 


## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
