### PR TITLE
Adds script to update ion token for dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.metadata
 /Build
+/.env
 /Cesium-*.zip
 /cesium-*.tgz
 /packages/**/*.tgz

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "build-sandcastle": "gulp -f gulpfile.apps.js buildSandcastle",
     "clean": "gulp clean",
     "cloc": "gulp cloc",
+    "update-ion-token": "node scripts/updateIonToken.js",
     "create-demo": "npm run create-demo --workspace=packages/sandcastle",
     "coverage": "gulp coverage",
     "build-docs": "gulp buildDocs",

--- a/scripts/updateIonToken.js
+++ b/scripts/updateIonToken.js
@@ -1,0 +1,96 @@
+// Updates the default Cesium ion access token baked into
+// packages/engine/Source/Core/Ion.js with the current default token from the
+// CesiumGS ion account (https://ion.cesium.com).
+//
+// This is handy when checking out an older branch or PR whose committed default
+// token has since expired. To restore the committed value, revert Ion.js in git.
+//
+// Before running this script the first time, set the CESIUM_ION_LIST_TOKENS_TOKEN environment variable or add it to a local .env file.
+// Use the token in the CesiumGS account called "Dev: Update Local Default Access Token", which has the "tokens:read" scope.
+//
+//   echo 'CESIUM_ION_LIST_TOKENS_TOKEN=<token>' > .env
+//
+// Then: npm run update-ion-token
+
+import { readFileSync, writeFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const ionPath = path.join(
+  repoRoot,
+  "packages",
+  "engine",
+  "Source",
+  "Core",
+  "Ion.js",
+);
+
+const defaultTokenUrl = "https://api.cesium.com/v2/tokens/default";
+
+// Matches: const defaultAccessToken =\n  "...";
+const tokenRegex = /(const defaultAccessToken =\s*)"[^"]*"/;
+
+/**
+ * Fetches the default access token from the CesiumGS ion account.
+ * @param {string} apiToken
+ * @returns {Promise<string>}
+ */
+async function fetchDefaultToken(apiToken) {
+  const response = await fetch(defaultTokenUrl, {
+    headers: { Authorization: `Bearer ${apiToken}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Request to ${defaultTokenUrl} failed with ${response.status} ${response.statusText}. ` +
+        `Ensure the ion token is valid and has the 'tokens:read' scope.`,
+    );
+  }
+  const { token } = await response.json();
+  if (!token) {
+    throw new Error("The ion API response did not include a token.");
+  }
+  return token;
+}
+
+// An explicit environment variable wins; otherwise fall back to a local .env file.
+if (!process.env.CESIUM_ION_LIST_TOKENS_TOKEN) {
+  try {
+    process.loadEnvFile(path.join(repoRoot, ".env"));
+  } catch {
+    // No .env file; that's fine.
+  }
+}
+
+const apiToken = process.env.CESIUM_ION_LIST_TOKENS_TOKEN;
+if (!apiToken) {
+  console.error(
+    "No ion API token found. Set the CESIUM_ION_LIST_TOKENS_TOKEN environment variable, or add it to a\n" +
+      "git-ignored .env file in the repo root:\n" +
+      "  echo 'CESIUM_ION_LIST_TOKENS_TOKEN=<token>' > .env\n" +
+      "The token must have the 'tokens:read' scope.",
+  );
+  process.exit(1);
+}
+
+const token = await fetchDefaultToken(apiToken);
+
+const source = readFileSync(ionPath, "utf8");
+if (!tokenRegex.test(source)) {
+  console.error(
+    `Could not find the default access token declaration in ${path.relative(repoRoot, ionPath)}.`,
+  );
+  process.exit(1);
+}
+
+const updated = source.replace(tokenRegex, `$1"${token}"`);
+if (updated === source) {
+  console.log("The default ion access token is already up to date.");
+  process.exit(0);
+}
+
+writeFileSync(ionPath, updated);
+console.log(
+  `Updated the default ion access token in ${path.relative(repoRoot, ionPath)}.`,
+);


### PR DESCRIPTION
# Description

When testing old PRs, or doing a git bisect, you often run into the issue of the Ion token being out of date. So you go to Ion, grab a fresh one, paste it in... and then you have to potentially stash or revert that change when switching branches and repeat.

This PR adds a script to grab the default Ion token and paste it into Ion.js. Of course, you need a token (with read:tokens scope) to run this script, but you only have to store that once in a .env file in the repo (which, as of this PR, is gitignored). 

The only downside is that this script won't exist in any commit before this one... so it will only work going forward. (But better late than never).

## Issue number and link

No issue

## Testing plan

1. Create a `.env` file in your local clone. 
2. Paste in `CESIUM_ION_LIST_TOKENS_TOKEN=<the new token from the CesiumGS Ion account called Dev: Update Local Default Access Token>`
3. Run `npm run update-ion-token`
4. Verify that it changes the token in Ion.js. Start Cesium locally and verify that the token works.

## Author checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code

## AI acknowledgment

- [x] I used AI to generate content in this PR
- [x] If yes, I have reviewed the AI-generated content before submitting

If yes, I used the following Tools(s) and/or Service(s):

Claude

If yes, I used the following Model(s):

Opus 4.8
