### PR TITLE
Fix 3D Tiles never enabling the edge MRT in SURFACES_AND_EDGES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 #### Fixes :wrench:
 
 - Fixed a GPU memory leak where the edge vertex array created for `EXT_mesh_primitive_edge_visibility` rendering was never destroyed when draw commands were rebuilt or the model was destroyed. [#13721](https://github.com/CesiumGS/cesium/pull/13721)
+- Fixed `Cesium3DTileset` never enabling the scene edge framebuffer in `EdgeDisplayMode.SURFACES_AND_EDGES`, which rendered interior edges as fainter than intended. [#13765](https://github.com/CesiumGS/cesium/issues/13765)
 - Changed the typing of `PrimitiveCollection.add` to return the added primitive as the same type instead of `any`. [#13742](https://github.com/CesiumGS/cesium/issues/13742)
 
 ## 1.145 - 2026-09-02

--- a/packages/engine/Source/Scene/FrameState.js
+++ b/packages/engine/Source/Scene/FrameState.js
@@ -472,7 +472,7 @@ function FrameState(context, creditDisplay, jobScheduler) {
    * edge visibility rendering (EXT_mesh_primitive_edge_visibility). This allows
    * lazy allocation/activation of the edge MRT without storing a Scene reference
    * on the frame state (avoids passing entire Scene through internal APIs).
-   * Set by model pipeline stages when they encounter edge visibility data.
+   * Renewed per frame by ModelDrawCommand while an MRT edge command renders.
    * Consumed by Scene to flip its _enableEdgeVisibility flag.
    * @type {boolean}
    * @private

--- a/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
+++ b/packages/engine/Source/Scene/Model/EdgeVisibilityPipelineStage.js
@@ -66,9 +66,6 @@ EdgeVisibilityPipelineStage.process = function (
     return;
   }
 
-  // Fallback request: mark that edge visibility is needed this frame.
-  frameState.edgeVisibilityRequested = true;
-
   const shaderBuilder = renderResources.shaderBuilder;
 
   // Add shader defines and fragment code

--- a/packages/engine/Source/Scene/Model/ModelDrawCommand.js
+++ b/packages/engine/Source/Scene/Model/ModelDrawCommand.js
@@ -715,6 +715,11 @@ ModelDrawCommand.prototype.pushEdgeCommands = function (frameState, result) {
       ? Pass.CESIUM_3D_TILE_EDGES_DIRECT
       : Pass.CESIUM_3D_TILE_EDGES;
 
+  if (edgePass === Pass.CESIUM_3D_TILE_EDGES) {
+    // Renewed per frame; Scene resets this flag before primitives update.
+    frameState.edgeVisibilityRequested = true;
+  }
+
   this._edgeCommand.command.pass = edgePass;
   if (defined(this._edgeCommand.derivedCommand2D)) {
     this._edgeCommand.derivedCommand2D.command.pass = edgePass;

--- a/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
+++ b/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
@@ -330,8 +330,6 @@ ModelRuntimePrimitive.prototype.configurePipeline = function (frameState) {
   }
 
   if (hasEdgeVisibility) {
-    // Indicate to Scene (after primitive updates) that the edge MRT should be enabled.
-    frameState.edgeVisibilityRequested = true;
     pipelineStages.push(EdgeVisibilityPipelineStage);
     pipelineStages.push(EdgeDetectionPipelineStage);
   }

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -3938,6 +3938,12 @@ function updateAndRenderPrimitives(scene) {
     scene._enableEdgeVisibility === false
   ) {
     scene._enableEdgeVisibility = true;
+    // Framebuffer setup already ran before primitive updates this frame.
+    scene._view.edgeFramebuffer.update(
+      scene._context,
+      scene._view.viewport,
+      scene._hdr,
+    );
   }
 
   // True only while at least one planar fill primitive is rendering;

--- a/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
+++ b/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
@@ -35,13 +35,16 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
     });
   }
 
-  async function loadEdgeVisibilityModel() {
+  async function loadEdgeVisibilityModel(edgeDisplayMode) {
     const model = await Model.fromGltfAsync({
       url: edgeVisibilityTestData,
       modelMatrix: Transforms.eastNorthUpToFixedFrame(
         Cartesian3.fromDegrees(0.0, 0.0, 100.0),
       ),
     });
+    if (defined(edgeDisplayMode)) {
+      model.edgeDisplayMode = edgeDisplayMode;
+    }
 
     scene.primitives.add(model);
     await waitForModelReady(model);
@@ -330,6 +333,109 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
     expect(hasDirectEdgeCommand).toBe(true);
     expect(hasSurfaceCommand).toBe(false);
   });
+
+  it("SURFACES_AND_EDGES enables scene edge visibility for a standalone model", async function () {
+    if (!!window.webglStub) {
+      pending("Skipping test in WebGL stub environment");
+    }
+
+    scene._enableEdgeVisibility = false;
+    await loadEdgeVisibilityModel(EdgeDisplayMode.SURFACES_AND_EDGES);
+    scene.renderForSpecs();
+
+    expect(scene._enableEdgeVisibility).toBe(true);
+  });
+
+  it("SURFACES_AND_EDGES enables scene edge visibility when draw commands are built in prePassesUpdate", async function () {
+    if (!!window.webglStub) {
+      pending("Skipping test in WebGL stub environment");
+    }
+
+    const model = await Model.fromGltfAsync({
+      url: edgeVisibilityTestData,
+      modelMatrix: Transforms.eastNorthUpToFixedFrame(
+        Cartesian3.fromDegrees(0.0, 0.0, 100.0),
+      ),
+    });
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
+
+    // Mimic Cesium3DTileset: tile content updates (and builds draw commands)
+    // in prePassesUpdate, before Scene resets frameState.edgeVisibilityRequested.
+    scene.primitives.add({
+      prePassesUpdate: (frameState) => model.update(frameState),
+      update: (frameState) => model.update(frameState),
+      isDestroyed: () => false,
+      destroy: () => model.destroy(),
+    });
+    await waitForModelReady(model);
+    // Let one-time post-ready rebuilds (e.g. texturesLoaded) settle.
+    scene.renderForSpecs();
+    scene.renderForSpecs();
+
+    // Force the next draw-command build to happen in prePassesUpdate.
+    scene._enableEdgeVisibility = false;
+    model.resetDrawCommands();
+    scene.renderForSpecs();
+
+    expect(scene._enableEdgeVisibility).toBe(true);
+  });
+
+  it("EDGES_ONLY does not enable scene edge visibility", async function () {
+    if (!!window.webglStub) {
+      pending("Skipping test in WebGL stub environment");
+    }
+
+    scene._enableEdgeVisibility = false;
+    await loadEdgeVisibilityModel(EdgeDisplayMode.EDGES_ONLY);
+    scene.renderForSpecs();
+
+    expect(scene._enableEdgeVisibility).toBe(false);
+  });
+
+  [EdgeDisplayMode.SURFACES_ONLY, EdgeDisplayMode.EDGES_ONLY].forEach(
+    function (initialMode) {
+      it(`initializes the edge framebuffer on the first requested frame after switching from mode ${initialMode} to SURFACES_AND_EDGES`, async function () {
+        if (!!window.webglStub) {
+          pending("Skipping test in WebGL stub environment");
+        }
+
+        // Use a fresh scene so earlier specs cannot leave an allocated MRT.
+        const requestRenderScene = createScene();
+        try {
+          const model = await Model.fromGltfAsync({
+            url: edgeVisibilityTestData,
+            edgeDisplayMode: initialMode,
+            modelMatrix: Transforms.eastNorthUpToFixedFrame(
+              Cartesian3.fromDegrees(0.0, 0.0, 100.0),
+            ),
+          });
+          requestRenderScene.primitives.add(model);
+          await pollToPromise(function () {
+            requestRenderScene.renderForSpecs();
+            return model.ready;
+          });
+          requestRenderScene.renderForSpecs();
+          requestRenderScene.renderForSpecs();
+
+          const edgeFramebuffer = requestRenderScene._view.edgeFramebuffer;
+          expect(edgeFramebuffer.framebuffer).toBeUndefined();
+
+          requestRenderScene.requestRenderMode = true;
+          requestRenderScene.maximumRenderTimeChange = Infinity;
+          model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
+          requestRenderScene.requestRender();
+          requestRenderScene.renderForSpecs();
+
+          expect(edgeFramebuffer.framebuffer).toBeDefined();
+          expect(edgeFramebuffer.colorTexture).toBeDefined();
+          expect(edgeFramebuffer.idTexture).toBeDefined();
+          expect(edgeFramebuffer.depthTexture).toBeDefined();
+        } finally {
+          requestRenderScene.destroyForSpecs();
+        }
+      });
+    },
+  );
 
   it("registers edge vertex array as a pipeline resource and destroys it on draw command rebuild", async function () {
     if (!!window.webglStub) {

--- a/packages/sandcastle/gallery/3d-tiles-edge-visibility/main.js
+++ b/packages/sandcastle/gallery/3d-tiles-edge-visibility/main.js
@@ -10,6 +10,14 @@ try {
   tileset.edgeDisplayMode = Cesium.EdgeDisplayMode.EDGES_ONLY;
   await viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, 0.0));
 
+  const initialView = {
+    destination: Cesium.Cartesian3.clone(viewer.camera.positionWC),
+    orientation: {
+      direction: Cesium.Cartesian3.clone(viewer.camera.directionWC),
+      up: Cesium.Cartesian3.clone(viewer.camera.upWC),
+    },
+  };
+
   Sandcastle.addToolbarMenu([
     {
       text: "Edges Only",
@@ -32,6 +40,19 @@ try {
   ]);
   Sandcastle.addToggleButton("Show Tile Bounds", false, function (checked) {
     tileset.debugShowBoundingVolume = checked;
+  });
+  Sandcastle.addToolbarButton("Zoom to Pipes", function () {
+    viewer.camera.setView({
+      destination: new Cesium.Cartesian3(
+        -491698.3382031368,
+        -5521053.190015137,
+        3144895.6141743367,
+      ),
+      orientation: { heading: 5.6, pitch: -0.4, roll: 0.0 },
+    });
+  });
+  Sandcastle.addToolbarButton("Zoom to Tileset", function () {
+    viewer.camera.setView(initialView);
   });
 } catch (error) {
   window.alert(`Error loading tileset: ${error}`);


### PR DESCRIPTION
# Description

In `SURFACES_AND_EDGES`, a `Cesium3DTileset` never enabled the scene edge framebuffer (MRT). Edges drew straight into the scene buffer at surface depth, so surfaces overwrote them: interior edges could z-fight against the surfaces and silhouettes came out thin.

`frameState.edgeVisibilityRequested` was set only at draw-command build time. Standalone `Model`s build inside `_primitives.update`, after `Scene` resets the flag, which results in fine behavior. However, tileset content builds in `prePassesUpdate`, before any reset, so the request was wiped every frame and never renewed. This has been the case ever since #12859.

To fix this... we set the flag where MRT edge commands are actually pushed, every frame (`ModelDrawCommand.pushEdgeCommands`, when selecting `Pass.CESIUM_3D_TILE_EDGES`). This follows the same pattern as `planarFillRequested`. The two build-time sites have been removed, leaving one writer. Side effect: `EDGES_ONLY`/`SURFACES_ONLY` no longer request the MRT, which is an optimization because they actually do not really need it!

With this change, I observe visual improvements (interior edges no longer faint or missing) and performance improvements (better FPS for `SURFACES_AND_EDGES`).

Incidentally, I enhanced the functionality of the `3D Tiles Edge Visibility` Sandcastle to allow us to be able to reproduce the visual difference more easily:
- Added *Zoom to Pipes*
- Added *Zoom to Tileset*
## Improvements

### Visual Improvements

Before:

<img width="249" height="230" alt="Before_Closeup" src="https://github.com/user-attachments/assets/5f74eba7-505e-41e9-b884-b958d2ab2436" />

After:

<img width="251" height="228" alt="After_Closeup" src="https://github.com/user-attachments/assets/437c6fa8-30cc-4eb0-867c-a8b2560487ce" />

### Performance Improvements

Below is the fix compared against two runs of main for a particular dataset.

```mermaid
---
config:
  xyChart:
    width: 700
    height: 500
    titleFontSize: 20
    xAxis:
      labelFontSize: 14
      titleFontSize: 16
    yAxis:
      labelFontSize: 14
      titleFontSize: 16
  themeVariables:
    xyChart:
      plotColorPalette: "#1f77b4"
---
xychart-beta
    title "Frame time, peak view, as % of 60 Hz (100 = limit)"
    x-axis ["A0", "A1", "A2"]
    y-axis "% of 60 Hz frame" 0 --> 48.8
    bar [32.6, 42.3, 42.4]
```

<div align="center">

| Bar | Dataset | Variant | Value |
|---|---|---|---|
| A0 | Dataset 1 | `edges [fix, SURFACES_AND_EDGES]` | **5.43 ms/frame** |
| A1 | Dataset 1 | `edges [main, SURFACES_AND_EDGES]` | **7.04 ms/frame** |
| A2 | Dataset 1 | `edges [main2, SURFACES_AND_EDGES]` | **7.06 ms/frame** |

</div>

## Issue number and link

https://github.com/CesiumGS/cesium/issues/13765

## Testing plan

- New specs in `EdgeVisibilityRenderingSpec` added + pass.
- A/B tested using [Sandcastle 3D Tiles Edge Visibility](https://ci-builds.cesium.com/cesium/fix-edge-mrt-bug/Apps/Sandcastle2/index.html?id=3d-tiles-edge-visibility). To reproduce / verify:
  1. Select *Surfaces + Edges*
  2. Click *Zoom to Pipes*
  3. compare against `main`.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

GitHub Copilot

If yes, I used the following Model(s):

GPT-5.6 Sol
Claude Fable 5
Claude Fable 5.1