### PR TITLE
Fix typo in modelMaterial.glsl comment (recieved -> received)

### DIFF
--- a/packages/engine/Source/Shaders/Builtin/Structs/modelMaterial.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Structs/modelMaterial.glsl
@@ -16,7 +16,7 @@
  * @property {vec3} specular Color of reflected light at normal incidence in PBR materials. This is sometimes referred to as f0 in the literature.
  * @property {float} roughness A number from 0.0 to 1.0 representing how rough the surface is. Values near 0.0 produce glossy surfaces, while values near 1.0 produce rough surfaces.
  * @property {vec3} normalEC Surface's normal in eye coordinates. It is used for effects such as normal mapping. The default is the surface's unmodified normal.
- * @property {float} occlusion Ambient occlusion recieved at this point on the material. 1.0 means fully lit, 0.0 means fully occluded.
+ * @property {float} occlusion Ambient occlusion received at this point on the material. 1.0 means fully lit, 0.0 means fully occluded.
  * @property {vec3} emissive Light emitted by the material equally in all directions. The default is vec3(0.0), which emits no light.
  */
 struct czm_modelMaterial {


### PR DESCRIPTION
Corrects the spelling of `received` in a shader comment. No functional change.