### PR TITLE
Implement a lazy loading strategy for edges based on the display mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 #### Fixes :wrench:
 
+- Reduced load time, memory usage, and rendering overhead for models and 3D Tiles using `EXT_mesh_primitive_edge_visibility` in `EdgeDisplayMode.SURFACES_ONLY` by deferring edge geometry construction until edges are displayed or needed for snapping.
 - Fixed a GPU memory leak where the edge vertex array created for `EXT_mesh_primitive_edge_visibility` rendering was never destroyed when draw commands were rebuilt or the model was destroyed. [#13721](https://github.com/CesiumGS/cesium/pull/13721)
 - Fixed `Cesium3DTileset` never enabling the scene edge framebuffer in `EdgeDisplayMode.SURFACES_AND_EDGES`, which rendered interior edges as fainter than intended. [#13765](https://github.com/CesiumGS/cesium/issues/13765)
 - Changed the typing of `PrimitiveCollection.add` to return the added primitive as the same type instead of `any`. [#13742](https://github.com/CesiumGS/cesium/issues/13742)

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -1266,7 +1266,17 @@ Object.defineProperties(Model.prototype, {
       return this._edgeDisplayMode;
     },
     set: function (value) {
-      this._edgeDisplayMode = value;
+      if (value !== this._edgeDisplayMode) {
+        // Edge geometry is only built when the mode allows edges to display,
+        // so invalidate the draw commands when the mode necessitates it.
+        const needsInvalidate =
+          (this._edgeDisplayMode === EdgeDisplayMode.SURFACES_ONLY) !==
+          (value === EdgeDisplayMode.SURFACES_ONLY);
+        this._edgeDisplayMode = value;
+        if (needsInvalidate) {
+          this.resetDrawCommands();
+        }
+      }
     },
   },
 

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -460,6 +460,11 @@ function Model(options) {
   this._debugWireframe = options.debugWireframe ?? false;
   this._edgeDisplayMode =
     options.edgeDisplayMode ?? EdgeDisplayMode.SURFACES_ONLY;
+  // Edge geometry is built lazily; see updateEdgeGeometryNeeded.
+  this._edgeGeometryNeeded =
+    this._edgeDisplayMode !== EdgeDisplayMode.SURFACES_ONLY;
+  this._edgeGeometryNeededForSnapping = false;
+  this._hasEdgeVisibilityData = undefined;
 
   // Warning for improper setup of debug wireframe
   if (
@@ -1266,17 +1271,7 @@ Object.defineProperties(Model.prototype, {
       return this._edgeDisplayMode;
     },
     set: function (value) {
-      if (value !== this._edgeDisplayMode) {
-        // Edge geometry is only built when the mode allows edges to display,
-        // so invalidate the draw commands when the mode necessitates it.
-        const needsInvalidate =
-          (this._edgeDisplayMode === EdgeDisplayMode.SURFACES_ONLY) !==
-          (value === EdgeDisplayMode.SURFACES_ONLY);
-        this._edgeDisplayMode = value;
-        if (needsInvalidate) {
-          this.resetDrawCommands();
-        }
-      }
+      this._edgeDisplayMode = value;
     },
   },
 
@@ -2102,6 +2097,7 @@ Model.prototype.update = function (frameState) {
   updateSceneMode(this, frameState);
   updateFog(this, frameState);
   updateVerticalExaggeration(this, frameState);
+  updateEdgeGeometryNeeded(this, frameState);
 
   this._defaultTexture = frameState.context.defaultTexture;
 
@@ -2468,6 +2464,34 @@ function updateVerticalExaggeration(model, frameState) {
     model.resetDrawCommands(); //if verticalExaggeration was on, reset.
     model._hasVerticalExaggeration = false;
   }
+}
+
+// Edge geometry is built only when edges are displayed, or once a snapping
+// pass has touched this model (snapping targets edges even in SURFACES_ONLY).
+function updateEdgeGeometryNeeded(model, frameState) {
+  if (frameState.passes.snap) {
+    model._edgeGeometryNeededForSnapping = true;
+  }
+
+  const needed =
+    model._edgeDisplayMode !== EdgeDisplayMode.SURFACES_ONLY ||
+    model._edgeGeometryNeededForSnapping;
+  if (needed !== model._edgeGeometryNeeded) {
+    model._edgeGeometryNeeded = needed;
+    if (hasEdgeVisibilityData(model)) {
+      model.resetDrawCommands();
+    }
+  }
+}
+
+function hasEdgeVisibilityData(model) {
+  if (!defined(model._hasEdgeVisibilityData)) {
+    model._hasEdgeVisibilityData = model._sceneGraph.components.nodes.some(
+      (node) =>
+        node.primitives.some((primitive) => defined(primitive.edgeVisibility)),
+    );
+  }
+  return model._hasEdgeVisibilityData;
 }
 
 function buildDrawCommands(model, frameState) {

--- a/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
+++ b/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
@@ -11,7 +11,6 @@ import CustomShaderMode from "./CustomShaderMode.js";
 import CustomShaderPipelineStage from "./CustomShaderPipelineStage.js";
 import DequantizationPipelineStage from "./DequantizationPipelineStage.js";
 import EdgeDetectionPipelineStage from "./EdgeDetectionPipelineStage.js";
-import EdgeDisplayMode from "../EdgeDisplayMode.js";
 import EdgeVisibilityPipelineStage from "./EdgeVisibilityPipelineStage.js";
 import FeatureIdPipelineStage from "./FeatureIdPipelineStage.js";
 import GeometryPipelineStage from "./GeometryPipelineStage.js";
@@ -248,12 +247,9 @@ ModelRuntimePrimitive.prototype.configurePipeline = function (frameState) {
   const hasOutlines =
     model._enableShowOutline && defined(primitive.outlineCoordinates);
 
-  // Edge geometry is only built when edges are actually expected to be
-  // displayed; in the default SURFACES_ONLY mode the edge pipeline stages are
-  // skipped entirely.
+  // Edge geometry is built lazily; see updateEdgeGeometryNeeded in Model.js.
   const hasEdgeVisibility =
-    defined(primitive.edgeVisibility) &&
-    model.edgeDisplayMode !== EdgeDisplayMode.SURFACES_ONLY;
+    defined(primitive.edgeVisibility) && model._edgeGeometryNeeded;
 
   const featureIdFlags = inspectFeatureIds(model, node, primitive);
 

--- a/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
+++ b/packages/engine/Source/Scene/Model/ModelRuntimePrimitive.js
@@ -11,6 +11,7 @@ import CustomShaderMode from "./CustomShaderMode.js";
 import CustomShaderPipelineStage from "./CustomShaderPipelineStage.js";
 import DequantizationPipelineStage from "./DequantizationPipelineStage.js";
 import EdgeDetectionPipelineStage from "./EdgeDetectionPipelineStage.js";
+import EdgeDisplayMode from "../EdgeDisplayMode.js";
 import EdgeVisibilityPipelineStage from "./EdgeVisibilityPipelineStage.js";
 import FeatureIdPipelineStage from "./FeatureIdPipelineStage.js";
 import GeometryPipelineStage from "./GeometryPipelineStage.js";
@@ -247,7 +248,12 @@ ModelRuntimePrimitive.prototype.configurePipeline = function (frameState) {
   const hasOutlines =
     model._enableShowOutline && defined(primitive.outlineCoordinates);
 
-  const hasEdgeVisibility = defined(primitive.edgeVisibility);
+  // Edge geometry is only built when edges are actually expected to be
+  // displayed; in the default SURFACES_ONLY mode the edge pipeline stages are
+  // skipped entirely.
+  const hasEdgeVisibility =
+    defined(primitive.edgeVisibility) &&
+    model.edgeDisplayMode !== EdgeDisplayMode.SURFACES_ONLY;
 
   const featureIdFlags = inspectFeatureIds(model, node, primitive);
 

--- a/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
+++ b/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
@@ -144,51 +144,6 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
     expect(scene.frameState.edgeVisibilityRequested).toBe(false);
   });
 
-  [EdgeDisplayMode.SURFACES_ONLY, EdgeDisplayMode.EDGES_ONLY].forEach(
-    function (initialMode) {
-      it(`initializes the edge framebuffer on the first requested frame after switching from mode ${initialMode} to SURFACES_AND_EDGES`, async function () {
-        if (!!window.webglStub) {
-          pending("Skipping test in WebGL stub environment");
-        }
-
-        // Use a fresh scene so earlier specs cannot leave an allocated MRT.
-        const requestRenderScene = createScene();
-        try {
-          const model = await Model.fromGltfAsync({
-            url: edgeVisibilityTestData,
-            edgeDisplayMode: initialMode,
-            modelMatrix: Transforms.eastNorthUpToFixedFrame(
-              Cartesian3.fromDegrees(0.0, 0.0, 100.0),
-            ),
-          });
-          requestRenderScene.primitives.add(model);
-          await pollToPromise(function () {
-            requestRenderScene.renderForSpecs();
-            return model.ready;
-          });
-          requestRenderScene.renderForSpecs();
-          requestRenderScene.renderForSpecs();
-
-          const edgeFramebuffer = requestRenderScene._view.edgeFramebuffer;
-          expect(edgeFramebuffer.framebuffer).toBeUndefined();
-
-          requestRenderScene.requestRenderMode = true;
-          requestRenderScene.maximumRenderTimeChange = Infinity;
-          model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
-          requestRenderScene.requestRender();
-          requestRenderScene.renderForSpecs();
-
-          expect(edgeFramebuffer.framebuffer).toBeDefined();
-          expect(edgeFramebuffer.colorTexture).toBeDefined();
-          expect(edgeFramebuffer.idTexture).toBeDefined();
-          expect(edgeFramebuffer.depthTexture).toBeDefined();
-        } finally {
-          requestRenderScene.destroyForSpecs();
-        }
-      });
-    },
-  );
-
   it("validates u_isEdgePass uniform and framebuffer attachments", async function () {
     // Skip this test in WebGL stub environment
     if (!!window.webglStub) {

--- a/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
+++ b/packages/engine/Specs/Scene/Model/EdgeVisibilityRenderingSpec.js
@@ -51,6 +51,144 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
     return model;
   }
 
+  function getEdgeCommands(model) {
+    return model._sceneGraph._runtimeNodes
+      .flatMap((node) => node.runtimePrimitives)
+      .map((runtimePrimitive) => runtimePrimitive.drawCommand._edgeCommand)
+      .filter((edgeCommand) => defined(edgeCommand));
+  }
+
+  it("SURFACES_ONLY builds no edge geometry and does not enable scene edge visibility", async function () {
+    scene._enableEdgeVisibility = false;
+    const model = await loadEdgeVisibilityModel();
+    scene.renderForSpecs();
+
+    expect(model._edgeGeometryNeeded).toBe(false);
+    expect(getEdgeCommands(model).length).toBe(0);
+    expect(scene.frameState.edgeVisibilityRequested).toBe(false);
+    expect(scene._enableEdgeVisibility).toBe(false);
+  });
+
+  it("builds edge geometry when edges become displayed and destroys it when hidden again", async function () {
+    if (!!window.webglStub) {
+      pending("Skipping test in WebGL stub environment");
+    }
+
+    scene._enableEdgeVisibility = false;
+    const model = await loadEdgeVisibilityModel();
+    scene.renderForSpecs();
+    expect(getEdgeCommands(model).length).toBe(0);
+
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
+    scene.renderForSpecs();
+    const edgeCommands = getEdgeCommands(model);
+    expect(edgeCommands.length).toBeGreaterThan(0);
+    expect(scene.frameState.edgeVisibilityRequested).toBe(true);
+    expect(scene._enableEdgeVisibility).toBe(true);
+
+    // EDGES_ONLY <-> SURFACES_AND_EDGES needs no rebuild.
+    model.edgeDisplayMode = EdgeDisplayMode.EDGES_ONLY;
+    scene.renderForSpecs();
+    expect(getEdgeCommands(model)).toEqual(edgeCommands);
+    expect(scene.frameState.edgeVisibilityRequested).toBe(false);
+
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_ONLY;
+    scene.renderForSpecs();
+    expect(getEdgeCommands(model).length).toBe(0);
+    for (const edgeCommand of edgeCommands) {
+      expect(edgeCommand.command.vertexArray.isDestroyed()).toBe(true);
+    }
+  });
+
+  it("builds edge geometry for snapping in SURFACES_ONLY without enabling scene edge visibility", async function () {
+    if (!!window.webglStub) {
+      pending("Skipping test in WebGL stub environment");
+    }
+
+    scene._enableEdgeVisibility = false;
+    const model = await loadEdgeVisibilityModel();
+    scene.renderForSpecs();
+    expect(getEdgeCommands(model).length).toBe(0);
+
+    // Simulate the model being updated during a snap pass.
+    const frameState = scene.frameState;
+    frameState.passes.snap = true;
+    model.update(frameState);
+    frameState.passes.snap = false;
+
+    expect(model._edgeGeometryNeededForSnapping).toBe(true);
+    const edgeCommands = getEdgeCommands(model);
+    expect(edgeCommands.length).toBeGreaterThan(0);
+
+    // Edges stay hidden and the snap latch survives a color render.
+    scene.renderForSpecs();
+    expect(getEdgeCommands(model)).toEqual(edgeCommands);
+    expect(scene.frameState.edgeVisibilityRequested).toBe(false);
+    expect(scene._enableEdgeVisibility).toBe(false);
+    const edgePasses = scene.frameState.commandList.filter(
+      (command) =>
+        command.pass === Pass.CESIUM_3D_TILE_EDGES ||
+        command.pass === Pass.CESIUM_3D_TILE_EDGES_DIRECT,
+    );
+    expect(edgePasses.length).toBe(0);
+
+    // Hiding edges after they were displayed keeps them for snapping.
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
+    scene.renderForSpecs();
+    expect(getEdgeCommands(model)).toEqual(edgeCommands);
+    expect(scene.frameState.edgeVisibilityRequested).toBe(true);
+    expect(scene._enableEdgeVisibility).toBe(true);
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_ONLY;
+    scene.renderForSpecs();
+    expect(getEdgeCommands(model)).toEqual(edgeCommands);
+    expect(scene.frameState.edgeVisibilityRequested).toBe(false);
+  });
+
+  [EdgeDisplayMode.SURFACES_ONLY, EdgeDisplayMode.EDGES_ONLY].forEach(
+    function (initialMode) {
+      it(`initializes the edge framebuffer on the first requested frame after switching from mode ${initialMode} to SURFACES_AND_EDGES`, async function () {
+        if (!!window.webglStub) {
+          pending("Skipping test in WebGL stub environment");
+        }
+
+        // Use a fresh scene so earlier specs cannot leave an allocated MRT.
+        const requestRenderScene = createScene();
+        try {
+          const model = await Model.fromGltfAsync({
+            url: edgeVisibilityTestData,
+            edgeDisplayMode: initialMode,
+            modelMatrix: Transforms.eastNorthUpToFixedFrame(
+              Cartesian3.fromDegrees(0.0, 0.0, 100.0),
+            ),
+          });
+          requestRenderScene.primitives.add(model);
+          await pollToPromise(function () {
+            requestRenderScene.renderForSpecs();
+            return model.ready;
+          });
+          requestRenderScene.renderForSpecs();
+          requestRenderScene.renderForSpecs();
+
+          const edgeFramebuffer = requestRenderScene._view.edgeFramebuffer;
+          expect(edgeFramebuffer.framebuffer).toBeUndefined();
+
+          requestRenderScene.requestRenderMode = true;
+          requestRenderScene.maximumRenderTimeChange = Infinity;
+          model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
+          requestRenderScene.requestRender();
+          requestRenderScene.renderForSpecs();
+
+          expect(edgeFramebuffer.framebuffer).toBeDefined();
+          expect(edgeFramebuffer.colorTexture).toBeDefined();
+          expect(edgeFramebuffer.idTexture).toBeDefined();
+          expect(edgeFramebuffer.depthTexture).toBeDefined();
+        } finally {
+          requestRenderScene.destroyForSpecs();
+        }
+      });
+    },
+  );
+
   it("validates u_isEdgePass uniform and framebuffer attachments", async function () {
     // Skip this test in WebGL stub environment
     if (!!window.webglStub) {
@@ -154,7 +292,8 @@ describe("Scene/Model/EdgeVisibilityRendering", function () {
       pending("Skipping test in WebGL stub environment");
     }
 
-    await loadEdgeVisibilityModel();
+    const model = await loadEdgeVisibilityModel();
+    model.edgeDisplayMode = EdgeDisplayMode.SURFACES_AND_EDGES;
 
     scene._enableEdgeVisibility = true;
     scene.renderForSpecs();

--- a/packages/engine/Specs/Scene/SnappingSpec.js
+++ b/packages/engine/Specs/Scene/SnappingSpec.js
@@ -2,6 +2,7 @@ import {
   Cartesian2,
   Cartesian3,
   EdgeDisplayMode,
+  Pass,
   Ray,
   Snapping,
 } from "../../index.js";
@@ -321,6 +322,49 @@ describe("Scene/Snapping", function () {
             model.boundingSphere.radius * 1.01,
           );
         }, windowPosition);
+      } finally {
+        scene.destroyForSpecs();
+      }
+    });
+
+    it("snaps to a model edge in SURFACES_ONLY mode while edges stay hidden", async function () {
+      const scene = createScene({ canvas: createCanvas(64, 64) });
+      try {
+        if (!scene.frameState.context.colorBufferFloat) {
+          return;
+        }
+        const model = await loadAndZoomToModelAsync(
+          {
+            url: "./Data/Models/glTF-2.0/EdgeVisibility/glTF-Binary/EdgeVisibility.glb",
+          },
+          scene,
+        );
+        scene.renderForSpecs();
+        // Edge geometry is built lazily; nothing exists before the snap.
+        expect(model._edgeGeometryNeeded).toBe(false);
+        expect(scene._enableEdgeVisibility).toBe(false);
+
+        const windowPosition = new Cartesian2(
+          scene.drawingBufferWidth / 2,
+          scene.drawingBufferHeight / 2,
+        );
+        expect(scene).toSnapAndCall(function (result) {
+          expect(result).toBeDefined();
+          expect(result.object.primitive).toBe(model);
+          expect(result.isEdge).toBe(true);
+        }, windowPosition);
+
+        // The snap latched edge geometry on this model, but edges remain
+        // hidden and the scene edge MRT stays off.
+        scene.renderForSpecs();
+        expect(model._edgeGeometryNeededForSnapping).toBe(true);
+        expect(scene._enableEdgeVisibility).toBe(false);
+        const edgeCommands = scene.frameState.commandList.filter(
+          (command) =>
+            command.pass === Pass.CESIUM_3D_TILE_EDGES ||
+            command.pass === Pass.CESIUM_3D_TILE_EDGES_DIRECT,
+        );
+        expect(edgeCommands.length).toBe(0);
       } finally {
         scene.destroyForSpecs();
       }


### PR DESCRIPTION
# Description

Defer building geometry for `EXT_mesh_primitive_edge_visibility` until edges are displayed or needed for snapping. Previously, models built and retained edge geometry even in the default `SURFACES_ONLY` mode, adding load time, GPU memory usage, and rendering overhead.

Display-mode changes build or release edge geometry as needed. Snapping to hidden edges remains supported: the first snap builds edge geometry for the models updated by the snap pass.

Benchmarks below compare eager and lazy builds on a representative AEC dataset with edges hidden, both including #13785.

With edges hidden:
- GPU-process RSS (Resident Set Size) decreased
- Initial tile load time decreased
- Interior frame time decreased

You can see that edges-hidden performance is now close to the equivalent tileset without the extension. With edges displayed from the start, frame time and memory usage are effectively unchanged. Results average two runs after discarding the first.

## Improvements

### Memory Improvements

```mermaid
---
config:
  xyChart:
    width: 700
    height: 500
    titleFontSize: 20
    xAxis:
      labelFontSize: 14
      titleFontSize: 16
    yAxis:
      labelFontSize: 14
      titleFontSize: 16
  themeVariables:
    xyChart:
      plotColorPalette: "#1f77b4"
---
xychart-beta
    title "GPU process RSS (peak view), as a multiple of no-ext"
    x-axis ["A0", "A1", "A2", "A3"]
    y-axis "relative" 0 --> 5.8
    bar [1.0, 1.0, 5.1, 1.0]
```

<div align="center">

| Bar | Dataset | Variant | Value |
|---|---|---|---|
| A0 | Dataset 1 | `no-ext [lazy]` | **245.3 MB** |
| A1 | Dataset 1 | `no-ext [eager]` | **245.5 MB** |
| A2 | Dataset 1 | `edges [eager]` | **1.2 GB** |
| A3 | Dataset 1 | `edges [lazy]` | **246.4 MB** |

</div>

### Performance Improvements

```mermaid
---
config:
  xyChart:
    width: 700
    height: 500
    titleFontSize: 20
    xAxis:
      labelFontSize: 14
      titleFontSize: 16
    yAxis:
      labelFontSize: 14
      titleFontSize: 16
  themeVariables:
    xyChart:
      plotColorPalette: "#1f77b4"
---
xychart-beta
    title "Load to all tiles, as a multiple of no-ext"
    x-axis ["A0", "A1", "A2", "A3"]
    y-axis "relative" 0 --> 1.5
    bar [1.0, 1.0, 1.3, 1.0]
```

<div align="center">

| Bar | Dataset | Variant | Value |
|---|---|---|---|
| A0 | Dataset 1 | `no-ext [lazy]` | **942 ms** |
| A1 | Dataset 1 | `no-ext [eager]` | **964 ms** |
| A2 | Dataset 1 | `edges [eager]` | **1249 ms** |
| A3 | Dataset 1 | `edges [lazy]` | **917 ms** |

</div>

```mermaid
---
config:
  xyChart:
    width: 700
    height: 500
    titleFontSize: 20
    xAxis:
      labelFontSize: 14
      titleFontSize: 16
    yAxis:
      labelFontSize: 14
      titleFontSize: 16
  themeVariables:
    xyChart:
      plotColorPalette: "#1f77b4"
---
xychart-beta
    title "Frame time, peak view, as % of 60 Hz (100 = limit)"
    x-axis ["A0", "A1", "A2", "A3"]
    y-axis "% of 60 Hz frame" 0 --> 20.1
    bar [15.8, 15.8, 17.4, 15.6]
```

<div align="center">

| Bar | Dataset | Variant | Value |
|---|---|---|---|
| A0 | Dataset 1 | `no-ext [lazy]` | **2.64 ms/frame** |
| A1 | Dataset 1 | `no-ext [eager]` | **2.62 ms/frame** |
| A2 | Dataset 1 | `edges [eager]` | **2.91 ms/frame** |
| A3 | Dataset 1 | `edges [lazy]` | **2.60 ms/frame** |

</div>


## Testing plan

- Added unit tests for lazy construction, display-mode changes, resource cleanup, and snapping to hidden edges.
- Manually exercised snapping and display-mode toggles in `client-side-snapping-dev` and `hybrid-snapping-dev`; minimal or no noticeable stutter.
- Compared eager and lazy builds on a representative AEC dataset with edges hidden and displayed; three runs each, first run discarded.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

GitHub Copilot

If yes, I used the following Model(s):

GPT-5.6 Sol
GPT-6 Astra
Claude Fable 5
Claude Fable 5.1
