### PR TITLE
Analytics scrub share URLs

### DIFF
--- a/packages/sandcastle/src/analytics/README.md
+++ b/packages/sandcastle/src/analytics/README.md
@@ -223,6 +223,13 @@ built-in `[Amplitude] Start Session` and `[Amplitude] End Session` events
 automatically; they are managed by Amplitude and are not part of
 `tracking-plan.csv`.
 
+Every other SDK collector is turned off explicitly in `amplitude.ts`,
+including page URL enrichment, which would otherwise stamp the full page
+URL on every event. Sandcastle share links carry the shared code in the URL
+(`#c=` or the legacy `code` query parameter), so that URL must never be
+recorded. As a safety net, an enrichment plugin reduces any URL-valued
+event property to its origin and path before the event is sent.
+
 ## Adding a new event
 
 This directory is the source of truth: change the code and tracking plan

--- a/packages/sandcastle/src/analytics/amplitude.ts
+++ b/packages/sandcastle/src/analytics/amplitude.ts
@@ -47,6 +47,35 @@ function analyticsBuildContext(): Record<string, string> {
 }
 
 /**
+ * Reduce every URL-valued event property to its origin and path. Sandcastle
+ * share links carry the shared code in the URL (the #c= fragment or the
+ * legacy code query parameter), and none of our own properties are URLs, so
+ * this is safe to apply to every event. The SDK's page URL enrichment is
+ * disabled in initAnalytics, so URL properties normally never appear; this
+ * is a safety net so a future SDK default cannot leak shared code.
+ */
+function scrubUrlProperties<T extends object | undefined>(properties: T): T {
+  if (!properties) {
+    return properties;
+  }
+  // The SDK types event properties as a union without an index signature
+  const record = properties as Record<string, unknown>;
+  for (const [key, value] of Object.entries(record)) {
+    if (typeof value !== "string" || !/^https?:\/\//i.test(value)) {
+      continue;
+    }
+    try {
+      const url = new URL(value);
+      record[key] = `${url.origin}${url.pathname}`;
+    } catch {
+      // Not a parseable URL; drop it rather than risk sending a payload
+      delete record[key];
+    }
+  }
+  return properties;
+}
+
+/**
  * Initialize Amplitude for this session. Reads the API key from the
  * VITE_AMPLITUDE_API_KEY environment variable; when it is not set (the
  * default for local development) analytics stay disabled and every
@@ -73,10 +102,12 @@ export function initAnalytics() {
     },
   });
 
-  amplitude.init(apiKey, {
+  const initialization = amplitude.init(apiKey, {
     appVersion: __CESIUM_VERSION__ || undefined,
     // Only session tracking is automatic; everything else must be an
-    // explicit trackEvent call so the data stays intentional
+    // explicit trackEvent call so the data stays intentional. Every collector
+    // the SDK turns on by default is listed here: an absent flag counts as
+    // enabled, and the SDK adds new default collectors over time.
     autocapture: {
       sessions: true,
       attribution: false,
@@ -84,7 +115,23 @@ export function initAnalytics() {
       formInteractions: false,
       fileDownloads: false,
       elementInteractions: false,
+      // Would stamp the full page URL on every event, and Sandcastle share
+      // URLs carry the shared code
+      pageUrlEnrichment: false,
     },
+  });
+  // Enrichment plugins run in registration order, and plugins added before
+  // init run before the SDK's own plugins. Register the scrubber once init
+  // completes so it runs after anything the SDK added.
+  void initialization.promise.then(() => {
+    amplitude.add({
+      name: "scrub-urls",
+      type: "enrichment",
+      execute: async (event) => {
+        event.event_properties = scrubUrlProperties(event.event_properties);
+        return event;
+      },
+    });
   });
   initialized = true;
 }


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Turns off the Amplitude SDK's page URL enrichment, which stamped full share URLs containing user code on every event, and adds a scrubber that strips the query and fragment from any URL-valued event property as a safety net.

## Issue number and link

https://github.com/iTwin/cesiumjs-web3d-internal/issues/80

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
