### PR TITLE
Support BlendOption.OPAQUE_AND_TRANSLUCENT for buffer primitive collections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Additions :tada:
 
 - Added `vectorBlendOption` to `Cesium3DTileset`, for selecting opaque or translucent modes. `blendOption` can now also be changed after construction on `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`. [#13764](https://github.com/CesiumGS/cesium/issues/13764)
+- Added support for `BlendOption.OPAQUE_AND_TRANSLUCENT` on `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`, and on the `vectorBlendOption` of `Cesium3DTileset`. Opaque primitives then occlude each other while translucent ones still blend, at roughly twice the cost of the other options. [#13778](https://github.com/CesiumGS/cesium/pull/13778)
 - Added `vectorZIndex` to `Cesium3DTileset` and a `zIndex` constructor parameter to `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`, to layer overlapping vector geometry and avoid z-fighting. [#13727](https://github.com/CesiumGS/cesium/pull/13727)
 
 #### Fixes :wrench:

--- a/packages/engine/Source/Scene/BufferPointCollection.js
+++ b/packages/engine/Source/Scene/BufferPointCollection.js
@@ -70,7 +70,7 @@ class BufferPointCollection extends BufferPrimitiveCollection {
    *    specified, users are responsible for updating bounding volume as needed. Pre-computing the bounding volume
    *    manually, and updating it only as needed, will improve performance for larger dynamic collections.
    * @param {boolean} [options.debugShowBoundingVolume=false]
-   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene.
    * @param {number} [options.zIndex=0] Integer z-order of collection, used to "layer" primitives at the same depth and to prevent z-fighting. In 3D scene modes, zIndex is limited by the precision of the depth buffer. Prefer the smallest (nearest to zero) acceptable positive or negative integer value. Points are not yet layered by this value.
    */
   constructor(options = Frozen.EMPTY_OBJECT) {

--- a/packages/engine/Source/Scene/BufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/BufferPolygonCollection.js
@@ -49,7 +49,7 @@ const { ERR_CAPACITY } = BufferPrimitiveCollection.Error;
  *    specified, users are responsible for updating bounding volume as needed. Pre-computing the bounding volume
  *    manually, and updating it only as needed, will improve performance for larger dynamic collections.
  * @property {boolean} [debugShowBoundingVolume=false]
- * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+ * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene.
  * @property {number} [zIndex=0] Integer z-order of collection, used to "layer" primitives at the same depth and to prevent z-fighting. In 3D scene modes, zIndex is limited by the precision of the depth buffer. Prefer the smallest (nearest to zero) acceptable positive or negative integer value.
  * @property {HeightReference} [heightReference=HeightReference.NONE] When set to a clamping value, the
  *   collection is draped onto terrain and/or 3D Tiles, rather than drawn as geometry of its own.

--- a/packages/engine/Source/Scene/BufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/BufferPolylineCollection.js
@@ -75,7 +75,7 @@ class BufferPolylineCollection extends BufferPrimitiveCollection {
    * @param {boolean} [options.allowPicking=false] When <code>true</code>, primitives are pickable with {@link Scene#pick}. When <code>false</code>, memory and initialization cost are lower.
    * @param {BoundingSphere} [options.boundingVolume] Bounding volume, in world space, for the collection.
    * @param {boolean} [options.debugShowBoundingVolume=false]
-   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+   * @param {BlendOption} [options.blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene.
    * @param {number} [options.zIndex=0] Integer z-order of collection, used to "layer" primitives at the same depth and to prevent z-fighting. In 3D scene modes, zIndex is limited by the precision of the depth buffer. Prefer the smallest (nearest to zero) acceptable positive or negative integer value.
    * @param {HeightReference} [options.heightReference=HeightReference.NONE]
    * @param {"pixels"|"meters"} [options.widthUnits="pixels"] Unit of polyline widths in this collection:

--- a/packages/engine/Source/Scene/BufferPrimitiveCollection.js
+++ b/packages/engine/Source/Scene/BufferPrimitiveCollection.js
@@ -49,7 +49,7 @@ import HeightReference, { isHeightReferenceClamp } from "./HeightReference.js";
  *    specified, users are responsible for updating bounding volume as needed. Pre-computing the bounding volume
  *    manually, and updating it only as needed, will improve performance for larger dynamic collections.
  * @property {boolean} [debugShowBoundingVolume=false]
- * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+ * @property {BlendOption} [blendOption=BlendOption.TRANSLUCENT] Determines how primitives in the collection are blended with the scene.
  * @property {number} [zIndex=0] Integer z-order of collection, used to "layer" primitives at the same depth and to prevent z-fighting. In 3D scene modes, zIndex is limited by the precision of the depth buffer. Prefer the smallest (nearest to zero) acceptable positive or negative integer value.
  * @property {HeightReference} [options.heightReference=HeightReference.NONE] When set to a clamping value, the
  *   collection is draped onto the surfaces selected by the value: {@link HeightReference.CLAMP_TO_TERRAIN} drapes
@@ -999,13 +999,13 @@ class BufferPrimitiveCollection {
 
   /**
    * Determines how primitives in the collection are blended with the scene.
-   * Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT};
-   * {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
    *
    * <p>{@link BlendOption.OPAQUE} disables blending and writes depth, so primitives
    * occlude each other and the geometry behind them. {@link BlendOption.TRANSLUCENT}
    * alpha blends primitives and does not write depth, so they are resolved by
-   * order-independent translucency instead.</p>
+   * order-independent translucency instead. {@link BlendOption.OPAQUE_AND_TRANSLUCENT}
+   * draws the collection once per pass, sorting each primitive by its own opacity, at
+   * roughly twice the cost of the other options.</p>
    *
    * @type {BlendOption}
    * @default BlendOption.TRANSLUCENT
@@ -1015,14 +1015,6 @@ class BufferPrimitiveCollection {
   }
 
   set blendOption(value) {
-    //>>includeStart('debug', pragmas.debug);
-    if (value !== BlendOption.OPAQUE && value !== BlendOption.TRANSLUCENT) {
-      throw new DeveloperError(
-        "blendOption must be BlendOption.OPAQUE or BlendOption.TRANSLUCENT.",
-      );
-    }
-    //>>includeEnd('debug');
-
     this._blendOption = value;
   }
 

--- a/packages/engine/Source/Scene/Cesium3DTileset.js
+++ b/packages/engine/Source/Scene/Cesium3DTileset.js
@@ -120,7 +120,7 @@ import ImageryLayerCollection from "./ImageryLayerCollection.js";
  * @property {Color} [outlineColor=Color.BLACK] The color to use when rendering outlines.
  * @property {boolean} [vectorClassificationOnly=false] Indicates that only the tileset's vector tiles should be used for classification.
  * @property {boolean} [vectorKeepDecodedPositions=false] Whether vector tiles should keep decoded positions in memory. This is used with {@link Cesium3DTileFeature.getPolylinePositions}.
- * @property {BlendOption} [vectorBlendOption=BlendOption.TRANSLUCENT] Determines how vector primitives in the tileset are blended with the scene. Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT}; {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
+ * @property {BlendOption} [vectorBlendOption=BlendOption.TRANSLUCENT] Determines how vector primitives in the tileset are blended with the scene.
  * @property {string|number} [featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @property {string|number} [instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @property {boolean} [showCreditsOnScreen=false] Whether to display the credits of this tileset on screen.
@@ -2098,8 +2098,6 @@ Object.defineProperties(Cesium3DTileset.prototype, {
 
   /**
    * Determines how vector primitives in the tileset are blended with the scene.
-   * Must be {@link BlendOption.OPAQUE} or {@link BlendOption.TRANSLUCENT};
-   * {@link BlendOption.OPAQUE_AND_TRANSLUCENT} is not supported.
    *
    * @memberof Cesium3DTileset.prototype
    *

--- a/packages/engine/Source/Scene/renderBufferPointCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPointCollection.js
@@ -63,9 +63,13 @@ const BufferPointAttributeLocations = {
  * @property {VertexArray} [vertexArray]
  * @property {Record<string, TypedArray>} [attributeArrays]
  * @property {RenderState} [renderState]
+ * @property {RenderState} [translucentRenderState]
  * @property {Record<string, unknown>} [uniformMap]
+ * @property {BlendOption} [blendOption] Blend option the cached resources were built for.
  * @property {ShaderProgram} [shaderProgram]
+ * @property {ShaderProgram} [translucentShaderProgram]
  * @property {DrawCommand} [command]
+ * @property {DrawCommand} [translucentCommand]
  * @property {Function} destroy
  * @ignore
  */
@@ -254,16 +258,16 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
   }
 
   const zIndex = collection._zIndex;
+  const blendOption = collection._blendOption;
 
-  const pass =
-    collection._blendOption === BlendOption.OPAQUE
-      ? Pass.OPAQUE
-      : Pass.TRANSLUCENT;
+  // OPAQUE_AND_TRANSLUCENT draws the collection twice, once per pass. The fragment
+  // shader defines make each pass discard the fragments belonging to the other.
+  const opaqueAndTranslucent =
+    blendOption === BlendOption.OPAQUE_AND_TRANSLUCENT;
 
-  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
-    RenderState.removeFromCache(renderContext.renderState);
-    renderContext.renderState = undefined;
-    renderContext.command = undefined;
+  if (renderContext.blendOption !== blendOption) {
+    releaseShaderResources(renderContext);
+    renderContext.blendOption = blendOption;
   }
 
   if (!defined(renderContext.uniformMap)) {
@@ -280,11 +284,20 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
     // fixed-function polygon offset applies to filled polygons, not to points.
     renderContext.renderState = RenderState.fromCache({
       blending:
-        pass === Pass.OPAQUE
-          ? BlendingState.DISABLED
-          : BlendingState.ALPHA_BLEND,
+        blendOption === BlendOption.TRANSLUCENT
+          ? BlendingState.ALPHA_BLEND
+          : BlendingState.DISABLED,
       depthTest: { enabled: true },
     });
+
+    if (opaqueAndTranslucent) {
+      // Only the opaque half of the pair writes depth.
+      renderContext.translucentRenderState = RenderState.fromCache({
+        blending: BlendingState.ALPHA_BLEND,
+        depthTest: { enabled: true },
+        depthMask: false,
+      });
+    }
   }
 
   if (!defined(renderContext.shaderProgram)) {
@@ -299,18 +312,34 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       fragmentDefines.push("POLYGON_OFFSET");
     }
 
+    const vertexShaderSource = new ShaderSource({
+      sources: [BufferPointMaterialVS],
+      defines: vertexDefines,
+    });
+
     renderContext.shaderProgram = ShaderProgram.fromCache({
       context,
-      vertexShaderSource: new ShaderSource({
-        sources: [BufferPointMaterialVS],
-        defines: vertexDefines,
-      }),
+      vertexShaderSource,
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPointMaterialFS],
-        defines: fragmentDefines,
+        defines: opaqueAndTranslucent
+          ? fragmentDefines.concat("OPAQUE")
+          : fragmentDefines,
       }),
       attributeLocations,
     });
+
+    if (opaqueAndTranslucent) {
+      renderContext.translucentShaderProgram = ShaderProgram.fromCache({
+        context,
+        vertexShaderSource,
+        fragmentShaderSource: new ShaderSource({
+          sources: [BufferPointMaterialFS],
+          defines: fragmentDefines.concat("TRANSLUCENT"),
+        }),
+        attributeLocations,
+      });
+    }
   }
 
   if (!defined(renderContext.command)) {
@@ -320,7 +349,10 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       shaderProgram: renderContext.shaderProgram,
       uniformMap: renderContext.uniformMap,
       primitiveType: PrimitiveType.POINTS,
-      pass,
+      pass:
+        blendOption === BlendOption.TRANSLUCENT
+          ? Pass.TRANSLUCENT
+          : Pass.OPAQUE,
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: collection.primitiveCount,
@@ -328,6 +360,23 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
       boundingVolume: collection.boundingVolume, // shared reference
       debugShowBoundingVolume: collection.debugShowBoundingVolume,
     });
+
+    if (opaqueAndTranslucent) {
+      renderContext.translucentCommand = new DrawCommand({
+        vertexArray: renderContext.vertexArray,
+        renderState: renderContext.translucentRenderState,
+        shaderProgram: renderContext.translucentShaderProgram,
+        uniformMap: renderContext.uniformMap,
+        primitiveType: PrimitiveType.POINTS,
+        pass: Pass.TRANSLUCENT,
+        pickId: collection._allowPicking ? "v_pickColor" : undefined,
+        owner: collection,
+        count: collection.primitiveCount,
+        modelMatrix: collection.modelMatrix, // shared reference
+        boundingVolume: collection.boundingVolume, // shared reference
+        debugShowBoundingVolume: collection.debugShowBoundingVolume,
+      });
+    }
   }
 
   const command = renderContext.command;
@@ -342,9 +391,48 @@ function renderBufferPointCollection(collection, frameState, renderContext) {
 
   frameState.commandList.push(command);
 
+  if (opaqueAndTranslucent) {
+    const translucentCommand = renderContext.translucentCommand;
+    translucentCommand.count = command.count;
+    translucentCommand.debugShowBoundingVolume =
+      command.debugShowBoundingVolume;
+    frameState.commandList.push(translucentCommand);
+  }
+
   collection._makeClean();
 
   return renderContext;
+}
+
+/**
+ * Releases the resources that depend on the blend option, leaving the vertex array and
+ * attribute arrays intact.
+ * @param {BufferPointRenderContext} renderContext
+ * @ignore
+ */
+function releaseShaderResources(renderContext) {
+  if (defined(renderContext.shaderProgram)) {
+    renderContext.shaderProgram.destroy();
+  }
+
+  if (defined(renderContext.translucentShaderProgram)) {
+    renderContext.translucentShaderProgram.destroy();
+  }
+
+  if (defined(renderContext.renderState)) {
+    RenderState.removeFromCache(renderContext.renderState);
+  }
+
+  if (defined(renderContext.translucentRenderState)) {
+    RenderState.removeFromCache(renderContext.translucentRenderState);
+  }
+
+  renderContext.shaderProgram = undefined;
+  renderContext.translucentShaderProgram = undefined;
+  renderContext.renderState = undefined;
+  renderContext.translucentRenderState = undefined;
+  renderContext.command = undefined;
+  renderContext.translucentCommand = undefined;
 }
 
 /**
@@ -359,13 +447,7 @@ function destroyRenderContext() {
     context.vertexArray.destroy();
   }
 
-  if (defined(context.shaderProgram)) {
-    context.shaderProgram.destroy();
-  }
-
-  if (defined(context.renderState)) {
-    RenderState.removeFromCache(context.renderState);
-  }
+  releaseShaderResources(context);
 }
 
 export default renderBufferPointCollection;

--- a/packages/engine/Source/Scene/renderBufferPolygonCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolygonCollection.js
@@ -63,9 +63,13 @@ const BufferPolygonAttributeLocations = {
  * @property {Record<string, TypedArray>} [attributeArrays]
  * @property {TypedArray} [indexArray]
  * @property {RenderState} [renderState]
+ * @property {RenderState} [translucentRenderState]
  * @property {Record<string, unknown>} [uniformMap]
+ * @property {BlendOption} [blendOption] Blend option the cached resources were built for.
  * @property {ShaderProgram} [shaderProgram]
+ * @property {ShaderProgram} [translucentShaderProgram]
  * @property {DrawCommand} [command]
+ * @property {DrawCommand} [translucentCommand]
  * @property {Function} destroy
  * @ignore
  */
@@ -278,16 +282,16 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
   }
 
   const zIndex = collection._zIndex;
+  const blendOption = collection._blendOption;
 
-  const pass =
-    collection._blendOption === BlendOption.OPAQUE
-      ? Pass.OPAQUE
-      : Pass.TRANSLUCENT;
+  // OPAQUE_AND_TRANSLUCENT draws the collection twice, once per pass. The fragment
+  // shader defines make each pass discard the fragments belonging to the other.
+  const opaqueAndTranslucent =
+    blendOption === BlendOption.OPAQUE_AND_TRANSLUCENT;
 
-  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
-    RenderState.removeFromCache(renderContext.renderState);
-    renderContext.renderState = undefined;
-    renderContext.command = undefined;
+  if (renderContext.blendOption !== blendOption) {
+    releaseShaderResources(renderContext);
+    renderContext.blendOption = blendOption;
   }
 
   if (!defined(renderContext.uniformMap)) {
@@ -303,19 +307,30 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
     // Offsets the fixed-function depth. The u_polygonOffset uniform offsets the
     // logarithmic depth, which the fragment shader writes instead when enabled.
     const depthOffset = zIndex === 0 ? 0 : -zIndex;
+    const polygonOffset = {
+      enabled: zIndex !== 0,
+      factor: depthOffset,
+      units: depthOffset,
+    };
 
     renderContext.renderState = RenderState.fromCache({
       blending:
-        pass === Pass.OPAQUE
-          ? BlendingState.DISABLED
-          : BlendingState.ALPHA_BLEND,
+        blendOption === BlendOption.TRANSLUCENT
+          ? BlendingState.ALPHA_BLEND
+          : BlendingState.DISABLED,
       depthTest: { enabled: true },
-      polygonOffset: {
-        enabled: zIndex !== 0,
-        factor: depthOffset,
-        units: depthOffset,
-      },
+      polygonOffset,
     });
+
+    if (opaqueAndTranslucent) {
+      // Only the opaque half of the pair writes depth.
+      renderContext.translucentRenderState = RenderState.fromCache({
+        blending: BlendingState.ALPHA_BLEND,
+        depthTest: { enabled: true },
+        depthMask: false,
+        polygonOffset,
+      });
+    }
   }
 
   if (!defined(renderContext.shaderProgram)) {
@@ -330,18 +345,34 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       fragmentDefines.push("POLYGON_OFFSET");
     }
 
+    const vertexShaderSource = new ShaderSource({
+      sources: [BufferPolygonMaterialVS],
+      defines: vertexDefines,
+    });
+
     renderContext.shaderProgram = ShaderProgram.fromCache({
       context,
-      vertexShaderSource: new ShaderSource({
-        sources: [BufferPolygonMaterialVS],
-        defines: vertexDefines,
-      }),
+      vertexShaderSource,
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolygonMaterialFS],
-        defines: fragmentDefines,
+        defines: opaqueAndTranslucent
+          ? fragmentDefines.concat("OPAQUE")
+          : fragmentDefines,
       }),
       attributeLocations,
     });
+
+    if (opaqueAndTranslucent) {
+      renderContext.translucentShaderProgram = ShaderProgram.fromCache({
+        context,
+        vertexShaderSource,
+        fragmentShaderSource: new ShaderSource({
+          sources: [BufferPolygonMaterialFS],
+          defines: fragmentDefines.concat("TRANSLUCENT"),
+        }),
+        attributeLocations,
+      });
+    }
   }
 
   const drawCount = collection.triangleCount * 3;
@@ -353,7 +384,10 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       shaderProgram: renderContext.shaderProgram,
       uniformMap: renderContext.uniformMap,
       primitiveType: PrimitiveType.TRIANGLES,
-      pass,
+      pass:
+        blendOption === BlendOption.TRANSLUCENT
+          ? Pass.TRANSLUCENT
+          : Pass.OPAQUE,
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: drawCount,
@@ -361,6 +395,23 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
       boundingVolume: collection.boundingVolume, // shared reference
       debugShowBoundingVolume: collection.debugShowBoundingVolume,
     });
+
+    if (opaqueAndTranslucent) {
+      renderContext.translucentCommand = new DrawCommand({
+        vertexArray: renderContext.vertexArray,
+        renderState: renderContext.translucentRenderState,
+        shaderProgram: renderContext.translucentShaderProgram,
+        uniformMap: renderContext.uniformMap,
+        primitiveType: PrimitiveType.TRIANGLES,
+        pass: Pass.TRANSLUCENT,
+        pickId: collection._allowPicking ? "v_pickColor" : undefined,
+        owner: collection,
+        count: drawCount,
+        modelMatrix: collection.modelMatrix, // shared reference
+        boundingVolume: collection.boundingVolume, // shared reference
+        debugShowBoundingVolume: collection.debugShowBoundingVolume,
+      });
+    }
   }
 
   const command = renderContext.command;
@@ -375,9 +426,48 @@ function renderBufferPolygonCollection(collection, frameState, renderContext) {
 
   frameState.commandList.push(command);
 
+  if (opaqueAndTranslucent) {
+    const translucentCommand = renderContext.translucentCommand;
+    translucentCommand.count = command.count;
+    translucentCommand.debugShowBoundingVolume =
+      command.debugShowBoundingVolume;
+    frameState.commandList.push(translucentCommand);
+  }
+
   collection._makeClean();
 
   return renderContext;
+}
+
+/**
+ * Releases the resources that depend on the blend option, leaving the vertex array and
+ * attribute arrays intact.
+ * @param {BufferPolygonRenderContext} renderContext
+ * @ignore
+ */
+function releaseShaderResources(renderContext) {
+  if (defined(renderContext.shaderProgram)) {
+    renderContext.shaderProgram.destroy();
+  }
+
+  if (defined(renderContext.translucentShaderProgram)) {
+    renderContext.translucentShaderProgram.destroy();
+  }
+
+  if (defined(renderContext.renderState)) {
+    RenderState.removeFromCache(renderContext.renderState);
+  }
+
+  if (defined(renderContext.translucentRenderState)) {
+    RenderState.removeFromCache(renderContext.translucentRenderState);
+  }
+
+  renderContext.shaderProgram = undefined;
+  renderContext.translucentShaderProgram = undefined;
+  renderContext.renderState = undefined;
+  renderContext.translucentRenderState = undefined;
+  renderContext.command = undefined;
+  renderContext.translucentCommand = undefined;
 }
 
 /**
@@ -412,13 +502,7 @@ function destroyRenderContext() {
     context.vertexArray.destroy();
   }
 
-  if (defined(context.shaderProgram)) {
-    context.shaderProgram.destroy();
-  }
-
-  if (defined(context.renderState)) {
-    RenderState.removeFromCache(context.renderState);
-  }
+  releaseShaderResources(context);
 }
 
 export default renderBufferPolygonCollection;

--- a/packages/engine/Source/Scene/renderBufferPolylineCollection.js
+++ b/packages/engine/Source/Scene/renderBufferPolylineCollection.js
@@ -72,9 +72,13 @@ const BufferPolylineAttributeLocations = {
  * @property {Record<string, TypedArray>} [attributeArrays]
  * @property {TypedArray} [indexArray]
  * @property {RenderState} [renderState]
+ * @property {RenderState} [translucentRenderState]
  * @property {Record<string, unknown>} [uniformMap]
+ * @property {BlendOption} [blendOption] Blend option the cached resources were built for.
  * @property {ShaderProgram} [shaderProgram]
+ * @property {ShaderProgram} [translucentShaderProgram]
  * @property {DrawCommand} [command]
+ * @property {DrawCommand} [translucentCommand]
  * @property {Function} destroy
  * @ignore
  */
@@ -494,16 +498,16 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
   }
 
   const zIndex = collection._zIndex;
+  const blendOption = collection._blendOption;
 
-  const pass =
-    collection._blendOption === BlendOption.OPAQUE
-      ? Pass.OPAQUE
-      : Pass.TRANSLUCENT;
+  // OPAQUE_AND_TRANSLUCENT draws the collection twice, once per pass. The fragment
+  // shader defines make each pass discard the fragments belonging to the other.
+  const opaqueAndTranslucent =
+    blendOption === BlendOption.OPAQUE_AND_TRANSLUCENT;
 
-  if (defined(renderContext.command) && renderContext.command.pass !== pass) {
-    RenderState.removeFromCache(renderContext.renderState);
-    renderContext.renderState = undefined;
-    renderContext.command = undefined;
+  if (renderContext.blendOption !== blendOption) {
+    releaseShaderResources(renderContext);
+    renderContext.blendOption = blendOption;
   }
 
   if (!defined(renderContext.uniformMap)) {
@@ -519,19 +523,30 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
     // Offsets the fixed-function depth. The u_polygonOffset uniform offsets the
     // logarithmic depth, which the fragment shader writes instead when enabled.
     const depthOffset = zIndex === 0 ? 0 : -zIndex;
+    const polygonOffset = {
+      enabled: zIndex !== 0,
+      factor: depthOffset,
+      units: depthOffset,
+    };
 
     renderContext.renderState = RenderState.fromCache({
       blending:
-        pass === Pass.OPAQUE
-          ? BlendingState.DISABLED
-          : BlendingState.ALPHA_BLEND,
+        blendOption === BlendOption.TRANSLUCENT
+          ? BlendingState.ALPHA_BLEND
+          : BlendingState.DISABLED,
       depthTest: { enabled: true },
-      polygonOffset: {
-        enabled: zIndex !== 0,
-        factor: depthOffset,
-        units: depthOffset,
-      },
+      polygonOffset,
     });
+
+    if (opaqueAndTranslucent) {
+      // Only the opaque half of the pair writes depth.
+      renderContext.translucentRenderState = RenderState.fromCache({
+        blending: BlendingState.ALPHA_BLEND,
+        depthTest: { enabled: true },
+        depthMask: false,
+        polygonOffset,
+      });
+    }
   }
 
   if (!defined(renderContext.shaderProgram)) {
@@ -546,18 +561,34 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       fragmentDefines.push("POLYGON_OFFSET");
     }
 
+    const vertexShaderSource = new ShaderSource({
+      sources: [PolylineCommon, BufferPolylineMaterialVS],
+      defines: vertexDefines,
+    });
+
     renderContext.shaderProgram = ShaderProgram.fromCache({
       context,
-      vertexShaderSource: new ShaderSource({
-        sources: [PolylineCommon, BufferPolylineMaterialVS],
-        defines: vertexDefines,
-      }),
+      vertexShaderSource,
       fragmentShaderSource: new ShaderSource({
         sources: [BufferPolylineMaterialFS],
-        defines: fragmentDefines,
+        defines: opaqueAndTranslucent
+          ? fragmentDefines.concat("OPAQUE")
+          : fragmentDefines,
       }),
       attributeLocations,
     });
+
+    if (opaqueAndTranslucent) {
+      renderContext.translucentShaderProgram = ShaderProgram.fromCache({
+        context,
+        vertexShaderSource,
+        fragmentShaderSource: new ShaderSource({
+          sources: [BufferPolylineMaterialFS],
+          defines: fragmentDefines.concat("TRANSLUCENT"),
+        }),
+        attributeLocations,
+      });
+    }
   }
 
   const drawCount = getDrawIndexCount(collection);
@@ -569,7 +600,10 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       shaderProgram: renderContext.shaderProgram,
       uniformMap: renderContext.uniformMap,
       primitiveType: PrimitiveType.TRIANGLES,
-      pass,
+      pass:
+        blendOption === BlendOption.TRANSLUCENT
+          ? Pass.TRANSLUCENT
+          : Pass.OPAQUE,
       pickId: collection._allowPicking ? "v_pickColor" : undefined,
       owner: collection,
       count: drawCount,
@@ -577,6 +611,23 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
       boundingVolume: collection.boundingVolume, // shared reference
       debugShowBoundingVolume: collection.debugShowBoundingVolume,
     });
+
+    if (opaqueAndTranslucent) {
+      renderContext.translucentCommand = new DrawCommand({
+        vertexArray: renderContext.vertexArray,
+        renderState: renderContext.translucentRenderState,
+        shaderProgram: renderContext.translucentShaderProgram,
+        uniformMap: renderContext.uniformMap,
+        primitiveType: PrimitiveType.TRIANGLES,
+        pass: Pass.TRANSLUCENT,
+        pickId: collection._allowPicking ? "v_pickColor" : undefined,
+        owner: collection,
+        count: drawCount,
+        modelMatrix: collection.modelMatrix, // shared reference
+        boundingVolume: collection.boundingVolume, // shared reference
+        debugShowBoundingVolume: collection.debugShowBoundingVolume,
+      });
+    }
   }
 
   const command = renderContext.command;
@@ -591,9 +642,48 @@ function renderBufferPolylineCollection(collection, frameState, renderContext) {
 
   frameState.commandList.push(command);
 
+  if (opaqueAndTranslucent) {
+    const translucentCommand = renderContext.translucentCommand;
+    translucentCommand.count = command.count;
+    translucentCommand.debugShowBoundingVolume =
+      command.debugShowBoundingVolume;
+    frameState.commandList.push(translucentCommand);
+  }
+
   collection._makeClean();
 
   return renderContext;
+}
+
+/**
+ * Releases the resources that depend on the blend option, leaving the vertex array and
+ * attribute arrays intact.
+ * @param {BufferPolylineRenderContext} renderContext
+ * @ignore
+ */
+function releaseShaderResources(renderContext) {
+  if (defined(renderContext.shaderProgram)) {
+    renderContext.shaderProgram.destroy();
+  }
+
+  if (defined(renderContext.translucentShaderProgram)) {
+    renderContext.translucentShaderProgram.destroy();
+  }
+
+  if (defined(renderContext.renderState)) {
+    RenderState.removeFromCache(renderContext.renderState);
+  }
+
+  if (defined(renderContext.translucentRenderState)) {
+    RenderState.removeFromCache(renderContext.translucentRenderState);
+  }
+
+  renderContext.shaderProgram = undefined;
+  renderContext.translucentShaderProgram = undefined;
+  renderContext.renderState = undefined;
+  renderContext.translucentRenderState = undefined;
+  renderContext.command = undefined;
+  renderContext.translucentCommand = undefined;
 }
 
 /**
@@ -639,13 +729,7 @@ function destroyRenderContext() {
     context.vertexArray.destroy();
   }
 
-  if (defined(context.shaderProgram)) {
-    context.shaderProgram.destroy();
-  }
-
-  if (defined(context.renderState)) {
-    RenderState.removeFromCache(context.renderState);
-  }
+  releaseShaderResources(context);
 }
 
 export default renderBufferPolylineCollection;

--- a/packages/engine/Source/Shaders/BufferPointMaterialFS.glsl
+++ b/packages/engine/Source/Shaders/BufferPointMaterialFS.glsl
@@ -18,10 +18,26 @@ void main()
     vec4 color = vec4(mix(v_outlineColor.rgb, v_color.rgb, innerAlpha), outerAlpha);
     color.a *= mix(v_outlineColor.a, v_color.a, innerAlpha);
 
+#if !defined(OPAQUE) && !defined(TRANSLUCENT)
     if (color.a < 0.005)   // matches 0/255 and 1/255
     {
         discard;
     }
+#else
+// The collection is drawn twice. The opaque pass discards translucent fragments
+// and the translucent pass discards opaque fragments.
+#ifdef OPAQUE
+    if (color.a < 0.995)   // matches < 254/255
+    {
+        discard;
+    }
+#else
+    if (color.a >= 0.995)  // matches 254/255 and 255/255
+    {
+        discard;
+    }
+#endif
+#endif
 
     out_FragColor = czm_gammaCorrect(color);
     czm_writeLogDepth();

--- a/packages/engine/Source/Shaders/BufferPolygonMaterialFS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolygonMaterialFS.glsl
@@ -3,10 +3,26 @@ in vec4 v_color;
 
 void main()
 {
+#if !defined(OPAQUE) && !defined(TRANSLUCENT)
     if (v_color.a < 0.005)   // matches 0/255 and 1/255
     {
         discard;
     }
+#else
+// The collection is drawn twice. The opaque pass discards translucent fragments
+// and the translucent pass discards opaque fragments.
+#ifdef OPAQUE
+    if (v_color.a < 0.995)   // matches < 254/255
+    {
+        discard;
+    }
+#else
+    if (v_color.a >= 0.995)  // matches 254/255 and 255/255
+    {
+        discard;
+    }
+#endif
+#endif
 
     out_FragColor = czm_gammaCorrect(v_color);
     czm_writeLogDepth();

--- a/packages/engine/Source/Shaders/BufferPolylineMaterialFS.glsl
+++ b/packages/engine/Source/Shaders/BufferPolylineMaterialFS.glsl
@@ -3,10 +3,26 @@ in vec4 v_color;
 
 void main()
 {
+#if !defined(OPAQUE) && !defined(TRANSLUCENT)
     if (v_color.a < 0.005)   // matches 0/255 and 1/255
     {
         discard;
     }
+#else
+// The collection is drawn twice. The opaque pass discards translucent fragments
+// and the translucent pass discards opaque fragments.
+#ifdef OPAQUE
+    if (v_color.a < 0.995)   // matches < 254/255
+    {
+        discard;
+    }
+#else
+    if (v_color.a >= 0.995)  // matches 254/255 and 255/255
+    {
+        discard;
+    }
+#endif
+#endif
 
     out_FragColor = czm_gammaCorrect(v_color);
     czm_writeLogDepth();

--- a/packages/engine/Specs/Scene/BufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BufferPolygonCollectionSpec.js
@@ -628,9 +628,8 @@ describe("Scene/BufferPolygonCollection", () => {
     collection.blendOption = BlendOption.OPAQUE;
     expect(collection.blendOption).toBe(BlendOption.OPAQUE);
 
-    expect(() => {
-      collection.blendOption = BlendOption.OPAQUE_AND_TRANSLUCENT;
-    }).toThrowDeveloperError();
+    collection.blendOption = BlendOption.OPAQUE_AND_TRANSLUCENT;
+    expect(collection.blendOption).toBe(BlendOption.OPAQUE_AND_TRANSLUCENT);
   });
 });
 

--- a/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPointCollectionSpec.js
@@ -78,6 +78,29 @@ describe(
       expect(scene).toRender([255, 0, 0, 255]);
     });
 
+    it("sorts points by their own opacity when OPAQUE_AND_TRANSLUCENT", function () {
+      collection = new BufferPointCollection({
+        blendOption: BlendOption.OPAQUE_AND_TRANSLUCENT,
+      });
+
+      const point = new BufferPoint();
+      const material = new BufferPointMaterial({ color: Color.RED, size: 8 });
+      collection.add(
+        { position: new Cartesian3(0, -1000, 0), material },
+        point,
+      );
+      scene.primitives.add(collection);
+
+      // The opaque command keeps the point, and blending is disabled there.
+      expect(scene).toRender([255, 0, 0, 255]);
+
+      material.color.alpha = 0.5;
+      point.setMaterial(material);
+
+      // The translucent command keeps it instead, so alpha applies.
+      expect(scene).toRender([128, 0, 0, 255]);
+    });
+
     it("renders points with color", function () {
       collection = new BufferPointCollection({
         blendOption: BlendOption.TRANSLUCENT,

--- a/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolygonCollectionSpec.js
@@ -95,6 +95,86 @@ describe(
 
       collection.blendOption = BlendOption.OPAQUE;
       expect(scene).toRender([255, 0, 0, 255]);
+
+      // Pairing the passes moves this polygon to the translucent command.
+      collection.blendOption = BlendOption.OPAQUE_AND_TRANSLUCENT;
+      expect(scene).toRender([128, 0, 0, 255]);
+    });
+
+    it("occludes translucent polygons behind opaque ones in the same collection", function () {
+      // prettier-ignore
+      const nearPositions = new Int32Array([
+        -500, -1000, -1000,
+        -500, -1000, +2000,
+        -500, +2000, -1000,
+      ]);
+
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE_AND_TRANSLUCENT,
+      });
+
+      collection.add(
+        {
+          positions: nearPositions,
+          triangles,
+          material: new BufferPolygonMaterial({ color: Color.RED }),
+        },
+        new BufferPolygon(),
+      );
+      collection.add(
+        {
+          positions,
+          triangles,
+          material: new BufferPolygonMaterial({
+            color: Color.BLUE.withAlpha(0.5),
+          }),
+        },
+        new BufferPolygon(),
+      );
+
+      scene.primitives.add(collection);
+
+      // The opaque polygon writes depth, so the translucent one behind it is culled.
+      expect(scene).toRender([255, 0, 0, 255]);
+    });
+
+    it("blends translucent polygons over opaque ones in the same collection", function () {
+      // prettier-ignore
+      const nearPositions = new Int32Array([
+        -500, -1000, -1000,
+        -500, -1000, +2000,
+        -500, +2000, -1000,
+      ]);
+
+      collection = new BufferPolygonCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE_AND_TRANSLUCENT,
+      });
+
+      collection.add(
+        {
+          positions: nearPositions,
+          triangles,
+          material: new BufferPolygonMaterial({
+            color: Color.BLUE.withAlpha(0.5),
+          }),
+        },
+        new BufferPolygon(),
+      );
+      collection.add(
+        {
+          positions,
+          triangles,
+          material: new BufferPolygonMaterial({ color: Color.RED }),
+        },
+        new BufferPolygon(),
+      );
+
+      scene.primitives.add(collection);
+
+      // The translucent polygon is in front, so it blends over the opaque one.
+      expect(scene).toRender([127, 0, 127, 255]);
     });
 
     it("does not render draped polygons", function () {

--- a/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
+++ b/packages/engine/Specs/Scene/renderBufferPolylineCollectionSpec.js
@@ -79,6 +79,28 @@ describe(
       expect(scene).toRender([255, 0, 0, 255]);
     });
 
+    it("sorts polylines by their own opacity when OPAQUE_AND_TRANSLUCENT", function () {
+      collection = new BufferPolylineCollection({
+        positionDatatype: ComponentDatatype.INT,
+        blendOption: BlendOption.OPAQUE_AND_TRANSLUCENT,
+      });
+
+      const line = new BufferPolyline();
+      const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);
+      const material = new BufferPolylineMaterial({ color: Color.RED });
+      collection.add({ positions, material }, line);
+      scene.primitives.add(collection);
+
+      // The opaque command keeps the polyline, and blending is disabled there.
+      expect(scene).toRender([255, 0, 0, 255]);
+
+      material.color.alpha = 0.5;
+      line.setMaterial(material);
+
+      // The translucent command keeps it instead, so alpha applies.
+      expect(scene).toRender([128, 0, 0, 255]);
+    });
+
     it("renders polylines with zIndex", function () {
       // Vector collections only layer against each other where they write depth.
       const positions = new Int32Array([0, -1000000, 0, 0, +1000000, 0]);


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description
Vector collections could only be drawn entirely opaque or entirely translucent, so a collection with mixed opacity had to sacrifice either occlusion or transparency. This adds `BlendOption.OPAQUE_AND_TRANSLUCENT`, which draws the collection once per pass and lets the fragment shader keep only the fragments belonging to that pass, following the `BillboardCollection` precedent. Opaque primitives now occlude each other while translucent ones still blend, at roughly twice the cost. The blend option indexes a small table of command variants in `buildBufferPrimitiveDrawCommand`, so one command or two falls out of
the same code path. The default is unchanged.
<!-- Describe your changes in detail -->

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link
[#13722](https://github.com/CesiumGS/cesium/issues/13722)
<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan
[sandcastle](https://ci-builds.cesium.com/cesium/DanielZ/feat/vector-opaque&translucent/Apps/Sandcastle2/index.html#c=zVdtU9s4EP4rO/nkXI1iCGlLIHAhpeXmQuF46RfcYRR7E2tQJCPJCdwN//3Gkhw7NO11rnc398W2dlf78uyLZDbPpTLwE1ANI9SsmMNUyTnErcSu4tZ+LJgTuqIiTag2HCuZmmLlYpFIoQ0sGC5RwQAELr1W8snSgkrvSApDmUAVt0L4IxYAE6pxTJ9QXbDkHlUfppRrDEvWjMsJ1oTn9n5lSScoEAbeIrHL/VjYN5nQ5H6mZCHSkeSy9Mf7YpfkeDwc/Wq9nhYiMUwKyKVm5Yd+r+T8Hc4Uog64FGNqTpHNMqPbzllnfSXuQ33PJTWvd4dK0af1bYSjmJmsdBxgKhUEHA0wGEC0DwwOYJN0yXk1gK63WVlNGoFQZVAzKrpk2vDYScO60lv2OfwKA17B9reYOxXT+Q8bzOc0uQ+SsIYkBOakn8uHQlOoBr77sXiu6+WhoOm1YlTMOFZY3jBhujsOytsohO0QdkKI7LP7ub2et1JBsERtQkBaPrUsTBaCkKp8ZTYWD+NLV5qpvnXhOU1eh9vsAVjTvoGzZjBsavuSY4NooHB+Mfzt5uTu9OSXD6fXMIDtXhStCv36cvjxanwzOvl4XUt0IytRyeSSP83qavRJOi6mU1QXjjeSnKPFLLBg5IrNmWELHMlCmDP62Idd69wClcHHmrr92pIzyRuikaUZn7ma/rZq0lh0OjDGqYGcMtUHmdOHAkFhCsPj808nkFE+3TKKCp1ThcLAhBdI4DpD+wVMQ8bSFAWJRRUeoWnqva9y2HcVsPVml0Q7Idh31AthNyJvdt2r1ws3gbhlYW6vBeLVrSrSMufUoGKU97+K7ZmXCFbdyqXqv5w5NydkyUw25HlGg4j0nOnndgXZj0e5Xkev/o0AN8Z2efKuEYdN/WVZ7D73G1Pty6CuC5f7skB0JpcaTKZkMcu+M/1dsrfXK5Hpkr233wbmv0fkxwP4sn7/R4VbnbqrkeICraJ+MbE1mmOOIj3P7TCa1N9+TK/QarBgAI2VPV2cTYUPBWpziSJFFazm6gsjVew1ifiSGH58d9cA1/laX27KQK6l5BOqzlAU7pjwYBl8NH2IW5s1xS1/CEihsZy8fQjaMDiEv+2aQz3c4ME/Y/b7bDnnfji62oI/0f09LqFzVJRoNOW10dVlitowQcvd/b+4/9jJ6LvnTS+EnSiqRqBUDIXxWnxQGdKUiVl1ngHkzCTZysgZNRkx8pKmjAodbO15VQBKcl7teq77YMlEKpckV3JS3k0dJC6IRvn2N5Z46G6X8zkVqe7Dqn3InbLFXd6b8dEckUoGjo7g9nObzGkeBJ7YMAiQU637lUpSrsKqzQthao5d+p5eNXUrbB1o88TxsGT87H8ECsUDQjoG5zmnBnVnUiT3aEiibZsfdKotBylbAEsHG279kHCq9SBuTQvOr9jvGLcODzopW6xt49Km5nyBitOnUiTbPhw7IiHkoJNtb9hlXK82NP4J)
<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [ ] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

<!--(e.g., ChatGPT, GitHub Copilot, Claude, Gemini, etc.) -->

If yes, I used the following Model(s):

<!-- (e.g., GPT-4.1, Claude 3.5 Sonnet, Gemini 1.5 Pro) -->
