### PR TITLE
BufferPrimitiveCollection: Make 'blendOption' mutable, add Cesium3DTileset 'vectorBlendOption'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ### @cesium/engine
 
+#### Additions :tada:
+
+- Added `vectorBlendOption` to `Cesium3DTileset`, so opaque vector tile features can hide the features behind them. `blendOption` can now also be changed after construction on `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`. [#13764](https://github.com/CesiumGS/cesium/issues/13764)
+
 #### Fixes :wrench:
 
 - Fixed a GPU memory leak where the edge vertex array created for `EXT_mesh_primitive_edge_visibility` rendering was never destroyed when draw commands were rebuilt or the model was destroyed. [#13721](https://github.com/CesiumGS/cesium/pull/13721)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 #### Additions :tada:
 
-- Added `vectorBlendOption` to `Cesium3DTileset`, so opaque vector tile features can hide the features behind them. `blendOption` can now also be changed after construction on `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`. [#13764](https://github.com/CesiumGS/cesium/issues/13764)
+- Added `vectorBlendOption` to `Cesium3DTileset`, for selecting opaque or translucent modes. `blendOption` can now also be changed after construction on `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`. [#13764](https://github.com/CesiumGS/cesium/issues/13764)
 
 #### Fixes :wrench:
 

--- a/packages/engine/Source/Scene/BlendOption.js
+++ b/packages/engine/Source/Scene/BlendOption.js
@@ -1,27 +1,31 @@
 // @ts-check
 
 /**
- * Determines how opaque and translucent parts of billboards, points, and labels are blended with the scene.
+ * Determines how opaque and translucent parts of primitives in a collection are blended
+ * with the scene. Collections differ in the render pass, blending, and depth behavior
+ * they select for each option; see the <code>blendOption</code> documentation of the
+ * collection in question.
  *
  * @enum {number}
  */
 const BlendOption = {
   /**
-   * The billboards, points, or labels in the collection are completely opaque.
+   * The primitives in the collection are completely opaque.
    * @type {number}
    * @constant
    */
   OPAQUE: 0,
 
   /**
-   * The billboards, points, or labels in the collection are completely translucent.
+   * The primitives in the collection are completely translucent.
    * @type {number}
    * @constant
    */
   TRANSLUCENT: 1,
 
   /**
-   * The billboards, points, or labels in the collection are both opaque and translucent.
+   * The primitives in the collection are both opaque and translucent, and each primitive
+   * is drawn according to its own opacity.
    * @type {number}
    * @constant
    */

--- a/packages/engine/Source/Scene/BufferPointCollection.js
+++ b/packages/engine/Source/Scene/BufferPointCollection.js
@@ -70,7 +70,7 @@ class BufferPointCollection extends BufferPrimitiveCollection {
    *    specified, users are responsible for updating bounding volume as needed. Pre-computing the bounding volume
    *    manually, and updating it only as needed, will improve performance for larger dynamic collections.
    * @param {boolean} [options.debugShowBoundingVolume=false]
-   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT]
+   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
    */
   constructor(options = Frozen.EMPTY_OBJECT) {
     super({ ...options, vertexCountMax: options.primitiveCountMax });

--- a/packages/engine/Source/Scene/BufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/BufferPolygonCollection.js
@@ -49,7 +49,7 @@ const { ERR_CAPACITY } = BufferPrimitiveCollection.Error;
  *    specified, users are responsible for updating bounding volume as needed. Pre-computing the bounding volume
  *    manually, and updating it only as needed, will improve performance for larger dynamic collections.
  * @property {boolean} [debugShowBoundingVolume=false]
- * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT]
+ * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
  * @property {HeightReference} [heightReference=HeightReference.NONE] When set to a clamping value, the
  *   collection is draped onto terrain and/or 3D Tiles, rather than drawn as geometry of its own.
  * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.

--- a/packages/engine/Source/Scene/BufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/BufferPolylineCollection.js
@@ -75,7 +75,7 @@ class BufferPolylineCollection extends BufferPrimitiveCollection {
    * @param {boolean} [options.allowPicking=false] When <code>true</code>, primitives are pickable with {@link Scene#pick}. When <code>false</code>, memory and initialization cost are lower.
    * @param {BoundingSphere} [options.boundingVolume] Bounding volume, in world space, for the collection.
    * @param {boolean} [options.debugShowBoundingVolume=false]
-   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT]
+   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
    * @param {HeightReference} [options.heightReference=HeightReference.NONE]
    * @param {"pixels"|"meters"} [options.widthUnits="pixels"] Unit of polyline widths in this collection:
    *   <code>"pixels"</code> on the screen, or <code>"meters"</code> in world space. A clamped

--- a/packages/engine/Source/Scene/BufferPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/BufferPrimitiveCollection.js
@@ -49,7 +49,7 @@ import HeightReference, { isHeightReferenceClamp } from "./HeightReference.js";
  *    specified, users are responsible for updating bounding volume as needed. Pre-computing the bounding volume
  *    manually, and updating it only as needed, will improve performance for larger dynamic collections.
  * @property {boolean} [debugShowBoundingVolume=false]
- * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT]
+ * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
  * @property {HeightReference} [options.heightReference=HeightReference.NONE] When set to a clamping value, the
  *   collection is draped onto the surfaces selected by the value: {@link HeightReference.CLAMP_TO_TERRAIN} drapes
  *   onto the globe, {@link HeightReference.CLAMP_TO_3D_TILE} drapes onto 3D Tiles, and
@@ -989,6 +989,11 @@ class BufferPrimitiveCollection {
    * Determines how primitives in the collection are blended with the scene.
    * Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT};
    * {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+   *
+   * <p>{@link BlendOption.OPAQUE} disables blending and writes depth, so primitives
+   * occlude each other and the geometry behind them. {@link BlendOption.TRANSLUCENT}
+   * alpha blends primitives and does not write depth, so they are resolved by
+   * order-independent translucency instead.</p>
    *
    * @type {BlendOption}
    * @default BlendOption.TRANSLUCENT

--- a/packages/engine/Source/Scene/BufferPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/BufferPrimitiveCollection.js
@@ -117,7 +117,6 @@ class BufferPrimitiveCollection {
     /**
      * Collection blend option; must be OPAQUE or TRANSLUCENT.
      * @type {BlendOption}
-     * @readonly
      * @ignore
      */
     this._blendOption = options.blendOption ?? BlendOption.TRANSLUCENT;
@@ -984,6 +983,30 @@ class BufferPrimitiveCollection {
    */
   get heightReference() {
     return this._heightReference;
+  }
+
+  /**
+   * Determines how primitives in the collection are blended with the scene.
+   * Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT};
+   * {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+   *
+   * @type {BlendOption}
+   * @default BlendOption.TRANSLUCENT
+   */
+  get blendOption() {
+    return this._blendOption;
+  }
+
+  set blendOption(value) {
+    //>>includeStart('debug', pragmas.debug);
+    if (value !== BlendOption.OPAQUE && value !== BlendOption.TRANSLUCENT) {
+      throw new DeveloperError(
+        "blendOption must be BlendOption.OPAQUE or BlendOption.TRANSLUCENT.",
+      );
+    }
+    //>>includeEnd('debug');
+
+    this._blendOption = value;
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -119,7 +119,7 @@ import ImageryLayerCollection from "./ImageryLayerCollection.js";
  * @property {Color} [outlineColor=Color.BLACK] The color to use when rendering outlines.
  * @property {boolean} [vectorClassificationOnly=false] Indicates that only the tileset's vector tiles should be used for classification.
  * @property {boolean} [vectorKeepDecodedPositions=false] Whether vector tiles should keep decoded positions in memory. This is used with {@link Cesium3DTileFeature.getPolylinePositions}.
- * @property {BlendOption} [vectorBlendOption=BlendOption.TRANSLUCENT] Whether vector tile geometry is rendered in the opaque or translucent pass. {@link BlendOption.OPAQUE} writes depth, so fully opaque features occlude each other. {@link BlendOption.TRANSLUCENT} blends features with order-independent translucency and does not write depth. {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+ * @property {BlendOption} [vectorBlendOption=BlendOption.TRANSLUCENT] Determines how vector primitives in the tileset are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
  * @property {string|number} [featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @property {string|number} [instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @property {boolean} [showCreditsOnScreen=false] Whether to display the credits of this tileset on screen.
@@ -2077,10 +2077,8 @@ Object.defineProperties(Cesium3DTileset.prototype, {
   },
 
   /**
-   * Whether vector tile geometry is rendered in the opaque or translucent pass.
-   * {@link BlendOption.OPAQUE} writes depth, so fully opaque features occlude
-   * each other. {@link BlendOption.TRANSLUCENT} blends features with
-   * order-independent translucency and does not write depth.
+   * Determines how vector primitives in the tileset are blended with the scene.
+   * Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT};
    * {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
    *
    * @memberof Cesium3DTileset.prototype

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -30,6 +30,7 @@ import ClearCommand from "../Renderer/ClearCommand.js";
 import Pass from "../Renderer/Pass.js";
 import RenderState from "../Renderer/RenderState.js";
 import Axis from "./Axis.js";
+import BlendOption from "./BlendOption.js";
 import Cesium3DTile from "./Cesium3DTile.js";
 import Cesium3DTileColorBlendMode from "./Cesium3DTileColorBlendMode.js";
 import Cesium3DTileContentState from "./Cesium3DTileContentState.js";
@@ -118,6 +119,7 @@ import ImageryLayerCollection from "./ImageryLayerCollection.js";
  * @property {Color} [outlineColor=Color.BLACK] The color to use when rendering outlines.
  * @property {boolean} [vectorClassificationOnly=false] Indicates that only the tileset's vector tiles should be used for classification.
  * @property {boolean} [vectorKeepDecodedPositions=false] Whether vector tiles should keep decoded positions in memory. This is used with {@link Cesium3DTileFeature.getPolylinePositions}.
+ * @property {BlendOption} [vectorBlendOption=BlendOption.TRANSLUCENT] Whether vector tile geometry is rendered in the opaque or translucent pass. {@link BlendOption.OPAQUE} writes depth, so fully opaque features occlude each other. {@link BlendOption.TRANSLUCENT} blends features with order-independent translucency and does not write depth. {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
  * @property {string|number} [featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @property {string|number} [instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @property {boolean} [showCreditsOnScreen=false] Whether to display the credits of this tileset on screen.
@@ -364,6 +366,9 @@ function Cesium3DTileset(options) {
 
   this._vectorKeepDecodedPositions =
     options.vectorKeepDecodedPositions ?? false;
+
+  this._vectorBlendOption =
+    options.vectorBlendOption ?? BlendOption.TRANSLUCENT;
 
   /**
    * The collection of <code>ImageryLayer</code> objects providing 2D georeferenced
@@ -2068,6 +2073,29 @@ Object.defineProperties(Cesium3DTileset.prototype, {
   vectorKeepDecodedPositions: {
     get: function () {
       return this._vectorKeepDecodedPositions;
+    },
+  },
+
+  /**
+   * Whether vector tile geometry is rendered in the opaque or translucent pass.
+   * {@link BlendOption.OPAQUE} writes depth, so fully opaque features occlude
+   * each other. {@link BlendOption.TRANSLUCENT} blends features with
+   * order-independent translucency and does not write depth.
+   * {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+   *
+   * @memberof Cesium3DTileset.prototype
+   *
+   * @experimental This feature is not final and is subject to change without Cesium's standard deprecation policy.
+   *
+   * @type {BlendOption}
+   * @default BlendOption.TRANSLUCENT
+   */
+  vectorBlendOption: {
+    get: function () {
+      return this._vectorBlendOption;
+    },
+    set: function (value) {
+      this._vectorBlendOption = value;
     },
   },
 

--- a/packages/engine/Source/Scene/VectorGltf3DTileContent.js
+++ b/packages/engine/Source/Scene/VectorGltf3DTileContent.js
@@ -349,6 +349,7 @@ class VectorGltf3DTileContent {
 
     for (let i = 0; i < this._collections.length; i++) {
       const collection = this._collections[i];
+      collection.blendOption = tileset._vectorBlendOption;
       Matrix4.multiplyTransformation(
         scratchTileModelMatrix,
         this._collectionLocalMatrices[i],

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -251,10 +251,21 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
     }
   }
 
+  const pass =
+    collection._blendOption === BlendOption.OPAQUE
+      ? Pass.OPAQUE
+      : Pass.TRANSLUCENT;
+
+  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
+    RenderState.removeFromCache(renderContext.renderState);
+    renderContext.renderState = undefined;
+    renderContext.command = undefined;
+  }
+
   if (!defined(renderContext.renderState)) {
     renderContext.renderState = RenderState.fromCache({
       blending:
-        collection._blendOption === BlendOption.OPAQUE
+        pass === Pass.OPAQUE
           ? BlendingState.DISABLED
           : BlendingState.ALPHA_BLEND,
       depthTest: { enabled: true },
@@ -281,10 +292,7 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       renderState: renderContext.renderState,
       shaderProgram: renderContext.shaderProgram,
       primitiveType: PrimitiveType.POINTS,
-      pass:
-        collection._blendOption === BlendOption.OPAQUE
-          ? Pass.OPAQUE
-          : Pass.TRANSLUCENT,
+      pass,
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: collection.primitiveCount,

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -275,10 +275,21 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
     }
   }
 
+  const pass =
+    collection._blendOption === BlendOption.OPAQUE
+      ? Pass.OPAQUE
+      : Pass.TRANSLUCENT;
+
+  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
+    RenderState.removeFromCache(renderContext.renderState);
+    renderContext.renderState = undefined;
+    renderContext.command = undefined;
+  }
+
   if (!defined(renderContext.renderState)) {
     renderContext.renderState = RenderState.fromCache({
       blending:
-        collection._blendOption === BlendOption.OPAQUE
+        pass === Pass.OPAQUE
           ? BlendingState.DISABLED
           : BlendingState.ALPHA_BLEND,
       depthTest: { enabled: true },
@@ -307,10 +318,7 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       renderState: renderContext.renderState,
       shaderProgram: renderContext.shaderProgram,
       primitiveType: PrimitiveType.TRIANGLES,
-      pass:
-        collection._blendOption === BlendOption.OPAQUE
-          ? Pass.OPAQUE
-          : Pass.TRANSLUCENT,
+      pass,
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: drawCount,

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -491,10 +491,21 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
     }
   }
 
+  const pass =
+    collection._blendOption === BlendOption.OPAQUE
+      ? Pass.OPAQUE
+      : Pass.TRANSLUCENT;
+
+  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
+    RenderState.removeFromCache(renderContext.renderState);
+    renderContext.renderState = undefined;
+    renderContext.command = undefined;
+  }
+
   if (!defined(renderContext.renderState)) {
     renderContext.renderState = RenderState.fromCache({
       blending:
-        collection._blendOption === BlendOption.OPAQUE
+        pass === Pass.OPAQUE
           ? BlendingState.DISABLED
           : BlendingState.ALPHA_BLEND,
       depthTest: { enabled: true },
@@ -523,10 +534,7 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       renderState: renderContext.renderState,
       shaderProgram: renderContext.shaderProgram,
       primitiveType: PrimitiveType.TRIANGLES,
-      pass:
-        collection._blendOption === BlendOption.OPAQUE
-          ? Pass.OPAQUE
-          : Pass.TRANSLUCENT,
+      pass,
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: drawCount,

--- a/packages/engine/Specs/Scene/BufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BufferPolygonCollectionSpec.js
@@ -620,6 +620,18 @@ describe("Scene/BufferPolygonCollection", () => {
       }).heightReference,
     ).toBe(HeightReference.CLAMP_TO_3D_TILE);
   });
+
+  it("blendOption", () => {
+    const collection = new BufferPolygonCollection();
+    expect(collection.blendOption).toBe(BlendOption.TRANSLUCENT);
+
+    collection.blendOption = BlendOption.OPAQUE;
+    expect(collection.blendOption).toBe(BlendOption.OPAQUE);
+
+    expect(() => {
+      collection.blendOption = BlendOption.OPAQUE_AND_TRANSLUCENT;
+    }).toThrowDeveloperError();
+  });
 });
 
 /**

--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1,5 +1,6 @@
 import {
   Axis,
+  BlendOption,
   Camera,
   Cartesian2,
   Cartesian3,
@@ -312,6 +313,16 @@ describe(
           heightReference: HeightReference.CLAMP_TO_GROUND,
         });
       }).toThrowDeveloperError();
+    });
+
+    it("vectorBlendOption", function () {
+      expect(new Cesium3DTileset().vectorBlendOption).toBe(
+        BlendOption.TRANSLUCENT,
+      );
+      expect(
+        new Cesium3DTileset({ vectorBlendOption: BlendOption.OPAQUE })
+          .vectorBlendOption,
+      ).toBe(BlendOption.OPAQUE);
     });
 
     it("fromUrl throws with unsupported version", async function () {

--- a/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
+++ b/packages/engine/Specs/Scene/VectorGltf3DTileContentSpec.js
@@ -1,4 +1,5 @@
 import {
+  BlendOption,
   BufferPoint,
   BufferPointCollection,
   BufferPointMaterial,
@@ -11,6 +12,8 @@ import {
   Cartesian3,
   Cesium3DTileStyle,
   Color,
+  Matrix4,
+  SceneMode,
   VectorGltf3DTileContent,
 } from "../../index.js";
 
@@ -278,6 +281,26 @@ describe("Scene/VectorGltf3DTileContent", () => {
         "#ff000080",
       );
     }
+  });
+
+  it("update syncs blendOption from the tileset", () => {
+    const tileset = { _vectorBlendOption: BlendOption.OPAQUE };
+    const tile = { computedTransform: Matrix4.clone(Matrix4.IDENTITY) };
+    content = new VectorGltf3DTileContent(tileset, tile, {});
+    content._ready = true;
+
+    const points = createBufferPointCollection();
+    content._collections = [points];
+    content._collectionLocalMatrices = [Matrix4.clone(Matrix4.IDENTITY)];
+
+    const frameState = { mode: SceneMode.SCENE3D, passes: {}, frameNumber: 0 };
+
+    content.update(tileset, frameState);
+    expect(points.blendOption).toBe(BlendOption.OPAQUE);
+
+    tileset._vectorBlendOption = BlendOption.TRANSLUCENT;
+    content.update(tileset, frameState);
+    expect(points.blendOption).toBe(BlendOption.TRANSLUCENT);
   });
 });
 

--- a/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
@@ -7,7 +7,6 @@ import {
   Cartesian3,
   Color,
   Matrix4,
-  Pass,
   SceneMode,
 } from "../../index.js";
 
@@ -59,15 +58,24 @@ describe(
       });
 
       const point = new BufferPoint();
-      collection.add({ position: new Cartesian3(0, -1000, 0) }, point);
+      const material = new BufferPointMaterial({
+        color: Color.RED.withAlpha(0.5),
+        size: 8,
+      });
+      collection.add(
+        { position: new Cartesian3(0, -1000, 0), material },
+        point,
+      );
       scene.primitives.add(collection);
 
-      expect(scene).toRender([255, 255, 255, 255]);
-      expect(collection._renderContext.command.pass).toBe(Pass.OPAQUE);
+      // Blending is disabled in the opaque pass, so alpha has no effect.
+      expect(scene).toRender([255, 0, 0, 255]);
 
       collection.blendOption = BlendOption.TRANSLUCENT;
-      expect(scene).toRender([255, 255, 255, 255]);
-      expect(collection._renderContext.command.pass).toBe(Pass.TRANSLUCENT);
+      expect(scene).toRender([128, 0, 0, 255]);
+
+      collection.blendOption = BlendOption.OPAQUE;
+      expect(scene).toRender([255, 0, 0, 255]);
     });
 
     it("renders points with color", function () {

--- a/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
@@ -7,6 +7,7 @@ import {
   Cartesian3,
   Color,
   Matrix4,
+  Pass,
   SceneMode,
 } from "../../index.js";
 
@@ -50,6 +51,23 @@ describe(
 
       scene.primitives.add(collection);
       expect(scene).toRender([255, 255, 255, 255]);
+    });
+
+    it("renders points after blendOption changes", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE,
+      });
+
+      const point = new BufferPoint();
+      collection.add({ position: new Cartesian3(0, -1000, 0) }, point);
+      scene.primitives.add(collection);
+
+      expect(scene).toRender([255, 255, 255, 255]);
+      expect(collection._renderContext.command.pass).toBe(Pass.OPAQUE);
+
+      collection.blendOption = BlendOption.TRANSLUCENT;
+      expect(scene).toRender([255, 255, 255, 255]);
+      expect(collection._renderContext.command.pass).toBe(Pass.TRANSLUCENT);
     });
 
     it("renders points with color", function () {

--- a/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
@@ -9,7 +9,6 @@ import {
   ComponentDatatype,
   HeightReference,
   Matrix4,
-  Pass,
   SceneMode,
 } from "../../index.js";
 
@@ -82,15 +81,20 @@ describe(
       });
 
       const polygon = new BufferPolygon();
-      collection.add({ positions, triangles }, polygon);
+      const material = new BufferPolygonMaterial({
+        color: Color.RED.withAlpha(0.5),
+      });
+      collection.add({ positions, triangles, material }, polygon);
       scene.primitives.add(collection);
 
-      expect(scene).toRender([255, 255, 255, 255]);
-      expect(collection._renderContext.command.pass).toBe(Pass.OPAQUE);
+      // Blending is disabled in the opaque pass, so alpha has no effect.
+      expect(scene).toRender([255, 0, 0, 255]);
 
       collection.blendOption = BlendOption.TRANSLUCENT;
-      expect(scene).toRender([255, 255, 255, 255]);
-      expect(collection._renderContext.command.pass).toBe(Pass.TRANSLUCENT);
+      expect(scene).toRender([128, 0, 0, 255]);
+
+      collection.blendOption = BlendOption.OPAQUE;
+      expect(scene).toRender([255, 0, 0, 255]);
     });
 
     it("does not render draped polygons", function () {

--- a/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
@@ -9,6 +9,7 @@ import {
   ComponentDatatype,
   HeightReference,
   Matrix4,
+  Pass,
   SceneMode,
 } from "../../index.js";
 
@@ -72,6 +73,24 @@ describe(
 
       scene.primitives.add(collection);
       expect(scene).toRender([255, 255, 255, 255]);
+    });
+
+    it("renders polygons after blendOption changes", function () {
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
+      const polygon = new BufferPolygon();
+      collection.add({ positions, triangles }, polygon);
+      scene.primitives.add(collection);
+
+      expect(scene).toRender([255, 255, 255, 255]);
+      expect(collection._renderContext.command.pass).toBe(Pass.OPAQUE);
+
+      collection.blendOption = BlendOption.TRANSLUCENT;
+      expect(scene).toRender([255, 255, 255, 255]);
+      expect(collection._renderContext.command.pass).toBe(Pass.TRANSLUCENT);
     });
 
     it("does not render draped polygons", function () {

--- a/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
@@ -8,6 +8,7 @@ import {
   ComponentDatatype,
   HeightReference,
   Matrix4,
+  Pass,
   SceneMode,
 } from "../../index.js";
 
@@ -53,6 +54,25 @@ describe(
 
       scene.primitives.add(collection);
       expect(scene).toRender([255, 255, 255, 255]);
+    });
+
+    it("renders polylines after blendOption changes", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE,
+      });
+
+      const line = new BufferPolyline();
+      const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
+      collection.add({ positions }, line);
+      scene.primitives.add(collection);
+
+      expect(scene).toRender([255, 255, 255, 255]);
+      expect(collection._renderContext.command.pass).toBe(Pass.OPAQUE);
+
+      collection.blendOption = BlendOption.TRANSLUCENT;
+      expect(scene).toRender([255, 255, 255, 255]);
+      expect(collection._renderContext.command.pass).toBe(Pass.TRANSLUCENT);
     });
 
     it("does not render draped polylines", function () {

--- a/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
@@ -8,7 +8,6 @@ import {
   ComponentDatatype,
   HeightReference,
   Matrix4,
-  Pass,
   SceneMode,
 } from "../../index.js";
 
@@ -64,15 +63,20 @@ describe(
 
       const line = new BufferPolyline();
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
-      collection.add({ positions }, line);
+      const material = new BufferPolylineMaterial({
+        color: Color.RED.withAlpha(0.5),
+      });
+      collection.add({ positions, material }, line);
       scene.primitives.add(collection);
 
-      expect(scene).toRender([255, 255, 255, 255]);
-      expect(collection._renderContext.command.pass).toBe(Pass.OPAQUE);
+      // Blending is disabled in the opaque pass, so alpha has no effect.
+      expect(scene).toRender([255, 0, 0, 255]);
 
       collection.blendOption = BlendOption.TRANSLUCENT;
-      expect(scene).toRender([255, 255, 255, 255]);
-      expect(collection._renderContext.command.pass).toBe(Pass.TRANSLUCENT);
+      expect(scene).toRender([128, 0, 0, 255]);
+
+      collection.blendOption = BlendOption.OPAQUE;
+      expect(scene).toRender([255, 0, 0, 255]);
     });
 
     it("does not render draped polylines", function () {


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Vector tile collections are currently created without a `blendOption`, so they default to `BlendOption.TRANSLUCENT` and render in `Pass.TRANSLUCENT`.

This becomes a problem with OIT. `OIT.createDerivedCommands` changes the render state to use `depthMask = false` and `ONE / ONE` blending. As a result, alpha acts more like a weight in the blend instead of normal coverage, so even two fully opaque overlapping surfaces are blended together instead of one occluding the other.

The translucent pass itself is behaving as expected. The issue is that opaque vector content is being sent to that pass in the first place.

This PR adds control over that classification:

- `blendOption` is now settable on `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`. Previously, it could only be set during construction.
- When the pass changes, each renderer rebuilds its render state and draw command while reusing the existing vertex array and shader.
- `Cesium3DTileset#vectorBlendOption` is added as both a constructor option and a mutable property.
- `VectorGltf3DTileContent.update` keeps the tileset's `vectorBlendOption` synced with each vector collection.

The default remains `BlendOption.TRANSLUCENT`, so there is no behavior change unless `vectorBlendOption` is explicitly set.

One limitation is that `blendOption` still applies to the entire collection. For example, with a mixed style like:
```
"${highlight} ? color('yellow', 0.4) : color('gray', 1.0)"
```

## Next steps

Once this lands, #13515 (`zIndex`) is next. `Pass.VECTOR` was originally added there to work around the same visual issue before we understood the OIT behavior, so it should no longer be necessary.

`zIndex` still depends on this PR, though. Polygon offset adjusts `gl_FragDepth`, but `Pass.TRANSLUCENT` does not write depth, so `zIndex` only produces visible layering once the collection is rendered in `Pass.OPAQUE`.

After that, I'll open a follow-up PR to support `BlendOption.OPAQUE_AND_TRANSLUCENT`, which will address the mixed-style limitation above. Each renderer would submit two draw commands: one opaque command with depth writes, and one translucent command through OIT. The fragment shaders would discard features that belong to the other pass, following the same approach already used by `BillboardCollection` and the `Model` pipeline.

Whether `BlendOption.OPAQUE_AND_TRANSLUCENT` should eventually become the default for vector tiles is probably worth discussing separately, since changing the default would affect the rendering behavior of existing tilesets.
<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link
https://github.com/CesiumGS/cesium/issues/13722
<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan
[sandcastle](http://localhost:8080/Apps/Sandcastle2/index.html#c=vVdtb9s2EP4rB3+pvCqSYjup68TFEjdFCyRp1zgbirofaOlscaVJlaTseoGB/Yj9wv2SgRL15tht0LX9kFjiHe+Ozz0PSdFFIqSGX4AoGKGi6QJmUixg0gqzt0nrZCInnOZuN4RHIVGaYeFVjVhP8xcKrjQsKa5QwhA4rmxs7/dszCmijwTXhHKUk1b7pJqpQuQIQxvBy17L4LOUh5oKDolQ1DyoF1IsnuNcIiqHCX5J9Euk81irNtyZGQB52HKCrekFE0Qf986kJOvmRI8hn+s4rwlgJiQ4DDVQGEJwAhROYZe/sTweQrfMW2QOYVggMCJSo6KEd71Zre7CH5qB39MP7l4TPIbDL5s7lblYC+woJCHhRyd0K4BcoIX/Jv+RqFNZwzyzbpoN/5SSaCwp4XOGBca3lOtuJ4f4feDCoQsdF4Lsf/dDu+yq78N4JUAsUTKSJJTPQSTkU4qQCLaem6YRDRGdzVAi1xBb4OEPqmMYvz27vrm8HV1cj20w5/WrcRt0jGsgS5RkjrCKUWI+ZNOcwMrMfv3m7LfbC2OBNElQgghDlkaovGptZRUNOp+npp43uW0kGMOMmo5tfyLpgmq6xJFIub4inwfQsQ1ZotT4uRrv2/FYsJp3YEe1RbWy9DLLpgKwKNAjUVTk931IJGpNUR7QORcSbV1FFwe7RfS+oMrBk6739GngQi/wnvR6LnSCwG0Yn/QfYDzq7DAWYZvGD+2tJatBk1fWvCAaJSVssLcdV9bDuYNQMCEHJfHNm/f24jls2j8Pxf6RBcqI4B5Q3YcY+zuMZdiG8aehePnq6mIHjL4PZ7wuYEY5QkKUMsKeIkeiY5gKHZfCuq9koNrGUpqsFSypolNmFCxFOo+NXhdNBVMNVEFMowh5Xe6h0TtQvaVnU9ReQRvjgxR9uEfRnV3cylJ+Z3L1vCCwWur2XdgiyLElyNFxZSrp8ZX+m2orAlRH2n0ejN6dXZd5VzTS8QAOe3bkPj+yE90rwcwRKZiQu+11ySBsUO363QiWGGohQVOGCjU4TISEtV1Qes0wglnK2NoS0oOxmM/NqJjNYLqGCGckZXV2FGGGQFaE6nKt2U/3+Tg3Zwf4rWT28J60Yq2Tge9nuWOh9KAf9AP/PKUs8vk6POhGWWDfhvf+VIJPWhk4+YIKQ1Z1k5n13DfG7JR3m6wdk1b24DwSkvA5PnLh0AvaNvpmK3wsVjCEGWEK94Ntvdv3b14K9TlDHr1OMm1Mq+fy5lPKumaEIdTeTirHXBVf8yyqz1t9/kXv8mZS3U/NmsZCsCmRV8jTQkElrTV+1gbG+g7kWGq04d+//yn2sxkSnUpUedJiO7JIm0iCKzT7xgCcNgyfbcNVyKwa8mo5C2lu3D312b1uV0H23vK/SsnDN6uo3dO28TRCOk+1FtyZtO4LcdJyc5q54IQxhh8xyuq4a7bUEtJ6nGztFjt7WCY1nxRGBHanVialU09ivyJCskBJPIXazKi2swiVppyYuYOvXNLzE7eTb6iHRy50j4KgXYEtKXJtI91V9/IYSUT5fFDbmgESqsO4THhFdOxp8ZZElHDlHPSO2jVfKRirz96UG+s3QGWaVOvOD4UqQ+r4qQv94AcBdRx8G1BfXOn3osTude5Y5cPJ0Fzhpr67t9zWaXZwPDOmX+0neyqZ43m+xkXCiEblT9PwI2ovVOYQ5ad+MeU0okug0XDHtzmEjCg1nLTMMXpD/8JJ69mpH9FlY5rO2Vaz/Qc)
<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
