### PR TITLE
Fix clipping polygon shadows in shadow casts

### DIFF
--- a/packages/engine/Source/Scene/Model/ModelClippingPolygonsPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/ModelClippingPolygonsPipelineStage.js
@@ -87,14 +87,13 @@ ModelClippingPolygonsPipelineStage.process = function (
         model._clippingPolygonData?.rectangle ?? defaultRectangle;
       const halfWidth = rectangle.width * 0.5;
       const centerLongitude = rectangle.west + halfWidth;
-      const carto = frameState.camera.positionCartographic;
+      const carto = frameState.context.uniformState.eyeCartographic;
 
       const longitudeOffset =
-        CesiumMath.negativePiToPi(carto.longitude - centerLongitude) +
-        halfWidth;
+        CesiumMath.negativePiToPi(carto.x - centerLongitude) + halfWidth;
       return Cartesian2.fromElements(
         longitudeOffset / rectangle.width,
-        (carto.latitude - rectangle.south) / rectangle.height,
+        (carto.y - rectangle.south) / rectangle.height,
         scratchCameraUv,
       );
     },

--- a/packages/engine/Specs/Scene/Model/ModelClippingPolygonsPipelineStageSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelClippingPolygonsPipelineStageSpec.js
@@ -17,6 +17,15 @@ describe("Scene/Model/ModelClippingPolygonsPipelineStage", function () {
     -1.3193931220959367, 0.698743632490865,
   ]);
 
+  function setActiveEye(frameState, cartographic) {
+    Cartesian3.fromElements(
+      cartographic.longitude,
+      cartographic.latitude,
+      cartographic.height,
+      frameState.context.uniformState.eyeCartographic,
+    );
+  }
+
   // The stage reads the vector-based clipping data that is normally produced
   // during Model update; provide the pieces it consumes, then run the stage.
   function processWithRectangle(rectangle) {
@@ -33,7 +42,10 @@ describe("Scene/Model/ModelClippingPolygonsPipelineStage", function () {
     };
     const frameState = {
       camera: { positionCartographic: new Cartographic() },
-      context: { defaultTexture: {} },
+      context: {
+        defaultTexture: {},
+        uniformState: { eyeCartographic: new Cartesian3() },
+      },
     };
 
     ModelClippingPolygonsPipelineStage.process(
@@ -53,6 +65,7 @@ describe("Scene/Model/ModelClippingPolygonsPipelineStage", function () {
       5.0,
       10.0,
     );
+    setActiveEye(frameState, frameState.camera.positionCartographic);
     const uv = renderResources.uniformMap.u_clippingCameraUv();
 
     // west=-10, width=20  -> u = (5 - (-10)) / 20 = 0.75
@@ -69,9 +82,24 @@ describe("Scene/Model/ModelClippingPolygonsPipelineStage", function () {
       -175.0,
       0.0,
     );
+    setActiveEye(frameState, frameState.camera.positionCartographic);
     const uv = renderResources.uniformMap.u_clippingCameraUv();
 
     // The rectangle spans 170 -> 190; the camera sits 15 degrees in -> u = 0.75.
     expect(uv).toEqualEpsilon(new Cartesian2(0.75, 0.5), CesiumMath.EPSILON7);
+  });
+
+  it("maps the active shadow pass eye to its uv", function () {
+    const rectangle = Rectangle.fromDegrees(-10.0, -20.0, 10.0, 20.0);
+    const { renderResources, frameState } = processWithRectangle(rectangle);
+
+    frameState.camera.positionCartographic = Cartographic.fromDegrees(
+      5.0,
+      10.0,
+    );
+    setActiveEye(frameState, Cartographic.fromDegrees(-5.0, -10.0));
+    const uv = renderResources.uniformMap.u_clippingCameraUv();
+
+    expect(uv).toEqualEpsilon(new Cartesian2(0.25, 0.25), CesiumMath.EPSILON7);
   });
 });


### PR DESCRIPTION
# Description

I changed clipping polygon UV origins to use the active render pass eye. During shadow casting, the vertex shader's eye-relative delta used the shadow-pass camera while the CPU UV origin used the scene camera, so clipped model geometry could still write to the shadow map. Using `uniformState.eyeCartographic` keeps both terms on the same eye. Diagnosis from #13768.

## Issue number and link

Fixes #13768

## Testing plan

- Before on current `main`, `npx gulp test --includeName=ModelClippingPolygonsPipelineStage` failed the active shadow-pass eye case with `(0.75, 0.75)` instead of `(0.25, 0.25)`.
- After the change, `npx gulp test --includeName=ModelClippingPolygonsPipelineStage` passed all 3 specs.
- `npx eslint packages/engine/Source/Scene/Model/ModelClippingPolygonsPipelineStage.js packages/engine/Specs/Scene/Model/ModelClippingPolygonsPipelineStageSpec.js`
- `npx prettier --check packages/engine/Source/Scene/Model/ModelClippingPolygonsPipelineStage.js packages/engine/Specs/Scene/Model/ModelClippingPolygonsPipelineStageSpec.js`

## Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [ ] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

OpenAI Codex

If yes, I used the following Model(s):

gpt-5.6-terra
