### PR TITLE
Extract shared draw command from buffer primitive renderers

### DIFF
--- a/packages/engine/Source/Scene/buildBufferPrimitiveDrawCommand.js
+++ b/packages/engine/Source/Scene/buildBufferPrimitiveDrawCommand.js
@@ -1,0 +1,187 @@
+// @ts-check
+
+import defined from "../Core/defined.js";
+import Cartesian2 from "../Core/Cartesian2.js";
+import PrimitiveType from "../Core/PrimitiveType.js";
+import BlendingState from "./BlendingState.js";
+import BlendOption from "./BlendOption.js";
+import DrawCommand from "../Renderer/DrawCommand.js";
+import Pass from "../Renderer/Pass.js";
+import RenderState from "../Renderer/RenderState.js";
+import ShaderProgram from "../Renderer/ShaderProgram.js";
+import ShaderSource from "../Renderer/ShaderSource.js";
+
+/** @import BufferPrimitiveCollection from "./BufferPrimitiveCollection.js"; */
+/** @import Context from "../Renderer/Context.js"; */
+/** @import VertexArray from "../Renderer/VertexArray.js"; */
+/** @import {TypedArray} from "../Core/globalTypes.js"; */
+
+/**
+ * GPU resources backing a single {@link BufferPrimitiveCollection}, cached across frames.
+ * @typedef {object} BufferPrimitiveRenderContext
+ * @property {VertexArray} [vertexArray]
+ * @property {Record<string, TypedArray>} [attributeArrays]
+ * @property {TypedArray} [indexArray]
+ * @property {RenderState} [renderState]
+ * @property {Record<string, unknown>} [uniformMap]
+ * @property {ShaderProgram} [shaderProgram]
+ * @property {DrawCommand} [command]
+ * @property {Function} destroy
+ * @ignore
+ */
+
+/**
+ * @typedef {object} BufferPrimitiveDrawCommandOptions
+ * @property {PrimitiveType} primitiveType Topology of the collection's vertex data.
+ * @property {Record<string, number>} attributeLocations
+ * @property {string[]} vertexShaderSources
+ * @property {string[]} fragmentShaderSources
+ * @property {boolean} useFloat64 Whether positions are encoded at 64-bit precision.
+ * @property {number} drawCount Number of vertices or indices to draw.
+ * @ignore
+ */
+
+/**
+ * Builds the render state, shader program, and draw command shared by every buffer
+ * primitive collection, and caches them on <code>renderContext</code>. The render state
+ * and command are rebuilt when the collection's blend option selects a different pass.
+ *
+ * @param {BufferPrimitiveCollection<*>} collection
+ * @param {Context} context
+ * @param {BufferPrimitiveRenderContext} renderContext
+ * @param {BufferPrimitiveDrawCommandOptions} options
+ * @ignore
+ */
+function buildBufferPrimitiveDrawCommand(
+  collection,
+  context,
+  renderContext,
+  options,
+) {
+  const {
+    primitiveType,
+    attributeLocations,
+    vertexShaderSources,
+    fragmentShaderSources,
+    useFloat64,
+    drawCount,
+  } = options;
+
+  const zIndex = collection._zIndex;
+
+  const pass =
+    collection._blendOption === BlendOption.OPAQUE
+      ? Pass.OPAQUE
+      : Pass.TRANSLUCENT;
+
+  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
+    RenderState.removeFromCache(renderContext.renderState);
+    renderContext.renderState = undefined;
+    renderContext.command = undefined;
+  }
+
+  if (!defined(renderContext.uniformMap)) {
+    renderContext.uniformMap = {};
+
+    if (zIndex !== 0) {
+      const polygonOffset = new Cartesian2(-zIndex, -zIndex);
+      renderContext.uniformMap.u_polygonOffset = () => polygonOffset;
+    }
+  }
+
+  if (!defined(renderContext.renderState)) {
+    // Fixed-function polygon offset applies to triangles only. The u_polygonOffset
+    // uniform offsets the logarithmic depth the fragment shader writes instead.
+    const depthOffset =
+      zIndex !== 0 && primitiveType === PrimitiveType.TRIANGLES ? -zIndex : 0;
+
+    renderContext.renderState = RenderState.fromCache({
+      blending:
+        pass === Pass.OPAQUE
+          ? BlendingState.DISABLED
+          : BlendingState.ALPHA_BLEND,
+      depthTest: { enabled: true },
+      polygonOffset: {
+        enabled: depthOffset !== 0,
+        factor: depthOffset,
+        units: depthOffset,
+      },
+    });
+  }
+
+  if (!defined(renderContext.shaderProgram)) {
+    const vertexDefines = [];
+    const fragmentDefines = [];
+
+    if (useFloat64) {
+      vertexDefines.push("USE_FLOAT64");
+    }
+
+    if (zIndex !== 0) {
+      fragmentDefines.push("POLYGON_OFFSET");
+    }
+
+    renderContext.shaderProgram = ShaderProgram.fromCache({
+      context,
+      vertexShaderSource: new ShaderSource({
+        sources: vertexShaderSources,
+        defines: vertexDefines,
+      }),
+      fragmentShaderSource: new ShaderSource({
+        sources: fragmentShaderSources,
+        defines: fragmentDefines,
+      }),
+      attributeLocations,
+    });
+  }
+
+  if (!defined(renderContext.command)) {
+    renderContext.command = new DrawCommand({
+      vertexArray: renderContext.vertexArray,
+      renderState: renderContext.renderState,
+      shaderProgram: renderContext.shaderProgram,
+      uniformMap: renderContext.uniformMap,
+      primitiveType,
+      pass,
+      pickId: collection._allowPicking ? "v_pickColor" : undefined,
+      owner: collection,
+      count: drawCount,
+      modelMatrix: collection.modelMatrix, // shared reference
+      boundingVolume: collection.boundingVolume, // shared reference
+      debugShowBoundingVolume: collection.debugShowBoundingVolume,
+    });
+  }
+
+  const command = renderContext.command;
+
+  if (command.count !== drawCount) {
+    command.count = drawCount;
+  }
+
+  if (command.debugShowBoundingVolume !== collection.debugShowBoundingVolume) {
+    command.debugShowBoundingVolume = collection.debugShowBoundingVolume;
+  }
+}
+
+/**
+ * Destroys render context resources. Deleting properties from the context
+ * object isn't necessary, as collection.destroy() will discard the object.
+ * @ignore
+ */
+export function destroyBufferPrimitiveRenderContext() {
+  const context = /** @type {BufferPrimitiveRenderContext} */ (this);
+
+  if (defined(context.vertexArray)) {
+    context.vertexArray.destroy();
+  }
+
+  if (defined(context.shaderProgram)) {
+    context.shaderProgram.destroy();
+  }
+
+  if (defined(context.renderState)) {
+    RenderState.removeFromCache(context.renderState);
+  }
+}
+
+export default buildBufferPrimitiveDrawCommand;

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -8,24 +8,20 @@ import Buffer from "../Renderer/Buffer.js";
 import BufferUsage from "../Renderer/BufferUsage.js";
 import VertexArray from "../Renderer/VertexArray.js";
 import ComponentDatatype from "../Core/ComponentDatatype.js";
-import RenderState from "../Renderer/RenderState.js";
-import BlendingState from "./BlendingState.js";
-import ShaderSource from "../Renderer/ShaderSource.js";
-import ShaderProgram from "../Renderer/ShaderProgram.js";
-import DrawCommand from "../Renderer/DrawCommand.js";
-import Pass from "../Renderer/Pass.js";
 import PrimitiveType from "../Core/PrimitiveType.js";
 import BufferPointMaterialVS from "../Shaders/BufferPointMaterialVS.js";
 import BufferPointMaterialFS from "../Shaders/BufferPointMaterialFS.js";
 import EncodedCartesian3 from "../Core/EncodedCartesian3.js";
 import AttributeCompression from "../Core/AttributeCompression.js";
 import BufferPointMaterial from "./BufferPointMaterial.js";
-import BlendOption from "./BlendOption.js";
-import Cartesian2 from "../Core/Cartesian2.js";
+import buildBufferPrimitiveDrawCommand, {
+  destroyBufferPrimitiveRenderContext,
+} from "./buildBufferPrimitiveDrawCommand.js";
 
 /** @import FrameState from "./FrameState.js"; */
 /** @import BufferPointCollection from "./BufferPointCollection.js"; */
 /** @import {TypedArray} from "../Core/globalTypes.js"; */
+/** @import {BufferPrimitiveRenderContext} from "./buildBufferPrimitiveDrawCommand.js"; */
 
 /**
  * TODO(PR#13211): Need 'keyof' syntax to avoid duplicating attribute names.
@@ -58,18 +54,6 @@ const BufferPointAttributeLocations = {
   outlineWidthColorAlpha: 3,
 };
 
-/**
- * @typedef {object} BufferPointRenderContext
- * @property {VertexArray} [vertexArray]
- * @property {Record<string, TypedArray>} [attributeArrays]
- * @property {RenderState} [renderState]
- * @property {Record<string, unknown>} [uniformMap]
- * @property {ShaderProgram} [shaderProgram]
- * @property {DrawCommand} [command]
- * @property {Function} destroy
- * @ignore
- */
-
 // Scratch variables.
 const point = new BufferPoint();
 const material = new BufferPointMaterial();
@@ -80,13 +64,15 @@ const encodedCartesian = new EncodedCartesian3();
 /**
  * @param {BufferPointCollection} collection
  * @param {FrameState} frameState
- * @param {BufferPointRenderContext} [renderContext]
- * @returns {BufferPointRenderContext}
+ * @param {BufferPrimitiveRenderContext} [renderContext]
+ * @returns {BufferPrimitiveRenderContext}
  * @ignore
  */
 function renderBufferPointCollection(collection, frameState, renderContext) {
   const context = frameState.context;
-  renderContext = renderContext || { destroy: destroyRenderContext };
+  renderContext = renderContext || {
+    destroy: destroyBufferPrimitiveRenderContext,
+  };
   const useFloat64 = collection._positionDatatype === ComponentDatatype.DOUBLE;
   const attributeLocations = useFloat64
     ? BufferPointAttributeLocationsFloat64
@@ -253,119 +239,20 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
     }
   }
 
-  const zIndex = collection._zIndex;
+  buildBufferPrimitiveDrawCommand(collection, context, renderContext, {
+    primitiveType: PrimitiveType.POINTS,
+    attributeLocations,
+    vertexShaderSources: [BufferPointMaterialVS],
+    fragmentShaderSources: [BufferPointMaterialFS],
+    useFloat64,
+    drawCount: collection.primitiveCount,
+  });
 
-  const pass =
-    collection._blendOption === BlendOption.OPAQUE
-      ? Pass.OPAQUE
-      : Pass.TRANSLUCENT;
-
-  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
-    RenderState.removeFromCache(renderContext.renderState);
-    renderContext.renderState = undefined;
-    renderContext.command = undefined;
-  }
-
-  if (!defined(renderContext.uniformMap)) {
-    renderContext.uniformMap = {};
-
-    if (zIndex !== 0) {
-      const polygonOffset = new Cartesian2(-zIndex, -zIndex);
-      renderContext.uniformMap.u_polygonOffset = () => polygonOffset;
-    }
-  }
-
-  if (!defined(renderContext.renderState)) {
-    // Points are offset only through the logarithmic depth the fragment shader writes;
-    // fixed-function polygon offset applies to filled polygons, not to points.
-    renderContext.renderState = RenderState.fromCache({
-      blending:
-        pass === Pass.OPAQUE
-          ? BlendingState.DISABLED
-          : BlendingState.ALPHA_BLEND,
-      depthTest: { enabled: true },
-    });
-  }
-
-  if (!defined(renderContext.shaderProgram)) {
-    const vertexDefines = [];
-    const fragmentDefines = [];
-
-    if (useFloat64) {
-      vertexDefines.push("USE_FLOAT64");
-    }
-
-    if (zIndex !== 0) {
-      fragmentDefines.push("POLYGON_OFFSET");
-    }
-
-    renderContext.shaderProgram = ShaderProgram.fromCache({
-      context,
-      vertexShaderSource: new ShaderSource({
-        sources: [BufferPointMaterialVS],
-        defines: vertexDefines,
-      }),
-      fragmentShaderSource: new ShaderSource({
-        sources: [BufferPointMaterialFS],
-        defines: fragmentDefines,
-      }),
-      attributeLocations,
-    });
-  }
-
-  if (!defined(renderContext.command)) {
-    renderContext.command = new DrawCommand({
-      vertexArray: renderContext.vertexArray,
-      renderState: renderContext.renderState,
-      shaderProgram: renderContext.shaderProgram,
-      uniformMap: renderContext.uniformMap,
-      primitiveType: PrimitiveType.POINTS,
-      pass,
-      pickId: collection._allowPicking ? "v_pickColor" : undefined,
-      owner: collection,
-      count: collection.primitiveCount,
-      modelMatrix: collection.modelMatrix, // shared reference
-      boundingVolume: collection.boundingVolume, // shared reference
-      debugShowBoundingVolume: collection.debugShowBoundingVolume,
-    });
-  }
-
-  const command = renderContext.command;
-
-  if (command.count !== collection.primitiveCount) {
-    command.count = collection.primitiveCount;
-  }
-
-  if (command.debugShowBoundingVolume !== collection.debugShowBoundingVolume) {
-    command.debugShowBoundingVolume = collection.debugShowBoundingVolume;
-  }
-
-  frameState.commandList.push(command);
+  frameState.commandList.push(renderContext.command);
 
   collection._makeClean();
 
   return renderContext;
-}
-
-/**
- * Destroys render context resources. Deleting properties from the context
- * object isn't necessary, as collection.destroy() will discard the object.
- * @ignore
- */
-function destroyRenderContext() {
-  const context = /** @type {BufferPointRenderContext} */ (this);
-
-  if (defined(context.vertexArray)) {
-    context.vertexArray.destroy();
-  }
-
-  if (defined(context.shaderProgram)) {
-    context.shaderProgram.destroy();
-  }
-
-  if (defined(context.renderState)) {
-    RenderState.removeFromCache(context.renderState);
-  }
 }
 
 export default renderBufferPointCollection;

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -8,12 +8,6 @@ import Buffer from "../Renderer/Buffer.js";
 import BufferUsage from "../Renderer/BufferUsage.js";
 import VertexArray from "../Renderer/VertexArray.js";
 import ComponentDatatype from "../Core/ComponentDatatype.js";
-import RenderState from "../Renderer/RenderState.js";
-import BlendingState from "./BlendingState.js";
-import ShaderSource from "../Renderer/ShaderSource.js";
-import ShaderProgram from "../Renderer/ShaderProgram.js";
-import DrawCommand from "../Renderer/DrawCommand.js";
-import Pass from "../Renderer/Pass.js";
 import PrimitiveType from "../Core/PrimitiveType.js";
 import BufferPolygonMaterialVS from "../Shaders/BufferPolygonMaterialVS.js";
 import BufferPolygonMaterialFS from "../Shaders/BufferPolygonMaterialFS.js";
@@ -21,12 +15,14 @@ import EncodedCartesian3 from "../Core/EncodedCartesian3.js";
 import AttributeCompression from "../Core/AttributeCompression.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
 import BufferPolygonMaterial from "./BufferPolygonMaterial.js";
-import BlendOption from "./BlendOption.js";
-import Cartesian2 from "../Core/Cartesian2.js";
+import buildBufferPrimitiveDrawCommand, {
+  destroyBufferPrimitiveRenderContext,
+} from "./buildBufferPrimitiveDrawCommand.js";
 
 /** @import {TypedArray} from "../Core/globalTypes.js"; */
 /** @import FrameState from "./FrameState.js"; */
 /** @import BufferPolygonCollection from "./BufferPolygonCollection.js"; */
+/** @import {BufferPrimitiveRenderContext} from "./buildBufferPrimitiveDrawCommand.js"; */
 
 /**
  * TODO(PR#13211): Need 'keyof' syntax to avoid duplicating attribute names.
@@ -57,19 +53,6 @@ const BufferPolygonAttributeLocations = {
   showColorAlpha: 2,
 };
 
-/**
- * @typedef {object} BufferPolygonRenderContext
- * @property {VertexArray} [vertexArray]
- * @property {Record<string, TypedArray>} [attributeArrays]
- * @property {TypedArray} [indexArray]
- * @property {RenderState} [renderState]
- * @property {Record<string, unknown>} [uniformMap]
- * @property {ShaderProgram} [shaderProgram]
- * @property {DrawCommand} [command]
- * @property {Function} destroy
- * @ignore
- */
-
 // Scratch variables.
 const polygon = new BufferPolygon();
 const material = new BufferPolygonMaterial();
@@ -80,13 +63,15 @@ const encodedC = new EncodedCartesian3();
 /**
  * @param {BufferPolygonCollection} collection
  * @param {FrameState} frameState
- * @param {BufferPolygonRenderContext} [renderContext]
- * @returns {BufferPolygonRenderContext}
+ * @param {BufferPrimitiveRenderContext} [renderContext]
+ * @returns {BufferPrimitiveRenderContext}
  * @ignore
  */
 function renderBufferPolygonCollection(collection, frameState, renderContext) {
   const context = frameState.context;
-  renderContext = renderContext || { destroy: destroyRenderContext };
+  renderContext = renderContext || {
+    destroy: destroyBufferPrimitiveRenderContext,
+  };
   const useFloat64 = collection._positionDatatype === ComponentDatatype.DOUBLE;
   const attributeLocations = useFloat64
     ? BufferPolygonAttributeLocationsFloat64
@@ -277,103 +262,16 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
     }
   }
 
-  const zIndex = collection._zIndex;
+  buildBufferPrimitiveDrawCommand(collection, context, renderContext, {
+    primitiveType: PrimitiveType.TRIANGLES,
+    attributeLocations,
+    vertexShaderSources: [BufferPolygonMaterialVS],
+    fragmentShaderSources: [BufferPolygonMaterialFS],
+    useFloat64,
+    drawCount: collection.triangleCount * 3,
+  });
 
-  const pass =
-    collection._blendOption === BlendOption.OPAQUE
-      ? Pass.OPAQUE
-      : Pass.TRANSLUCENT;
-
-  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
-    RenderState.removeFromCache(renderContext.renderState);
-    renderContext.renderState = undefined;
-    renderContext.command = undefined;
-  }
-
-  if (!defined(renderContext.uniformMap)) {
-    renderContext.uniformMap = {};
-
-    if (zIndex !== 0) {
-      const polygonOffset = new Cartesian2(-zIndex, -zIndex);
-      renderContext.uniformMap.u_polygonOffset = () => polygonOffset;
-    }
-  }
-
-  if (!defined(renderContext.renderState)) {
-    // Offsets the fixed-function depth. The u_polygonOffset uniform offsets the
-    // logarithmic depth, which the fragment shader writes instead when enabled.
-    const depthOffset = zIndex === 0 ? 0 : -zIndex;
-
-    renderContext.renderState = RenderState.fromCache({
-      blending:
-        pass === Pass.OPAQUE
-          ? BlendingState.DISABLED
-          : BlendingState.ALPHA_BLEND,
-      depthTest: { enabled: true },
-      polygonOffset: {
-        enabled: zIndex !== 0,
-        factor: depthOffset,
-        units: depthOffset,
-      },
-    });
-  }
-
-  if (!defined(renderContext.shaderProgram)) {
-    const vertexDefines = [];
-    const fragmentDefines = [];
-
-    if (useFloat64) {
-      vertexDefines.push("USE_FLOAT64");
-    }
-
-    if (zIndex !== 0) {
-      fragmentDefines.push("POLYGON_OFFSET");
-    }
-
-    renderContext.shaderProgram = ShaderProgram.fromCache({
-      context,
-      vertexShaderSource: new ShaderSource({
-        sources: [BufferPolygonMaterialVS],
-        defines: vertexDefines,
-      }),
-      fragmentShaderSource: new ShaderSource({
-        sources: [BufferPolygonMaterialFS],
-        defines: fragmentDefines,
-      }),
-      attributeLocations,
-    });
-  }
-
-  const drawCount = collection.triangleCount * 3;
-
-  if (!defined(renderContext.command)) {
-    renderContext.command = new DrawCommand({
-      vertexArray: renderContext.vertexArray,
-      renderState: renderContext.renderState,
-      shaderProgram: renderContext.shaderProgram,
-      uniformMap: renderContext.uniformMap,
-      primitiveType: PrimitiveType.TRIANGLES,
-      pass,
-      pickId: collection._allowPicking ? "v_pickColor" : undefined,
-      owner: collection,
-      count: drawCount,
-      modelMatrix: collection.modelMatrix, // shared reference
-      boundingVolume: collection.boundingVolume, // shared reference
-      debugShowBoundingVolume: collection.debugShowBoundingVolume,
-    });
-  }
-
-  const command = renderContext.command;
-
-  if (command.count !== drawCount) {
-    command.count = drawCount;
-  }
-
-  if (command.debugShowBoundingVolume !== collection.debugShowBoundingVolume) {
-    command.debugShowBoundingVolume = collection.debugShowBoundingVolume;
-  }
-
-  frameState.commandList.push(command);
+  frameState.commandList.push(renderContext.command);
 
   collection._makeClean();
 
@@ -398,27 +296,6 @@ function getPolygonDirtyRanges(collection) {
     (polygon.triangleOffset + polygon.triangleCount) * 3 - indexOffset;
 
   return { indexOffset, indexCount, vertexOffset, vertexCount };
-}
-
-/**
- * Destroys render context resources. Deleting properties from the context
- * object isn't necessary, as collection.destroy() will discard the object.
- * @ignore
- */
-function destroyRenderContext() {
-  const context = /** @type {BufferPolygonRenderContext} */ (this);
-
-  if (defined(context.vertexArray)) {
-    context.vertexArray.destroy();
-  }
-
-  if (defined(context.shaderProgram)) {
-    context.shaderProgram.destroy();
-  }
-
-  if (defined(context.renderState)) {
-    RenderState.removeFromCache(context.renderState);
-  }
 }
 
 export default renderBufferPolygonCollection;

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -8,12 +8,6 @@ import Buffer from "../Renderer/Buffer.js";
 import BufferUsage from "../Renderer/BufferUsage.js";
 import VertexArray from "../Renderer/VertexArray.js";
 import ComponentDatatype from "../Core/ComponentDatatype.js";
-import RenderState from "../Renderer/RenderState.js";
-import BlendingState from "./BlendingState.js";
-import ShaderSource from "../Renderer/ShaderSource.js";
-import ShaderProgram from "../Renderer/ShaderProgram.js";
-import DrawCommand from "../Renderer/DrawCommand.js";
-import Pass from "../Renderer/Pass.js";
 import PrimitiveType from "../Core/PrimitiveType.js";
 import BufferPolylineMaterialVS from "../Shaders/BufferPolylineMaterialVS.js";
 import BufferPolylineMaterialFS from "../Shaders/BufferPolylineMaterialFS.js";
@@ -22,12 +16,14 @@ import AttributeCompression from "../Core/AttributeCompression.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
 import PolylineCommon from "../Shaders/PolylineCommon.js";
 import BufferPolylineMaterial from "./BufferPolylineMaterial.js";
-import BlendOption from "./BlendOption.js";
-import Cartesian2 from "../Core/Cartesian2.js";
+import buildBufferPrimitiveDrawCommand, {
+  destroyBufferPrimitiveRenderContext,
+} from "./buildBufferPrimitiveDrawCommand.js";
 
 /** @import FrameState from "./FrameState.js"; */
 /** @import BufferPolylineCollection from "./BufferPolylineCollection.js"; */
 /** @import {TypedArray} from "../Core/globalTypes.js"; */
+/** @import {BufferPrimitiveRenderContext} from "./buildBufferPrimitiveDrawCommand.js"; */
 
 /**
  * TODO(PR#13211): Need 'keyof' syntax to avoid duplicating attribute names.
@@ -66,19 +62,6 @@ const BufferPolylineAttributeLocations = {
   alpha: 5,
 };
 
-/**
- * @typedef {object} BufferPolylineRenderContext
- * @property {VertexArray} [vertexArray]
- * @property {Record<string, TypedArray>} [attributeArrays]
- * @property {TypedArray} [indexArray]
- * @property {RenderState} [renderState]
- * @property {Record<string, unknown>} [uniformMap]
- * @property {ShaderProgram} [shaderProgram]
- * @property {DrawCommand} [command]
- * @property {Function} destroy
- * @ignore
- */
-
 // Scratch variables.
 const polyline = new BufferPolyline();
 const material = new BufferPolylineMaterial();
@@ -106,13 +89,15 @@ const encodedN = new EncodedCartesian3();
  *
  * @param {BufferPolylineCollection} collection
  * @param {FrameState} frameState
- * @param {BufferPolylineRenderContext} [renderContext]
- * @returns {BufferPolylineRenderContext}
+ * @param {BufferPrimitiveRenderContext} [renderContext]
+ * @returns {BufferPrimitiveRenderContext}
  * @ignore
  */
 function renderBufferPolylineCollection(collection, frameState, renderContext) {
   const context = frameState.context;
-  renderContext = renderContext || { destroy: destroyRenderContext };
+  renderContext = renderContext || {
+    destroy: destroyBufferPrimitiveRenderContext,
+  };
   const useFloat64 = collection._positionDatatype === ComponentDatatype.DOUBLE;
   const attributeLocations = useFloat64
     ? BufferPolylineAttributeLocationsFloat64
@@ -493,103 +478,16 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
     }
   }
 
-  const zIndex = collection._zIndex;
+  buildBufferPrimitiveDrawCommand(collection, context, renderContext, {
+    primitiveType: PrimitiveType.TRIANGLES,
+    attributeLocations,
+    vertexShaderSources: [PolylineCommon, BufferPolylineMaterialVS],
+    fragmentShaderSources: [BufferPolylineMaterialFS],
+    useFloat64,
+    drawCount: getDrawIndexCount(collection),
+  });
 
-  const pass =
-    collection._blendOption === BlendOption.OPAQUE
-      ? Pass.OPAQUE
-      : Pass.TRANSLUCENT;
-
-  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
-    RenderState.removeFromCache(renderContext.renderState);
-    renderContext.renderState = undefined;
-    renderContext.command = undefined;
-  }
-
-  if (!defined(renderContext.uniformMap)) {
-    renderContext.uniformMap = {};
-
-    if (zIndex !== 0) {
-      const polygonOffset = new Cartesian2(-zIndex, -zIndex);
-      renderContext.uniformMap.u_polygonOffset = () => polygonOffset;
-    }
-  }
-
-  if (!defined(renderContext.renderState)) {
-    // Offsets the fixed-function depth. The u_polygonOffset uniform offsets the
-    // logarithmic depth, which the fragment shader writes instead when enabled.
-    const depthOffset = zIndex === 0 ? 0 : -zIndex;
-
-    renderContext.renderState = RenderState.fromCache({
-      blending:
-        pass === Pass.OPAQUE
-          ? BlendingState.DISABLED
-          : BlendingState.ALPHA_BLEND,
-      depthTest: { enabled: true },
-      polygonOffset: {
-        enabled: zIndex !== 0,
-        factor: depthOffset,
-        units: depthOffset,
-      },
-    });
-  }
-
-  if (!defined(renderContext.shaderProgram)) {
-    const vertexDefines = [];
-    const fragmentDefines = [];
-
-    if (useFloat64) {
-      vertexDefines.push("USE_FLOAT64");
-    }
-
-    if (zIndex !== 0) {
-      fragmentDefines.push("POLYGON_OFFSET");
-    }
-
-    renderContext.shaderProgram = ShaderProgram.fromCache({
-      context,
-      vertexShaderSource: new ShaderSource({
-        sources: [PolylineCommon, BufferPolylineMaterialVS],
-        defines: vertexDefines,
-      }),
-      fragmentShaderSource: new ShaderSource({
-        sources: [BufferPolylineMaterialFS],
-        defines: fragmentDefines,
-      }),
-      attributeLocations,
-    });
-  }
-
-  const drawCount = getDrawIndexCount(collection);
-
-  if (!defined(renderContext.command)) {
-    renderContext.command = new DrawCommand({
-      vertexArray: renderContext.vertexArray,
-      renderState: renderContext.renderState,
-      shaderProgram: renderContext.shaderProgram,
-      uniformMap: renderContext.uniformMap,
-      primitiveType: PrimitiveType.TRIANGLES,
-      pass,
-      pickId: collection._allowPicking ? "v_pickColor" : undefined,
-      owner: collection,
-      count: drawCount,
-      modelMatrix: collection.modelMatrix, // shared reference
-      boundingVolume: collection.boundingVolume, // shared reference
-      debugShowBoundingVolume: collection.debugShowBoundingVolume,
-    });
-  }
-
-  const command = renderContext.command;
-
-  if (command.count !== drawCount) {
-    command.count = drawCount;
-  }
-
-  if (command.debugShowBoundingVolume !== collection.debugShowBoundingVolume) {
-    command.debugShowBoundingVolume = collection.debugShowBoundingVolume;
-  }
-
-  frameState.commandList.push(command);
+  frameState.commandList.push(renderContext.command);
 
   collection._makeClean();
 
@@ -625,27 +523,6 @@ function getPolylineDirtyRanges(collection) {
   const indexCount = segmentCount * 6;
 
   return { indexOffset, indexCount, vertexOffset, vertexCount };
-}
-
-/**
- * Destroys render context resources. Deleting properties from the context
- * object isn't necessary, as collection.destroy() will discard the object.
- * @ignore
- */
-function destroyRenderContext() {
-  const context = /** @type {BufferPolylineRenderContext} */ (this);
-
-  if (defined(context.vertexArray)) {
-    context.vertexArray.destroy();
-  }
-
-  if (defined(context.shaderProgram)) {
-    context.shaderProgram.destroy();
-  }
-
-  if (defined(context.renderState)) {
-    RenderState.removeFromCache(context.renderState);
-  }
 }
 
 export default renderBufferPolylineCollection;


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
This refactors the shared tail of the three buffer primitive renderers into buildBufferPrimitiveDrawCommand.js. This extracts it into `buildBufferPrimitiveDrawCommand.js`: the shared render context typedef, its destroy function, and pass selection, render state, shader program, and draw command creation. Each renderer keeps only what genuinely differs. No behavior change. This is groundwork for `VectorLayer`, which will build on this module once rendering moves off the collections.

<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
