### PR TITLE
Preserve enableInputs across camera flights

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 - Fixed a GPU memory leak where the edge vertex array created for `EXT_mesh_primitive_edge_visibility` rendering was never destroyed when draw commands were rebuilt or the model was destroyed. [#13721](https://github.com/CesiumGS/cesium/pull/13721)
 - Changed the typing of `PrimitiveCollection.add` to return the added primitive as the same type instead of `any`. [#13742](https://github.com/CesiumGS/cesium/issues/13742)
+- Fixed camera flights re-enabling `enableInputs` even when it was `false` before the flight started. `Camera.flyTo` and `Camera.flyToBoundingSphere` now restore the previous value instead of unconditionally setting `true`. [#13771](https://github.com/CesiumGS/cesium/pull/13771)
 
 ## 1.145 - 2026-09-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -224,6 +224,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Jules Blom](https://github.com/JulesBlm)
 - [CloudRF](https://cloudrf.com/)
   - [Jos-Elliot Jeapes](https://github.com/appybara13)
+- [EBP Schweiz AG](https://ebp.global)
+  - [Urs Honegger](https://github.com/uhon)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/packages/engine/Source/Scene/CameraFlightPath.js
+++ b/packages/engine/Source/Scene/CameraFlightPath.js
@@ -392,13 +392,13 @@ function emptyFlight(complete, cancel) {
   };
 }
 
-function wrapCallback(controller, cb) {
+function wrapCallback(controller, cb, enableInputs) {
   function wrapped() {
     if (typeof cb === "function") {
       cb();
     }
 
-    controller.enableInputs = true;
+    controller.enableInputs = enableInputs;
   }
   return wrapped;
 }
@@ -454,10 +454,16 @@ CameraFlightPath.createTween = function (scene, options) {
   const roll = options.roll ?? 0.0;
 
   const controller = scene.screenSpaceCameraController;
+
+  // Input is suspended for the duration of the flight and restored when it
+  // ends. Restore whatever the application had set rather than an
+  // unconditional `true`, which would silently re-enable input for
+  // applications that deliberately disabled it before the flight started.
+  const wasInputEnabled = controller.enableInputs;
   controller.enableInputs = false;
 
-  const complete = wrapCallback(controller, options.complete);
-  const cancel = wrapCallback(controller, options.cancel);
+  const complete = wrapCallback(controller, options.complete, wasInputEnabled);
+  const cancel = wrapCallback(controller, options.cancel, wasInputEnabled);
 
   const frustum = camera.frustum;
 

--- a/packages/engine/Specs/Scene/CameraFlightPathSpec.js
+++ b/packages/engine/Specs/Scene/CameraFlightPathSpec.js
@@ -481,6 +481,69 @@ describe(
       expect(camera.position).toEqualEpsilon(destination, CesiumMath.EPSILON8);
     });
 
+    it("restores enableInputs to its previous value when the flight completes", function () {
+      const controller = scene.screenSpaceCameraController;
+      controller.enableInputs = false;
+
+      const flight = CameraFlightPath.createTween(scene, {
+        destination: new Cartesian3(1e9, 1e9, 1e9),
+        duration: 5.0,
+      });
+
+      expect(controller.enableInputs).toEqual(false);
+
+      flight.complete();
+      expect(controller.enableInputs).toEqual(false);
+    });
+
+    it("restores enableInputs to its previous value when the flight is cancelled", function () {
+      const controller = scene.screenSpaceCameraController;
+      controller.enableInputs = false;
+
+      const flight = CameraFlightPath.createTween(scene, {
+        destination: new Cartesian3(1e9, 1e9, 1e9),
+        duration: 5.0,
+      });
+
+      expect(controller.enableInputs).toEqual(false);
+
+      flight.cancel();
+      expect(controller.enableInputs).toEqual(false);
+    });
+
+    it("re-enables inputs after a flight when they were enabled beforehand", function () {
+      const controller = scene.screenSpaceCameraController;
+      controller.enableInputs = true;
+
+      const flight = CameraFlightPath.createTween(scene, {
+        destination: new Cartesian3(1e9, 1e9, 1e9),
+        duration: 5.0,
+      });
+
+      expect(controller.enableInputs).toEqual(false);
+
+      flight.complete();
+      expect(controller.enableInputs).toEqual(true);
+    });
+
+    it("does not enable inputs when the camera is already at the destination", function () {
+      const camera = scene.camera;
+      const controller = scene.screenSpaceCameraController;
+      controller.enableInputs = false;
+
+      const flight = CameraFlightPath.createTween(scene, {
+        destination: Cartesian3.clone(camera.position),
+        heading: camera.heading,
+        pitch: camera.pitch,
+        roll: camera.roll,
+      });
+
+      expect(flight.duration).toEqual(0.0);
+
+      flight.complete();
+      expect(controller.enableInputs).toEqual(false);
+    });
+
     it("creates an animation in 3d 0 duration", function () {
       const camera = scene.camera;
 


### PR DESCRIPTION
# Description

`CameraFlightPath.createTween()` suspends screen space camera input for the duration of a flight, but restores it by hard-coding `enableInputs = true` in `wrapCallback()` rather than restoring the value it replaced.

As a result, applications that intentionally set `scene.screenSpaceCameraController.enableInputs = false` have camera input silently switched back on by the first flight that completes or is cancelled. It also triggers when the camera is already at the destination: `createTween()` short-circuits to `emptyFlight()` and `Camera#flyTo` then invokes the callback synchronously, so even a no-op "fly home" re-enables input.

This is especially disruptive for applications adopting the modular camera controllers (`ScreenSpaceMapCameraController`, `ScreenSpaceTiltOrbitCameraController`, `ScreenSpaceZoomCameraController`), which must disable the legacy monolithic `ScreenSpaceCameraController` so the two do not both handle the same gestures. After any flight the legacy controller silently reactivates and competes with the modular controllers for the same input — in our application it breaks orbit-around-a-point (CTRL+Drag and middle-drag) until the page is reloaded.

This PR captures `enableInputs` before the flight suspends it and restores that value on both `complete` and `cancel`:

```js
const controller = scene.screenSpaceCameraController;

const wasInputEnabled = controller.enableInputs;
controller.enableInputs = false;

const complete = wrapCallback(controller, options.complete, wasInputEnabled);
const cancel = wrapCallback(controller, options.cancel, wasInputEnabled);
```

Behaviour is unchanged for applications that had input enabled before the flight — it is still enabled afterwards.

An alternative would be to leave the flag untouched entirely when `createTween()` returns an empty flight. Happy to switch to that if you prefer it.

## Not covered by this PR: controllers registered with `Scene.controllerHost`

This PR deliberately fixes only the legacy `ScreenSpaceCameraController` path, to keep the change small and reviewable. `createTween()` still does not suspend controllers registered with `Scene.controllerHost` (the new `Controller` framework from #13604), so an application that has fully migrated to it loses flight input-suspension entirely.  I added a second issue #13772 and can help with a PR, after this is merged.

Found and fixed while working on the [swissgeol viewer](https://github.com/swisstopo/swissgeol-viewer-suite), which is migrating to the modular camera controllers.

## Issue number and link

Fixes #13770 

## Testing plan

Added four specs to `packages/engine/Specs/Scene/CameraFlightPathSpec.js`:

- `enableInputs` stays `false` when the flight completes
- `enableInputs` stays `false` when the flight is cancelled
- `enableInputs` is still restored to `true` when it was enabled beforehand (guards against regressing the existing behaviour)
- the empty-flight case, where the camera is already at the destination

Run with:

```bash
npm test -- --includeName CameraFlightPath
```

To reproduce the original issue manually:

1. Open the Sandcastle linked in the issue. It starts with `scene.screenSpaceCameraController.enableInputs = false`.
2. The HUD reads `enableInputs: false`, and dragging the globe does nothing.
3. Click **Fly somewhere** and wait for the 3 second flight to finish.
4. Before this change the HUD flips to `enableInputs: true` and the globe becomes draggable again. After this change it stays `false`.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

GitHub Copilot CLI

If yes, I used the following Model(s):

Claude Opus 5
